### PR TITLE
Disable white flash on startup

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:logo="@mipmap/ic_launcher"
-        android:theme="@style/AppTheme"
+        android:theme="@style/NoSplashScreenTheme"
         tools:ignore="AllowBackup">
         <activity
             android:name=".MainActivity"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -31,7 +31,6 @@
         <item name="colorControlHighlight">@color/light_ripple_color</item>
     </style>
 
-
     <!-- Dark Theme-->
     <style name="DarkTheme" parent="Theme.AppCompat.NoActionBar">
         <item name="colorPrimary">@color/dark_youtube_primary_color</item>
@@ -85,6 +84,10 @@
 
     <style name="SplashScreenTheme" parent="@style/AppTheme">
         <item name="android:windowBackground">@drawable/splash_screen</item>
+    </style>
+
+    <style name="NoSplashScreenTheme" parent="AppTheme">
+        <item name="android:windowDisablePreview">true</item>
     </style>
 
     <!-- You can also inherit from NNF_BaseTheme.Light -->


### PR DESCRIPTION
Hi!
As described in #590 the app shows a white screen while loading the first Activity. The white corresponds to the `android:windowBackground` of the default app theme (`AppTheme`). The problem is there is no way (at least I found none) to set this background at runtime from the configured theme.

The nicest looking fix is to just disable this screen. I think this is okay because there is no heavy loading in the main activity or app creation.

Regards

PS: I see this is a matter of discussion (see issue)