### PR TITLE
Fix bug when fetching unavailable content

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/PopupVideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/PopupVideoPlayer.java
@@ -819,7 +819,14 @@ public class PopupVideoPlayer extends Service implements StateInterface {
                     }
                 });
             } catch (Exception e) {
-                e.printStackTrace();
+                if (DEBUG) e.printStackTrace();
+                mainHandler.post(new Runnable() {
+                    @Override
+                    public void run() {
+                        Toast.makeText(PopupVideoPlayer.this, R.string.content_not_available, Toast.LENGTH_SHORT).show();
+                    }
+                });
+                stopSelf();
             }
         }
     }

--- a/app/src/main/java/org/schabi/newpipe/player/PopupVideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/PopupVideoPlayer.java
@@ -818,6 +818,15 @@ public class PopupVideoPlayer extends Service implements StateInterface {
                         });
                     }
                 });
+            } catch (IOException ie) {
+                if (DEBUG) ie.printStackTrace();
+                mainHandler.post(new Runnable() {
+                    @Override
+                    public void run() {
+                        Toast.makeText(PopupVideoPlayer.this, R.string.network_error, Toast.LENGTH_SHORT).show();
+                    }
+                });
+                stopSelf();
             } catch (Exception e) {
                 if (DEBUG) e.printStackTrace();
                 mainHandler.post(new Runnable() {


### PR DESCRIPTION
- Fix #482
- When opening a invalid/deleted/unavailable video, the popup was just printing the error, now it shows a message to the user and exits