### PR TITLE
Prevent "time links" from beeing clicked

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -23,6 +23,7 @@ import android.text.Html;
 import android.text.Spanned;
 import android.text.TextUtils;
 import android.text.method.LinkMovementMethod;
+import android.text.util.Linkify;
 import android.util.Log;
 import android.util.TypedValue;
 import android.view.Gravity;
@@ -549,6 +550,7 @@ public class VideoDetailFragment extends BaseFragment implements StreamExtractor
         relatedStreamExpandButton = ((ImageButton) rootView.findViewById(R.id.detail_related_streams_expand));
 
         actionBarHandler = new ActionBarHandler(activity);
+        videoDescriptionView.setAutoLinkMask(Linkify.WEB_URLS);
         videoDescriptionView.setMovementMethod(LinkMovementMethod.getInstance());
 
         infoItemBuilder = new InfoItemBuilder(activity);


### PR DESCRIPTION
Added a line to only link web URLs. Before this the links for time were linked and created an Intent with the data "#" which caused an `ActivityNotFoundException` (Fixes #632). 

I think it would be nice to implement support for times but with the current links it wont work.