### PR TITLE
Update English short_thousand string

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -152,7 +152,7 @@
     <string name="videos">videos</string>
     <string name="subscriber">subscriber</string>
     <string name="views">views</string>
-    <string name="short_thousand">T</string>
+    <string name="short_thousand">K</string>
     <string name="short_million">M</string>
     <string name="short_billion">B</string>
 


### PR DESCRIPTION
The commonly used abbreviation for thousands in English is K; T is almost never used because it usually represents trillions. Because of this, I have changed the value of the English short_thousand sting to K.