### PR TITLE
[WIP] Add root-path /storage (fixes #707)

### DIFF
--- a/app/src/main/res/xml/provider_paths.xml
+++ b/app/src/main/res/xml/provider_paths.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
     <external-path name="external_files" path="."/>
+    <root-path name="external_files" path="/storage/" />
 </paths>


### PR DESCRIPTION
- [x] I carefully reed the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

Use undocumented root-path element to the file providers paths. See https://stackoverflow.com/a/37807813/7026879 for why this solution might work.

To do:
 - [x] Test with SD Card