### PR TITLE
Fix top border of launcher icon

### DIFF
--- a/assets/new_pipe_icon_5.svg
+++ b/assets/new_pipe_icon_5.svg
@@ -505,7 +505,7 @@
      cx="96"
      cy="96"
      rx="88"
-     ry="87" />
+     ry="88" />
   <circle
      style="opacity:1;fill:url(#radialGradient4453);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      id="path4445"


### PR DESCRIPTION
There was a small typo which caused this tiny border at the top of the launcher icon:
![launcher_icon_before](https://user-images.githubusercontent.com/17365767/30970741-348d60bc-a466-11e7-86d1-427655b84a62.png)
This blemish is usually not noticeable, but since we also want to provide our icons in the press kit, they should be perfect.