### PR TITLE
Add subject to shared URL's (fixes #975)

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/BaseStateFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/BaseStateFragment.java
@@ -19,6 +19,7 @@ import org.schabi.newpipe.MainActivity;
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.ReCaptchaActivity;
 import org.schabi.newpipe.extractor.exceptions.ReCaptchaException;
+import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.report.ErrorActivity;
 import org.schabi.newpipe.report.UserAction;
 import org.schabi.newpipe.util.ExtractorHelper;
@@ -252,9 +253,10 @@ public abstract class BaseStateFragment<I> extends BaseFragment implements ViewC
         startActivity(intent);
     }
 
-    protected void shareUrl(String url) {
+    protected void shareUrl(String subject, String url) {
         Intent intent = new Intent(Intent.ACTION_SEND);
         intent.setType("text/plain");
+        intent.putExtra(Intent.EXTRA_SUBJECT, subject);
         intent.putExtra(Intent.EXTRA_TEXT, url);
         startActivity(Intent.createChooser(intent, getString(R.string.share_dialog_title)));
     }

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -623,12 +623,7 @@ public class VideoDetailFragment extends BaseStateFragment<StreamInfo> implement
         if (DEBUG) Log.d(TAG, "setupActionBarHandler() called with: info = [" + info + "]");
         sortedStreamVideosList = new ArrayList<>(ListHelper.getSortedStreamVideosList(activity, info.getVideoStreams(), info.getVideoOnlyStreams(), false));
         actionBarHandler.setupStreamList(sortedStreamVideosList, spinnerToolbar);
-        actionBarHandler.setOnShareListener(new ActionBarHandler.OnActionListener() {
-            @Override
-            public void onActionSelected(int selectedStreamId) {
-                shareUrl(info.getUrl());
-            }
-        });
+        actionBarHandler.setOnShareListener(selectedStreamId -> shareUrl(info.name, info.url));
 
         actionBarHandler.setOnOpenInBrowserListener(new ActionBarHandler.OnActionListener() {
             @Override

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
@@ -231,7 +231,7 @@ public class ChannelFragment extends BaseListInfoFragment<ChannelInfo> {
                 openUrlInBrowser(url);
                 break;
             case R.id.menu_item_share: {
-                shareUrl(url);
+                shareUrl(name, url);
                 break;
             }
             default:

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
@@ -167,7 +167,7 @@ public class PlaylistFragment extends BaseListInfoFragment<PlaylistInfo> {
                 openUrlInBrowser(url);
                 break;
             case R.id.menu_item_share: {
-                shareUrl(url);
+                shareUrl(name, url);
                 break;
             }
             default:


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

I've added a subject argument to the `shareUrl` method.

Here some examples screenshots for when the playlist/channel/video is shared with firefox:

<img src="https://user-images.githubusercontent.com/5737978/34719455-343402b2-f53b-11e7-9f88-4b0218e8ecb3.png" width="30%" /> <img src="https://user-images.githubusercontent.com/5737978/34719377-e715e676-f53a-11e7-9533-22ced9362101.png" width="30%" />  <img src="https://user-images.githubusercontent.com/5737978/34719422-1dd2f154-f53b-11e7-8406-aa946721361b.png" width="30%" />

