### PR TITLE
Delete Swiss High German translation

### DIFF
--- a/app/src/main/res/values-de-rCH/strings.xml
+++ b/app/src/main/res/values-de-rCH/strings.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources></resources>


### PR DESCRIPTION
Hello

I realized I accidental opened a new translation "de-rCH" on Weblat, but I don't think it makes sense to add it because its basically the same as German. Also it's empty. 
Otherwise I would recommend to copy the German part to Swiss German.

Regards
