### PR TITLE
Settings export

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
@@ -197,7 +197,7 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
                             new FileOutputStream(path)));
             ZipHelper.addFileToZip(outZip, newpipe_db.getPath(), "newpipe.db");
             ZipHelper.addFileToZip(outZip, newpipe_db_journal.getPath(), "newpipe.db-journal");
-
+            //add settings
             outZip.close();
 
             Toast.makeText(getContext(), R.string.export_complete_toast, Toast.LENGTH_SHORT)

--- a/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
@@ -4,7 +4,9 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.preference.ListPreference;
@@ -30,14 +32,20 @@ import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
+import java.util.Map;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
+
+import static android.content.Context.MODE_PRIVATE;
 
 public class ContentSettingsFragment extends BasePreferenceFragment {
 
@@ -48,6 +56,7 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
     private File databasesDir;
     private File newpipe_db;
     private File newpipe_db_journal;
+    private File newpipe_settings;
 
     private String thumbnailLoadToggleKey;
 
@@ -79,6 +88,8 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
         databasesDir = new File(homeDir + "/databases");
         newpipe_db = new File(homeDir + "/databases/newpipe.db");
         newpipe_db_journal = new File(homeDir + "/databases/newpipe.db-journal");
+        newpipe_settings = new File(homeDir + "/databases/newpipe.settings");
+        newpipe_settings.delete();
 
         addPreferencesFromResource(R.xml.content_settings);
 
@@ -174,19 +185,19 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
 
         if ((requestCode == REQUEST_IMPORT_PATH || requestCode == REQUEST_EXPORT_PATH)
                 && resultCode == Activity.RESULT_OK && data.getData() != null) {
-                String path = Utils.getFileForUri(data.getData()).getAbsolutePath();
-                if (requestCode == REQUEST_EXPORT_PATH) {
-                    SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US);
-                    exportDatabase(path + "/NewPipeData-" + sdf.format(new Date()) + ".zip");
-                } else {
-                    AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-                    builder.setMessage(R.string.override_current_data)
-                            .setPositiveButton(android.R.string.ok,
-                                    (DialogInterface d, int id) -> importDatabase(path))
-                            .setNegativeButton(android.R.string.cancel,
-                                    (DialogInterface d, int id) -> d.cancel());
-                    builder.create().show();
-                }
+            String path = Utils.getFileForUri(data.getData()).getAbsolutePath();
+            if (requestCode == REQUEST_EXPORT_PATH) {
+                SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US);
+                exportDatabase(path + "/NewPipeData-" + sdf.format(new Date()) + ".zip");
+            } else {
+                AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+                builder.setMessage(R.string.override_current_data)
+                        .setPositiveButton(android.R.string.ok,
+                                (DialogInterface d, int id) -> importDatabase(path))
+                        .setNegativeButton(android.R.string.cancel,
+                                (DialogInterface d, int id) -> d.cancel());
+                builder.create().show();
+            }
         }
     }
 
@@ -197,13 +208,38 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
                             new FileOutputStream(path)));
             ZipHelper.addFileToZip(outZip, newpipe_db.getPath(), "newpipe.db");
             ZipHelper.addFileToZip(outZip, newpipe_db_journal.getPath(), "newpipe.db-journal");
-            //add settings
+            saveSharedPreferencesToFile(newpipe_settings);
+            ZipHelper.addFileToZip(outZip, newpipe_settings.getPath(), "newpipe.settings");
+
             outZip.close();
 
             Toast.makeText(getContext(), R.string.export_complete_toast, Toast.LENGTH_SHORT)
                     .show();
         } catch (Exception e) {
             onError(e);
+        }
+    }
+
+    private void saveSharedPreferencesToFile(File dst) {
+        ObjectOutputStream output = null;
+        try {
+            output = new ObjectOutputStream(new FileOutputStream(dst));
+            SharedPreferences pref = PreferenceManager.getDefaultSharedPreferences(getContext());
+            output.writeObject(pref.getAll());
+
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }finally {
+            try {
+                if (output != null) {
+                    output.flush();
+                    output.close();
+                }
+            } catch (IOException ex) {
+                ex.printStackTrace();
+            }
         }
     }
 
@@ -223,27 +259,86 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
         }
 
         try {
-            ZipInputStream zipIn = new ZipInputStream(
-                    new BufferedInputStream(
-                            new FileInputStream(filePath)));
-
             if (!databasesDir.exists() && !databasesDir.mkdir()) {
                 throw new Exception("Could not create databases dir");
             }
 
-            if(!(ZipHelper.extractFileFromZip(zipIn, newpipe_db.getPath(), "newpipe.db")
-                && ZipHelper.extractFileFromZip(zipIn, newpipe_db_journal.getPath(), "newpipe.db-journal"))) {
-               Toast.makeText(getContext(), R.string.could_not_import_all_files, Toast.LENGTH_LONG)
-                       .show();
+            if(!(ZipHelper.extractFileFromZip(filePath, newpipe_db.getPath(), "newpipe.db")
+                    && ZipHelper.extractFileFromZip(filePath, newpipe_db_journal.getPath(), "newpipe.db-journal"))) {
+                Toast.makeText(getContext(), R.string.could_not_import_all_files, Toast.LENGTH_LONG)
+                        .show();
             }
 
-            zipIn.close();
+            //If settings file exist, ask if it should be imported.
+            if(ZipHelper.extractFileFromZip(filePath, newpipe_settings.getPath(), "newpipe.settings")) {
+                AlertDialog.Builder alert = new AlertDialog.Builder(getContext());
+                alert.setTitle(R.string.import_settings);
 
-            // restart app to properly load db
-            //App.restart(getContext());
-            System.exit(0);
+                alert.setNegativeButton(android.R.string.no, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        dialog.dismiss();
+                        // restart app to properly load db
+                        System.exit(0);
+                    }
+                });
+                alert.setPositiveButton(android.R.string.yes, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        dialog.dismiss();
+                        loadSharedPreferences(newpipe_settings);
+                        // restart app to properly load db
+                        System.exit(0);
+                    }
+                });
+                alert.show();
+            } else {
+                // restart app to properly load db
+                System.exit(0);
+            }
+
         } catch (Exception e) {
             onError(e);
+        }
+    }
+
+    private void loadSharedPreferences(File src) {
+        ObjectInputStream input = null;
+        try {
+            input = new ObjectInputStream(new FileInputStream(src));
+            SharedPreferences.Editor prefEdit = PreferenceManager.getDefaultSharedPreferences(getContext()).edit();
+            prefEdit.clear();
+            Map<String, ?> entries = (Map<String, ?>) input.readObject();
+            for (Map.Entry<String, ?> entry : entries.entrySet()) {
+                Object v = entry.getValue();
+                String key = entry.getKey();
+
+                if (v instanceof Boolean)
+                    prefEdit.putBoolean(key, ((Boolean) v).booleanValue());
+                else if (v instanceof Float)
+                    prefEdit.putFloat(key, ((Float) v).floatValue());
+                else if (v instanceof Integer)
+                    prefEdit.putInt(key, ((Integer) v).intValue());
+                else if (v instanceof Long)
+                    prefEdit.putLong(key, ((Long) v).longValue());
+                else if (v instanceof String)
+                    prefEdit.putString(key, ((String) v));
+            }
+            prefEdit.commit();
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        } catch (ClassNotFoundException e) {
+            e.printStackTrace();
+        }finally {
+            try {
+                if (input != null) {
+                    input.close();
+                }
+            } catch (IOException ex) {
+                ex.printStackTrace();
+            }
         }
     }
 

--- a/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
@@ -274,22 +274,16 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
                 AlertDialog.Builder alert = new AlertDialog.Builder(getContext());
                 alert.setTitle(R.string.import_settings);
 
-                alert.setNegativeButton(android.R.string.no, new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        dialog.dismiss();
-                        // restart app to properly load db
-                        System.exit(0);
-                    }
+                alert.setNegativeButton(android.R.string.no, (dialog, which) -> {
+                    dialog.dismiss();
+                    // restart app to properly load db
+                    System.exit(0);
                 });
-                alert.setPositiveButton(android.R.string.yes, new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        dialog.dismiss();
-                        loadSharedPreferences(newpipe_settings);
-                        // restart app to properly load db
-                        System.exit(0);
-                    }
+                alert.setPositiveButton(android.R.string.yes, (dialog, which) -> {
+                    dialog.dismiss();
+                    loadSharedPreferences(newpipe_settings);
+                    // restart app to properly load db
+                    System.exit(0);
                 });
                 alert.show();
             } else {

--- a/app/src/main/java/org/schabi/newpipe/util/ZipHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ZipHelper.java
@@ -62,7 +62,12 @@ public class ZipHelper {
      * @return will return true if the file was found within the zip file
      * @throws Exception
      */
-    public static boolean extractFileFromZip(ZipInputStream inZip, String file, String name) throws Exception {
+    public static boolean extractFileFromZip(String filePath, String file, String name) throws Exception {
+
+        ZipInputStream inZip = new ZipInputStream(
+                new BufferedInputStream(
+                        new FileInputStream(filePath)));
+
         byte data[] = new byte[BUFFER_SIZE];
 
         boolean found = false;
@@ -89,6 +94,6 @@ public class ZipHelper {
                 inZip.closeEntry();
             }
         }
-        return true;
+        return found;
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -359,6 +359,7 @@
     <string name="no_valid_zip_file">No valid ZIP file</string>
     <string name="could_not_import_all_files">Warning: Could not import all files.</string>
     <string name="override_current_data">This will override your current setup.</string>
+    <string name="import_settings">Do you want to also import settings?</string>
 
     <!-- Kiosk Names -->
     <string name="kiosk">Kiosk</string>


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

Alright, this actually seems to work now! I haven't encountered any issues with this yet, but I will continue testing it because exports feel quite important. I hope someone else can also confirm there are no issues.

Anyways, I had to change how ZipHelper.extractFileFromZip works because it was broken and always returned true and also didn't work for the same ZipInputStream more than once. It now uses the filepath, but as the function isn't used outside of ContentSettingsFragment.java this won't be an issue. 

The exports now contain a new file called newpipe.settings. If while importing it is detected, it will trigger a second dialog asking if to import settings too. If you press Ok it will import the settings from there.

#849