### PR TITLE
Fix dublicated results

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ android:
     - build-tools-23.0.3
 
     # The SDK version used to compile NewPipe
-    - android-24
+    - android-25
 
     # Additional components
     - extra-android-support

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,3 +33,7 @@ before_script:
   - adb shell input keyevent 82 &
 
 script: ./gradlew --info build connectedCheck
+
+licenses:
+  - 'android-sdk-license-.+'
+

--- a/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeSearchEngine.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeSearchEngine.java
@@ -53,7 +53,7 @@ public class YoutubeSearchEngine extends SearchEngine {
 
         String url = "https://www.youtube.com/results"
                 + "?search_query=" + URLEncoder.encode(query, CHARSET_UTF_8)
-                + "&page=" + Integer.toString(page)
+                + "&page=" + Integer.toString(page + 1)
                 + "&filters=" + "video";
 
         String site;


### PR DESCRIPTION
Fix for  #388:
Google begins with page 1 so we can add 1 to the page before creating the URL.
I've tested it on my Phone and it worked.

Examples:
https://www.youtube.com/results?search_query=test&page=0&filters=video
is the same as 
https://www.youtube.com/results?search_query=test&page=1&filters=video
but
https://www.youtube.com/results?search_query=test&page=2&filters=video
is different