### PR TITLE
Leak Canary

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -89,4 +89,8 @@ dependencies {
 
     implementation 'frankiesardo:icepick:3.2.0'
     annotationProcessor 'frankiesardo:icepick-processor:3.2.0'
+
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:1.5.4'
+    betaImplementation 'com.squareup.leakcanary:leakcanary-android-no-op:1.5.4'
+    releaseImplementation 'com.squareup.leakcanary:leakcanary-android-no-op:1.5.4'
 }

--- a/app/src/debug/java/org/schabi/newpipe/DebugApp.java
+++ b/app/src/debug/java/org/schabi/newpipe/DebugApp.java
@@ -4,6 +4,10 @@ import android.content.Context;
 import android.support.multidex.MultiDex;
 
 import com.facebook.stetho.Stetho;
+import com.squareup.leakcanary.LeakCanary;
+import com.squareup.leakcanary.RefWatcher;
+
+import java.util.concurrent.TimeUnit;
 
 public class DebugApp extends App {
     private static final String TAG = DebugApp.class.toString();
@@ -40,5 +44,12 @@ public class DebugApp extends App {
 
         // Initialize Stetho with the Initializer
         Stetho.initialize(initializer);
+    }
+
+    @Override
+    protected RefWatcher installLeakCanary() {
+        return LeakCanary.refWatcher(this)
+                .watchDelay(5, TimeUnit.SECONDS)
+                .buildAndInstall();
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/App.java
+++ b/app/src/main/java/org/schabi/newpipe/App.java
@@ -5,6 +5,7 @@ import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.content.Context;
 import android.os.Build;
+import android.support.annotation.Nullable;
 import android.util.Log;
 
 import com.nostra13.universalimageloader.cache.memory.impl.LRULimitedMemoryCache;
@@ -167,6 +168,7 @@ public class App extends Application {
         mNotificationManager.createNotificationChannel(mChannel);
     }
 
+    @Nullable
     public static RefWatcher getRefWatcher(Context context) {
         final App application = (App) context.getApplicationContext();
         return application.refWatcher;

--- a/app/src/main/java/org/schabi/newpipe/App.java
+++ b/app/src/main/java/org/schabi/newpipe/App.java
@@ -10,6 +10,8 @@ import android.util.Log;
 import com.nostra13.universalimageloader.cache.memory.impl.LRULimitedMemoryCache;
 import com.nostra13.universalimageloader.core.ImageLoader;
 import com.nostra13.universalimageloader.core.ImageLoaderConfiguration;
+import com.squareup.leakcanary.LeakCanary;
+import com.squareup.leakcanary.RefWatcher;
 
 import org.acra.ACRA;
 import org.acra.config.ACRAConfiguration;
@@ -54,6 +56,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 public class App extends Application {
     protected static final String TAG = App.class.toString();
+    private RefWatcher refWatcher;
 
     @SuppressWarnings("unchecked")
     private static final Class<? extends ReportSenderFactory>[] reportSenderFactoryClasses = new Class[]{AcraReportSenderFactory.class};
@@ -68,6 +71,13 @@ public class App extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
+
+        if (LeakCanary.isInAnalyzerProcess(this)) {
+            // This process is dedicated to LeakCanary for heap analysis.
+            // You should not init your app in this process.
+            return;
+        }
+        refWatcher = installLeakCanary();
 
         // Initialize settings first because others inits can use its values
         SettingsActivity.initSettings(this);
@@ -157,4 +167,12 @@ public class App extends Application {
         mNotificationManager.createNotificationChannel(mChannel);
     }
 
+    public static RefWatcher getRefWatcher(Context context) {
+        final App application = (App) context.getApplicationContext();
+        return application.refWatcher;
+    }
+
+    protected RefWatcher installLeakCanary() {
+        return RefWatcher.DISABLED;
+    }
 }

--- a/app/src/main/java/org/schabi/newpipe/BaseFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/BaseFragment.java
@@ -71,8 +71,9 @@ public abstract class BaseFragment extends Fragment {
     @Override
     public void onDestroy() {
         super.onDestroy();
+
         RefWatcher refWatcher = App.getRefWatcher(getActivity());
-        refWatcher.watch(this);
+        if (refWatcher != null) refWatcher.watch(this);
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/app/src/main/java/org/schabi/newpipe/BaseFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/BaseFragment.java
@@ -13,6 +13,7 @@ import android.view.View;
 import com.nostra13.universalimageloader.core.DisplayImageOptions;
 import com.nostra13.universalimageloader.core.ImageLoader;
 import com.nostra13.universalimageloader.core.display.FadeInBitmapDisplayer;
+import com.squareup.leakcanary.RefWatcher;
 
 import icepick.Icepick;
 
@@ -65,6 +66,13 @@ public abstract class BaseFragment extends Fragment {
     }
 
     protected void onRestoreInstanceState(@NonNull Bundle savedInstanceState) {
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        RefWatcher refWatcher = App.getRefWatcher(getActivity());
+        refWatcher.watch(this);
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -211,6 +211,12 @@ public class MainActivity extends AppCompatActivity {
         }
     }
 
+    private void onHeapDumpToggled(@NonNull MenuItem item) {
+        final boolean newToggleState = !item.isChecked();
+        sharedPreferences.edit().putBoolean(getString(R.string.allow_heap_dumping_key),
+                newToggleState).apply();
+        item.setChecked(newToggleState);
+    }
     /*//////////////////////////////////////////////////////////////////////////
     // Menu
     //////////////////////////////////////////////////////////////////////////*/
@@ -232,6 +238,10 @@ public class MainActivity extends AppCompatActivity {
             inflater.inflate(R.menu.main_menu, menu);
         }
 
+        if (DEBUG) {
+            getMenuInflater().inflate(R.menu.debug_menu, menu);
+        }
+
         ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
             actionBar.setDisplayHomeAsUpEnabled(false);
@@ -240,6 +250,17 @@ public class MainActivity extends AppCompatActivity {
         updateDrawerNavigation();
 
         return true;
+    }
+
+    @Override
+    public boolean onPrepareOptionsMenu(Menu menu) {
+        MenuItem heapDumpToggle = menu.findItem(R.id.action_toggle_heap_dump);
+        if (heapDumpToggle != null) {
+            final boolean isToggled = sharedPreferences.getBoolean(
+                    getString(R.string.allow_heap_dumping_key), false);
+            heapDumpToggle.setChecked(isToggled);
+        }
+        return super.onPrepareOptionsMenu(menu);
     }
 
     @Override
@@ -261,6 +282,9 @@ public class MainActivity extends AppCompatActivity {
                 return true;
             case R.id.action_history:
                 NavigationHelper.openHistory(this);
+                return true;
+            case R.id.action_toggle_heap_dump:
+                onHeapDumpToggled(item);
                 return true;
             default:
                 return super.onOptionsItemSelected(item);

--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -27,6 +27,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.preference.PreferenceManager;
+import android.support.annotation.NonNull;
 import android.support.design.widget.NavigationView;
 import android.support.v4.app.Fragment;
 import android.support.v4.view.GravityCompat;
@@ -217,7 +218,8 @@ public class MainActivity extends AppCompatActivity {
     private void onHeapDumpToggled(@NonNull MenuItem item) {
         final boolean isHeapDumpEnabled = !item.isChecked();
 
-        sharedPreferences.edit().putBoolean(getString(R.string.allow_heap_dumping_key), isHeapDumpEnabled).apply();
+        PreferenceManager.getDefaultSharedPreferences(this).edit()
+                .putBoolean(getString(R.string.allow_heap_dumping_key), isHeapDumpEnabled).apply();
         item.setChecked(isHeapDumpEnabled);
 
         final String heapDumpNotice;
@@ -267,8 +269,8 @@ public class MainActivity extends AppCompatActivity {
     public boolean onPrepareOptionsMenu(Menu menu) {
         MenuItem heapDumpToggle = menu.findItem(R.id.action_toggle_heap_dump);
         if (heapDumpToggle != null) {
-            final boolean isToggled = sharedPreferences.getBoolean(
-                    getString(R.string.allow_heap_dumping_key), false);
+            final boolean isToggled = PreferenceManager.getDefaultSharedPreferences(this)
+                    .getBoolean(getString(R.string.allow_heap_dumping_key), false);
             heapDumpToggle.setChecked(isToggled);
         }
         return super.onPrepareOptionsMenu(menu);

--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -20,6 +20,7 @@
 
 package org.schabi.newpipe;
 
+import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
@@ -39,6 +40,7 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
+import android.widget.Toast;
 
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.fragments.BackPressable;
@@ -211,11 +213,20 @@ public class MainActivity extends AppCompatActivity {
         }
     }
 
+    @SuppressLint("ShowToast")
     private void onHeapDumpToggled(@NonNull MenuItem item) {
-        final boolean newToggleState = !item.isChecked();
-        sharedPreferences.edit().putBoolean(getString(R.string.allow_heap_dumping_key),
-                newToggleState).apply();
-        item.setChecked(newToggleState);
+        final boolean isHeapDumpEnabled = !item.isChecked();
+
+        sharedPreferences.edit().putBoolean(getString(R.string.allow_heap_dumping_key), isHeapDumpEnabled).apply();
+        item.setChecked(isHeapDumpEnabled);
+
+        final String heapDumpNotice;
+        if (isHeapDumpEnabled) {
+            heapDumpNotice = getString(R.string.enable_leak_canary_notice);
+        } else {
+            heapDumpNotice = getString(R.string.disable_leak_canary_notice);
+        }
+        Toast.makeText(getApplicationContext(), heapDumpNotice, Toast.LENGTH_SHORT).show();
     }
     /*//////////////////////////////////////////////////////////////////////////
     // Menu

--- a/app/src/main/res/menu/debug_menu.xml
+++ b/app/src/main/res/menu/debug_menu.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item android:id="@+id/action_toggle_heap_dump"
+        android:orderInCategory="9999"
+        android:checkable="true"
+        android:title="@string/toggle_leak_canary"
+        android:visible="true"
+        app:showAsAction="never"/>
+
+</menu>

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -83,6 +83,9 @@
 
     <string name="last_orientation_landscape_key" translatable="false">last_orientation_landscape_key</string>
 
+    <!-- DEBUG ONLY -->
+    <string name="allow_heap_dumping_key" translatable="false">allow_heap_dumping_key</string>
+
     <!-- THEMES -->
     <string name="theme_key" translatable="false">theme</string>
     <string name="light_theme_key" translatable="false">light_theme</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -397,5 +397,7 @@
     <string name="playlist_delete_failure">Failed to delete playlist</string>
 
     <!-- Debug Only -->
-    <string name="toggle_leak_canary">Leak Canary</string>
+    <string name="toggle_leak_canary">Monitor Leaks</string>
+    <string name="enable_leak_canary_notice">Memory leak monitoring enabled, app may become unresponsive when heap dumping</string>
+    <string name="disable_leak_canary_notice">Memory leak monitoring disabled</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -395,4 +395,7 @@
     <string name="playlist_add_stream_success">Added to playlist</string>
     <string name="playlist_thumbnail_change_success">Playlist thumbnail changed</string>
     <string name="playlist_delete_failure">Failed to delete playlist</string>
+
+    <!-- Debug Only -->
+    <string name="toggle_leak_canary">Leak Canary</string>
 </resources>


### PR DESCRIPTION
This PR adds LeakCanary for detecting memory leaks.

<img src="https://user-images.githubusercontent.com/5570482/35997880-c68f57aa-0ccf-11e8-8a47-bfed4df48b0d.png" width="200">

As you can see, we have many things that needs patching up. Even though these leaks are small, they can quickly add up on older devices. The only downside to this is the dependency dumps the heap from time to time and will hog the app for a few seconds, hence why it is debug build only. 