### PR TITLE
Use google() in buildscript

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ android:
     # The SDK version used to compile NewPipe
     - android-26
 
-    # Additional components
-    - extra-android-m2repository
-
 script: ./gradlew -Dorg.gradle.jvmargs=-Xmx1536m assembleDebug lintDebug testDebugUnitTest
 
 licenses:

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.3'
@@ -16,7 +17,7 @@ allprojects {
     repositories {
         jcenter()
         maven { url 'https://jitpack.io' }
-        maven { url 'https://maven.google.com' }
+        google()
         maven { url 'https://clojars.org/repo' }
     }
 }


### PR DESCRIPTION
Hey there, 

Using `google()` in the buildscript block is going to become needed for Android Studio 3.0, so might as well add it now!