### PR TITLE
Fix #1345 Gradle build fails 

### DIFF
--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -409,7 +409,7 @@
         <item>Congo, (Kinshasa)</item>
         <item>Cook Islands</item>
         <item>CostaRica</item>
-        <item>Côted'Ivoire</item>
+        <item>Côted\'Ivoire</item>
         <item>Croatia</item>
         <item>Cuba</item>
         <item>Cyprus</item>


### PR DESCRIPTION
Fix #1345 Gradle build fails with "error: unescaped apostrophe in string"

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
