### PR TITLE
Handle links with time specified (ex. &t=xxx)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,7 +54,7 @@ dependencies {
         exclude module: 'support-annotations'
     }
 
-    implementation 'com.github.TeamNewPipe:NewPipeExtractor:a6b6235644474'
+    implementation 'com.github.TeamNewPipe:NewPipeExtractor:77a74b8'
 
 
     testImplementation 'junit:junit:4.12'

--- a/app/src/main/java/org/schabi/newpipe/RouterActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/RouterActivity.java
@@ -122,7 +122,7 @@ public class RouterActivity extends AppCompatActivity {
                         currentService = NewPipe.getServiceByUrl(url);
                         currentServiceId = currentService.getServiceId();
                         currentLinkType = currentService.getLinkTypeByUrl(url);
-                        currentUrl = NavigationHelper.getCleanUrl(currentService, url, currentLinkType);
+                        currentUrl = url;
                     } else {
                         currentService = NewPipe.getService(currentServiceId);
                     }
@@ -307,7 +307,8 @@ public class RouterActivity extends AppCompatActivity {
         // StreamDetailFragment can fetch data itself
         if(playerChoiceKey.equals(getString(R.string.show_info_key))) {
             disposables.add(Observable
-                    .fromCallable(() -> NavigationHelper.getIntentByLink(this, currentUrl))
+                    .fromCallable(() -> NavigationHelper.getIntentByLink(this,
+                            NavigationHelper.getCleanUrl(currentService, currentUrl, currentLinkType)))
                     .subscribeOn(Schedulers.io())
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe(intent -> {

--- a/app/src/main/java/org/schabi/newpipe/RouterActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/RouterActivity.java
@@ -307,8 +307,7 @@ public class RouterActivity extends AppCompatActivity {
         // StreamDetailFragment can fetch data itself
         if(playerChoiceKey.equals(getString(R.string.show_info_key))) {
             disposables.add(Observable
-                    .fromCallable(() -> NavigationHelper.getIntentByLink(this,
-                            NavigationHelper.getCleanUrl(currentService, currentUrl, currentLinkType)))
+                    .fromCallable(() -> NavigationHelper.getIntentByLink(this, currentUrl))
                     .subscribeOn(Schedulers.io())
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe(intent -> {

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -70,7 +70,6 @@ import org.schabi.newpipe.player.helper.PlayerHelper;
 import org.schabi.newpipe.player.old.PlayVideoActivity;
 import org.schabi.newpipe.playlist.PlayQueue;
 import org.schabi.newpipe.playlist.SinglePlayQueue;
-import org.schabi.newpipe.report.ErrorActivity;
 import org.schabi.newpipe.report.UserAction;
 import org.schabi.newpipe.util.Constants;
 import org.schabi.newpipe.util.ExtractorHelper;
@@ -205,7 +204,7 @@ public class VideoDetailFragment
     }
 
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         return inflater.inflate(R.layout.fragment_video_detail, container, false);
     }
 
@@ -681,15 +680,15 @@ public class VideoDetailFragment
         int id = item.getItemId();
         switch (id) {
             case R.id.menu_item_share: {
-                if(currentInfo != null) {
-                    shareUrl(currentInfo.getName(), url);
-                } else {
-                    shareUrl(url, url);
+                if (currentInfo != null) {
+                    shareUrl(currentInfo.getName(), currentInfo.getUrl());
                 }
                 return true;
             }
             case R.id.menu_item_openInBrowser: {
-                openUrlInBrowser(url);
+                if (currentInfo != null) {
+                    openUrlInBrowser(currentInfo.getUrl());
+                }
                 return true;
             }
             case R.id.action_play_with_kodi:
@@ -818,7 +817,7 @@ public class VideoDetailFragment
     public void prepareAndHandleInfo(final StreamInfo info, boolean scrollToTop) {
         if (DEBUG) Log.d(TAG, "prepareAndHandleInfo() called with: info = [" + info + "], scrollToTop = [" + scrollToTop + "]");
 
-        setInitialData(info.getServiceId(), info.getUrl(), info.getName());
+        setInitialData(info.getServiceId(), info.getOriginalUrl(), info.getName());
         pushToStack(serviceId, url, name);
         showLoading();
 
@@ -1112,7 +1111,7 @@ public class VideoDetailFragment
     public void handleResult(@NonNull StreamInfo info) {
         super.handleResult(info);
 
-        setInitialData(info.getServiceId(), info.getUrl(), info.getName());
+        setInitialData(info.getServiceId(), info.getOriginalUrl(), info.getName());
         pushToStack(serviceId, url, name);
 
         animateView(thumbnailPlayButton, true, 200);
@@ -1192,7 +1191,9 @@ public class VideoDetailFragment
             toggleExpandRelatedVideos(currentInfo);
             wasRelatedStreamsExpanded = false;
         }
+
         setTitleToUrl(info.getServiceId(), info.getUrl(), info.getName());
+        setTitleToUrl(info.getServiceId(), info.getOriginalUrl(), info.getName());
 
         if (!info.getErrors().isEmpty()) {
             showSnackBarError(info.getErrors(),

--- a/app/src/main/java/org/schabi/newpipe/playlist/PlayQueueItem.java
+++ b/app/src/main/java/org/schabi/newpipe/playlist/PlayQueueItem.java
@@ -29,11 +29,13 @@ public class PlayQueueItem implements Serializable {
     private Throwable error;
 
     private transient Single<StreamInfo> stream;
+    private StreamInfo info;
 
     PlayQueueItem(@NonNull final StreamInfo info) {
         this(info.getName(), info.getUrl(), info.getServiceId(), info.getDuration(),
                 info.getThumbnailUrl(), info.getUploaderName(), info.getStreamType());
         this.stream = Single.just(info);
+        this.info = info;
     }
 
     PlayQueueItem(@NonNull final StreamInfoItem item) {
@@ -105,7 +107,13 @@ public class PlayQueueItem implements Serializable {
 
     @NonNull
     private Single<StreamInfo> getInfo() {
-        return ExtractorHelper.getStreamInfo(this.serviceId, this.url, false)
+        Single<StreamInfo> single;
+        if (this.info != null){
+            single = Single.just(info);
+        } else {
+            single = ExtractorHelper.getStreamInfo(this.serviceId, this.url, false);
+        }
+        return single
                 .subscribeOn(Schedulers.io())
                 .doOnError(throwable -> error = throwable);
     }

--- a/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
@@ -475,7 +475,6 @@ public class NavigationHelper {
             throw new ExtractionException("Url not known to service. service=" + service + " url=" + url);
         }
 
-        url = getCleanUrl(service, url, linkType);
         Intent rIntent = getOpenIntent(context, url, service.getServiceId(), linkType);
 
         switch (linkType) {
@@ -486,20 +485,6 @@ public class NavigationHelper {
         }
 
         return rIntent;
-    }
-
-    public static String getCleanUrl(StreamingService service, String dirtyUrl, StreamingService.LinkType linkType) throws ExtractionException {
-        switch (linkType) {
-            case STREAM:
-                return service.getStreamUrlIdHandler().cleanUrl(dirtyUrl);
-            case CHANNEL:
-                return service.getChannelUrlIdHandler().cleanUrl(dirtyUrl);
-            case PLAYLIST:
-                return service.getPlaylistUrlIdHandler().cleanUrl(dirtyUrl);
-            case NONE:
-                break;
-        }
-        return null;
     }
 
     private static Uri openMarketUrl(String packageName) {


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

Issue #861 

This fixes the starting time for videos opened in the video player. This wasn't working before because:
1. The url was cleaned immediately upon opening, removing the time info. This isn't necessary because NewPipeExtractor should clean urls on its own anyways
2. PlayQueueItem used a transient Single to store the StreamInfo, and it regenerated the Single with only the url, not all of the information.

I fixed these issues by not cleaning the url initially, and storing StreamInfo with PlayQueueItems. This solution works for links opened with the Background, Video, and Popup players.

I've tested this change with a variety of link types and it works with youtube and soundcloud links