### PR TITLE
make click on metadata open info screen

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/ServicePlayerActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ServicePlayerActivity.java
@@ -438,9 +438,6 @@ public abstract class ServicePlayerActivity extends AppCompatActivity
         } else if (view.getId() == playbackPitchButton.getId()) {
             openPlaybackParameterDialog();
 
-        } else if (view.getId() == metadata.getId()) {
-            scrollToSelected();
-
         } else if (view.getId() == progressLiveSync.getId()) {
             player.seekToDefault();
 
@@ -520,10 +517,12 @@ public abstract class ServicePlayerActivity extends AppCompatActivity
     }
 
     @Override
-    public void onMetadataUpdate(StreamInfo info) {
+    public void onMetadataUpdate(final StreamInfo info) {
         if (info != null) {
             metadataTitle.setText(info.getName());
             metadataArtist.setText(info.getUploaderName());
+            metadata.setOnClickListener(view ->
+                    onOpenDetail(info.getServiceId(), info.getUrl(), info.getName()));
 
             progressEndTime.setVisibility(View.GONE);
             progressLiveSync.setVisibility(View.GONE);


### PR DESCRIPTION
@karyogamy  



> I wouldn't do this, since the service player activity is a singleTask and is separate from the main activity, so if you open the service player activity while inside the app, and then open the detail fragment, you won't be able to return to the service activity when back button is pressed. Having an easily accessible button open detail fragment will just cause more inconveniences.

> It would be better if we create another button on the player activity to expand a description view, or just make this activity a fragment, so it can be on the fragment stack.
