### PR TITLE
 Fix crash when returning to player

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
@@ -178,6 +178,10 @@ public abstract class BasePlayer implements Player.EventListener, AudioManager.O
         if (DEBUG) Log.d(TAG, "initPlayer() called with: context = [" + context + "]");
         initExoPlayerCache();
 
+        if (audioManager == null) {
+            this.audioManager = ((AudioManager) context.getSystemService(Context.AUDIO_SERVICE));
+        }
+
         AdaptiveTrackSelection.Factory trackSelectionFactory = new AdaptiveTrackSelection.Factory(bandwidthMeter);
         DefaultTrackSelector defaultTrackSelector = new DefaultTrackSelector(trackSelectionFactory);
         DefaultLoadControl loadControl = new DefaultLoadControl();


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

When switching apps or locking the phone, destroyPlayer is called which sets audioManager to null. So upon returning to the player and pressing play, the app crashes.
So now initPlayer checks if audioManager is null and sets it if needed.

Closes issue #737