### PR TITLE
Add restart dialog on theme change

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/settings/SettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/SettingsFragment.java
@@ -98,6 +98,8 @@ public class SettingsFragment  extends PreferenceFragment
         downloadPathAudioPreference = findPreference(DOWNLOAD_PATH_AUDIO_PREFERENCE);
         themePreference = findPreference(THEME);
 
+        final String currentTheme = defaultPreferences.getString(THEME, "Light");
+
         prefListener = new SharedPreferences.OnSharedPreferenceChangeListener() {
             @Override
             public void onSharedPreferenceChanged(SharedPreferences sharedPreferences,
@@ -139,25 +141,27 @@ public class SettingsFragment  extends PreferenceFragment
                 }
                 else if (key == THEME)
                 {
-                    String theme = sharedPreferences.getString(THEME, "Light");
-                    themePreference.setSummary(theme);
+                    String selectedTheme = sharedPreferences.getString(THEME, "Light");
+                    themePreference.setSummary(selectedTheme);
 
-                    new AlertDialog.Builder(activity)
-                            .setTitle(R.string.restart_title)
-                            .setMessage(R.string.msg_restart)
-                            .setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
-                                @Override
-                                public void onClick(DialogInterface dialog, int which) {
-                                    Intent intentToMain = new Intent(activity, MainActivity.class);
-                                    intentToMain.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
-                                    activity.startActivity(intentToMain);
+                    if(!selectedTheme.equals(currentTheme)) { // If it's not the current theme
+                        new AlertDialog.Builder(activity)
+                                .setTitle(R.string.restart_title)
+                                .setMessage(R.string.msg_restart)
+                                .setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
+                                    @Override
+                                    public void onClick(DialogInterface dialog, int which) {
+                                        Intent intentToMain = new Intent(activity, MainActivity.class);
+                                        intentToMain.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
+                                        activity.startActivity(intentToMain);
 
-                                    activity.finish();
-                                    Runtime.getRuntime().exit(0);
-                                }
-                            })
-                            .setNegativeButton(R.string.later, null)
-                            .create().show();
+                                        activity.finish();
+                                        Runtime.getRuntime().exit(0);
+                                    }
+                                })
+                                .setNegativeButton(R.string.later, null)
+                                .create().show();
+                    }
                 }
                 updateSummary();
             }

--- a/app/src/main/java/org/schabi/newpipe/settings/SettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/SettingsFragment.java
@@ -1,27 +1,27 @@
 package org.schabi.newpipe.settings;
 
 import android.app.Activity;
-import android.app.ListActivity;
 import android.content.ClipData;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
-import android.preference.CheckBoxPreference;
 import android.preference.ListPreference;
 import android.preference.Preference;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceManager;
 import android.preference.PreferenceScreen;
+import android.support.v7.app.AlertDialog;
 
 import com.nononsenseapps.filepicker.FilePickerActivity;
 
 import org.schabi.newpipe.App;
+import org.schabi.newpipe.MainActivity;
 import org.schabi.newpipe.R;
 
 import java.util.ArrayList;
-import java.util.Objects;
 
 import info.guardianproject.netcipher.proxy.OrbotHelper;
 
@@ -141,6 +141,23 @@ public class SettingsFragment  extends PreferenceFragment
                 {
                     String theme = sharedPreferences.getString(THEME, "Light");
                     themePreference.setSummary(theme);
+
+                    new AlertDialog.Builder(activity)
+                            .setTitle(R.string.restart_title)
+                            .setMessage(R.string.msg_restart)
+                            .setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
+                                @Override
+                                public void onClick(DialogInterface dialog, int which) {
+                                    Intent intentToMain = new Intent(activity, MainActivity.class);
+                                    intentToMain.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
+                                    activity.startActivity(intentToMain);
+
+                                    activity.finish();
+                                    Runtime.getRuntime().exit(0);
+                                }
+                            })
+                            .setNegativeButton(R.string.later, null)
+                            .create().show();
                 }
                 updateSummary();
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,6 +86,8 @@
     <string name="error_report_title">Error report</string>
     <string name="all">All</string>
     <string name="channel">Channel</string>
+    <string name="yes">Yes</string>
+    <string name="later">Later</string>
 
     <!-- error strings -->
     <string name="general_error">Error</string>
@@ -155,6 +157,7 @@
     <string name="short_thousand">K</string>
     <string name="short_million">M</string>
     <string name="short_billion">B</string>
+    <string name="restart_title">Restart</string>
 
     <!-- Missions -->
     <string name="start">Start</string>
@@ -183,6 +186,7 @@
     <string name="msg_wait">Please wait…</string>
     <string name="msg_copied">Copied to clipboard.</string>
     <string name="no_available_dir">Please select an available download directory.</string>
+    <string name="msg_restart">You have to restart the application to apply the theme.\n\nDo you want to restart now?</string>
 
     <!-- Checksum types -->
     <string name="md5" translatable="false">MD5</string>


### PR DESCRIPTION
Hey,

This pull request implements a dialog asking if the user want to restart the application when the theme changes.

- Added necessary strings on resource file
- Remove some unused imports
- Only show the dialog when the selected theme it's not the current theme

![dialog_device_newpipe](https://cloud.githubusercontent.com/assets/13389907/23334053/ce5c5328-fb75-11e6-9207-efcd3fa59bf2.png)

