### PR TITLE
Add about activity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -212,11 +212,7 @@
         <activity
             android:name=".about.AboutActivity"
             android:label="@string/title_activity_about"
-            android:parentActivityName=".MainActivity"
             android:theme="@style/AppTheme">
-            <meta-data
-                android:name="android.support.PARENT_ACTIVITY"
-                android:value="org.schabi.newpipe.MainActivity" />
         </activity>
     </application>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -209,7 +209,15 @@
                 <data android:mimeType="text/plain"/>
             </intent-filter>
         </activity>
-
+        <activity
+            android:name=".about.AboutActivity"
+            android:label="@string/title_activity_about"
+            android:parentActivityName=".MainActivity"
+            android:theme="@style/AppTheme">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="org.schabi.newpipe.MainActivity" />
+        </activity>
     </application>
 
 </manifest>

--- a/app/src/main/assets/apache2.html
+++ b/app/src/main/assets/apache2.html
@@ -1,0 +1,162 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <title>Apache License - Version 2.0, January 2004</title>
+</head>
+<body>
+<p>Apache License<br>Version 2.0, January 2004<br>
+    <a href="http://www.apache.org/licenses/">http://www.apache.org/licenses/</a> </p>
+<p>TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION</p>
+<p><strong><a name="definitions">1. Definitions</a></strong>.</p>
+<p>"License" shall mean the terms and conditions for use, reproduction, and
+    distribution as defined by Sections 1 through 9 of this document.</p>
+<p>"Licensor" shall mean the copyright owner or entity authorized by the
+    copyright owner that is granting the License.</p>
+<p>"Legal Entity" shall mean the union of the acting entity and all other
+    entities that control, are controlled by, or are under common control with
+    that entity. For the purposes of this definition, "control" means (i) the
+    power, direct or indirect, to cause the direction or management of such
+    entity, whether by contract or otherwise, or (ii) ownership of fifty
+    percent (50%) or more of the outstanding shares, or (iii) beneficial
+    ownership of such entity.</p>
+<p>"You" (or "Your") shall mean an individual or Legal Entity exercising
+    permissions granted by this License.</p>
+<p>"Source" form shall mean the preferred form for making modifications,
+    including but not limited to software source code, documentation source,
+    and configuration files.</p>
+<p>"Object" form shall mean any form resulting from mechanical transformation
+    or translation of a Source form, including but not limited to compiled
+    object code, generated documentation, and conversions to other media types.</p>
+<p>"Work" shall mean the work of authorship, whether in Source or Object form,
+    made available under the License, as indicated by a copyright notice that
+    is included in or attached to the work (an example is provided in the
+    Appendix below).</p>
+<p>"Derivative Works" shall mean any work, whether in Source or Object form,
+    that is based on (or derived from) the Work and for which the editorial
+    revisions, annotations, elaborations, or other modifications represent, as
+    a whole, an original work of authorship. For the purposes of this License,
+    Derivative Works shall not include works that remain separable from, or
+    merely link (or bind by name) to the interfaces of, the Work and Derivative
+    Works thereof.</p>
+<p>"Contribution" shall mean any work of authorship, including the original
+    version of the Work and any modifications or additions to that Work or
+    Derivative Works thereof, that is intentionally submitted to Licensor for
+    inclusion in the Work by the copyright owner or by an individual or Legal
+    Entity authorized to submit on behalf of the copyright owner. For the
+    purposes of this definition, "submitted" means any form of electronic,
+    verbal, or written communication sent to the Licensor or its
+    representatives, including but not limited to communication on electronic
+    mailing lists, source code control systems, and issue tracking systems that
+    are managed by, or on behalf of, the Licensor for the purpose of discussing
+    and improving the Work, but excluding communication that is conspicuously
+    marked or otherwise designated in writing by the copyright owner as "Not a
+    Contribution."</p>
+<p>"Contributor" shall mean Licensor and any individual or Legal Entity on
+    behalf of whom a Contribution has been received by Licensor and
+    subsequently incorporated within the Work.</p>
+<p><strong><a name="copyright">2. Grant of Copyright License</a></strong>. Subject to the
+    terms and conditions of this License, each Contributor hereby grants to You
+    a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    copyright license to reproduce, prepare Derivative Works of, publicly
+    display, publicly perform, sublicense, and distribute the Work and such
+    Derivative Works in Source or Object form.</p>
+<p><strong><a name="patent">3. Grant of Patent License</a></strong>. Subject to the terms
+    and conditions of this License, each Contributor hereby grants to You a
+    perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    (except as stated in this section) patent license to make, have made, use,
+    offer to sell, sell, import, and otherwise transfer the Work, where such
+    license applies only to those patent claims licensable by such Contributor
+    that are necessarily infringed by their Contribution(s) alone or by
+    combination of their Contribution(s) with the Work to which such
+    Contribution(s) was submitted. If You institute patent litigation against
+    any entity (including a cross-claim or counterclaim in a lawsuit) alleging
+    that the Work or a Contribution incorporated within the Work constitutes
+    direct or contributory patent infringement, then any patent licenses
+    granted to You under this License for that Work shall terminate as of the
+    date such litigation is filed.</p>
+<p><strong><a name="redistribution">4. Redistribution</a></strong>. You may reproduce and
+    distribute copies of the Work or Derivative Works thereof in any medium,
+    with or without modifications, and in Source or Object form, provided that
+    You meet the following conditions:</p>
+<ol style="list-style: lower-latin;">
+    <li>You must give any other recipients of the Work or Derivative Works a
+        copy of this License; and</li>
+
+    <li>You must cause any modified files to carry prominent notices stating
+        that You changed the files; and</li>
+
+    <li>You must retain, in the Source form of any Derivative Works that You
+        distribute, all copyright, patent, trademark, and attribution notices from
+        the Source form of the Work, excluding those notices that do not pertain to
+        any part of the Derivative Works; and</li>
+
+    <li>If the Work includes a "NOTICE" text file as part of its distribution,
+        then any Derivative Works that You distribute must include a readable copy
+        of the attribution notices contained within such NOTICE file, excluding
+        those notices that do not pertain to any part of the Derivative Works, in
+        at least one of the following places: within a NOTICE text file distributed
+        as part of the Derivative Works; within the Source form or documentation,
+        if provided along with the Derivative Works; or, within a display generated
+        by the Derivative Works, if and wherever such third-party notices normally
+        appear. The contents of the NOTICE file are for informational purposes only
+        and do not modify the License. You may add Your own attribution notices
+        within Derivative Works that You distribute, alongside or as an addendum to
+        the NOTICE text from the Work, provided that such additional attribution
+        notices cannot be construed as modifying the License.
+        <br/>
+        <br/>
+        You may add Your own copyright statement to Your modifications and may
+        provide additional or different license terms and conditions for use,
+        reproduction, or distribution of Your modifications, or for any such
+        Derivative Works as a whole, provided Your use, reproduction, and
+        distribution of the Work otherwise complies with the conditions stated in
+        this License.
+    </li>
+
+</ol>
+
+<p><strong><a name="contributions">5. Submission of Contributions</a></strong>. Unless You
+    explicitly state otherwise, any Contribution intentionally submitted for
+    inclusion in the Work by You to the Licensor shall be under the terms and
+    conditions of this License, without any additional terms or conditions.
+    Notwithstanding the above, nothing herein shall supersede or modify the
+    terms of any separate license agreement you may have executed with Licensor
+    regarding such Contributions.</p>
+<p><strong><a name="trademarks">6. Trademarks</a></strong>. This License does not grant
+    permission to use the trade names, trademarks, service marks, or product
+    names of the Licensor, except as required for reasonable and customary use
+    in describing the origin of the Work and reproducing the content of the
+    NOTICE file.</p>
+<p><strong><a name="no-warranty">7. Disclaimer of Warranty</a></strong>. Unless required by
+    applicable law or agreed to in writing, Licensor provides the Work (and
+    each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including,
+    without limitation, any warranties or conditions of TITLE,
+    NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You
+    are solely responsible for determining the appropriateness of using or
+    redistributing the Work and assume any risks associated with Your exercise
+    of permissions under this License.</p>
+<p><strong><a name="no-liability">8. Limitation of Liability</a></strong>. In no event and
+    under no legal theory, whether in tort (including negligence), contract, or
+    otherwise, unless required by applicable law (such as deliberate and
+    grossly negligent acts) or agreed to in writing, shall any Contributor be
+    liable to You for damages, including any direct, indirect, special,
+    incidental, or consequential damages of any character arising as a result
+    of this License or out of the use or inability to use the Work (including
+    but not limited to damages for loss of goodwill, work stoppage, computer
+    failure or malfunction, or any and all other commercial damages or losses),
+    even if such Contributor has been advised of the possibility of such
+    damages.</p>
+<p><strong><a name="additional">9. Accepting Warranty or Additional Liability</a></strong>.
+    While redistributing the Work or Derivative Works thereof, You may choose
+    to offer, and charge a fee for, acceptance of support, warranty, indemnity,
+    or other liability obligations and/or rights consistent with this License.
+    However, in accepting such obligations, You may act only on Your own behalf
+    and on Your sole responsibility, not on behalf of any other Contributor,
+    and only if You agree to indemnify, defend, and hold each Contributor
+    harmless for any liability incurred by, or claims asserted against, such
+    Contributor by reason of your accepting any such warranty or additional
+    liability.</p>
+</body>
+</html>

--- a/app/src/main/assets/gpl_2.html
+++ b/app/src/main/assets/gpl_2.html
@@ -1,0 +1,400 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+ <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+ <title>GNU General Public License v2.0 - GNU Project - Free Software Foundation (FSF)</title>
+ <link rel="alternate" type="application/rdf+xml"
+       href="http://www.gnu.org/licenses/old-licenses/gpl-2.0.rdf" />
+</head>
+<body>
+<h3><a id="SEC1">GNU GENERAL PUBLIC LICENSE</a></h3>
+<p>
+Version 2, June 1991
+</p>
+
+<pre>
+Copyright (C) 1989, 1991 Free Software Foundation, Inc.  
+51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+
+Everyone is permitted to copy and distribute verbatim copies
+of this license document, but changing it is not allowed.
+</pre>
+
+<h3 id="preamble"><a id="SEC2">Preamble</a></h3>
+
+<p>
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+</p>
+
+<p>
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+</p>
+
+<p>
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+</p>
+
+<p>
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+</p>
+
+<p>
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+</p>
+
+<p>
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+</p>
+
+<p>
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+</p>
+
+<p>
+  The precise terms and conditions for copying, distribution and
+modification follow.
+</p>
+
+
+<h3 id="terms"><a id="SEC3">TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION</a></h3>
+
+
+<p id="section0">
+<strong>0.</strong>
+ This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+</p>
+
+<p>
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+</p>
+
+<p id="section1">
+<strong>1.</strong>
+ You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+</p>
+
+<p>
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+</p>
+
+<p id="section2">
+<strong>2.</strong>
+ You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+</p>
+
+<dl>
+  <dt></dt>
+    <dd>
+      <strong>a)</strong>
+      You must cause the modified files to carry prominent notices
+      stating that you changed the files and the date of any change.
+    </dd>
+  <dt></dt>
+    <dd>
+      <strong>b)</strong>
+      You must cause any work that you distribute or publish, that in
+      whole or in part contains or is derived from the Program or any
+      part thereof, to be licensed as a whole at no charge to all third
+      parties under the terms of this License.
+    </dd>
+  <dt></dt>
+    <dd>
+      <strong>c)</strong>
+      If the modified program normally reads commands interactively
+      when run, you must cause it, when started running for such
+      interactive use in the most ordinary way, to print or display an
+      announcement including an appropriate copyright notice and a
+      notice that there is no warranty (or else, saying that you provide
+      a warranty) and that users may redistribute the program under
+      these conditions, and telling the user how to view a copy of this
+      License.  (Exception: if the Program itself is interactive but
+      does not normally print such an announcement, your work based on
+      the Program is not required to print an announcement.)
+    </dd>
+</dl>
+
+<p>
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+</p>
+
+<p>
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+</p>
+
+<p>
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+</p>
+
+<p id="section3">
+<strong>3.</strong>
+ You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+</p>
+
+<!-- we use this doubled UL to get the sub-sections indented, -->
+<!-- while making the bullets as unobvious as possible. -->
+
+<dl>
+  <dt></dt>
+    <dd>
+      <strong>a)</strong>
+      Accompany it with the complete corresponding machine-readable
+      source code, which must be distributed under the terms of Sections
+      1 and 2 above on a medium customarily used for software interchange; or,
+    </dd>
+  <dt></dt>
+    <dd>
+      <strong>b)</strong>
+      Accompany it with a written offer, valid for at least three
+      years, to give any third party, for a charge no more than your
+      cost of physically performing source distribution, a complete
+      machine-readable copy of the corresponding source code, to be
+      distributed under the terms of Sections 1 and 2 above on a medium
+      customarily used for software interchange; or,
+    </dd>
+  <dt></dt>
+    <dd>
+      <strong>c)</strong>
+      Accompany it with the information you received as to the offer
+      to distribute corresponding source code.  (This alternative is
+      allowed only for noncommercial distribution and only if you
+      received the program in object code or executable form with such
+      an offer, in accord with Subsection b above.)
+    </dd>
+</dl>
+
+<p>
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major softwareComponents (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+</p>
+
+<p>
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+</p>
+
+<p id="section4">
+<strong>4.</strong>
+ You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+</p>
+
+<p id="section5">
+<strong>5.</strong>
+ You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+</p>
+
+<p id="section6">
+<strong>6.</strong>
+ Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+</p>
+
+<p id="section7">
+<strong>7.</strong>
+ If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+</p>
+
+<p>
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+</p>
+
+<p>
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+</p>
+
+<p>
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+</p>
+
+<p id="section8">
+<strong>8.</strong>
+ If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+</p>
+
+<p id="section9">
+<strong>9.</strong>
+ The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+</p>
+
+<p>
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+</p>
+
+<p id="section10">
+<strong>10.</strong>
+ If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+</p>
+
+<p id="section11"><strong>NO WARRANTY</strong></p>
+
+<p>
+<strong>11.</strong>
+ BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+</p>
+
+<p id="section12">
+<strong>12.</strong>
+ IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+</p>
+</body></html>

--- a/app/src/main/assets/gpl_3.html
+++ b/app/src/main/assets/gpl_3.html
@@ -1,0 +1,639 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+ <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+ <title>GNU General Public License v3.0 - GNU Project - Free Software Foundation (FSF)</title>
+ <link rel="alternate" type="application/rdf+xml"
+       href="http://www.gnu.org/licenses/gpl-3.0.rdf" /> 
+</head>
+<body>
+<h3 style="text-align: center;">GNU GENERAL PUBLIC LICENSE</h3>
+<p style="text-align: center;">Version 3, 29 June 2007</p>
+
+<p>Copyright &copy; 2007 Free Software Foundation, Inc.
+ &lt;<a href="http://fsf.org/">http://fsf.org/</a>&gt;</p><p>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.</p>
+
+<h3><a name="preamble"></a>Preamble</h3>
+
+<p>The GNU General Public License is a free, copyleft license for
+software and other kinds of works.</p>
+
+<p>The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.</p>
+
+<p>When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.</p>
+
+<p>To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.</p>
+
+<p>For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.</p>
+
+<p>Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.</p>
+
+<p>For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.</p>
+
+<p>Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.</p>
+
+<p>Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.</p>
+
+<p>The precise terms and conditions for copying, distribution and
+modification follow.</p>
+
+<h3><a name="terms"></a>TERMS AND CONDITIONS</h3>
+
+<h4><a name="section0"></a>0. Definitions.</h4>
+
+<p>&ldquo;This License&rdquo; refers to version 3 of the GNU General Public License.</p>
+
+<p>&ldquo;Copyright&rdquo; also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.</p>
+ 
+<p>&ldquo;The Program&rdquo; refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as &ldquo;you&rdquo;.  &ldquo;Licensees&rdquo; and
+&ldquo;recipients&rdquo; may be individuals or organizations.</p>
+
+<p>To &ldquo;modify&rdquo; a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a &ldquo;modified version&rdquo; of the
+earlier work or a work &ldquo;based on&rdquo; the earlier work.</p>
+
+<p>A &ldquo;covered work&rdquo; means either the unmodified Program or a work based
+on the Program.</p>
+
+<p>To &ldquo;propagate&rdquo; a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.</p>
+
+<p>To &ldquo;convey&rdquo; a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.</p>
+
+<p>An interactive user interface displays &ldquo;Appropriate Legal Notices&rdquo;
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.</p>
+
+<h4><a name="section1"></a>1. Source Code.</h4>
+
+<p>The &ldquo;source code&rdquo; for a work means the preferred form of the work
+for making modifications to it.  &ldquo;Object code&rdquo; means any non-source
+form of a work.</p>
+
+<p>A &ldquo;Standard Interface&rdquo; means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.</p>
+
+<p>The &ldquo;System Libraries&rdquo; of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+&ldquo;Major Component&rdquo;, in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.</p>
+
+<p>The &ldquo;Corresponding Source&rdquo; for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.</p>
+
+<p>The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.</p>
+
+<p>The Corresponding Source for a work in source code form is that
+same work.</p>
+
+<h4><a name="section2"></a>2. Basic Permissions.</h4>
+
+<p>All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.</p>
+
+<p>You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.</p>
+
+<p>Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.</p>
+
+<h4><a name="section3"></a>3. Protecting Users' Legal Rights From Anti-Circumvention Law.</h4>
+
+<p>No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.</p>
+
+<p>When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.</p>
+
+<h4><a name="section4"></a>4. Conveying Verbatim Copies.</h4>
+
+<p>You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.</p>
+
+<p>You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.</p>
+
+<h4><a name="section5"></a>5. Conveying Modified Source Versions.</h4>
+
+<p>You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:</p>
+
+<ul>
+<li>a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.</li>
+
+<li>b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    &ldquo;keep intact all notices&rdquo;.</li>
+
+<li>c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.</li>
+
+<li>d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.</li>
+</ul>
+
+<p>A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+&ldquo;aggregate&rdquo; if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.</p>
+
+<h4><a name="section6"></a>6. Conveying Non-Source Forms.</h4>
+
+<p>You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:</p>
+
+<ul>
+<li>a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.</li>
+
+<li>b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.</li>
+
+<li>c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.</li>
+
+<li>d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.</li>
+
+<li>e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.</li>
+</ul>
+
+<p>A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.</p>
+
+<p>A &ldquo;User Product&rdquo; is either (1) a &ldquo;consumer product&rdquo;, which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, &ldquo;normally used&rdquo; refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.</p>
+
+<p>&ldquo;Installation Information&rdquo; for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.</p>
+
+<p>If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).</p>
+
+<p>The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.</p>
+
+<p>Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.</p>
+
+<h4><a name="section7"></a>7. Additional Terms.</h4>
+
+<p>&ldquo;Additional permissions&rdquo; are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.</p>
+
+<p>When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.</p>
+
+<p>Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:</p>
+
+<ul>
+<li>a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or</li>
+
+<li>b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or</li>
+
+<li>c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or</li>
+
+<li>d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or</li>
+
+<li>e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or</li>
+
+<li>f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.</li>
+</ul>
+
+<p>All other non-permissive additional terms are considered &ldquo;further
+restrictions&rdquo; within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.</p>
+
+<p>If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.</p>
+
+<p>Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.</p>
+
+<h4><a name="section8"></a>8. Termination.</h4>
+
+<p>You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).</p>
+
+<p>However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.</p>
+
+<p>Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.</p>
+
+<p>Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.</p>
+
+<h4><a name="section9"></a>9. Acceptance Not Required for Having Copies.</h4>
+
+<p>You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.</p>
+
+<h4><a name="section10"></a>10. Automatic Licensing of Downstream Recipients.</h4>
+
+<p>Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.</p>
+
+<p>An &ldquo;entity transaction&rdquo; is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.</p>
+
+<p>You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.</p>
+
+<h4><a name="section11"></a>11. Patents.</h4>
+
+<p>A &ldquo;contributor&rdquo; is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's &ldquo;contributor version&rdquo;.</p>
+
+<p>A contributor's &ldquo;essential patent claims&rdquo; are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, &ldquo;control&rdquo; includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.</p>
+
+<p>Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.</p>
+
+<p>In the following three paragraphs, a &ldquo;patent license&rdquo; is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To &ldquo;grant&rdquo; such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.</p>
+
+<p>If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  &ldquo;Knowingly relying&rdquo; means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.</p>
+  
+<p>If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.</p>
+
+<p>A patent license is &ldquo;discriminatory&rdquo; if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.</p>
+
+<p>Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.</p>
+
+<h4><a name="section12"></a>12. No Surrender of Others' Freedom.</h4>
+
+<p>If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.</p>
+
+<h4><a name="section13"></a>13. Use with the GNU Affero General Public License.</h4>
+
+<p>Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.</p>
+
+<h4><a name="section14"></a>14. Revised Versions of this License.</h4>
+
+<p>The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.</p>
+
+<p>Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License &ldquo;or any later version&rdquo; applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.</p>
+
+<p>If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.</p>
+
+<p>Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.</p>
+
+<h4><a name="section15"></a>15. Disclaimer of Warranty.</h4>
+
+<p>THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM &ldquo;AS IS&rdquo; WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.</p>
+
+<h4><a name="section16"></a>16. Limitation of Liability.</h4>
+
+<p>IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.</p>
+
+<h4><a name="section17"></a>17. Interpretation of Sections 15 and 16.</h4>
+
+<p>If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.</p>
+
+</body></html>

--- a/app/src/main/assets/mit.html
+++ b/app/src/main/assets/mit.html
@@ -1,0 +1,26 @@
+<html>
+<head></head>
+<body>
+<p>Copyright (c) &lt;year&gt; &lt;copyright holders&gt;</p>
+
+<p>Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:</p>
+
+<p>
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.</p>
+<p>
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.<br />
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>
+</body>
+</html>

--- a/app/src/main/assets/mpl2.html
+++ b/app/src/main/assets/mpl2.html
@@ -1,0 +1,260 @@
+<!DOCTYPE html>
+<!-- saved from url=(0038)https://www.mozilla.org/en-US/MPL/2.0/ -->
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>Mozilla Public License, version 2.0</title>
+<body>
+<h1 id="mozilla-public-license-version-2.0">Mozilla Public License<br>Version 2.0</h1>
+<h2 id="definitions">1. Definitions</h2>
+<dl>
+    <dt>1.1. “Contributor”</dt>
+    <dd><p>means each individual or legal entity that creates, contributes to the creation of, or
+        owns Covered Software.</p>
+    </dd>
+    <dt>1.2. “Contributor Version”</dt>
+    <dd><p>means the combination of the Contributions of others (if any) used by a Contributor and
+        that particular Contributor’s Contribution.</p>
+    </dd>
+    <dt>1.3. “Contribution”</dt>
+    <dd><p>means Covered Software of a particular Contributor.</p>
+    </dd>
+    <dt>1.4. “Covered Software”</dt>
+    <dd><p>means Source Code Form to which the initial Contributor has attached the notice in
+        Exhibit A, the Executable Form of such Source Code Form, and Modifications of such Source
+        Code Form, in each case including portions thereof.</p>
+    </dd>
+    <dt>1.5. “Incompatible With Secondary Licenses”</dt>
+    <dd><p>means</p>
+        <ol type="a">
+            <li><p>that the initial Contributor has attached the notice described in Exhibit B to
+                the Covered Software; or</p></li>
+            <li><p>that the Covered Software was made available under the terms of version 1.1 or
+                earlier of the License, but not also under the terms of a Secondary License.</p>
+            </li>
+        </ol>
+    </dd>
+    <dt>1.6. “Executable Form”</dt>
+    <dd><p>means any form of the work other than Source Code Form.</p>
+    </dd>
+    <dt>1.7. “Larger Work”</dt>
+    <dd><p>means a work that combines Covered Software with other material, in a separate file or
+        files, that is not Covered Software.</p>
+    </dd>
+    <dt>1.8. “License”</dt>
+    <dd><p>means this document.</p>
+    </dd>
+    <dt>1.9. “Licensable”</dt>
+    <dd><p>means having the right to grant, to the maximum extent possible, whether at the time of
+        the initial grant or subsequently, any and all of the rights conveyed by this License.</p>
+    </dd>
+    <dt>1.10. “Modifications”</dt>
+    <dd><p>means any of the following:</p>
+        <ol type="a">
+            <li><p>any file in Source Code Form that results from an addition to, deletion from, or
+                modification of the contents of Covered Software; or</p></li>
+            <li><p>any new file in Source Code Form that contains any Covered Software.</p></li>
+        </ol>
+    </dd>
+    <dt>1.11. “Patent Claims” of a Contributor</dt>
+    <dd><p>means any patent claim(s), including without limitation, method, process, and apparatus
+        claims, in any patent Licensable by such Contributor that would be infringed, but for the
+        grant of the License, by the making, using, selling, offering for sale, having made, import,
+        or transfer of either its Contributions or its Contributor Version.</p>
+    </dd>
+    <dt>1.12. “Secondary License”</dt>
+    <dd><p>means either the GNU General Public License, Version 2.0, the GNU Lesser General Public
+        License, Version 2.1, the GNU Affero General Public License, Version 3.0, or any later
+        versions of those licenses.</p>
+    </dd>
+    <dt>1.13. “Source Code Form”</dt>
+    <dd><p>means the form of the work preferred for making modifications.</p>
+    </dd>
+    <dt>1.14. “You” (or “Your”)</dt>
+    <dd><p>means an individual or a legal entity exercising rights under this License. For legal
+        entities, “You” includes any entity that controls, is controlled by, or is under common
+        control with You. For purposes of this definition, “control” means (a) the power, direct or
+        indirect, to cause the direction or management of such entity, whether by contract or
+        otherwise, or (b) ownership of more than fifty percent (50%) of the outstanding shares or
+        beneficial ownership of such entity.</p>
+    </dd>
+</dl>
+<h2 id="license-grants-and-conditions">2. License Grants and Conditions</h2>
+<h3 id="grants">2.1. Grants</h3>
+<p>Each Contributor hereby grants You a world-wide, royalty-free, non-exclusive license:</p>
+<ol type="a">
+    <li><p>under intellectual property rights (other than patent or trademark) Licensable by such
+        Contributor to use, reproduce, make available, modify, display, perform, distribute, and
+        otherwise exploit its Contributions, either on an unmodified basis, with Modifications, or
+        as part of a Larger Work; and</p></li>
+    <li><p>under Patent Claims of such Contributor to make, use, sell, offer for sale, have made,
+        import, and otherwise transfer either its Contributions or its Contributor Version.</p></li>
+</ol>
+<h3 id="effective-date">2.2. Effective Date</h3>
+<p>The licenses granted in Section&nbsp;2.1 with respect to any Contribution become effective for
+    each Contribution on the date the Contributor first distributes such Contribution.</p>
+<h3 id="limitations-on-grant-scope">2.3. Limitations on Grant Scope</h3>
+<p>The licenses granted in this Section&nbsp;2 are the only rights granted under this License. No
+    additional rights or licenses will be implied from the distribution or licensing of Covered
+    Software under this License. Notwithstanding Section&nbsp;2.1(b) above, no patent license is
+    granted by a Contributor:</p>
+<ol type="a">
+    <li><p>for any code that a Contributor has removed from Covered Software; or</p></li>
+    <li><p>for infringements caused by: (i) Your and any other third party’s modifications of
+        Covered Software, or (ii) the combination of its Contributions with other software (except
+        as part of its Contributor Version); or</p></li>
+    <li><p>under Patent Claims infringed by Covered Software in the absence of its
+        Contributions.</p></li>
+</ol>
+<p>This License does not grant any rights in the trademarks, service marks, or logos of any
+    Contributor (except as may be necessary to comply with the notice requirements in Section&nbsp;3.4).</p>
+<h3 id="subsequent-licenses">2.4. Subsequent Licenses</h3>
+<p>No Contributor makes additional grants as a result of Your choice to distribute the Covered
+    Software under a subsequent version of this License (see Section&nbsp;10.2) or under the terms
+    of a Secondary License (if permitted under the terms of Section&nbsp;3.3).</p>
+<h3 id="representation">2.5. Representation</h3>
+<p>Each Contributor represents that the Contributor believes its Contributions are its original
+    creation(s) or it has sufficient rights to grant the rights to its Contributions conveyed by
+    this License.</p>
+<h3 id="fair-use">2.6. Fair Use</h3>
+<p>This License is not intended to limit any rights You have under applicable copyright doctrines of
+    fair use, fair dealing, or other equivalents.</p>
+<h3 id="conditions">2.7. Conditions</h3>
+<p>Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in Section&nbsp;2.1.</p>
+<h2 id="responsibilities">3. Responsibilities</h2>
+<h3 id="distribution-of-source-form">3.1. Distribution of Source Form</h3>
+<p>All distribution of Covered Software in Source Code Form, including any Modifications that You
+    create or to which You contribute, must be under the terms of this License. You must inform
+    recipients that the Source Code Form of the Covered Software is governed by the terms of this
+    License, and how they can obtain a copy of this License. You may not attempt to alter or
+    restrict the recipients’ rights in the Source Code Form.</p>
+<h3 id="distribution-of-executable-form">3.2. Distribution of Executable Form</h3>
+<p>If You distribute Covered Software in Executable Form then:</p>
+<ol type="a">
+    <li><p>such Covered Software must also be made available in Source Code Form, as described in
+        Section&nbsp;3.1, and You must inform recipients of the Executable Form how they can obtain
+        a copy of such Source Code Form by reasonable means in a timely manner, at a charge no more
+        than the cost of distribution to the recipient; and</p></li>
+    <li><p>You may distribute such Executable Form under the terms of this License, or sublicense it
+        under different terms, provided that the license for the Executable Form does not attempt to
+        limit or alter the recipients’ rights in the Source Code Form under this License.</p></li>
+</ol>
+<h3 id="distribution-of-a-larger-work">3.3. Distribution of a Larger Work</h3>
+<p>You may create and distribute a Larger Work under terms of Your choice, provided that You also
+    comply with the requirements of this License for the Covered Software. If the Larger Work is a
+    combination of Covered Software with a work governed by one or more Secondary Licenses, and the
+    Covered Software is not Incompatible With Secondary Licenses, this License permits You to
+    additionally distribute such Covered Software under the terms of such Secondary License(s), so
+    that the recipient of the Larger Work may, at their option, further distribute the Covered
+    Software under the terms of either this License or such Secondary License(s).</p>
+<h3 id="notices">3.4. Notices</h3>
+<p>You may not remove or alter the substance of any license notices (including copyright notices,
+    patent notices, disclaimers of warranty, or limitations of liability) contained within the
+    Source Code Form of the Covered Software, except that You may alter any license notices to the
+    extent required to remedy known factual inaccuracies.</p>
+<h3 id="application-of-additional-terms">3.5. Application of Additional Terms</h3>
+<p>You may choose to offer, and to charge a fee for, warranty, support, indemnity or liability
+    obligations to one or more recipients of Covered Software. However, You may do so only on Your
+    own behalf, and not on behalf of any Contributor. You must make it absolutely clear that any
+    such warranty, support, indemnity, or liability obligation is offered by You alone, and You
+    hereby agree to indemnify every Contributor for any liability incurred by such Contributor as a
+    result of warranty, support, indemnity or liability terms You offer. You may include additional
+    disclaimers of warranty and limitations of liability specific to any jurisdiction.</p>
+<h2 id="inability-to-comply-due-to-statute-or-regulation">4. Inability to Comply Due to Statute or
+    Regulation</h2>
+<p>If it is impossible for You to comply with any of the terms of this License with respect to some
+    or all of the Covered Software due to statute, judicial order, or regulation then You must: (a)
+    comply with the terms of this License to the maximum extent possible; and (b) describe the
+    limitations and the code they affect. Such description must be placed in a text file included
+    with all distributions of the Covered Software under this License. Except to the extent
+    prohibited by statute or regulation, such description must be sufficiently detailed for a
+    recipient of ordinary skill to be able to understand it.</p>
+<h2 id="termination">5. Termination</h2>
+<p>5.1. The rights granted under this License will terminate automatically if You fail to comply
+    with any of its terms. However, if You become compliant, then the rights granted under this
+    License from a particular Contributor are reinstated (a) provisionally, unless and until such
+    Contributor explicitly and finally terminates Your grants, and (b) on an ongoing basis, if such
+    Contributor fails to notify You of the non-compliance by some reasonable means prior to 60 days
+    after You have come back into compliance. Moreover, Your grants from a particular Contributor
+    are reinstated on an ongoing basis if such Contributor notifies You of the non-compliance by
+    some reasonable means, this is the first time You have received notice of non-compliance with
+    this License from such Contributor, and You become compliant prior to 30 days after Your receipt
+    of the notice.</p>
+<p>5.2. If You initiate litigation against any entity by asserting a patent infringement claim
+    (excluding declaratory judgment actions, counter-claims, and cross-claims) alleging that a
+    Contributor Version directly or indirectly infringes any patent, then the rights granted to You
+    by any and all Contributors for the Covered Software under Section&nbsp;2.1 of this License
+    shall terminate.</p>
+<p>5.3. In the event of termination under Sections&nbsp;5.1 or 5.2 above, all end user license
+    agreements (excluding distributors and resellers) which have been validly granted by You or Your
+    distributors under this License prior to termination shall survive termination.</p>
+<h2 id="disclaimer-of-warranty">6. Disclaimer of Warranty</h2>
+<p><em>Covered Software is provided under this License on an “as is” basis, without warranty of any
+    kind, either expressed, implied, or statutory, including, without limitation, warranties that
+    the Covered Software is free of defects, merchantable, fit for a particular purpose or
+    non-infringing. The entire risk as to the quality and performance of the Covered Software is
+    with You. Should any Covered Software prove defective in any respect, You (not any Contributor)
+    assume the cost of any necessary servicing, repair, or correction. This disclaimer of warranty
+    constitutes an essential part of this License. No use of any Covered Software is authorized
+    under this License except under this disclaimer.</em></p>
+<h2 id="limitation-of-liability">7. Limitation of Liability</h2>
+<p><em>Under no circumstances and under no legal theory, whether tort (including negligence),
+    contract, or otherwise, shall any Contributor, or anyone who distributes Covered Software as
+    permitted above, be liable to You for any direct, indirect, special, incidental, or
+    consequential damages of any character including, without limitation, damages for lost profits,
+    loss of goodwill, work stoppage, computer failure or malfunction, or any and all other
+    commercial damages or losses, even if such party shall have been informed of the possibility of
+    such damages. This limitation of liability shall not apply to liability for death or personal
+    injury resulting from such party’s negligence to the extent applicable law prohibits such
+    limitation. Some jurisdictions do not allow the exclusion or limitation of incidental or
+    consequential damages, so this exclusion and limitation may not apply to You.</em></p>
+<h2 id="litigation">8. Litigation</h2>
+<p>Any litigation relating to this License may be brought only in the courts of a jurisdiction where
+    the defendant maintains its principal place of business and such litigation shall be governed by
+    laws of that jurisdiction, without reference to its conflict-of-law provisions. Nothing in this
+    Section shall prevent a party’s ability to bring cross-claims or counter-claims.</p>
+<h2 id="miscellaneous">9. Miscellaneous</h2>
+<p>This License represents the complete agreement concerning the subject matter hereof. If any
+    provision of this License is held to be unenforceable, such provision shall be reformed only to
+    the extent necessary to make it enforceable. Any law or regulation which provides that the
+    language of a contract shall be construed against the drafter shall not be used to construe this
+    License against a Contributor.</p>
+<h2 id="versions-of-the-license">10. Versions of the License</h2>
+<h3 id="new-versions">10.1. New Versions</h3>
+<p>Mozilla Foundation is the license steward. Except as provided in Section&nbsp;10.3, no one other
+    than the license steward has the right to modify or publish new versions of this License. Each
+    version will be given a distinguishing version number.</p>
+<h3 id="effect-of-new-versions">10.2. Effect of New Versions</h3>
+<p>You may distribute the Covered Software under the terms of the version of the License under which
+    You originally received the Covered Software, or under the terms of any subsequent version
+    published by the license steward.</p>
+<h3 id="modified-versions">10.3. Modified Versions</h3>
+<p>If you create software not governed by this License, and you want to create a new license for
+    such software, you may create and use a modified version of this License if you rename the
+    license and remove any references to the name of the license steward (except to note that such
+    modified license differs from this License).</p>
+<h3 id="distributing-source-code-form-that-is-incompatible-with-secondary-licenses">10.4.
+    Distributing Source Code Form that is Incompatible With Secondary Licenses</h3>
+<p>If You choose to distribute Source Code Form that is Incompatible With Secondary Licenses under
+    the terms of this version of the License, the notice described in Exhibit B of this License must
+    be attached.</p>
+<h2 id="exhibit-a---source-code-form-license-notice">Exhibit A - Source Code Form License
+    Notice</h2>
+<blockquote>
+    <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a
+        copy of the MPL was not distributed with this file, You can obtain one at
+        https://mozilla.org/MPL/2.0/.</p>
+</blockquote>
+<p>If it is not possible or desirable to put the notice in a particular file, then You may include
+    the notice in a location (such as a LICENSE file in a relevant directory) where a recipient
+    would be likely to look for such a notice.</p>
+<p>You may add additional accurate notices of copyright ownership.</p>
+<h2 id="exhibit-b---incompatible-with-secondary-licenses-notice">Exhibit B - “Incompatible With
+    Secondary Licenses” Notice</h2>
+<blockquote>
+    <p>This Source Code Form is “Incompatible With Secondary Licenses”, as defined by the Mozilla
+        Public License, v. 2.0.</p>
+</blockquote>
+
+</body>
+</html>

--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -156,18 +156,15 @@ public class MainActivity extends AppCompatActivity {
                 return true;
             }
             case R.id.action_settings: {
-                Intent intent = new Intent(this, SettingsActivity.class);
-                startActivity(intent);
+                NavigationHelper.openSettings(this);
                 return true;
             }
             case R.id.action_show_downloads: {
-                if (!PermissionHelper.checkStoragePermissions(this)) {
-                    return false;
-                }
-                Intent intent = new Intent(this, DownloadActivity.class);
-                startActivity(intent);
-                return true;
+                return NavigationHelper.openDownloads(this);
             }
+            case R.id.action_about:
+                NavigationHelper.openAbout(this);
+                return true;
             default:
                 return super.onOptionsItemSelected(item);
         }

--- a/app/src/main/java/org/schabi/newpipe/about/AboutActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/about/AboutActivity.java
@@ -94,6 +94,9 @@ public class AboutActivity extends AppCompatActivity {
         int id = item.getItemId();
 
         switch (id) {
+            case android.R.id.home:
+                finish();
+                return true;
             case R.id.action_settings:
                 NavigationHelper.openSettings(this);
                 return true;

--- a/app/src/main/java/org/schabi/newpipe/about/AboutActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/about/AboutActivity.java
@@ -1,0 +1,194 @@
+package org.schabi.newpipe.about;
+
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.support.design.widget.TabLayout;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentPagerAdapter;
+import android.support.v4.view.ViewPager;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import org.schabi.newpipe.BuildConfig;
+import org.schabi.newpipe.R;
+import org.schabi.newpipe.util.NavigationHelper;
+import org.schabi.newpipe.util.ThemeHelper;
+
+public class AboutActivity extends AppCompatActivity {
+
+    /**
+     * List of all software components
+     */
+    private static final SoftwareComponent[] SOFTWARE_COMPONENTS = new SoftwareComponent[]{
+            new SoftwareComponent("Giga Get", "2014", "Peter Cai", "https://github.com/PaperAirplane-Dev-Team/GigaGet", StandardLicenses.GPL2),
+            new SoftwareComponent("NewPipe Extractor", "2017", "Christian Schabesberger", "https://github.com/TeamNewPipe/NewPipeExtractor", StandardLicenses.GPL3),
+            new SoftwareComponent("Jsoup", "2017", "Jonathan Hedley", "https://github.com/jhy/jsoup", StandardLicenses.MIT),
+            new SoftwareComponent("Google Gson", "2008", "Google Inc", "https://github.com/google/gson", StandardLicenses.APACHE2),
+            new SoftwareComponent("Rhino", "2015", "Mozilla", "https://www.mozilla.org/rhino/", StandardLicenses.MPL2),
+            new SoftwareComponent("ACRA", "2013", "Kevin Gaudin", "http://www.acra.ch", StandardLicenses.APACHE2),
+            new SoftwareComponent("Universal Image Loader", "2011 - 2015", "Sergey Tarasevich", "https://github.com/nostra13/Android-Universal-Image-Loader", StandardLicenses.APACHE2),
+            new SoftwareComponent("Netcipher", "2015", "The Guardian Project", "https://guardianproject.info/code/netcipher/", StandardLicenses.APACHE2),
+            new SoftwareComponent("CircleImageView", "2014 - 2017", "Henning Dodenhof", "https://github.com/hdodenhof/CircleImageView", StandardLicenses.APACHE2),
+            new SoftwareComponent("ParalaxScrollView", "2014", "Nir Hartmann", "https://github.com/nirhart/ParallaxScroll", StandardLicenses.MIT),
+            new SoftwareComponent("NoNonsense-FilePicker", "2016", "Jonas Kalderstam", "https://github.com/spacecowboy/NoNonsense-FilePicker", StandardLicenses.MPL2),
+            new SoftwareComponent("ExoPlayer", "2014-2017", "Google Inc", "https://github.com/google/ExoPlayer", StandardLicenses.APACHE2)
+    };
+
+    /**
+     * The {@link android.support.v4.view.PagerAdapter} that will provide
+     * fragments for each of the sections. We use a
+     * {@link FragmentPagerAdapter} derivative, which will keep every
+     * loaded fragment in memory. If this becomes too memory intensive, it
+     * may be best to switch to a
+     * {@link android.support.v4.app.FragmentStatePagerAdapter}.
+     */
+    private SectionsPagerAdapter mSectionsPagerAdapter;
+
+    /**
+     * The {@link ViewPager} that will host the section contents.
+     */
+    private ViewPager mViewPager;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        ThemeHelper.setTheme(this);
+
+        setContentView(R.layout.activity_about);
+
+        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        setSupportActionBar(toolbar);
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        // Create the adapter that will return a fragment for each of the three
+        // primary sections of the activity.
+        mSectionsPagerAdapter = new SectionsPagerAdapter(getSupportFragmentManager());
+
+        // Set up the ViewPager with the sections adapter.
+        mViewPager = (ViewPager) findViewById(R.id.container);
+        mViewPager.setAdapter(mSectionsPagerAdapter);
+
+        TabLayout tabLayout = (TabLayout) findViewById(R.id.tabs);
+        tabLayout.setupWithViewPager(mViewPager);
+    }
+
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        // Inflate the menu; this adds items to the action bar if it is present.
+        getMenuInflater().inflate(R.menu.menu_about, menu);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+
+        int id = item.getItemId();
+
+        switch (id) {
+            case R.id.action_settings:
+                NavigationHelper.openSettings(this);
+                return true;
+            case R.id.action_show_downloads:
+                return NavigationHelper.openDownloads(this);
+        }
+
+        return super.onOptionsItemSelected(item);
+    }
+
+    /**
+     * A placeholder fragment containing a simple view.
+     */
+    public static class AboutFragment extends Fragment {
+
+        public AboutFragment() {
+        }
+
+        /**
+         * Returns a new instance of this fragment for the given section
+         * number.
+         */
+        public static AboutFragment newInstance() {
+            return new AboutFragment();
+        }
+
+        @Override
+        public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                                 Bundle savedInstanceState) {
+            View rootView = inflater.inflate(R.layout.fragment_about, container, false);
+            TextView version = (TextView) rootView.findViewById(R.id.app_version);
+            version.setText(BuildConfig.VERSION_NAME);
+
+            View githubLink = rootView.findViewById(R.id.github_link);
+            githubLink.setOnClickListener(new OnGithubLinkClickListener());
+
+            View licenseLink = rootView.findViewById(R.id.app_read_license);
+            licenseLink.setOnClickListener(new OnReadFullLicenseClickListener());
+            return rootView;
+        }
+
+        private static class OnGithubLinkClickListener implements View.OnClickListener {
+            @Override
+            public void onClick(final View view) {
+                final Context context = view.getContext();
+                Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(context.getString(R.string.github_url)));
+                context.startActivity(intent);
+            }
+        }
+
+        private static class OnReadFullLicenseClickListener implements View.OnClickListener {
+            @Override
+            public void onClick(View v) {
+                LicenseFragment.showLicense(v.getContext(), StandardLicenses.GPL3);
+            }
+        }
+    }
+
+
+    /**
+     * A {@link FragmentPagerAdapter} that returns a fragment corresponding to
+     * one of the sections/tabs/pages.
+     */
+    public class SectionsPagerAdapter extends FragmentPagerAdapter {
+
+        public SectionsPagerAdapter(FragmentManager fm) {
+            super(fm);
+        }
+
+        @Override
+        public Fragment getItem(int position) {
+            switch (position) {
+                case 0:
+                    return AboutFragment.newInstance();
+                case 1:
+                    return LicenseFragment.newInstance(SOFTWARE_COMPONENTS);
+            }
+            return null;
+        }
+
+        @Override
+        public int getCount() {
+            // Show 2 total pages.
+            return 2;
+        }
+
+        @Override
+        public CharSequence getPageTitle(int position) {
+            switch (position) {
+                case 0:
+                    return getString(R.string.tab_about);
+                case 1:
+                    return getString(R.string.tab_licenses);
+            }
+            return null;
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/about/License.java
+++ b/app/src/main/java/org/schabi/newpipe/about/License.java
@@ -1,0 +1,72 @@
+package org.schabi.newpipe.about;
+
+import android.net.Uri;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.text.TextUtils;
+
+import java.net.URLEncoder;
+
+/**
+ * A software license
+ */
+public class License implements Parcelable {
+
+    public static final Creator<License> CREATOR = new Creator<License>() {
+        @Override
+        public License createFromParcel(Parcel source) {
+            return new License(source);
+        }
+
+        @Override
+        public License[] newArray(int size) {
+            return new License[size];
+        }
+    };
+    private final String abbreviation;
+    private final String name;
+    private String filename;
+
+    public License(String name, String abbreviation, String filename) {
+        if(name == null) throw new NullPointerException("name is null");
+        if(abbreviation == null) throw new NullPointerException("abbreviation is null");
+        if(filename == null) throw new NullPointerException("filename is null");
+        this.name = name;
+        this.filename = filename;
+        this.abbreviation = abbreviation;
+    }
+
+    protected License(Parcel in) {
+        this.filename = in.readString();
+        this.abbreviation = in.readString();
+        this.name = in.readString();
+    }
+
+    public Uri getContentUri() {
+        return new Uri.Builder()
+                .scheme("file")
+                .path("/android_asset")
+                .appendPath(filename)
+                .build();
+    }
+
+    public String getAbbreviation() {
+        return abbreviation;
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(this.filename);
+        dest.writeString(this.abbreviation);
+        dest.writeString(this.name);
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/about/LicenseFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/about/LicenseFragment.java
@@ -1,0 +1,150 @@
+package org.schabi.newpipe.about;
+
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.support.v7.app.AlertDialog;
+import android.view.ContextMenu;
+import android.view.LayoutInflater;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.webkit.WebView;
+import android.widget.TextView;
+
+import org.schabi.newpipe.R;
+
+import java.util.Arrays;
+import java.util.Comparator;
+
+/**
+ * Fragment containing the software licenses
+ */
+public class LicenseFragment extends Fragment {
+
+    private static final String ARG_COMPONENTS = "components";
+    private SoftwareComponent[] softwareComponents;
+    private SoftwareComponent mComponentForContextMenu;
+
+    public static LicenseFragment newInstance(SoftwareComponent[] softwareComponents) {
+        if(softwareComponents == null) {
+            throw new NullPointerException("softwareComponents is null");
+        }
+        LicenseFragment fragment = new LicenseFragment();
+        Bundle bundle = new Bundle();
+        bundle.putParcelableArray(ARG_COMPONENTS, softwareComponents);
+        fragment.setArguments(bundle);
+        return fragment;
+    }
+
+    /**
+     * Shows a popup containing the license
+     * @param context the context to use
+     * @param license the license to show
+     */
+    public static void showLicense(Context context, License license) {
+        if(context == null) {
+            throw new NullPointerException("context is null");
+        }
+        if(license == null) {
+            throw new NullPointerException("license is null");
+        }
+        AlertDialog.Builder alert = new AlertDialog.Builder(context);
+        alert.setTitle(license.getName());
+
+        WebView wv = new WebView(context);
+        wv.loadUrl(license.getContentUri().toString());
+        alert.setView(wv);
+        alert.setNegativeButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                dialog.dismiss();
+            }
+        });
+        alert.show();
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        softwareComponents = (SoftwareComponent[]) getArguments().getParcelableArray(ARG_COMPONENTS);
+
+        // Sort components by name
+        Arrays.sort(softwareComponents, new Comparator<SoftwareComponent>() {
+            @Override
+            public int compare(SoftwareComponent o1, SoftwareComponent o2) {
+                return o1.getName().compareTo(o2.getName());
+            }
+        });
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        View rootView = inflater.inflate(R.layout.fragment_licenses, container, false);
+        ViewGroup softwareComponentsView = (ViewGroup) rootView.findViewById(R.id.software_components);
+
+        for (final SoftwareComponent component : softwareComponents) {
+            View componentView = inflater.inflate(R.layout.item_software_component, container, false);
+            TextView softwareName = (TextView) componentView.findViewById(R.id.name);
+            TextView copyright = (TextView) componentView.findViewById(R.id.copyright);
+            softwareName.setText(component.getName());
+            copyright.setText(getContext().getString(R.string.copyright,
+                    component.getYears(),
+                    component.getCopyrightOwner(),
+                    component.getLicense().getAbbreviation()));
+
+            componentView.setTag(component);
+            componentView.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    Context context = v.getContext();
+                    if (context != null) {
+                        showLicense(context, component.getLicense());
+                    }
+                }
+            });
+            softwareComponentsView.addView(componentView);
+            registerForContextMenu(componentView);
+
+        }
+        return rootView;
+    }
+
+    @Override
+    public void onCreateContextMenu(ContextMenu menu, View v, ContextMenu.ContextMenuInfo menuInfo) {
+        MenuInflater inflater = getActivity().getMenuInflater();
+        SoftwareComponent component = (SoftwareComponent) v.getTag();
+        menu.setHeaderTitle(component.getName());
+        inflater.inflate(R.menu.software_component, menu);
+        super.onCreateContextMenu(menu, v, menuInfo);
+        mComponentForContextMenu = (SoftwareComponent) v.getTag();
+    }
+
+    @Override
+    public boolean onContextItemSelected(MenuItem item) {
+        // item.getMenuInfo() is null so we use the tag of the view
+        final SoftwareComponent component = mComponentForContextMenu;
+        if (component == null) {
+            return false;
+        }
+        switch (item.getItemId()) {
+            case R.id.action_website:
+                openWebsite(component.getLink());
+                return true;
+            case R.id.action_show_license:
+                showLicense(getContext(), component.getLicense());
+        }
+        return false;
+    }
+
+    private void openWebsite(String componentLink) {
+        Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(componentLink));
+        startActivity(browserIntent);
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/about/SoftwareComponent.java
+++ b/app/src/main/java/org/schabi/newpipe/about/SoftwareComponent.java
@@ -1,0 +1,83 @@
+package org.schabi.newpipe.about;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+public class SoftwareComponent implements Parcelable {
+
+    public static final Creator<SoftwareComponent> CREATOR = new Creator<SoftwareComponent>() {
+        @Override
+        public SoftwareComponent createFromParcel(Parcel source) {
+            return new SoftwareComponent(source);
+        }
+
+        @Override
+        public SoftwareComponent[] newArray(int size) {
+            return new SoftwareComponent[size];
+        }
+    };
+
+    public String getName() {
+        return name;
+    }
+
+    public String getYears() {
+        return years;
+    }
+
+    public String getCopyrightOwner() {
+        return copyrightOwner;
+    }
+
+    public String getLink() {
+        return link;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    private final License license;
+    private final String name;
+    private final String years;
+    private final String copyrightOwner;
+    private final String link;
+    private final String version;
+
+    public SoftwareComponent(String name, String years, String copyrightOwner, String link, License license) {
+        this.name = name;
+        this.years = years;
+        this.copyrightOwner = copyrightOwner;
+        this.link = link;
+        this.license = license;
+        this.version = null;
+    }
+
+    protected SoftwareComponent(Parcel in) {
+        this.name = in.readString();
+        this.license = in.readParcelable(License.class.getClassLoader());
+        this.copyrightOwner = in.readString();
+        this.link = in.readString();
+        this.years = in.readString();
+        this.version = in.readString();
+    }
+
+    public License getLicense() {
+        return license;
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(name);
+        dest.writeParcelable(license, flags);
+        dest.writeString(copyrightOwner);
+        dest.writeString(link);
+        dest.writeString(years);
+        dest.writeString(version);
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/about/StandardLicenses.java
+++ b/app/src/main/java/org/schabi/newpipe/about/StandardLicenses.java
@@ -1,0 +1,12 @@
+package org.schabi.newpipe.about;
+
+/**
+ * Standard software licenses
+ */
+public final class StandardLicenses {
+    public static final License GPL2 = new License("GNU General Public License, Version 2.0", "GPLv2", "gpl_2.html");
+    public static final License GPL3 = new License("GNU General Public License, Version 3.0", "GPLv3", "gpl_3.html");
+    public static final License APACHE2 = new License("Apache License, Version 2.0", "ALv2", "apache2.html");
+    public static final License MPL2 = new License("Mozilla Public License, Version 2.0", "MPL 2.0", "mpl2.html");
+    public static final License MIT = new License("MIT License", "MIT", "mit.html");
+}

--- a/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
@@ -1,15 +1,19 @@
 package org.schabi.newpipe.util;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.preference.PreferenceManager;
+import android.support.annotation.CheckResult;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 
 import com.nostra13.universalimageloader.core.ImageLoader;
 
+import org.schabi.newpipe.about.AboutActivity;
 import org.schabi.newpipe.MainActivity;
 import org.schabi.newpipe.R;
+import org.schabi.newpipe.download.DownloadActivity;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.stream_info.AudioStream;
@@ -21,6 +25,7 @@ import org.schabi.newpipe.fragments.search.SearchFragment;
 import org.schabi.newpipe.player.BackgroundPlayer;
 import org.schabi.newpipe.player.BasePlayer;
 import org.schabi.newpipe.player.VideoPlayer;
+import org.schabi.newpipe.settings.SettingsActivity;
 
 @SuppressWarnings({"unused", "WeakerAccess"})
 public class NavigationHelper {
@@ -193,5 +198,24 @@ public class NavigationHelper {
                 throw new Exception("Url not known to service. service=" + serviceId + " url=" + url);
         }
         return null;
+    }
+
+    public static void openAbout(Context context) {
+        Intent intent = new Intent(context, AboutActivity.class);
+        context.startActivity(intent);
+    }
+
+    public static void openSettings(Context context) {
+        Intent intent = new Intent(context, SettingsActivity.class);
+        context.startActivity(intent);
+    }
+
+    public static boolean openDownloads(Activity activity) {
+        if (!PermissionHelper.checkStoragePermissions(activity)) {
+            return false;
+        }
+        Intent intent = new Intent(activity, DownloadActivity.class);
+        activity.startActivity(intent);
+        return true;
     }
 }

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main_content"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
+    tools:context="org.schabi.newpipe.about.AboutActivity">
+
+    <android.support.design.widget.AppBarLayout
+        android:id="@+id/appbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="@dimen/appbar_padding_top"
+        android:theme="@style/AppTheme.AppBarOverlay">
+
+        <android.support.v7.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="?attr/colorPrimary"
+            app:layout_scrollFlags="scroll|enterAlways"
+            app:popupTheme="@style/AppTheme.PopupOverlay">
+
+        </android.support.v7.widget.Toolbar>
+
+        <android.support.design.widget.TabLayout
+            android:id="@+id/tabs"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+    </android.support.design.widget.AppBarLayout>
+
+    <android.support.v4.view.ViewPager
+        android:id="@+id/container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"/>
+</android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_about.xml
+++ b/app/src/main/res/layout/fragment_about.xml
@@ -1,0 +1,95 @@
+<android.support.v4.widget.NestedScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="org.schabi.newpipe.about.AboutActivity$AboutFragment">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingBottom="@dimen/activity_vertical_margin"
+        android:paddingLeft="@dimen/activity_horizontal_margin"
+        android:paddingRight="@dimen/activity_horizontal_margin"
+        android:paddingTop="@dimen/activity_vertical_margin">
+
+        <ImageView
+            android:id="@+id/logo"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginBottom="8dp"
+            app:srcCompat="@mipmap/ic_launcher" />
+
+        <TextView
+            android:id="@+id/app_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:text="@string/app_name"
+            android:textAppearance="@android:style/TextAppearance.Large" />
+
+
+        <TextView
+            android:id="@+id/app_version"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginBottom="16dp"
+            android:textAppearance="@android:style/TextAppearance.Medium"
+            tools:text="0.9.9" />
+
+        <TextView
+            android:id="@+id/app_description"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/app_description" />
+
+        <TextView
+            android:id="@+id/title_contribution"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="10dp"
+            android:text="@string/contribution_title"
+            android:textAppearance="@android:style/TextAppearance.Medium" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/contribution_encouragement" />
+
+
+        <Button
+            android:id="@+id/github_link"
+            style="@style/Base.Widget.AppCompat.Button.Borderless"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end"
+            android:text="@string/view_on_github" />
+
+        <TextView
+            android:id="@+id/app_license_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="10dp"
+            android:text="@string/app_license_title"
+            android:textAppearance="@android:style/TextAppearance.Medium" />
+
+        <TextView
+            android:id="@+id/app_license"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/app_license" />
+
+        <Button
+            android:id="@+id/app_read_license"
+            style="@style/Base.Widget.AppCompat.Button.Borderless"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end"
+            android:text="@string/read_full_license" />
+
+    </LinearLayout>
+</android.support.v4.widget.NestedScrollView>

--- a/app/src/main/res/layout/fragment_licenses.xml
+++ b/app/src/main/res/layout/fragment_licenses.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v4.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingBottom="@dimen/activity_vertical_margin"
+        android:paddingTop="@dimen/activity_vertical_margin">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingLeft="@dimen/activity_horizontal_margin"
+            android:paddingRight="@dimen/activity_horizontal_margin"
+            android:paddingTop="20dp"
+            android:text="@string/title_licenses"
+            android:textAppearance="?android:attr/textAppearanceLarge" />
+
+        <LinearLayout
+            android:id="@+id/software_components"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical" />
+    </LinearLayout>
+</android.support.v4.widget.NestedScrollView>

--- a/app/src/main/res/layout/item_software_component.xml
+++ b/app/src/main/res/layout/item_software_component.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:orientation="vertical"
+    android:background="?attr/selectableItemBackground"
+    android:clickable="true">
+
+    <TextView
+        android:id="@+id/name"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingTop="10dp"
+        android:textAppearance="@android:style/TextAppearance.Medium"
+        tools:text="Software Name" />
+
+    <TextView
+        android:id="@+id/copyright"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/name"
+        android:paddingBottom="10dp"
+        tools:text="@string/copyright" />
+</RelativeLayout>

--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -12,4 +12,7 @@
           android:title="@string/settings"
           app:showAsAction="never"/>
 
+    <item android:id="@+id/action_about"
+            android:orderInCategory="1000"
+            android:title="@string/action_about" />
 </menu>

--- a/app/src/main/res/menu/menu_about.xml
+++ b/app/src/main/res/menu/menu_about.xml
@@ -1,0 +1,16 @@
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context="org.schabi.newpipe.about.AboutActivity">
+
+    <item android:id="@+id/action_show_downloads"
+        android:orderInCategory="980"
+        android:title="@string/downloads"
+        app:showAsAction="never"/>
+
+    <item android:id="@+id/action_settings"
+        android:orderInCategory="990"
+        android:title="@string/settings"
+        app:showAsAction="never"/>
+
+</menu>

--- a/app/src/main/res/menu/software_component.xml
+++ b/app/src/main/res/menu/software_component.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/action_website"
+        android:title="@string/action_open_website" />
+    <item
+        android:id="@+id/action_show_license"
+        android:title="@string/read_full_license">
+    </item>
+</menu>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -20,6 +20,7 @@
     <dimen name="video_item_search_duration_horizontal_padding">5sp</dimen>
     <dimen name="video_item_search_duration_margin">2sp</dimen>
     <dimen name="video_item_detail_description_to_details_margin">4dp</dimen>
+    <dimen name="software_component_item_padding">8dp</dimen>
     <!-- Miscellaneous -->
     <dimen name="popup_default_width">180dp</dimen>
     <dimen name="popup_minimum_width">120dp</dimen>
@@ -46,5 +47,9 @@
     <!-- Default screen margins, per the Android Design guidelines. -->
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
+    <dimen name="app_bar_height">180dp</dimen>
+    <dimen name="fab_margin">16dp</dimen>
+    <dimen name="text_margin">16dp</dimen>
+    <dimen name="appbar_padding_top">8dp</dimen>
 
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -47,9 +47,6 @@
     <!-- Default screen margins, per the Android Design guidelines. -->
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
-    <dimen name="app_bar_height">180dp</dimen>
-    <dimen name="fab_margin">16dp</dimen>
-    <dimen name="text_margin">16dp</dimen>
     <dimen name="appbar_padding_top">8dp</dimen>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -190,4 +190,23 @@
 
     <!-- End of GigaGet's Strings -->
 
+    <!-- About -->
+    <string name="title_activity_about">About NewPipe</string>
+    <string name="action_settings">Settings</string>
+    <string name="action_about">About</string>
+    <string name="title_licenses">Third-party Licenses</string>
+    <string name="copyright" formatted="true">© %1$s by %2$s under %3$s</string>
+    <string name="error_unable_to_load_license">Could not load license</string>
+    <string name="action_open_website">Open website</string>
+    <string name="tab_about">About</string>
+    <string name="tab_contributors">Contributors</string>
+    <string name="tab_licenses">Licenses</string>
+    <string name="github_url">https://github.com/TeamNewPipe/NewPipe</string>
+    <string name="app_description">A free lightweight Youtube frontend for Android.</string>
+    <string name="app_license" translatable="false">NewPipe is Free Software: You can use, study share and improve it at your will. Specifically you can redistribute and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.</string>
+    <string name="view_on_github">View on Github</string>
+    <string name="app_license_title">NewPipe\'s License</string>
+    <string name="contribution_encouragement">Whether you have ideas, translation, design changes, code cleaning, or real heavy code changes, help is always welcome. The more is done the better it gets!</string>
+    <string name="read_full_license">Read license</string>
+    <string name="contribution_title">Contribution</string>
 </resources>


### PR DESCRIPTION
I have created a about activity which includes the following information:
 * NewPipe's License
   Maybe this should include something like `(c) 2017 by ...` or similar. 
 * Note on how to contribute and a link to GitHub
 * Copyright of the software components used including full license texts

**Additional ideas**
 * Donate button
 * Tab containing the "privacy policy":
   * What data is sent to YouTube
   * What data is included in the crash reports

**Implementation Notes**
The software components list is created by inflating the layout and adding it to the `LinearLayout` because I couldn't get it working otherwise. `ListView` doesn't support the `NestedScrollingView` scroll behavior and I didn't get the `RecyclerView` to handle the context menu correctly (+ the scrolling needs to be disabled).   

**Screenshots**
 * [About](https://user-images.githubusercontent.com/5737978/27877057-8be983d0-61b9-11e7-94cb-52f5e21a5703.png)
 * [Licenses](https://user-images.githubusercontent.com/5737978/27877055-8be8ae2e-61b9-11e7-89fd-a7385c210f0d.png)
* [License context menu](https://user-images.githubusercontent.com/5737978/27877056-8be92cf0-61b9-11e7-81d2-c3447a294990.png)

Please let me know if you like it, have additions or want anything changed.