### PR TITLE
Spelling: View → Play

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -194,7 +194,7 @@
     <!-- Missions -->
     <string name="start">Start</string>
     <string name="pause">Pause</string>
-    <string name="view">View</string>
+    <string name="view">Play</string>
     <string name="delete">Delete</string>
     <string name="checksum">Checksum</string>
 


### PR DESCRIPTION
The rationale being audio-files can currently also be "viewed".
