### PR TITLE
fix NullPointerExcpeption when opening "Downloads" with android-api < 23

### DIFF
--- a/app/src/main/java/us/shandian/giga/ui/fragment/MissionsFragment.java
+++ b/app/src/main/java/us/shandian/giga/ui/fragment/MissionsFragment.java
@@ -84,9 +84,23 @@ public abstract class MissionsFragment extends Fragment
 		return v;
 	}
 
-	@Override
+	/** Added in API level 23. */
+    @Override
 	public void onAttach(Context activity) {
 		super.onAttach(activity);
+
+		// Bug: in api< 23 this is never called
+		// so mActivity=null
+		// so app crashes with nullpointer exception
+		mActivity = activity;
+	}
+
+	/** deprecated in API level 23,
+	 * but must remain to allow compatibility with api<23 */
+	@Override
+	public void onAttach(Activity activity) {
+		super.onAttach(activity);
+
 		mActivity = activity;
 	}
 


### PR DESCRIPTION
on my android-4.2 (api-17) NewPipe-0.8.8 and 0.8.9 crashes with nullpointer-exception when openinge the "Downloads"

reason: in api < 23 Fragment.onAttach(Context)  is never called by android  so mActivity is null

fix: re add deprecated Fragment.onAttach(Activity) which exist since api-11 that will set mActivity instead.
