### PR TITLE
Fix banner extaction

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeChannelExtractor.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeChannelExtractor.java
@@ -136,7 +136,7 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
             if(!isAjaxPage) {
                 Element el = doc.select("div[id=\"gh-banner\"]").first().select("style").first();
                 String cssContent = el.html();
-                String url = "https:" + Parser.matchGroup1("url\\((.*)\\)", cssContent);
+                String url = "https:" + Parser.matchGroup1("url\\(([^)]+)\\)", cssContent);
                 if (url.contains("s.ytimg.com")) {
                     bannerUrl = null;
                 } else {


### PR DESCRIPTION
When opening a channel i get an error.

The error is caused by matching all characters greedy which results the next parentheses to match:
```
java.io.FileNotFoundException: https://yt3.ggpht.com/ZENp6vo0Y1Brsnshet01VoLrhwa-73XUlsyVayXHaBA6IhmabLghw4NjeJS4qAF61CQxkNJqNpU=w1060-fcrop64=1,00005a57ffffa5a8-nd-c0xffffffff-rj-k-no)%3B%20%20%7D%20%20@media%20screen%20and%20(-webkit-min-device-pixel-ratio:%201.5),%20%20%20%20%20%20%20%20%20screen%20and%20(min-resolution:%201.5dppx)%20%7B#c4-header-bg-container%20%7B%20%20%20%20%20%20%20%20background-image:%20url(//yt3.ggpht.com/ZENp6vo0Y1Brsnshet01VoLrhwa-73XUlsyVayXHaBA6IhmabLghw4NjeJS4qAF61CQxkNJqNpU=w2120-fcrop64=1,00005a57ffffa5a8-nd-c0xffffffff-rj-k-no)%3B%20%20%20%20%7D%20%20%7D#c4-header-bg-container%20.hd-banner-image%20%7B%20%20%20%20%20%20background-image:%20url(//yt3.ggpht.com/ZENp6vo0Y1Brsnshet01VoLrhwa-73XUlsyVayXHaBA6IhmabLghw4NjeJS4qAF61CQxkNJqNpU=w2120-fcrop64=1,00005a57ffffa5a8-nd-c0xffffffff-rj-k-no
	at com.android.okhttp.internal.huc.HttpURLConnectionImpl.getInputStream(HttpURLConnectionImpl.java:238)
	at com.android.okhttp.internal.huc.DelegatingHttpsURLConnection.getInputStream(DelegatingHttpsURLConnection.java:210)
	at com.android.okhttp.internal.huc.HttpsURLConnectionImpl.getInputStream(HttpsURLConnectionImpl.java)
	at com.nostra13.universalimageloader.core.download.BaseImageDownloader.getStreamFromNetwork(BaseImageDownloader.java:124)
	at com.nostra13.universalimageloader.core.download.BaseImageDownloader.getStream(BaseImageDownloader.java:88)
	at com.nostra13.universalimageloader.core.decode.BaseImageDecoder.getImageStream(BaseImageDecoder.java:98)
	at com.nostra13.universalimageloader.core.decode.BaseImageDecoder.decode(BaseImageDecoder.java:74)
	at com.nostra13.universalimageloader.core.LoadAndDisplayImageTask.decodeImage(LoadAndDisplayImageTask.java:265)
	at com.nostra13.universalimageloader.core.LoadAndDisplayImageTask.tryLoadBitmap(LoadAndDisplayImageTask.java:238)
	at com.nostra13.universalimageloader.core.LoadAndDisplayImageTask.run(LoadAndDisplayImageTask.java:136)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1113)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:588)
	at java.lang.Thread.run(Thread.java:818)
```
