### PR TITLE
Fix travis and YoutubeStreamUrlIdHandler

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamUrlIdHandler.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamUrlIdHandler.java
@@ -15,7 +15,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
-import java.util.regex.Matcher;
 
 /**
  * Created by Christian Schabesberger on 02.02.16.
@@ -149,12 +148,14 @@ public class YoutubeStreamUrlIdHandler implements UrlIdHandler {
 
     @Override
     public boolean acceptUrl(String videoUrl) {
+        String originalUrl = videoUrl;
+
         videoUrl = videoUrl.toLowerCase();
         if(videoUrl.contains("youtube") ||
                 videoUrl.contains("youtu.be")) {
             // bad programming I know
             try {
-                getId(videoUrl);
+                getId(originalUrl);
                 return true;
             } catch (Exception e) {
                 return false;

--- a/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamUrlIdHandler.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeStreamUrlIdHandler.java
@@ -148,14 +148,12 @@ public class YoutubeStreamUrlIdHandler implements UrlIdHandler {
 
     @Override
     public boolean acceptUrl(String videoUrl) {
-        String originalUrl = videoUrl;
-
-        videoUrl = videoUrl.toLowerCase();
-        if(videoUrl.contains("youtube") ||
-                videoUrl.contains("youtu.be")) {
+        String lowercaseUrl = videoUrl.toLowerCase();
+        if(lowercaseUrl.contains("youtube") ||
+                lowercaseUrl.contains("youtu.be")) {
             // bad programming I know
             try {
-                getId(originalUrl);
+                getId(videoUrl);
                 return true;
             } catch (Exception e) {
                 return false;

--- a/app/src/test/java/org/schabi/newpipe/extractor/services/youtube/youtube/YoutubeStreamUrlIdHandlerTest.java
+++ b/app/src/test/java/org/schabi/newpipe/extractor/services/youtube/youtube/YoutubeStreamUrlIdHandlerTest.java
@@ -111,9 +111,9 @@ public class YoutubeStreamUrlIdHandlerTest {
 
         assertTrue(urlIdHandler.acceptUrl("vnd.youtube:jZViOEv90dI"));
 
-        String sharedId = "7JIArTByb3E";
+        String sharedId = "8A940MXKFmQ";
         assertTrue(urlIdHandler.acceptUrl("vnd.youtube://www.youtube.com/shared?ci=" + sharedId + "&feature=twitter-deep-link"));
         assertTrue(urlIdHandler.acceptUrl("vnd.youtube://www.youtube.com/shared?ci=" + sharedId ));
-        assertTrue(urlIdHandler.acceptUrl("https://www.youtube.com/shared?ci=7JIArTByb3E"));
+        assertTrue(urlIdHandler.acceptUrl("https://www.youtube.com/shared?ci=" + sharedId));
     }
 }


### PR DESCRIPTION
Just discovered that some of the links `https://www.youtube.com/shared?ci=` works and others don't, like:

https://www.youtube.com/shared?ci=FM7MFYoylVs
https://www.youtube.com/shared?ci=8A940MXKFmQ

So I changed the test to the working one.

And the bug in the `YoutubeStreamUrlIdHandler`, was that it was passing a lowercase URL to the checking method, which obviously failed.