### PR TITLE
Fix failing test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ android:
     # The SDK version used to compile NewPipe
     - android-27
 
+before_install: 
+  - yes | sdkmanager "platforms;android-27"
 script: ./gradlew -Dorg.gradle.jvmargs=-Xmx1536m assembleDebug lintDebug testDebugUnitTest
 
 licenses:

--- a/app/src/test/java/org/schabi/newpipe/util/ListHelperTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/ListHelperTest.java
@@ -14,35 +14,35 @@ import static org.junit.Assert.assertEquals;
 public class ListHelperTest {
     private static final String BEST_RESOLUTION_KEY = "best_resolution";
     private static final List<AudioStream> audioStreamsTestList = Arrays.asList(
-            new AudioStream("", MediaFormat.M4A.id,   /**/ 128),
-            new AudioStream("", MediaFormat.WEBMA.id, /**/ 192),
-            new AudioStream("", MediaFormat.MP3.id,   /**/ 64),
-            new AudioStream("", MediaFormat.WEBMA.id, /**/ 192),
-            new AudioStream("", MediaFormat.M4A.id,   /**/ 128),
-            new AudioStream("", MediaFormat.MP3.id,   /**/ 128),
-            new AudioStream("", MediaFormat.WEBMA.id, /**/ 64),
-            new AudioStream("", MediaFormat.M4A.id,   /**/ 320),
-            new AudioStream("", MediaFormat.MP3.id,   /**/ 192),
-            new AudioStream("", MediaFormat.WEBMA.id, /**/ 320));
+            new AudioStream("", MediaFormat.M4A,   /**/ 128),
+            new AudioStream("", MediaFormat.WEBMA, /**/ 192),
+            new AudioStream("", MediaFormat.MP3,   /**/ 64),
+            new AudioStream("", MediaFormat.WEBMA, /**/ 192),
+            new AudioStream("", MediaFormat.M4A,   /**/ 128),
+            new AudioStream("", MediaFormat.MP3,   /**/ 128),
+            new AudioStream("", MediaFormat.WEBMA, /**/ 64),
+            new AudioStream("", MediaFormat.M4A,   /**/ 320),
+            new AudioStream("", MediaFormat.MP3,   /**/ 192),
+            new AudioStream("", MediaFormat.WEBMA, /**/ 320));
 
     private static final List<VideoStream> videoStreamsTestList = Arrays.asList(
-            new VideoStream("", MediaFormat.MPEG_4.id,   /**/ "720p"),
-            new VideoStream("", MediaFormat.v3GPP.id,    /**/ "240p"),
-            new VideoStream("", MediaFormat.WEBM.id,     /**/ "480p"),
-            new VideoStream("", MediaFormat.v3GPP.id,    /**/ "144p"),
-            new VideoStream("", MediaFormat.MPEG_4.id,   /**/ "360p"),
-            new VideoStream("", MediaFormat.WEBM.id,     /**/ "360p"));
+            new VideoStream("", MediaFormat.MPEG_4,   /**/ "720p"),
+            new VideoStream("", MediaFormat.v3GPP,    /**/ "240p"),
+            new VideoStream("", MediaFormat.WEBM,     /**/ "480p"),
+            new VideoStream("", MediaFormat.v3GPP,    /**/ "144p"),
+            new VideoStream("", MediaFormat.MPEG_4,   /**/ "360p"),
+            new VideoStream("", MediaFormat.WEBM,     /**/ "360p"));
 
     private static final List<VideoStream> videoOnlyStreamsTestList = Arrays.asList(
-            new VideoStream("", MediaFormat.MPEG_4.id,   /**/ "720p", true),
-            new VideoStream("", MediaFormat.MPEG_4.id,   /**/ "720p", true),
-            new VideoStream("", MediaFormat.MPEG_4.id,   /**/ "2160p", true),
-            new VideoStream("", MediaFormat.MPEG_4.id,   /**/ "1440p60", true),
-            new VideoStream("", MediaFormat.WEBM.id,     /**/ "720p60", true),
-            new VideoStream("", MediaFormat.MPEG_4.id,   /**/ "2160p60", true),
-            new VideoStream("", MediaFormat.MPEG_4.id,   /**/ "720p60", true),
-            new VideoStream("", MediaFormat.MPEG_4.id,   /**/ "1080p", true),
-            new VideoStream("", MediaFormat.MPEG_4.id,   /**/ "1080p60", true));
+            new VideoStream("", MediaFormat.MPEG_4,   /**/ "720p", true),
+            new VideoStream("", MediaFormat.MPEG_4,   /**/ "720p", true),
+            new VideoStream("", MediaFormat.MPEG_4,   /**/ "2160p", true),
+            new VideoStream("", MediaFormat.MPEG_4,   /**/ "1440p60", true),
+            new VideoStream("", MediaFormat.WEBM,     /**/ "720p60", true),
+            new VideoStream("", MediaFormat.MPEG_4,   /**/ "2160p60", true),
+            new VideoStream("", MediaFormat.MPEG_4,   /**/ "720p60", true),
+            new VideoStream("", MediaFormat.MPEG_4,   /**/ "1080p", true),
+            new VideoStream("", MediaFormat.MPEG_4,   /**/ "1080p60", true));
 
     @Test
     public void getSortedStreamVideosListTest() throws Exception {
@@ -81,52 +81,52 @@ public class ListHelperTest {
     @Test
     public void getDefaultResolutionTest() throws Exception {
         List<VideoStream> testList = Arrays.asList(
-                new VideoStream("", MediaFormat.MPEG_4.id,   /**/ "720p"),
-                new VideoStream("", MediaFormat.v3GPP.id,    /**/ "240p"),
-                new VideoStream("", MediaFormat.WEBM.id,     /**/ "480p"),
-                new VideoStream("", MediaFormat.WEBM.id,     /**/ "240p"),
-                new VideoStream("", MediaFormat.MPEG_4.id,   /**/ "240p"),
-                new VideoStream("", MediaFormat.WEBM.id,     /**/ "144p"),
-                new VideoStream("", MediaFormat.MPEG_4.id,   /**/ "360p"),
-                new VideoStream("", MediaFormat.WEBM.id,     /**/ "360p"));
+                new VideoStream("", MediaFormat.MPEG_4,   /**/ "720p"),
+                new VideoStream("", MediaFormat.v3GPP,    /**/ "240p"),
+                new VideoStream("", MediaFormat.WEBM,     /**/ "480p"),
+                new VideoStream("", MediaFormat.WEBM,     /**/ "240p"),
+                new VideoStream("", MediaFormat.MPEG_4,   /**/ "240p"),
+                new VideoStream("", MediaFormat.WEBM,     /**/ "144p"),
+                new VideoStream("", MediaFormat.MPEG_4,   /**/ "360p"),
+                new VideoStream("", MediaFormat.WEBM,     /**/ "360p"));
         VideoStream result = testList.get(ListHelper.getDefaultResolutionIndex("720p", BEST_RESOLUTION_KEY, MediaFormat.MPEG_4, testList));
         assertEquals("720p", result.resolution);
-        assertEquals(MediaFormat.MPEG_4.id, result.format);
+        assertEquals(MediaFormat.MPEG_4, result.getFormat());
 
         // Have resolution and the format
         result = testList.get(ListHelper.getDefaultResolutionIndex("480p", BEST_RESOLUTION_KEY, MediaFormat.WEBM, testList));
         assertEquals("480p", result.resolution);
-        assertEquals(MediaFormat.WEBM.id, result.format);
+        assertEquals(MediaFormat.WEBM, result.getFormat());
 
         // Have resolution but not the format
         result = testList.get(ListHelper.getDefaultResolutionIndex("480p", BEST_RESOLUTION_KEY, MediaFormat.MPEG_4, testList));
         assertEquals("480p", result.resolution);
-        assertEquals(MediaFormat.WEBM.id, result.format);
+        assertEquals(MediaFormat.WEBM, result.getFormat());
 
         // Have resolution and the format
         result = testList.get(ListHelper.getDefaultResolutionIndex("240p", BEST_RESOLUTION_KEY, MediaFormat.WEBM, testList));
         assertEquals("240p", result.resolution);
-        assertEquals(MediaFormat.WEBM.id, result.format);
+        assertEquals(MediaFormat.WEBM, result.getFormat());
 
         // The best resolution
         result = testList.get(ListHelper.getDefaultResolutionIndex(BEST_RESOLUTION_KEY, BEST_RESOLUTION_KEY, MediaFormat.WEBM, testList));
         assertEquals("720p", result.resolution);
-        assertEquals(MediaFormat.MPEG_4.id, result.format);
+        assertEquals(MediaFormat.MPEG_4, result.getFormat());
 
         // Doesn't have the 60fps variant and format
         result = testList.get(ListHelper.getDefaultResolutionIndex("720p60", BEST_RESOLUTION_KEY, MediaFormat.WEBM, testList));
         assertEquals("720p", result.resolution);
-        assertEquals(MediaFormat.MPEG_4.id, result.format);
+        assertEquals(MediaFormat.MPEG_4, result.getFormat());
 
         // Doesn't have the 60fps variant
         result = testList.get(ListHelper.getDefaultResolutionIndex("480p60", BEST_RESOLUTION_KEY, MediaFormat.WEBM, testList));
         assertEquals("480p", result.resolution);
-        assertEquals(MediaFormat.WEBM.id, result.format);
+        assertEquals(MediaFormat.WEBM, result.getFormat());
 
         // Doesn't have the resolution, will return the best one
         result = testList.get(ListHelper.getDefaultResolutionIndex("2160p60", BEST_RESOLUTION_KEY, MediaFormat.WEBM, testList));
         assertEquals("720p", result.resolution);
-        assertEquals(MediaFormat.MPEG_4.id, result.format);
+        assertEquals(MediaFormat.MPEG_4, result.getFormat());
     }
 
     @Test
@@ -138,15 +138,15 @@ public class ListHelperTest {
     public void getHighestQualityAudioFormatTest() throws Exception {
         AudioStream stream = audioStreamsTestList.get(ListHelper.getHighestQualityAudioIndex(MediaFormat.M4A, audioStreamsTestList));
         assertEquals(320, stream.average_bitrate);
-        assertEquals(MediaFormat.M4A.id, stream.format);
+        assertEquals(MediaFormat.M4A, stream.getFormat());
 
         stream = audioStreamsTestList.get(ListHelper.getHighestQualityAudioIndex(MediaFormat.WEBMA, audioStreamsTestList));
         assertEquals(320, stream.average_bitrate);
-        assertEquals(MediaFormat.WEBMA.id, stream.format);
+        assertEquals(MediaFormat.WEBMA, stream.getFormat());
 
         stream = audioStreamsTestList.get(ListHelper.getHighestQualityAudioIndex(MediaFormat.MP3, audioStreamsTestList));
         assertEquals(192, stream.average_bitrate);
-        assertEquals(MediaFormat.MP3.id, stream.format);
+        assertEquals(MediaFormat.MP3, stream.getFormat());
     }
 
     @Test
@@ -157,36 +157,36 @@ public class ListHelperTest {
         ////////////////////////////////////////
 
         List<AudioStream> testList = Arrays.asList(
-                new AudioStream("", MediaFormat.M4A.id,   /**/ 128),
-                new AudioStream("", MediaFormat.WEBMA.id, /**/ 192));
+                new AudioStream("", MediaFormat.M4A,   /**/ 128),
+                new AudioStream("", MediaFormat.WEBMA, /**/ 192));
         // List doesn't contains this format, it should fallback to the highest bitrate audio no matter what format it is
         AudioStream stream = testList.get(ListHelper.getHighestQualityAudioIndex(MediaFormat.MP3, testList));
         assertEquals(192, stream.average_bitrate);
-        assertEquals(MediaFormat.WEBMA.id, stream.format);
+        assertEquals(MediaFormat.WEBMA, stream.getFormat());
 
         ////////////////////////////////////////////////////////
         // Multiple not-preferred-formats and equal bitrates //
         //////////////////////////////////////////////////////
 
         testList = new ArrayList<>(Arrays.asList(
-                new AudioStream("", MediaFormat.WEBMA.id, /**/ 192),
-                new AudioStream("", MediaFormat.M4A.id,   /**/ 192),
-                new AudioStream("", MediaFormat.WEBMA.id, /**/ 192),
-                new AudioStream("", MediaFormat.M4A.id,   /**/ 192),
-                new AudioStream("", MediaFormat.WEBMA.id, /**/ 192),
-                new AudioStream("", MediaFormat.M4A.id,   /**/ 192)));
+                new AudioStream("", MediaFormat.WEBMA, /**/ 192),
+                new AudioStream("", MediaFormat.M4A,   /**/ 192),
+                new AudioStream("", MediaFormat.WEBMA, /**/ 192),
+                new AudioStream("", MediaFormat.M4A,   /**/ 192),
+                new AudioStream("", MediaFormat.WEBMA, /**/ 192),
+                new AudioStream("", MediaFormat.M4A,   /**/ 192)));
         // List doesn't contains this format, it should fallback to the highest bitrate audio no matter what format it is
         // and as it have multiple with the same high value, the last one wins
         stream = testList.get(ListHelper.getHighestQualityAudioIndex(MediaFormat.MP3, testList));
         assertEquals(192, stream.average_bitrate);
-        assertEquals(MediaFormat.M4A.id, stream.format);
+        assertEquals(MediaFormat.M4A, stream.getFormat());
 
 
         // Again with a new element
-        testList.add(new AudioStream("", MediaFormat.WEBMA.id, /**/ 192));
+        testList.add(new AudioStream("", MediaFormat.WEBMA, /**/ 192));
         stream = testList.get(ListHelper.getHighestQualityAudioIndex(MediaFormat.MP3, testList));
         assertEquals(192, stream.average_bitrate);
-        assertEquals(MediaFormat.WEBMA.id, stream.format);
+        assertEquals(MediaFormat.WEBMA, stream.getFormat());
     }
 
     @Test


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

The update of the extractor changed the signature of the `VideoStream` and `VideoStream`. I've changed the test accordingly.

**Update**: Also fixes installation of Android components in Travis CI