### PR TITLE
Media Button Play/Pause, Previous and Next in Background Player

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,6 +43,12 @@
             android:launchMode="singleTask"
             android:label="@string/title_activity_background_player"/>
 
+        <receiver android:name="org.schabi.newpipe.player.BackgroundPlayer$MediaButtonReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.MEDIA_BUTTON" />
+            </intent-filter>
+        </receiver>
+
         <activity
             android:name=".player.PopupVideoPlayerActivity"
             android:launchMode="singleTask"

--- a/app/src/main/java/org/schabi/newpipe/player/BackgroundPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/BackgroundPlayer.java
@@ -591,7 +591,7 @@ public final class BackgroundPlayer extends Service {
                         pendingIntent = PendingIntent.getBroadcast(context, NOTIFICATION_ID, new Intent(ACTION_PLAY_NEXT), PendingIntent.FLAG_UPDATE_CURRENT);
                     } else if (keycode == KeyEvent.KEYCODE_MEDIA_PREVIOUS) {
                         pendingIntent = PendingIntent.getBroadcast(context, NOTIFICATION_ID, new Intent(ACTION_PLAY_PREVIOUS), PendingIntent.FLAG_UPDATE_CURRENT);
-                    } else if (keycode == KeyEvent.KEYCODE_HEADSETHOOK) {
+                    } else if (keycode == KeyEvent.KEYCODE_HEADSETHOOK || keycode == KeyEvent.KEYCODE_MEDIA_PAUSE || keycode == KeyEvent.KEYCODE_MEDIA_PLAY) {
                         pendingIntent = PendingIntent.getBroadcast(context, NOTIFICATION_ID, new Intent(ACTION_PLAY_PAUSE), PendingIntent.FLAG_UPDATE_CURRENT);
                     } else if (keycode == KeyEvent.KEYCODE_MEDIA_FAST_FORWARD) {
                         pendingIntent = PendingIntent.getBroadcast(context, NOTIFICATION_ID, new Intent(ACTION_FAST_FORWARD), PendingIntent.FLAG_UPDATE_CURRENT);

--- a/app/src/main/java/org/schabi/newpipe/player/BackgroundPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/BackgroundPlayer.java
@@ -152,6 +152,7 @@ public final class BackgroundPlayer extends Service {
             lockManager.releaseWifiAndCpu();
         }
         if (basePlayerImpl != null) {
+            basePlayerImpl.audioReactor.unregisterMediaButtonEventReceiver(mReceiverComponent);
             basePlayerImpl.stopActivityBinding();
             basePlayerImpl.destroy();
         }
@@ -159,8 +160,6 @@ public final class BackgroundPlayer extends Service {
         mBinder = null;
         basePlayerImpl = null;
         lockManager = null;
-
-        basePlayerImpl.audioReactor.unregisterMediaButtonEventReceiver(mReceiverComponent);
 
         stopForeground(true);
         stopSelf();
@@ -594,6 +593,10 @@ public final class BackgroundPlayer extends Service {
                         pendingIntent = PendingIntent.getBroadcast(context, NOTIFICATION_ID, new Intent(ACTION_PLAY_PREVIOUS), PendingIntent.FLAG_UPDATE_CURRENT);
                     } else if (keycode == KeyEvent.KEYCODE_HEADSETHOOK) {
                         pendingIntent = PendingIntent.getBroadcast(context, NOTIFICATION_ID, new Intent(ACTION_PLAY_PAUSE), PendingIntent.FLAG_UPDATE_CURRENT);
+                    } else if (keycode == KeyEvent.KEYCODE_MEDIA_FAST_FORWARD) {
+                        pendingIntent = PendingIntent.getBroadcast(context, NOTIFICATION_ID, new Intent(ACTION_FAST_FORWARD), PendingIntent.FLAG_UPDATE_CURRENT);
+                    } else if (keycode == KeyEvent.KEYCODE_MEDIA_REWIND) {
+                        pendingIntent = PendingIntent.getBroadcast(context, NOTIFICATION_ID, new Intent(ACTION_FAST_REWIND), PendingIntent.FLAG_UPDATE_CURRENT);
                     }
                     if (pendingIntent != null) {
                         try {

--- a/app/src/main/java/org/schabi/newpipe/player/BackgroundPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/BackgroundPlayer.java
@@ -28,7 +28,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.graphics.Bitmap;
-import android.media.AudioManager;
 import android.os.Build;
 import android.os.IBinder;
 import android.support.annotation.IntRange;
@@ -82,7 +81,6 @@ public final class BackgroundPlayer extends Service {
     private BasePlayerImpl basePlayerImpl;
     private LockManager lockManager;
 
-    private AudioManager mAudioManager;
     private ComponentName mReceiverComponent;
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -122,9 +120,8 @@ public final class BackgroundPlayer extends Service {
         mBinder = new PlayerServiceBinder(basePlayerImpl);
         shouldUpdateOnProgress = true;
 
-        mAudioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
         mReceiverComponent = new ComponentName(this, MediaButtonReceiver.class);
-        mAudioManager.registerMediaButtonEventReceiver(mReceiverComponent);
+        basePlayerImpl.audioReactor.registerMediaButtonEventReceiver(mReceiverComponent);
     }
 
     @Override
@@ -163,7 +160,7 @@ public final class BackgroundPlayer extends Service {
         basePlayerImpl = null;
         lockManager = null;
 
-        mAudioManager.unregisterMediaButtonEventReceiver(mReceiverComponent);
+        basePlayerImpl.audioReactor.unregisterMediaButtonEventReceiver(mReceiverComponent);
 
         stopForeground(true);
         stopSelf();

--- a/app/src/main/java/org/schabi/newpipe/player/helper/AudioReactor.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/AudioReactor.java
@@ -88,10 +88,18 @@ public class AudioReactor implements AudioManager.OnAudioFocusChangeListener, Au
     }
 
     public void registerMediaButtonEventReceiver(ComponentName componentName) {
+        if (android.os.Build.VERSION.SDK_INT > 27) {
+            Log.e(TAG, "registerMediaButtonEventReceiver has been deprecated and maybe not supported anymore.");
+            return;
+        }
         audioManager.registerMediaButtonEventReceiver(componentName);
     }
 
     public void unregisterMediaButtonEventReceiver(ComponentName componentName) {
+        if (android.os.Build.VERSION.SDK_INT > 27) {
+            Log.e(TAG, "unregisterMediaButtonEventReceiver has been deprecated and maybe not supported anymore.");
+            return;
+        }
         audioManager.unregisterMediaButtonEventReceiver(componentName);
     }
 

--- a/app/src/main/java/org/schabi/newpipe/player/helper/AudioReactor.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/AudioReactor.java
@@ -3,6 +3,7 @@ package org.schabi.newpipe.player.helper;
 import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
 import android.animation.ValueAnimator;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.media.AudioFocusRequest;
@@ -84,6 +85,14 @@ public class AudioReactor implements AudioManager.OnAudioFocusChangeListener, Au
 
     private boolean shouldBuildFocusRequest() {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.O;
+    }
+
+    public void registerMediaButtonEventReceiver(ComponentName componentName) {
+        audioManager.registerMediaButtonEventReceiver(componentName);
+    }
+
+    public void unregisterMediaButtonEventReceiver(ComponentName componentName) {
+        audioManager.unregisterMediaButtonEventReceiver(componentName);
     }
 
     /*//////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

I've just added a MediaButtonReceiver which handles Play/Pause Next and Previous actions in the background player.
So basically now you can control the player from headset buttons which I found really conveniant.
