### PR TITLE
Support playing videos on DIAL-Server

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -89,4 +89,6 @@ dependencies {
 
     implementation 'frankiesardo:icepick:3.2.0'
     annotationProcessor 'frankiesardo:icepick-processor:3.2.0'
+
+    implementation 'de.w3is:jdial:1.2'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+    <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
 
     <application
         android:name=".App"
@@ -58,6 +59,10 @@
             android:label="@string/app_name"
             android:launchMode="singleTask"
             android:theme="@style/PlayerTheme"/>
+
+        <activity android:name=".player.PlayOnTvActivity"
+            android:launchMode="singleTask"
+            android:label="@string/play_on_tv"/>
 
         <activity
             android:name=".settings.SettingsActivity"
@@ -235,5 +240,8 @@
                 <data android:mimeType="text/plain"/>
             </intent-filter>
         </activity>
+        <service
+            android:name=".dial.DialService"
+            android:exported="false"/>
     </application>
 </manifest>

--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -50,6 +50,7 @@ import org.schabi.newpipe.database.history.dao.WatchHistoryDAO;
 import org.schabi.newpipe.database.history.model.HistoryEntry;
 import org.schabi.newpipe.database.history.model.SearchHistoryEntry;
 import org.schabi.newpipe.database.history.model.WatchHistoryEntry;
+import org.schabi.newpipe.dial.DialService;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.stream.AudioStream;
@@ -149,6 +150,7 @@ public class MainActivity extends AppCompatActivity implements HistoryListener {
         sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
 
         initHistory();
+        discoverDialServers();
     }
 
     @Override
@@ -314,6 +316,13 @@ public class MainActivity extends AppCompatActivity implements HistoryListener {
         } else {
             NavigationHelper.gotoMainFragment(getSupportFragmentManager());
         }
+    }
+
+    private void discoverDialServers() {
+
+        Intent discoveryIntent = new Intent(this, DialService.class);
+        discoveryIntent.setAction(DialService.ACTION_DISCOVERY);
+        startService(discoveryIntent);
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/app/src/main/java/org/schabi/newpipe/dial/DialService.java
+++ b/app/src/main/java/org/schabi/newpipe/dial/DialService.java
@@ -1,0 +1,173 @@
+package org.schabi.newpipe.dial;
+
+import android.app.IntentService;
+import android.content.Context;
+import android.content.Intent;
+import android.net.wifi.WifiManager;
+import android.support.annotation.Nullable;
+import android.support.v4.content.LocalBroadcastManager;
+import android.util.Log;
+
+import java.io.Serializable;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+
+import de.w3is.jdial.DialClient;
+import de.w3is.jdial.Discovery;
+import de.w3is.jdial.model.Application;
+import de.w3is.jdial.model.DialClientException;
+import de.w3is.jdial.model.DialContent;
+import de.w3is.jdial.model.DialServer;
+import de.w3is.jdial.protocol.ProtocolFactory;
+import de.w3is.jdial.protocol.ProtocolFactoryImpl;
+
+public class DialService extends IntentService {
+
+    public static final String ACTION_DISCOVERY = "dial.intent.action.discovery";
+    public static final String ACTION_START = "dial.intent.action.start";
+
+    public static final String EXTRA_CLEAR_CACHE = "dial.intent.extra.clearCache";
+    public static final String EXTRA_DIAL_SERVERS = "dial.intent.extra.servers";
+    public static final String EXTRA_DIAL_SERVER = "dial.intent.extra.server";
+    public static final String EXTRA_VIDEO_ID = "dial.intent.extra.videoId";
+    public static final String EXTRA_VIDEO_STARTED = "dial.intent.extra.videoStarted";
+
+    private static final String SERVICE_NAME = "dialService";
+    private static final String TAG = ".DialService";
+
+    private final Discovery discovery;
+    private final DialClient dialClient;
+    private WifiManager wifiManager;
+
+    private List<DialServer> dialServerCache = new ArrayList<>();
+
+    public DialService() {
+        super(SERVICE_NAME);
+
+        ProtocolFactory protocolFactory = new ProtocolFactoryImpl(true);
+        discovery = new Discovery(protocolFactory);
+        dialClient = new DialClient(protocolFactory);
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+
+        wifiManager = (WifiManager) getApplicationContext()
+                .getSystemService(Context.WIFI_SERVICE);
+    }
+
+    @Override
+    protected void onHandleIntent(@Nullable Intent intent) {
+
+        if (intent == null) {
+            return;
+        }
+
+        if (ACTION_DISCOVERY.equals(intent.getAction())) {
+
+            discoverServers(intent);
+
+        } else if (ACTION_START.equals(intent.getAction())) {
+
+            startVideo(intent);
+        }
+    }
+
+    private void startVideo(Intent intent) {
+
+        String videoId = intent.getStringExtra(EXTRA_VIDEO_ID);
+        DialServer dialServer = (DialServer) intent.getSerializableExtra(EXTRA_DIAL_SERVER);
+
+        if (videoId == null || dialServer == null || videoId.isEmpty()) {
+
+            Log.e(TAG, "Not all extras were set");
+            sendStartActionResponse(false);
+            return;
+        }
+
+        boolean success = false;
+
+        try {
+
+            URL instanceURL = dialClient.connectTo(dialServer)
+                    .startApplication(Application.YOUTUBE, createVideoStartContent(videoId));
+
+            success = instanceURL != null;
+
+        } catch (DialClientException e) {
+
+            Log.e(TAG, "Error while launching video on tv [ dialServer: " + dialServer.getServerDescription() + ", videoId: " + videoId + "]", e);
+        }
+
+        sendStartActionResponse(success);
+    }
+
+    private void discoverServers(Intent intent) {
+
+        if (intent.getBooleanExtra(EXTRA_CLEAR_CACHE, false)) {
+
+            dialServerCache.clear();
+        }
+
+        if (dialServerCache.isEmpty()) {
+
+            dialServerCache.addAll(discoverYoutubeServer());
+        }
+
+        Intent resultIntent = new Intent(ACTION_DISCOVERY);
+        resultIntent.putExtra(EXTRA_DIAL_SERVERS, (Serializable) dialServerCache);
+        LocalBroadcastManager.getInstance(this).sendBroadcast(resultIntent);
+    }
+
+    private List<DialServer> discoverYoutubeServer() {
+
+        WifiManager.MulticastLock multicastLock = wifiManager.createMulticastLock(TAG);
+        multicastLock.acquire();
+
+        List<DialServer> allServers = discovery.discover();
+
+        multicastLock.release();
+
+        List<DialServer> youtubeServers = new ArrayList<>();
+
+        for (DialServer server : allServers) {
+
+            if (supportsYoutube(server)) {
+
+                youtubeServers.add(server);
+            }
+        }
+
+        return youtubeServers;
+    }
+
+    private boolean supportsYoutube(DialServer server) {
+
+        return dialClient.connectTo(server).supportsApplication(Application.YOUTUBE);
+    }
+
+    private DialContent createVideoStartContent(final String videoId) {
+
+        return new DialContent() {
+            @Override
+            public String getContentType() {
+                return "application/x-www-form-urlencoded; encoding=UTF-8";
+            }
+
+            @Override
+            public byte[] getData() {
+                return String.format("v=%s", videoId).getBytes(Charset.forName("UTF-8"));
+            }
+        };
+    }
+
+    private void sendStartActionResponse(boolean success) {
+
+        Intent resultIntent = new Intent(ACTION_START);
+        resultIntent.putExtra(EXTRA_VIDEO_STARTED, success);
+        LocalBroadcastManager.getInstance(this).sendBroadcast(resultIntent);
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/ActionBarHandler.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/ActionBarHandler.java
@@ -55,6 +55,7 @@ class ActionBarHandler {
     private OnActionListener onOpenInBrowserListener;
     private OnActionListener onDownloadListener;
     private OnActionListener onPlayWithKodiListener;
+    private OnActionListener onPlayOnTvListener;
 
     // Triggered when a stream related action is triggered.
     public interface OnActionListener {
@@ -127,6 +128,12 @@ class ActionBarHandler {
                     onPlayWithKodiListener.onActionSelected(selectedVideoStream);
                 }
                 return true;
+            case R.id.menu_item_playOnTv: {
+                if (onPlayOnTvListener != null) {
+                    onPlayOnTvListener.onActionSelected(selectedVideoStream);
+                }
+            }
+            return true;
             default:
                 Log.e(TAG, "Menu Item not known");
         }
@@ -143,6 +150,10 @@ class ActionBarHandler {
 
     public void setOnOpenInBrowserListener(OnActionListener listener) {
         onOpenInBrowserListener = listener;
+    }
+
+    public void setOnPlayOnTvListener(OnActionListener listener) {
+        onPlayOnTvListener = listener;
     }
 
     public void setOnDownloadListener(OnActionListener listener) {

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -13,7 +13,6 @@ import android.support.annotation.DrawableRes;
 import android.support.annotation.FloatRange;
 import android.support.annotation.NonNull;
 import android.support.v4.content.ContextCompat;
-import android.support.v4.text.TextUtilsCompat;
 import android.support.v4.view.animation.FastOutSlowInInterpolator;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AlertDialog;
@@ -25,7 +24,6 @@ import android.text.util.Linkify;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.util.TypedValue;
-import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -37,7 +35,6 @@ import android.widget.FrameLayout;
 import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
-import android.widget.PopupMenu;
 import android.widget.RelativeLayout;
 import android.widget.Spinner;
 import android.widget.TextView;
@@ -51,7 +48,6 @@ import org.schabi.newpipe.R;
 import org.schabi.newpipe.ReCaptchaActivity;
 import org.schabi.newpipe.download.DownloadDialog;
 import org.schabi.newpipe.extractor.InfoItem;
-import org.schabi.newpipe.extractor.MediaFormat;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.exceptions.ContentNotAvailableException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
@@ -67,6 +63,7 @@ import org.schabi.newpipe.info_list.InfoItemBuilder;
 import org.schabi.newpipe.info_list.InfoItemDialog;
 import org.schabi.newpipe.player.MainVideoPlayer;
 import org.schabi.newpipe.player.PopupVideoPlayer;
+import org.schabi.newpipe.player.PlayOnTvActivity;
 import org.schabi.newpipe.player.helper.PlayerHelper;
 import org.schabi.newpipe.player.old.PlayVideoActivity;
 import org.schabi.newpipe.playlist.PlayQueue;
@@ -636,6 +633,13 @@ public class VideoDetailFragment extends BaseStateFragment<StreamInfo> implement
             }
         });
 
+        actionBarHandler.setOnPlayOnTvListener(new ActionBarHandler.OnActionListener() {
+            @Override
+            public void onActionSelected(int selectedStreamId) {
+                playOnTv(info.getId());
+            }
+        });
+
         actionBarHandler.setOnPlayWithKodiListener(new ActionBarHandler.OnActionListener() {
             @Override
             public void onActionSelected(int selectedStreamId) {
@@ -890,6 +894,14 @@ public class VideoDetailFragment extends BaseStateFragment<StreamInfo> implement
             e.printStackTrace();
         }
     }
+
+
+    private void playOnTv(String videoId) {
+
+        startActivity(new Intent(activity, PlayOnTvActivity.class)
+                .putExtra(PlayOnTvActivity.VIDEO_ID, videoId));
+    }
+
 
     private void openNormalPlayer(VideoStream selectedVideoStream) {
         Intent mIntent;

--- a/app/src/main/java/org/schabi/newpipe/player/PlayOnTvActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayOnTvActivity.java
@@ -1,0 +1,238 @@
+package org.schabi.newpipe.player;
+
+import android.app.Activity;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.content.LocalBroadcastManager;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.ImageButton;
+import android.widget.ListView;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import org.schabi.newpipe.R;
+import org.schabi.newpipe.dial.DialService;
+
+import java.util.List;
+
+import de.w3is.jdial.model.DialServer;
+
+public class PlayOnTvActivity extends Activity {
+
+    public static final String VIDEO_ID = "video_id";
+
+    private static final boolean DEBUG = BasePlayer.DEBUG;
+    private static final String TAG = ".TvPlayer";
+    private static final String STATE_INTENT = "tv_player_state_intent";
+
+    private ImageButton refreshButton;
+    protected ProgressBar progressBar;
+
+    private ListView serverList;
+    private ServerListAdapter serverListAdapter;
+
+    private BroadcastReceiver serverListReceiver;
+    private BroadcastReceiver videoStartedReceiver;
+
+    private String videoId;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (DEBUG) Log.d(TAG, "onCreate() called with: savedInstanceState = [" + savedInstanceState + "]");
+
+        final Intent intent;
+        if (savedInstanceState != null && savedInstanceState.getParcelable(STATE_INTENT) != null) {
+            intent = savedInstanceState.getParcelable(STATE_INTENT);
+        } else {
+            intent = getIntent();
+        }
+
+        if (intent == null) {
+            Toast.makeText(this, R.string.general_error, Toast.LENGTH_SHORT).show();
+            finish();
+            return;
+        }
+
+        setContentView(R.layout.activity_play_on_tv);
+
+        initView();
+        initBroadcastReceiver();
+        getVideoInfoFromIntent(intent);
+
+        sendRefreshIntent(false);
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+
+        Intent intent = new Intent(getApplicationContext(), PlayOnTvActivity.class)
+                .putExtra(VIDEO_ID, videoId);
+        outState.putParcelable(STATE_INTENT, intent);
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        if (DEBUG) Log.d(TAG, "onNewIntent() called with: intent = [" + intent + "]");
+        super.onNewIntent(intent);
+        getVideoInfoFromIntent(intent);
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+
+        LocalBroadcastManager broadcastManager = LocalBroadcastManager.getInstance(this);
+        broadcastManager.unregisterReceiver(serverListReceiver);
+        broadcastManager.unregisterReceiver(videoStartedReceiver);
+    }
+
+    private void sendRefreshIntent(boolean clearCache) {
+        if (DEBUG) Log.d(TAG, "sendRefreshIntent() called with: clearCache = [" + clearCache + "]");
+
+        Intent discoveryIntent = new Intent(this, DialService.class);
+        discoveryIntent.setAction(DialService.ACTION_DISCOVERY);
+        discoveryIntent.putExtra(DialService.EXTRA_CLEAR_CACHE, clearCache);
+        startService(discoveryIntent);
+
+        showLoadAnimation();
+    }
+
+    private void getVideoInfoFromIntent(Intent intent) {
+
+        videoId = intent.getStringExtra(VIDEO_ID);
+    }
+
+    private void initView() {
+
+        refreshButton = findViewById(R.id.refreshButton);
+        refreshButton.setOnClickListener(view -> sendRefreshIntent(true));
+
+        serverListAdapter = new ServerListAdapter(this, R.layout.list_tv_item);
+
+        serverList = findViewById(R.id.serverList);
+        serverList.setClickable(true);
+        serverList.setAdapter(serverListAdapter);
+        serverList.setOnItemClickListener(onServerItemClick());
+
+        progressBar = findViewById(R.id.progressBar);
+    }
+
+    private AdapterView.OnItemClickListener onServerItemClick() {
+
+        return (parent, view, position, id) -> {
+
+            DialServer selectedServer = (DialServer) serverList.getItemAtPosition(position);
+
+            if(DEBUG) Log.d(TAG, "Play video on tv [ server: "+ selectedServer.getServerDescription() +", videoId: " + videoId + "]");
+
+            Intent startIntent = new Intent(this, DialService.class);
+            startIntent.setAction(DialService.ACTION_START);
+            startIntent.putExtra(DialService.EXTRA_DIAL_SERVER, selectedServer);
+            startIntent.putExtra(DialService.EXTRA_VIDEO_ID, videoId);
+
+            startService(startIntent);
+            showLoadAnimation();
+        };
+    }
+
+    private void initBroadcastReceiver() {
+
+        serverListReceiver = createServerListReceiver();
+        videoStartedReceiver = createVideoStartedReceiver();
+
+        LocalBroadcastManager broadcastManager = LocalBroadcastManager.getInstance(this);
+
+        broadcastManager.registerReceiver(serverListReceiver, new IntentFilter(DialService.ACTION_DISCOVERY));
+        broadcastManager.registerReceiver(videoStartedReceiver, new IntentFilter(DialService.ACTION_START));
+    }
+
+    private BroadcastReceiver createServerListReceiver() {
+
+        return new BroadcastReceiver() {
+
+            @Override
+            public void onReceive(Context context, Intent intent) {
+
+                    List<DialServer> discoveredServers = (List<DialServer>) intent.getSerializableExtra(DialService.EXTRA_DIAL_SERVERS);
+                    showInList(discoveredServers);
+                    endLoadAnimation();
+            }
+        };
+    }
+
+    private BroadcastReceiver createVideoStartedReceiver() {
+
+        return new BroadcastReceiver() {
+
+            @Override
+            public void onReceive(Context context, Intent intent) {
+
+                endLoadAnimation();
+
+                if (intent.getBooleanExtra(DialService.EXTRA_VIDEO_STARTED, false)) {
+                    finish();
+                }
+            }
+        };
+    }
+
+    private void showInList(List<DialServer> discoveredServers) {
+
+        this.serverListAdapter.clear();
+        this.serverListAdapter.addAll(discoveredServers);
+    }
+
+    private void showLoadAnimation() {
+
+        refreshButton.setClickable(false);
+        progressBar.setVisibility(View.VISIBLE);
+    }
+
+    private void endLoadAnimation() {
+
+        refreshButton.setClickable(true);
+        progressBar.setVisibility(View.GONE);
+    }
+
+    private class ServerListAdapter extends ArrayAdapter<DialServer> {
+
+        ServerListAdapter(@NonNull Context context, int resource) {
+            super(context, resource);
+        }
+
+        @NonNull
+        @Override
+        public View getView(int position, View convertView, @NonNull ViewGroup parent) {
+
+            DialServer server = getItem(position);
+
+            if (convertView == null) {
+                convertView = LayoutInflater.from(getContext()).inflate(R.layout.list_tv_item, parent, false);
+            }
+
+            if (server != null) {
+
+                TextView tvName = convertView.findViewById(R.id.itemTvName);
+                TextView tvDescription = convertView.findViewById(R.id.itemTvDescription);
+
+                tvName.setText(server.getFriendlyName());
+                tvDescription.setText(server.getServerDescription());
+            }
+
+            return convertView;
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_play_on_tv.xml
+++ b/app/src/main/res/layout/activity_play_on_tv.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/black"
+    android:gravity="center">
+
+    <com.google.android.exoplayer2.ui.AspectRatioFrameLayout
+        android:id="@+id/aspectRatioLayout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_centerInParent="true"
+        android:layout_gravity="center">
+
+        <SurfaceView
+            android:id="@+id/surfaceView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_gravity="center" />
+
+
+        <View
+            android:id="@+id/surfaceForeground"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@android:color/black" />
+
+    </com.google.android.exoplayer2.ui.AspectRatioFrameLayout>
+
+    <RelativeLayout
+        android:id="@+id/playbackControlRoot"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="#64000000"
+        tools:visibility="visible">
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="?attr/queue_background_color"
+            tools:visibility="visible">
+
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="60dp"
+                android:id="@+id/serverListControls">
+
+                <LinearLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentLeft="true"
+                    android:layout_alignParentTop="true"
+                    android:gravity="top"
+                    android:orientation="vertical"
+                    android:paddingLeft="8dp"
+                    android:paddingRight="8dp"
+                    tools:ignore="RtlHardcoded">
+
+                    <TextView
+                        android:id="@+id/titleTextView"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:paddingTop="@dimen/play_on_tv_header_padding_top"
+                        android:paddingLeft="@dimen/play_on_tv_header_padding_left"
+                        android:paddingRight="@dimen/play_on_tv_header_padding_right"
+                        android:ellipsize="marquee"
+                        android:fadingEdge="horizontal"
+                        android:focusable="true"
+                        android:marqueeRepeatLimit="marquee_forever"
+                        android:scrollHorizontally="true"
+                        android:singleLine="true"
+                        android:textColor="@android:color/white"
+                        android:textSize="15sp"
+                        android:textStyle="bold"
+                        android:text="@string/play_on_tv"
+                        tools:ignore="RtlHardcoded"/>
+
+                </LinearLayout>
+
+                <ImageButton
+                    android:id="@+id/refreshButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentRight="true"
+                    android:layout_marginLeft="2dp"
+                    android:background="#00ffffff"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:padding="10dp"
+                    android:scaleType="fitXY"
+                    android:src="@android:drawable/ic_popup_sync"
+                    tools:ignore="ContentDescription,RtlHardcoded" />
+
+            </RelativeLayout>
+
+            <ProgressBar
+                android:id="@+id/progressBar"
+                style="?android:attr/progressBarStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerHorizontal="true"
+                android:layout_centerVertical="true"/>
+
+            <ListView
+                android:id="@+id/serverList"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_below="@id/serverListControls"
+                android:choiceMode="singleChoice"
+                android:scrollbars="vertical"
+                tools:listitem="@layout/list_tv_item"/>
+
+        </RelativeLayout>
+
+    </RelativeLayout>
+
+</RelativeLayout>

--- a/app/src/main/res/layout/list_tv_item.xml
+++ b/app/src/main/res/layout/list_tv_item.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/selectableItemBackground"
+    android:padding="@dimen/play_on_tv_item_padding">
+
+    <TextView
+        android:id="@+id/itemTvName"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:textAppearance="?android:attr/textAppearanceLarge"
+        android:textSize="@dimen/play_on_tv_item_text_size"
+        android:lines="1"
+        tools:text="LG Smart TV" />
+    <TextView
+        android:id="@+id/itemTvDescription"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/itemTvName"
+        android:lines="1"
+        android:ellipsize="end"
+        android:textAppearance="?android:attr/textAppearanceSmall"
+        android:textSize="@dimen/play_on_tv_item_text_size_small"
+        tools:text="Linux 3.11, LG Smart TV v. 1.0" />
+</RelativeLayout>

--- a/app/src/main/res/menu/video_detail_menu.xml
+++ b/app/src/main/res/menu/video_detail_menu.xml
@@ -24,4 +24,9 @@
         android:id="@+id/menu_item_openInBrowser"
         android:title="@string/open_in_browser"
         app:showAsAction="never"/>
+
+    <item
+        android:id="@+id/menu_item_playOnTv"
+        android:title="@string/play_on_tv"
+        app:showAsAction="never"/>
 </menu>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -300,4 +300,5 @@
     <string name="website_title">Website</string>
     <string name="website_encouragement">Um mehr Informationen und die aktuellsten Nachrichten über NewPipe zu bekommen, besuche unsere Website.</string>
     <string name="donation_encouragement">NewPipe wird von Freiwilligen entwickelt, die ihre Freizeit damit verbringen, dir das beste Erlebnis zu bieten. Jetzt ist es an der Zeit, etwas zurückzugeben, um sicherzustellen, dass unsere Entwickler NewPipe noch besser machen können, während sie eine Tasse Java genießen!</string>
+    <string name="play_on_tv">Auf TV wiedergeben</string>
     </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -75,4 +75,14 @@
 
     <!-- Kiosk view Dimensions-->
     <dimen name="kiosk_title_text_size">30sp</dimen>
+
+    <!-- Play on TV Dimensions-->
+    <dimen name="play_on_tv_header_padding_top">18dp</dimen>
+    <dimen name="play_on_tv_header_padding_left">10dp</dimen>
+    <dimen name="play_on_tv_header_padding_right">10dp</dimen>
+    <dimen name="play_on_tv_item_text_size">16sp</dimen>
+    <dimen name="play_on_tv_item_text_size_small">14sp</dimen>
+    <dimen name="play_on_tv_item_padding">8dp</dimen>
+    <dimen name="play_on_tv_progressbar">50dp</dimen>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -331,6 +331,7 @@
     <string name="start_here_on_background">Start Here on Background</string>
     <string name="start_here_on_popup">Start Here on Popup</string>
 
+    <!-- Drawer -->
     <string name="drawer_open">Open Drawer</string>
     <string name="drawer_close">Close Drawer</string>
     <string name="youtube" translatable="false">YouTube</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -331,9 +331,11 @@
     <string name="start_here_on_background">Start Here on Background</string>
     <string name="start_here_on_popup">Start Here on Popup</string>
 
-    <!-- Drawer -->
     <string name="drawer_open">Open Drawer</string>
     <string name="drawer_close">Close Drawer</string>
     <string name="youtube" translatable="false">YouTube</string>
     <string name="soundcloud" translatable="false">SoundCloud</string>
+    
+    <!-- Play on TV -->
+    <string name="play_on_tv">Play on TV</string>
 </resources>


### PR DESCRIPTION
I would like to contribute the feature to play videos on smart TVs.

Netflix and Youtube created the DIAL protocol specification that describes the communication with apps installed on a smart TV (http://www.dial-multiscreen.org/).

On the video detail screen I added an entry to the menu header. In English it is "Play on TV", in german "Auf TV wiedergeben".

<img src="https://user-images.githubusercontent.com/5504749/35198950-e2f4f4ea-fef6-11e7-8e22-b6f24b86469d.png" height="450">

This item opens an activity showing the discovered DIAL-Servers:

<img src="https://user-images.githubusercontent.com/5504749/35198978-38a8de7e-fef7-11e7-921e-96ee97acaeae.png" height="450">

Clicking on one of the discovered servers sends a play request to the Youtube app on the TV.

For implementing this feature I added a dependency to my DIAL client library JDial: https://github.com/detached/jdial
The library has no dependency to other libraries and is licensed under GPL v3.

The discovery of DIAL-Servers in the local network requires enabling multicast support in the wifi stack of the android device. For that I added the permission `CHANGE_WIFI_MULTICAST_STATE`.

I didn't found a refresh icon in your code base and I was not sure about your style guide and policies for adding content to the code. So I just used the stock android sync icon for this purpose.

I am not a experienced android developer, so please have a critical look at this code.

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.