### PR TITLE
Improve reCaptcha integration

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/ReCaptchaActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/ReCaptchaActivity.java
@@ -2,6 +2,7 @@ package org.schabi.newpipe;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.graphics.Bitmap;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.v4.app.NavUtils;
@@ -34,6 +35,8 @@ import android.webkit.WebViewClient;
  * along with NewPipe.  If not, see <http://www.gnu.org/licenses/>.
  */
 public class ReCaptchaActivity extends AppCompatActivity {
+    public static final int RECAPTCHA_REQUEST = 10;
+
     public static final String TAG = ReCaptchaActivity.class.toString();
     public static final String YT_URL = "https://www.youtube.com";
 
@@ -41,6 +44,9 @@ public class ReCaptchaActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_recaptcha);
+
+        // Set return to Cancel by default
+        setResult(RESULT_CANCELED);
 
         ActionBar actionBar = getSupportActionBar();
         actionBar.setDisplayHomeAsUpEnabled(true);
@@ -81,18 +87,25 @@ public class ReCaptchaActivity extends AppCompatActivity {
         }
 
         @Override
+        public void onPageStarted(WebView view, String url, Bitmap favicon) {
+            // TODO: Start Loader
+            super.onPageStarted(view, url, favicon);
+        }
+
+        @Override
         public void onPageFinished(WebView view, String url) {
             String cookies = CookieManager.getInstance().getCookie(url);
+
+            // TODO: Stop Loader
 
             // find cookies : s_gl & goojf and Add cookies to Downloader
             if (find_access_cookies(cookies)) {
                 // Give cookies to Downloader class
                 Downloader.setCookies(mCookies);
 
-                // Closing activity and return to parent.
-                Intent intent = new Intent(context, org.schabi.newpipe.MainActivity.class);
-                intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-                NavUtils.navigateUpTo(context, intent);
+                // Closing activity and return to parent
+                setResult(RESULT_OK);
+                finish();
             }
         }
 

--- a/app/src/main/java/org/schabi/newpipe/detail/StreamInfoWorker.java
+++ b/app/src/main/java/org/schabi/newpipe/detail/StreamInfoWorker.java
@@ -123,9 +123,8 @@ public class StreamInfoWorker {
                     }
                 });
                 e.printStackTrace();
-            }
-            // custom service related exceptions
-            catch (YoutubeStreamExtractor.DecryptException de) {
+            } catch (YoutubeStreamExtractor.DecryptException de) {
+                // custom service related exceptions
                 h.post(new Runnable() {
                     @Override
                     public void run() {

--- a/app/src/main/java/org/schabi/newpipe/detail/StreamInfoWorker.java
+++ b/app/src/main/java/org/schabi/newpipe/detail/StreamInfoWorker.java
@@ -5,8 +5,8 @@ import android.os.Handler;
 import android.util.Log;
 import android.view.View;
 
-import org.schabi.newpipe.Downloader;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
+import org.schabi.newpipe.extractor.exceptions.ReCaptchaException;
 import org.schabi.newpipe.extractor.stream_info.StreamExtractor;
 import org.schabi.newpipe.extractor.stream_info.StreamInfo;
 import org.schabi.newpipe.report.ErrorActivity;
@@ -44,6 +44,7 @@ public class StreamInfoWorker {
     public interface OnStreamInfoReceivedListener {
         void onReceive(StreamInfo info);
         void onError(int messageId);
+        void onReCaptchaException();
         void onBlockedByGemaError();
         void onContentErrorWithMessage(int messageId);
         void onContentError();
@@ -107,6 +108,13 @@ public class StreamInfoWorker {
                 }
 
                 // These errors render the stream information unusable.
+            } catch (ReCaptchaException e) {
+                h.post(new Runnable() {
+                    @Override
+                    public void run() {
+                        onStreamInfoReceivedListener.onReCaptchaException();
+                    }
+                });
             } catch (IOException e) {
                 h.post(new Runnable() {
                     @Override

--- a/app/src/main/java/org/schabi/newpipe/detail/VideoItemDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/detail/VideoItemDetailFragment.java
@@ -43,6 +43,7 @@ import java.util.Vector;
 
 import org.schabi.newpipe.ActivityCommunicator;
 import org.schabi.newpipe.ChannelActivity;
+import org.schabi.newpipe.ReCaptchaActivity;
 import org.schabi.newpipe.extractor.stream_info.StreamInfo;
 import org.schabi.newpipe.extractor.stream_info.StreamPreviewInfo;
 import org.schabi.newpipe.info_list.InfoItemBuilder;
@@ -58,6 +59,9 @@ import org.schabi.newpipe.extractor.stream_info.VideoStream;
 import org.schabi.newpipe.player.BackgroundPlayer;
 import org.schabi.newpipe.player.PlayVideoActivity;
 import org.schabi.newpipe.player.ExoPlayerActivity;
+
+import static android.app.Activity.RESULT_OK;
+import static org.schabi.newpipe.ReCaptchaActivity.RECAPTCHA_REQUEST;
 
 
 /**
@@ -605,6 +609,17 @@ public class VideoItemDetailFragment extends Fragment {
             }
 
             @Override
+            public void onReCaptchaException() {
+                Toast.makeText(getActivity(), R.string.recaptcha_request_toast,
+                        Toast.LENGTH_LONG).show();
+
+                // Starting ReCaptcha Challenge Activity
+                startActivityForResult(
+                        new Intent(getActivity(), ReCaptchaActivity.class),
+                        RECAPTCHA_REQUEST);
+            }
+
+            @Override
             public void onBlockedByGemaError() {
                 onErrorBlockedByGema();
             }
@@ -792,5 +807,24 @@ public class VideoItemDetailFragment extends Fragment {
         detailIntent.putExtra(
                 VideoItemDetailFragment.STREAMING_SERVICE, streamingServiceId);
         activity.startActivity(detailIntent);
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        switch (requestCode) {
+            case RECAPTCHA_REQUEST:
+                if (resultCode == RESULT_OK) {
+                    String videoUrl = getArguments().getString(VIDEO_URL);
+                    StreamInfoWorker siw = StreamInfoWorker.getInstance();
+                    siw.search(streamingServiceId, videoUrl, getActivity());
+                } else {
+                    Log.d(TAG, "ReCaptcha failed");
+                }
+                break;
+
+            default:
+                Log.e(TAG, "Request code from activity not supported [" + requestCode + "]");
+                break;
+        }
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/detail/VideoItemDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/detail/VideoItemDetailFragment.java
@@ -583,11 +583,6 @@ public class VideoItemDetailFragment extends Fragment {
         return true;
     }
 
-    /**
-     * Mandatory empty constructor for the fragment manager to instantiate the
-     * fragment (e.g. upon screen orientation changes).
-     */
-
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/app/src/main/java/org/schabi/newpipe/search_fragment/SearchInfoItemFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/search_fragment/SearchInfoItemFragment.java
@@ -8,6 +8,7 @@ import android.support.v4.app.Fragment;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.SearchView;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -27,6 +28,9 @@ import org.schabi.newpipe.R;
 import org.schabi.newpipe.detail.VideoItemDetailActivity;
 import org.schabi.newpipe.detail.VideoItemDetailFragment;
 import org.schabi.newpipe.info_list.InfoListAdapter;
+
+import static android.app.Activity.RESULT_OK;
+import static org.schabi.newpipe.ReCaptchaActivity.RECAPTCHA_REQUEST;
 
 /**
  * Created by Christian Schabesberger on 02.08.16.
@@ -180,9 +184,11 @@ public class SearchInfoItemFragment extends Fragment {
             public void onReCaptchaChallenge() {
                 Toast.makeText(getActivity(), "ReCaptcha Challenge requested",
                         Toast.LENGTH_LONG).show();
+
                 // Starting ReCaptcha Challenge Activity
-                Intent i = new Intent(getActivity(), ReCaptchaActivity.class);
-                getActivity().startActivity(i);
+                startActivityForResult(
+                        new Intent(getActivity(), ReCaptchaActivity.class),
+                        RECAPTCHA_REQUEST);
             }
         });
     }
@@ -288,5 +294,24 @@ public class SearchInfoItemFragment extends Fragment {
                 new SuggestionSearchRunnable(streamingServiceId, query, getActivity(), suggestionListAdapter);
         Thread suggestionThread = new Thread(suggestionSearchRunnable);
         suggestionThread.start();
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        switch (requestCode) {
+            case RECAPTCHA_REQUEST:
+                if (resultCode == RESULT_OK) {
+                    if (searchQuery.length() != 0) {
+                        search(searchQuery);
+                    }
+                } else {
+                    Log.d(TAG, "ReCaptcha failed");
+                }
+                break;
+
+            default:
+                Log.e(TAG, "Request code from activity not supported [" + requestCode + "]");
+                break;
+        }
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/search_fragment/SearchInfoItemFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/search_fragment/SearchInfoItemFragment.java
@@ -72,7 +72,7 @@ public class SearchInfoItemFragment extends Fragment {
                     //noinspection ConstantConditions
                     inputManager.hideSoftInputFromWindow(
                             a.getCurrentFocus().getWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS);
-                } catch(NullPointerException e) {
+                } catch (NullPointerException e) {
                     e.printStackTrace();
                     ErrorActivity.reportError(a, e, null,
                             a.findViewById(android.R.id.content),
@@ -86,7 +86,7 @@ public class SearchInfoItemFragment extends Fragment {
                 //    onQueryTextSubmit to trigger twice when focus is not cleared.
                 // See: http://stackoverflow.com/questions/17874951/searchview-onquerytextsubmit-runs-twice-while-i-pressed-once
                 a.getCurrentFocus().clearFocus();
-            } catch(Exception e) {
+            } catch (Exception e) {
                 e.printStackTrace();
             }
             View bg = a.findViewById(R.id.mainBG);
@@ -96,7 +96,7 @@ public class SearchInfoItemFragment extends Fragment {
 
         @Override
         public boolean onQueryTextChange(String newText) {
-            if(!newText.isEmpty()) {
+            if (!newText.isEmpty()) {
                 searchSuggestions(newText);
             }
             return true;
@@ -137,13 +137,13 @@ public class SearchInfoItemFragment extends Fragment {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        if(savedInstanceState != null) {
+        if (savedInstanceState != null) {
             searchQuery = savedInstanceState.getString(QUERY);
             streamingServiceId = savedInstanceState.getInt(STREAMING_SERVICE);
         } else {
             try {
                 streamingServiceId = NewPipe.getIdOfService("Youtube");
-            } catch(Exception e) {
+            } catch (Exception e) {
                 e.printStackTrace();
                 ErrorActivity.reportError(getActivity(), e, null,
                         getActivity().findViewById(android.R.id.content),
@@ -222,14 +222,13 @@ public class SearchInfoItemFragment extends Fragment {
             public void onScrolled(RecyclerView recyclerView, int dx, int dy) {
                 int pastVisiblesItems, visibleItemCount, totalItemCount;
                 super.onScrolled(recyclerView, dx, dy);
-                if(dy > 0) //check for scroll down
+                if (dy > 0) //check for scroll down
                 {
                     visibleItemCount = streamInfoListLayoutManager.getChildCount();
                     totalItemCount = streamInfoListLayoutManager.getItemCount();
                     pastVisiblesItems = streamInfoListLayoutManager.findFirstVisibleItemPosition();
 
-                    if ( (visibleItemCount + pastVisiblesItems) >= totalItemCount && !isLoading)
-                    {
+                    if ((visibleItemCount + pastVisiblesItems) >= totalItemCount && !isLoading) {
                         pageNumber++;
                         search(searchQuery, pageNumber);
                     }
@@ -270,7 +269,7 @@ public class SearchInfoItemFragment extends Fragment {
         searchView.setSuggestionsAdapter(suggestionListAdapter);
         searchView.setOnSuggestionListener(new SearchSuggestionListener(searchView, suggestionListAdapter));
         searchView.setOnQueryTextListener(new SearchQueryListener());
-        if(searchQuery != null && !searchQuery.isEmpty()) {
+        if (searchQuery != null && !searchQuery.isEmpty()) {
             searchView.setQuery(searchQuery, false);
             searchView.setIconifiedByDefault(false);
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -271,6 +271,7 @@
     <string name="action_settings">Settings</string>
     <string name="reCaptchaActivity">reCaptcha</string>
     <string name="reCaptcha_title">reCaptcha Challenge</string>
+    <string name="recaptcha_request_toast">ReCaptcha Challenge requested</string>
 
     <!-- End of GigaGet's Strings -->
 


### PR DESCRIPTION
This pull request fixes the following issues from first reCaptcha integration ( #387 ).

> After exiting the reCaptcha activity, I need to re-click on the search field to refresh the query.

Fixed.

> If I click from outside Newpipe Application on a Youtube link the reCaptcha exception is thrown but the activity is not started.

Fixed.

I change the way of starting reCaptchaActivity, using startActivityForResult() and onActivityResult().