### PR TITLE
Use correct long comparison (fixes #726)

### DIFF
--- a/app/src/main/java/us/shandian/giga/get/DownloadManagerImpl.java
+++ b/app/src/main/java/us/shandian/giga/get/DownloadManagerImpl.java
@@ -101,6 +101,18 @@ public class DownloadManagerImpl implements DownloadManager {
 
     }
 
+    /**
+     * Sort a list of mission by its timestamp. Oldest first
+     * @param missions the missions to sort
+     */
+    static void sortByTimestamp(List<DownloadMission> missions) {
+        Collections.sort(missions, new Comparator<DownloadMission>() {
+            @Override
+            public int compare(DownloadMission o1, DownloadMission o2) {
+                return Long.valueOf(o1.timestamp).compareTo(o2.timestamp);
+            }
+        });
+    }
 
     /**
      * Loads finished missions from the data source
@@ -111,12 +123,8 @@ public class DownloadManagerImpl implements DownloadManager {
             finishedMissions = new ArrayList<>();
         }
         // Ensure its sorted
-        Collections.sort(finishedMissions, new Comparator<DownloadMission>() {
-            @Override
-            public int compare(DownloadMission o1, DownloadMission o2) {
-                return (int) (o1.timestamp - o2.timestamp);
-            }
-        });
+        sortByTimestamp(finishedMissions);
+
         mMissions.ensureCapacity(mMissions.size() + finishedMissions.size());
         for (DownloadMission mission : finishedMissions) {
             File downloadedFile = mission.getDownloadedFile();

--- a/app/src/test/java/us/shandian/giga/get/DownloadManagerImplTest.java
+++ b/app/src/test/java/us/shandian/giga/get/DownloadManagerImplTest.java
@@ -1,4 +1,4 @@
-package us.shandian.giga.get.get;
+package us.shandian.giga.get;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -151,6 +151,36 @@ public class DownloadManagerImplTest {
     public void getMission() throws Exception {
         assertSame(missions.get(0), downloadManager.getMission(0));
         assertSame(missions.get(1), downloadManager.getMission(1));
+    }
+
+    @Test
+    public void sortByTimestamp() throws Exception {
+        ArrayList<DownloadMission> downloadMissions = new ArrayList<>();
+        DownloadMission mission = new DownloadMission();
+        mission.timestamp = 0;
+
+        DownloadMission mission1 = new DownloadMission();
+        mission1.timestamp = Integer.MAX_VALUE + 1L;
+
+        DownloadMission mission2 = new DownloadMission();
+        mission2.timestamp = 2L * Integer.MAX_VALUE ;
+
+        DownloadMission mission3 = new DownloadMission();
+        mission3.timestamp = 2L * Integer.MAX_VALUE + 5L;
+
+
+        downloadMissions.add(mission3);
+        downloadMissions.add(mission1);
+        downloadMissions.add(mission2);
+        downloadMissions.add(mission);
+
+
+        DownloadManagerImpl.sortByTimestamp(downloadMissions);
+
+        assertEquals(mission, downloadMissions.get(0));
+        assertEquals(mission1, downloadMissions.get(1));
+        assertEquals(mission2, downloadMissions.get(2));
+        assertEquals(mission3, downloadMissions.get(3));
     }
 
 }


### PR DESCRIPTION
The line `(int) (o1.timestamp - o2.timestamp)` causes errors. Replacing this with the Java default comparison should fix this issue.

PS: Is this how I should create fixes for sentry entries? 