### PR TITLE
fix dex build error

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,10 @@ apply plugin: 'com.android.application'
 android {
     compileSdkVersion 26
     buildToolsVersion '26.0.1'
+    
+    dexOptions {
+        jumboMode = true
+    }
 
     defaultConfig {
         applicationId "org.schabi.newpipe"


### PR DESCRIPTION
fix 'Cannot merge new index 65536 into a non-jumbo instruction' build error

- [x] I carefully reed the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
