### PR TITLE
Added option to ignore permanent audio focus loss

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
@@ -309,7 +309,6 @@ public abstract class BasePlayer implements ExoPlayer.EventListener, AudioManage
     public void onAudioFocusChange(int focusChange) {
         if (DEBUG) Log.d(TAG, "onAudioFocusChange() called with: focusChange = [" + focusChange + "]");
         if (simpleExoPlayer == null) return;
-
         switch (focusChange) {
             case AudioManager.AUDIOFOCUS_GAIN:
                 onAudioFocusGain();
@@ -318,7 +317,6 @@ public abstract class BasePlayer implements ExoPlayer.EventListener, AudioManage
                 onAudioFocusLossCanDuck();
                 break;
             case AudioManager.AUDIOFOCUS_LOSS:
-                if (isAudioFocusLossIgnored()) break;
             case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
                 onAudioFocusLoss();
                 break;
@@ -333,16 +331,6 @@ public abstract class BasePlayer implements ExoPlayer.EventListener, AudioManage
                 false
         );
     }
-
-    private boolean isAudioFocusLossIgnored() {
-        if (this.sharedPreferences == null || this.context == null) return false;
-
-        return this.sharedPreferences.getBoolean(
-                this.context.getString(R.string.ignore_audio_focus_loss_key),
-                false
-        );
-    }
-
 
     protected void onAudioFocusGain() {
         if (DEBUG) Log.d(TAG, "onAudioFocusGain() called");

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -14,7 +14,6 @@
     <string name="autoplay_through_intent_key" translatable="false">autoplay_through_intent</string>
     <string name="use_old_player_key" translatable="false">use_oldplayer</string>
     <string name="player_gesture_controls_key" translatable="false">player_gesture_controls</string>
-    <string name="ignore_audio_focus_loss_key" translatable="false">ignore_audio_focus_loss</string>
     <string name="resume_on_audio_focus_gain_key" translatable="false">resume_on_audio_focus_gain</string>
     <string name="default_resolution_key" translatable="false">default_resolution_preference</string>
     <string name="default_resolution_value" translatable="false">360p</string>

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -14,7 +14,8 @@
     <string name="autoplay_through_intent_key" translatable="false">autoplay_through_intent</string>
     <string name="use_old_player_key" translatable="false">use_oldplayer</string>
     <string name="player_gesture_controls_key" translatable="false">player_gesture_controls</string>
-
+    <string name="ignore_audio_focus_loss_key" translatable="false">ignore_audio_focus_loss</string>
+    <string name="resume_on_audio_focus_gain_key" translatable="false">resume_on_audio_focus_gain</string>
     <string name="default_resolution_key" translatable="false">default_resolution_preference</string>
     <string name="default_resolution_value" translatable="false">360p</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,6 +61,10 @@
     <string name="player_gesture_controls_summary">Use gestures to control the brightness and volume of the player</string>
     <string name="show_search_suggestions_title">Search suggestions</string>
     <string name="show_search_suggestions_summary">Show suggestions when searching</string>
+    <string name="resume_on_audio_focus_gain_title">Resume audio on focus gain</string>
+    <string name="resume_on_audio_focus_gain_summary">Continue playing background audio after interruptions</string>
+    <string name="ignore_audio_focus_loss_title">Ignore permanent audio focus loss</string>
+    <string name="ignore_audio_focus_loss_summary">Allow multiple audio and video streams to play in tandem</string>
 
     <string name="download_dialog_title">Download</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,8 +63,6 @@
     <string name="show_search_suggestions_summary">Show suggestions when searching</string>
     <string name="resume_on_audio_focus_gain_title">Resume on focus gain</string>
     <string name="resume_on_audio_focus_gain_summary">Continue playing after interruptions (e.g. phone calls)</string>
-    <string name="ignore_audio_focus_loss_title">Ignore permanent audio focus loss</string>
-    <string name="ignore_audio_focus_loss_summary">(Experimental) Allow multiple audio and video streams to play in tandem. Running multiple NewPipe players concurrently may cause issues.</string>
 
     <string name="download_dialog_title">Download</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,10 +61,10 @@
     <string name="player_gesture_controls_summary">Use gestures to control the brightness and volume of the player</string>
     <string name="show_search_suggestions_title">Search suggestions</string>
     <string name="show_search_suggestions_summary">Show suggestions when searching</string>
-    <string name="resume_on_audio_focus_gain_title">Resume audio on focus gain</string>
-    <string name="resume_on_audio_focus_gain_summary">Continue playing background audio after interruptions</string>
+    <string name="resume_on_audio_focus_gain_title">Resume on focus gain</string>
+    <string name="resume_on_audio_focus_gain_summary">Continue playing after interruptions (e.g. phone calls)</string>
     <string name="ignore_audio_focus_loss_title">Ignore permanent audio focus loss</string>
-    <string name="ignore_audio_focus_loss_summary">Allow multiple audio and video streams to play in tandem</string>
+    <string name="ignore_audio_focus_loss_summary">(Experimental) Allow multiple audio and video streams to play in tandem. Running multiple NewPipe players concurrently may cause issues.</string>
 
     <string name="download_dialog_title">Download</string>
 

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -64,6 +64,18 @@
             android:summary="@string/player_gesture_controls_summary"
             android:title="@string/player_gesture_controls_title"/>
 
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="@string/resume_on_audio_focus_gain_key"
+            android:summary="@string/resume_on_audio_focus_gain_summary"
+            android:title="@string/resume_on_audio_focus_gain_title"/>
+
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="@string/ignore_audio_focus_loss_key"
+            android:summary="@string/ignore_audio_focus_loss_summary"
+            android:title="@string/ignore_audio_focus_loss_title"/>
+
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -70,12 +70,6 @@
             android:summary="@string/resume_on_audio_focus_gain_summary"
             android:title="@string/resume_on_audio_focus_gain_title"/>
 
-        <CheckBoxPreference
-            android:defaultValue="false"
-            android:key="@string/ignore_audio_focus_loss_key"
-            android:summary="@string/ignore_audio_focus_loss_summary"
-            android:title="@string/ignore_audio_focus_loss_title"/>
-
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
Ignoring non-transient audio focus loss, so multiple streams can play at the same time.

Also added the option to resume background audio on audio focus regain (say, after a phone call interruption). However, this option only works on background audio and popup/main video player will not resume.

Perhaps I should categorize these settings under experimental rather than video and audio.

Let me know what you guys think.