### PR TITLE
Update menu items after change in settings

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/ActionBarHandler.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/ActionBarHandler.java
@@ -40,6 +40,7 @@ import java.util.List;
  */
 
 
+@SuppressWarnings("WeakerAccess")
 class ActionBarHandler {
     private static final String TAG = "ActionBarHandler";
 
@@ -103,6 +104,10 @@ class ActionBarHandler {
         defaultPreferences = PreferenceManager.getDefaultSharedPreferences(activity);
         inflater.inflate(R.menu.video_detail_menu, menu);
 
+        updateItemsVisibility();
+    }
+
+    public void updateItemsVisibility(){
         showPlayWithKodiAction(defaultPreferences.getBoolean(activity.getString(R.string.show_play_with_kodi_key), false));
     }
 

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -98,6 +98,7 @@ public class VideoDetailFragment extends BaseFragment implements StreamExtractor
 
     private static final int RELATED_STREAMS_UPDATE_FLAG = 0x1;
     private static final int RESOLUTIONS_MENU_UPDATE_FLAG = 0x2;
+    private static final int TOOLBAR_ITEMS_UPDATE_FLAG = 0x4;
     private int updateFlags = 0;
 
     private boolean autoPlayEnabled;
@@ -219,6 +220,8 @@ public class VideoDetailFragment extends BaseFragment implements StreamExtractor
                 if ((updateFlags & RELATED_STREAMS_UPDATE_FLAG) != 0) initRelatedVideos(currentStreamInfo);
                 if ((updateFlags & RESOLUTIONS_MENU_UPDATE_FLAG) != 0) setupActionBarHandler(currentStreamInfo);
             }
+
+            if ((updateFlags & TOOLBAR_ITEMS_UPDATE_FLAG) != 0 && actionBarHandler != null) actionBarHandler.updateItemsVisibility();
             updateFlags = 0;
         }
 
@@ -329,6 +332,8 @@ public class VideoDetailFragment extends BaseFragment implements StreamExtractor
                 || key.equals(getString(R.string.default_resolution_key))
                 || key.equals(getString(R.string.show_higher_resolutions_key))) {
             updateFlags |= RESOLUTIONS_MENU_UPDATE_FLAG;
+        } else if (key.equals(getString(R.string.show_play_with_kodi_key))) {
+            updateFlags |= TOOLBAR_ITEMS_UPDATE_FLAG;
         }
     }
 


### PR DESCRIPTION
Live settings changes (Show Higher Resolutions and such) are already available, but this PR implement an update to the visibility of some toolbar/menu items (like the Play on Kodi) that I forgot to add originally.