### PR TITLE
Launch video player in single task mode

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,6 +29,7 @@
         <activity
             android:name=".detail.VideoItemDetailActivity"
             android:label="@string/title_videoitem_detail"
+            android:launchMode="singleTask"
             android:theme="@style/AppTheme">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"

--- a/app/src/main/java/org/schabi/newpipe/detail/ActionBarHandler.java
+++ b/app/src/main/java/org/schabi/newpipe/detail/ActionBarHandler.java
@@ -111,6 +111,9 @@ class ActionBarHandler {
 
 
     private int getDefaultResolution(final List<VideoStream> videoStreams) {
+        if (defaultPreferences == null)
+            return 0;
+
         String defaultResolution = defaultPreferences
                 .getString(activity.getString(R.string.default_resolution_key),
                         activity.getString(R.string.default_resolution_value));

--- a/app/src/main/java/org/schabi/newpipe/detail/VideoItemDetailActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/detail/VideoItemDetailActivity.java
@@ -68,52 +68,66 @@ public class VideoItemDetailActivity extends AppCompatActivity {
         // http://developer.android.com/guide/components/fragments.html
         //
 
-        Bundle arguments = new Bundle();
         if (savedInstanceState == null) {
-            // this means the video was called though another app
-            if (getIntent().getData() != null) {
-                videoUrl = getIntent().getData().toString();
-                StreamingService[] serviceList = ServiceList.getServices();
-                //StreamExtractor videoExtractor = null;
-                for (int i = 0; i < serviceList.length; i++) {
-                    if (serviceList[i].getUrlIdHandlerInstance().acceptUrl(videoUrl)) {
-                        arguments.putInt(VideoItemDetailFragment.STREAMING_SERVICE, i);
-                        currentStreamingService = i;
-                        //videoExtractor = ServiceList.getService(i).getExtractorInstance();
-                        break;
-                    }
-                }
-                if(currentStreamingService == -1) {
-                    Toast.makeText(this, R.string.url_not_supported_toast, Toast.LENGTH_LONG)
-                            .show();
-                }
-                //arguments.putString(VideoItemDetailFragment.VIDEO_URL,
-                //        videoExtractor.getUrl(videoExtractor.getId(videoUrl)));//cleans URL
-                arguments.putString(VideoItemDetailFragment.VIDEO_URL, videoUrl);
-
-                arguments.putBoolean(VideoItemDetailFragment.AUTO_PLAY,
-                        PreferenceManager.getDefaultSharedPreferences(this)
-                                .getBoolean(getString(R.string.autoplay_through_intent_key), false));
-            } else {
-                videoUrl = getIntent().getStringExtra(VideoItemDetailFragment.VIDEO_URL);
-                currentStreamingService = getIntent().getIntExtra(VideoItemDetailFragment.STREAMING_SERVICE, -1);
-                arguments.putString(VideoItemDetailFragment.VIDEO_URL, videoUrl);
-                arguments.putInt(VideoItemDetailFragment.STREAMING_SERVICE, currentStreamingService);
-                arguments.putBoolean(VideoItemDetailFragment.AUTO_PLAY, false);
-            }
-
+            handleIntent(getIntent());
         } else {
             videoUrl = savedInstanceState.getString(VideoItemDetailFragment.VIDEO_URL);
             currentStreamingService = savedInstanceState.getInt(VideoItemDetailFragment.STREAMING_SERVICE);
-            arguments = savedInstanceState;
+            addFragment(savedInstanceState);
         }
+    }
 
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        setIntent(intent);
+        handleIntent(intent);
+    }
+
+    private void handleIntent(Intent intent) {
+        Bundle arguments = new Bundle();
+        // this means the video was called though another app
+        if (intent.getData() != null) {
+            videoUrl = intent.getData().toString();
+            StreamingService[] serviceList = ServiceList.getServices();
+            //StreamExtractor videoExtractor = null;
+            for (int i = 0; i < serviceList.length; i++) {
+                if (serviceList[i].getUrlIdHandlerInstance().acceptUrl(videoUrl)) {
+                    arguments.putInt(VideoItemDetailFragment.STREAMING_SERVICE, i);
+                    currentStreamingService = i;
+                    //videoExtractor = ServiceList.getService(i).getExtractorInstance();
+                    break;
+                }
+            }
+            if(currentStreamingService == -1) {
+                Toast.makeText(this, R.string.url_not_supported_toast, Toast.LENGTH_LONG)
+                        .show();
+            }
+            //arguments.putString(VideoItemDetailFragment.VIDEO_URL,
+            //        videoExtractor.getUrl(videoExtractor.getId(videoUrl)));//cleans URL
+            arguments.putString(VideoItemDetailFragment.VIDEO_URL, videoUrl);
+
+            arguments.putBoolean(VideoItemDetailFragment.AUTO_PLAY,
+                    PreferenceManager.getDefaultSharedPreferences(this)
+                            .getBoolean(getString(R.string.autoplay_through_intent_key), false));
+        } else {
+            videoUrl = intent.getStringExtra(VideoItemDetailFragment.VIDEO_URL);
+            currentStreamingService = intent.getIntExtra(VideoItemDetailFragment.STREAMING_SERVICE, -1);
+            arguments.putString(VideoItemDetailFragment.VIDEO_URL, videoUrl);
+            arguments.putInt(VideoItemDetailFragment.STREAMING_SERVICE, currentStreamingService);
+            arguments.putBoolean(VideoItemDetailFragment.AUTO_PLAY, false);
+        }
+        addFragment(arguments);
+
+    }
+
+    private void addFragment(final Bundle arguments) {
         // Create the detail fragment and add it to the activity
         // using a fragment transaction.
         fragment = new VideoItemDetailFragment();
         fragment.setArguments(arguments);
         getSupportFragmentManager().beginTransaction()
-                .add(R.id.videoitem_detail_container, fragment)
+                .replace(R.id.videoitem_detail_container, fragment)
                 .commit();
     }
 


### PR DESCRIPTION
This makes sure VideoItemDetailActivity is always started as a seperate app, and is displayed in recent apps seperately.

Changes in VideoItemDetailActivity are necessary to replace the existing video/fragment with the new one.

The change in ActionBarHandler was required to avoid a crash when opening a new video from a different app.