### PR TITLE
Fix keep screen on

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
@@ -184,6 +184,7 @@ public class MainVideoPlayer extends Activity {
                 repeatButton.setAlpha(77);
             }
 
+            getRootView().setKeepScreenOn(true);
         }
 
         @Override
@@ -308,12 +309,14 @@ public class MainVideoPlayer extends Activity {
             super.onLoading();
             playPauseButton.setImageResource(R.drawable.ic_pause_white);
             animateView(playPauseButton, AnimationUtils.Type.SCALE_AND_ALPHA, false, 100);
+            getRootView().setKeepScreenOn(true);
         }
 
         @Override
         public void onBuffering() {
             super.onBuffering();
             animateView(playPauseButton, AnimationUtils.Type.SCALE_AND_ALPHA, false, 100);
+            getRootView().setKeepScreenOn(true);
         }
 
         @Override
@@ -326,8 +329,8 @@ public class MainVideoPlayer extends Activity {
                     animateView(playPauseButton, AnimationUtils.Type.SCALE_AND_ALPHA, true, 200);
                 }
             });
-
             showSystemUi();
+            getRootView().setKeepScreenOn(true);
         }
 
         @Override
@@ -342,12 +345,14 @@ public class MainVideoPlayer extends Activity {
             });
 
             showSystemUi();
+            getRootView().setKeepScreenOn(false);
         }
 
         @Override
         public void onPausedSeek() {
             super.onPausedSeek();
             animateView(playPauseButton, AnimationUtils.Type.SCALE_AND_ALPHA, false, 100);
+            getRootView().setKeepScreenOn(true);
         }
 
 
@@ -365,6 +370,7 @@ public class MainVideoPlayer extends Activity {
                     }
                 });
             }
+            getRootView().setKeepScreenOn(false);
             super.onCompleted();
         }
 

--- a/app/src/main/res/layout/activity_main_player.xml
+++ b/app/src/main/res/layout/activity_main_player.xml
@@ -5,8 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@android:color/black"
-    android:gravity="center"
-    android:keepScreenOn="true">
+    android:gravity="center">
 
     <com.google.android.exoplayer2.ui.AspectRatioFrameLayout
         android:id="@+id/aspectRatioLayout"


### PR DESCRIPTION
When a video was finished or paused, the screen wouldn't turn off, then if a user forgot that is paused or the video is finished, the screen would stay on and drain up the battery.

- Fixes #511