### PR TITLE
Fix crash due to no "other" item in plurals

### DIFF
--- a/fixplurals.sh
+++ b/fixplurals.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 javac CheckTranslations.java
-find app/src -name "*.xml" | grep values | xargs java CheckTranslations -r
+find app/src -name "*.xml" | grep values | xargs java CheckTranslations -d -r


### PR DESCRIPTION
@theScrabi Here is the update for the script, so you don't have to do it manually. You just could have waited a little longer and you'd have saved some time ;)