### PR TITLE
Upgrade target sdk and support library version to 26

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,5 @@
 apply plugin: 'com.android.application'
 
-allprojects {
-    repositories {
-        jcenter()
-        maven { url 'https://maven.google.com' }
-    }
-}
-
 android {
     compileSdkVersion 26
     buildToolsVersion '26.0.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,20 @@
 apply plugin: 'com.android.application'
 
+allprojects {
+    repositories {
+        jcenter()
+        maven { url 'https://maven.google.com' }
+    }
+}
+
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 26
+    buildToolsVersion '26.0.1'
 
     defaultConfig {
         applicationId "org.schabi.newpipe"
         minSdkVersion 15
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 37
         versionName "0.9.10"
 
@@ -42,10 +49,10 @@ dependencies {
     testCompile 'org.mockito:mockito-core:1.10.19'
     testCompile 'org.json:json:20160810'
 
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    compile 'com.android.support:support-v4:25.3.1'
-    compile 'com.android.support:design:25.3.1'
-    compile 'com.android.support:recyclerview-v7:25.3.1'
+    compile 'com.android.support:appcompat-v7:26.0.0'
+    compile 'com.android.support:support-v4:26.0.0'
+    compile 'com.android.support:design:26.0.0'
+    compile 'com.android.support:recyclerview-v7:26.0.0'
 
     compile 'com.google.code.gson:gson:2.7'
     compile 'org.jsoup:jsoup:1.8.3'

--- a/app/src/main/java/us/shandian/giga/ui/common/ToolbarActivity.java
+++ b/app/src/main/java/us/shandian/giga/ui/common/ToolbarActivity.java
@@ -1,12 +1,12 @@
 package us.shandian.giga.ui.common;
 
 import android.os.Bundle;
-import android.support.v7.app.ActionBarActivity;
+import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 
 import org.schabi.newpipe.R;
 
-public abstract class ToolbarActivity extends ActionBarActivity {
+public abstract class ToolbarActivity extends AppCompatActivity {
     protected Toolbar mToolbar;
 
     @Override

--- a/build.gradle
+++ b/build.gradle
@@ -15,5 +15,6 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        maven { url 'https://maven.google.com' }
     }
 }


### PR DESCRIPTION
This change bumps the target version to Android O and changes the deprecated ActionBarActivity (now removed) to AppCompatActivity.

Because support libraries 26+ are now hosted on 'maven.google.com', as seen [here](https://developer.android.com/topic/libraries/support-library/setup.html) and [here](https://stackoverflow.com/questions/45103230/failed-to-resolve-com-android-supportcardview-v726-0-0-android), this endpoint is added as part of our dependency repository. 

Support library version 26+ is also needed for later versions of Room Persistence used in #620.

Note: Currently the CI test is failing because it uses build tool version 25.