### PR TITLE
Remove unused "service_kosk_string" strings

### DIFF
--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -273,5 +273,4 @@ abrir en modo popup</string>
     <string name="kiosk">Kiosco</string>
     <string name="trending">Tendencias</string>
     <string name="top_50">Top 50</string>
-    <string name="service_kosk_string">%1$s/%2$s</string>
 </resources>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -252,7 +252,6 @@
     <string name="trending">Nousussa</string>
     <string name="top_50">Top 50</string>
     <string name="new_and_hot">Uudet &amp; kuumat</string>
-    <string name="service_kosk_string">%1$s/%2$s</string>
 <string name="show_hold_to_append_summary">Näytä vihje kun taustasoitto tai popup painiketta on painettu</string>
     <string name="background_player_append">Lisätty taustasoittojonoon</string>
     <string name="popup_playing_append">Lisätty popup-jonoon</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -257,7 +257,6 @@
 
     <string name="item_deleted">Objet effacé</string>
 <string name="delete_item_search_history">Voulez-vous supprimer cet élément de l\'historique de recherche ?</string>
-<string name="service_kosk_string">%1$s/%2$s</string>
 <string name="main_page_content">Contentu</string>
     <string name="blank_page_summary">Page vide</string>
     <string name="subscription_page_summary">Page de souscription</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -279,7 +279,6 @@
     <string name="trending">In tendenza</string>
     <string name="top_50">Primi 50</string>
     <string name="new_and_hot">Nuovi e caldi</string>
-    <string name="service_kosk_string">%1$s/%2$s</string>
 <string name="show_hold_to_append_title">Mostra il suggerimento di tenere premuto per appendere</string>
     <string name="show_hold_to_append_summary">Mostra un suggerimento quando il pulsante in sottofondo o a comparsa viene premuto nella pagina dei dettagli di un video</string>
     <string name="background_player_append">In coda al riproduttore in sottofondo</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -256,7 +256,6 @@ abrir em modo popup</string>
     <string name="trending">Em Alta</string>
     <string name="top_50">Top 50</string>
     <string name="new_and_hot">Novos e tendências</string>
-    <string name="service_kosk_string">%1$s/%2$s</string>
 <string name="show_hold_to_append_title">Mostrar dica para Mantenha pressionado para colocar na fila</string>
     <string name="show_hold_to_append_summary">Mostrar dica quando o botão de plano de fundo ou de popup for pressionado na página de detalhes do vídeo</string>
     <string name="background_player_append">Adicionado a fila do reprodutor em plano de fundo</string>


### PR DESCRIPTION
In #784 I corrected a typo: 
`<string name="service_kosk_string">%1$s/%2$s</string>` => `<string name="service_kiosk_string" translatable="false">%1$s/%2$s</string>`
While I did this some more users translated the false string on wablate. They got merged later and now cause a warning: `Warning:string 'service_kosk_string' has no default translation.` This PR removes them.