### PR TITLE
Misc history ui fixes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,8 +20,7 @@
         tools:ignore="AllowBackup">
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name"
-            android:launchMode="singleTask">
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -219,7 +219,8 @@ public class MainActivity extends AppCompatActivity implements HistoryListener {
     private void initFragments() {
         if (DEBUG) Log.d(TAG, "initFragments() called");
         StateSaver.clearStateFiles();
-        if (getIntent() != null && getIntent().hasExtra(Constants.KEY_LINK_TYPE)) {
+        if (getIntent() != null && (getIntent().hasExtra(Constants.KEY_LINK_TYPE)
+                || getIntent().hasExtra(Constants.KEY_OPEN_SEARCH))) {
             handleIntent(getIntent());
         } else NavigationHelper.gotoMainFragment(getSupportFragmentManager());
     }

--- a/app/src/main/java/org/schabi/newpipe/history/HistoryEntryAdapter.java
+++ b/app/src/main/java/org/schabi/newpipe/history/HistoryEntryAdapter.java
@@ -75,6 +75,16 @@ public abstract class HistoryEntryAdapter<E extends HistoryEntry, VH extends Rec
                 }
             }
         });
+        holder.itemView.setOnLongClickListener(new View.OnLongClickListener() {
+            @Override
+            public boolean onLongClick(View v) {
+                final OnHistoryItemClickListener<E> historyItemClickListener = onHistoryItemClickListener;
+                if(historyItemClickListener != null) {
+                    return historyItemClickListener.onHistoryItemLongClick(entry);
+                }
+                return false;
+            }
+        });
         onBindViewHolder(holder, entry, position);
     }
 
@@ -102,5 +112,6 @@ public abstract class HistoryEntryAdapter<E extends HistoryEntry, VH extends Rec
 
     public interface OnHistoryItemClickListener<E extends HistoryEntry> {
         void onHistoryItemClick(E historyItem);
+        boolean onHistoryItemLongClick(E historyItem);
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/history/HistoryFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/history/HistoryFragment.java
@@ -1,6 +1,9 @@
 package org.schabi.newpipe.history;
 
 
+import android.app.Activity;
+import android.content.Context;
+import android.content.DialogInterface;
 import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.os.Bundle;
@@ -23,6 +26,10 @@ import org.schabi.newpipe.BaseFragment;
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.database.history.dao.HistoryDAO;
 import org.schabi.newpipe.database.history.model.HistoryEntry;
+import org.schabi.newpipe.extractor.stream.StreamInfoItem;
+import org.schabi.newpipe.info_list.InfoItemDialog;
+import org.schabi.newpipe.playlist.SinglePlayQueue;
+import org.schabi.newpipe.util.NavigationHelper;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -267,6 +274,35 @@ public abstract class HistoryFragment<E extends HistoryEntry> extends BaseFragme
     public void onPause() {
         super.onPause();
         mRecyclerViewState = mRecyclerView.getLayoutManager().onSaveInstanceState();
+    }
+
+    protected void showStreamDialog(final StreamInfoItem item) {
+        final Context context = getContext();
+        final Activity activity = getActivity();
+        if (context == null || context.getResources() == null || getActivity() == null) return;
+
+        final String[] commands = new String[]{
+                context.getResources().getString(R.string.enqueue_on_background),
+                context.getResources().getString(R.string.enqueue_on_popup),
+        };
+
+        final DialogInterface.OnClickListener actions = new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialogInterface, int i) {
+                switch (i) {
+                    case 0:
+                        NavigationHelper.enqueueOnBackgroundPlayer(context, new SinglePlayQueue(item));
+                        break;
+                    case 1:
+                        NavigationHelper.enqueueOnPopupPlayer(activity, new SinglePlayQueue(item));
+                        break;
+                    default:
+                        break;
+                }
+            }
+        };
+
+        new InfoItemDialog(getActivity(), item, commands, actions).show();
     }
 
     /**

--- a/app/src/main/java/org/schabi/newpipe/history/SearchHistoryFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/history/SearchHistoryFragment.java
@@ -56,6 +56,11 @@ public class SearchHistoryFragment extends HistoryFragment<SearchHistoryEntry> {
         NavigationHelper.openSearch(getContext(), historyItem.getServiceId(), historyItem.getSearch());
     }
 
+    @Override
+    public boolean onHistoryItemLongClick(SearchHistoryEntry historyItem) {
+        return false;
+    }
+
     private static class ViewHolder extends RecyclerView.ViewHolder {
         private final TextView search;
         private final TextView time;

--- a/app/src/main/java/org/schabi/newpipe/history/WatchedHistoryFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/history/WatchedHistoryFragment.java
@@ -20,6 +20,8 @@ import org.schabi.newpipe.NewPipeDatabase;
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.database.history.dao.HistoryDAO;
 import org.schabi.newpipe.database.history.model.WatchHistoryEntry;
+import org.schabi.newpipe.extractor.stream.StreamInfoItem;
+import org.schabi.newpipe.extractor.stream.StreamType;
 import org.schabi.newpipe.info_list.holder.StreamInfoItemHolder;
 import org.schabi.newpipe.util.Localization;
 import org.schabi.newpipe.util.NavigationHelper;
@@ -64,6 +66,13 @@ public class WatchedHistoryFragment extends HistoryFragment<WatchHistoryEntry> {
                 historyItem.getServiceId(),
                 historyItem.getUrl(),
                 historyItem.getTitle());
+    }
+
+    @Override
+    public boolean onHistoryItemLongClick(WatchHistoryEntry historyItem) {
+        StreamInfoItem item = new StreamInfoItem(historyItem.getServiceId(), historyItem.getUrl(), historyItem.getTitle(), StreamType.NONE);
+        showStreamDialog(item);
+        return true;
     }
 
     private static class WatchedHistoryAdapter extends HistoryEntryAdapter<WatchHistoryEntry, ViewHolder> {


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

Added long press to enqueue from History view - works just like the implementation in related videos.

I also made it so tapping back after opening a video from history takes you back to the history view, although I'm not 100% confident my implementation is correct. It was a pretty confusing UX to be thrown back to the initial screen when I wanted to go back to my history.