### PR TITLE
Fix image loading bug

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
@@ -189,6 +189,7 @@ public abstract class BasePlayer implements ExoPlayer.EventListener, AudioManage
         ImageLoader.getInstance().loadImage(videoThumbnailUrl, new SimpleImageLoadingListener() {
             @Override
             public void onLoadingComplete(String imageUri, View view, Bitmap loadedImage) {
+                if (simpleExoPlayer == null) return;
                 if (DEBUG) Log.d(TAG, "onLoadingComplete() called with: imageUri = [" + imageUri + "], view = [" + view + "], loadedImage = [" + loadedImage + "]");
                 videoThumbnail = loadedImage;
                 onThumbnailReceived(loadedImage);

--- a/app/src/main/java/org/schabi/newpipe/player/PopupVideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/PopupVideoPlayer.java
@@ -677,7 +677,9 @@ public class PopupVideoPlayer extends Service {
             imageLoader.resume();
             imageLoader.loadImage(info.thumbnail_url, displayImageOptions, new SimpleImageLoadingListener() {
                 @Override
-                public void onLoadingComplete(String imageUri, View view, final Bitmap loadedImage) {
+                public void onLoadingComplete(final String imageUri, View view, final Bitmap loadedImage) {
+                    if (playerImpl == null || playerImpl.getPlayer() == null) return;
+                    if (DEBUG) Log.d(TAG, "FetcherRunnable.imageLoader.onLoadingComplete() called with: imageUri = [" + imageUri + "]");
                     mainHandler.post(new Runnable() {
                         @Override
                         public void run() {


### PR DESCRIPTION
After closing a player (popup in this case), and the image loader was still loading, `onLoadingComplete` is still being called and the notification control was being created after the popup was destroyed (getting stuck, user cannot close it) as the `loadImage` task is not cancelled, and we cannot cancel these with the current imageloader.

And that's one more reason that we **still** need to change it, the one that we are using (UIL) is discontinued since 2015.