### PR TITLE
remember last screen orientation

### DIFF
--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -75,6 +75,8 @@
         <item>@string/audio_webm_key</item>
     </string-array>
 
+    <string name="last_orientation_landscape_key" translatable="false">last_orientation_landscape_key</string>
+
     <!-- THEMES -->
     <string name="theme_key" translatable="false">theme</string>
     <string name="light_theme_key" translatable="false">light_theme</string>


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

This makes NewPipePlayer remember its last screen orientation when locking the screen orientation globally, like I suggested here:https://github.com/TeamNewPipe/NewPipe/issues/894