### PR TITLE
Hide the 'Threads' slider from Download dialog.

### DIFF
--- a/app/src/main/res/layout/dialog_url.xml
+++ b/app/src/main/res/layout/dialog_url.xml
@@ -43,17 +43,18 @@
         tools:ignore="RtlHardcoded">
 
         <RadioButton
-            android:id="@+id/video_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:checked="true"
-            android:text="@string/video"/>
-
-        <RadioButton
             android:id="@+id/audio_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/audio"/>
+            android:checked="true"
+            android:text="@string/audio" />
+
+        <RadioButton
+            android:id="@+id/video_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="10dp"
+            android:text="@string/video" />
     </RadioGroup>
 
     <TextView
@@ -64,7 +65,8 @@
         android:layout_marginBottom="6dp"
         android:layout_marginLeft="24dp"
         android:layout_marginRight="24dp"
-        android:text="@string/msg_threads"/>
+        android:text="@string/msg_threads"
+        android:visibility="gone" />
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -72,8 +74,9 @@
         android:layout_below="@+id/threads_text_view"
         android:layout_marginLeft="24dp"
         android:layout_marginRight="24dp"
+        android:orientation="horizontal"
         android:paddingBottom="12dp"
-        android:orientation="horizontal">
+        android:visibility="gone">
 
         <TextView
             android:id="@+id/threads_count"
@@ -82,13 +85,13 @@
             android:gravity="center_vertical"
             android:paddingLeft="2dp"
             tools:ignore="RtlHardcoded,RtlSymmetry"
-            tools:text="3"/>
+            tools:text="3" />
 
         <SeekBar
             android:id="@+id/threads"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:max="31"
-            android:progress="3"/>
+            android:progress="3" />
     </LinearLayout>
 </RelativeLayout>


### PR DESCRIPTION
This pull request hides (`visibility: gone`) the 'Threads' slider in the Download dialog as it makes the UI weird and not user-friendly, also changed the radio buttons order to make it more straightforward as I guess many users download songs with NewPipe, removing a little user friction against the UI.