### PR TITLE
Minimize main player on exit

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
@@ -104,6 +104,7 @@ public final class MainVideoPlayer extends AppCompatActivity
 
     @Nullable private PlayerState playerState;
     private boolean isInMultiWindow;
+    private boolean isBackPressed;
 
     /*//////////////////////////////////////////////////////////////////////////
     // Activity LifeCycle
@@ -192,6 +193,12 @@ public final class MainVideoPlayer extends AppCompatActivity
     }
 
     @Override
+    public void onBackPressed() {
+        super.onBackPressed();
+        isBackPressed = true;
+    }
+
+    @Override
     protected void onSaveInstanceState(Bundle outState) {
         if (DEBUG) Log.d(TAG, "onSaveInstanceState() called");
         super.onSaveInstanceState(outState);
@@ -211,9 +218,15 @@ public final class MainVideoPlayer extends AppCompatActivity
         PlayerHelper.setScreenBrightness(getApplicationContext(),
                 getWindow().getAttributes().screenBrightness);
 
-        isInMultiWindow = false;
+        if (playerImpl == null) return;
+        if (isBackPressed) {
+            playerImpl.destroy();
+        } else {
+            playerImpl.minimize();
+        }
 
-        if (playerImpl != null) playerImpl.terminate();
+        isInMultiWindow = false;
+        isBackPressed = false;
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -443,7 +456,7 @@ public final class MainVideoPlayer extends AppCompatActivity
             switchPopupButton.setOnClickListener(this);
         }
 
-        public void terminate() {
+        public void minimize() {
             switch (PlayerHelper.getMinimizeOnExitAction(context)) {
                 case PlayerHelper.MinimizeMode.MINIMIZE_ON_EXIT_MODE_BACKGROUND:
                     onPlayBackgroundButtonClicked();

--- a/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
@@ -213,12 +213,7 @@ public final class MainVideoPlayer extends AppCompatActivity
 
         isInMultiWindow = false;
 
-        if (playerImpl == null) return;
-        if (PlayerHelper.isMinimizeOnExitEnabled(this)) {
-            playerImpl.onFullScreenButtonClicked();
-        } else {
-            playerImpl.destroy();
-        }
+        if (playerImpl != null) playerImpl.terminate();
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -446,6 +441,20 @@ public final class MainVideoPlayer extends AppCompatActivity
             toggleOrientationButton.setOnClickListener(this);
             switchBackgroundButton.setOnClickListener(this);
             switchPopupButton.setOnClickListener(this);
+        }
+
+        public void terminate() {
+            switch (PlayerHelper.getMinimizeOnExitAction(context)) {
+                case PlayerHelper.MinimizeMode.MINIMIZE_ON_EXIT_MODE_BACKGROUND:
+                    onPlayBackgroundButtonClicked();
+                    break;
+                case PlayerHelper.MinimizeMode.MINIMIZE_ON_EXIT_MODE_POPUP:
+                    onFullScreenButtonClicked();
+                    break;
+                case PlayerHelper.MinimizeMode.MINIMIZE_ON_EXIT_MODE_NONE:
+                    destroy();
+                    break;
+            }
         }
 
         /*//////////////////////////////////////////////////////////////////////////

--- a/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
@@ -208,10 +208,17 @@ public final class MainVideoPlayer extends AppCompatActivity
     protected void onStop() {
         if (DEBUG) Log.d(TAG, "onStop() called");
         super.onStop();
-        playerImpl.destroy();
-
         PlayerHelper.setScreenBrightness(getApplicationContext(),
                 getWindow().getAttributes().screenBrightness);
+
+        isInMultiWindow = false;
+
+        if (playerImpl == null) return;
+        if (PlayerHelper.isMinimizeOnExitEnabled(this)) {
+            playerImpl.onFullScreenButtonClicked();
+        } else {
+            playerImpl.destroy();
+        }
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
@@ -173,6 +173,10 @@ public class PlayerHelper {
         return isAutoQueueEnabled(context, false);
     }
 
+    public static boolean isMinimizeOnExitEnabled(@NonNull final Context context) {
+        return isMinimizeOnExitEnabled(context, false);
+    }
+
     @NonNull
     public static SeekParameters getSeekParameters(@NonNull final Context context) {
         return isUsingInexactSeek(context, false) ?
@@ -249,7 +253,6 @@ public class PlayerHelper {
      * System font scaling:
      * Very small - 0.25f, Small - 0.5f, Normal - 1.0f, Large - 1.5f, Very Large - 2.0f
      * */
-    @NonNull
     public static float getCaptionScale(@NonNull final Context context) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT) return 1f;
 
@@ -321,5 +324,9 @@ public class PlayerHelper {
         } else {
             return sp.getFloat(context.getString(R.string.screen_brightness_key), screenBrightness);
         }
+    }
+
+    private static boolean isMinimizeOnExitEnabled(@NonNull final Context context, final boolean b) {
+        return getPreferences(context).getBoolean(context.getString(R.string.minimize_on_exit_key), b);
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Build;
 import android.preference.PreferenceManager;
+import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.view.accessibility.CaptioningManager;
@@ -28,6 +29,7 @@ import org.schabi.newpipe.player.playqueue.PlayQueue;
 import org.schabi.newpipe.player.playqueue.PlayQueueItem;
 import org.schabi.newpipe.player.playqueue.SinglePlayQueue;
 
+import java.lang.annotation.Retention;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.ArrayList;
@@ -42,6 +44,8 @@ import java.util.concurrent.TimeUnit;
 import static com.google.android.exoplayer2.ui.AspectRatioFrameLayout.RESIZE_MODE_FILL;
 import static com.google.android.exoplayer2.ui.AspectRatioFrameLayout.RESIZE_MODE_FIT;
 import static com.google.android.exoplayer2.ui.AspectRatioFrameLayout.RESIZE_MODE_ZOOM;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+import static org.schabi.newpipe.player.helper.PlayerHelper.MinimizeMode.*;
 
 public class PlayerHelper {
     private PlayerHelper() {}
@@ -51,6 +55,14 @@ public class PlayerHelper {
     private static final NumberFormat speedFormatter = new DecimalFormat("0.##x");
     private static final NumberFormat pitchFormatter = new DecimalFormat("##%");
 
+    @Retention(SOURCE)
+    @IntDef({MINIMIZE_ON_EXIT_MODE_NONE, MINIMIZE_ON_EXIT_MODE_BACKGROUND,
+            MINIMIZE_ON_EXIT_MODE_POPUP})
+    public @interface MinimizeMode {
+        int MINIMIZE_ON_EXIT_MODE_NONE = 0;
+        int MINIMIZE_ON_EXIT_MODE_BACKGROUND = 1;
+        int MINIMIZE_ON_EXIT_MODE_POPUP = 2;
+    }
     ////////////////////////////////////////////////////////////////////////////
     // Exposed helpers
     ////////////////////////////////////////////////////////////////////////////
@@ -173,8 +185,20 @@ public class PlayerHelper {
         return isAutoQueueEnabled(context, false);
     }
 
-    public static boolean isMinimizeOnExitEnabled(@NonNull final Context context) {
-        return isMinimizeOnExitEnabled(context, false);
+    @MinimizeMode
+    public static int getMinimizeOnExitAction(@NonNull final Context context) {
+        final String defaultAction = context.getString(R.string.minimize_on_exit_none_key);
+        final String popupAction = context.getString(R.string.minimize_on_exit_popup_key);
+        final String backgroundAction = context.getString(R.string.minimize_on_exit_background_key);
+
+        final String action = getMinimizeOnExitAction(context, defaultAction);
+        if (action.equals(popupAction)) {
+            return MINIMIZE_ON_EXIT_MODE_POPUP;
+        } else if (action.equals(backgroundAction)) {
+            return MINIMIZE_ON_EXIT_MODE_BACKGROUND;
+        } else {
+            return MINIMIZE_ON_EXIT_MODE_NONE;
+        }
     }
 
     @NonNull
@@ -326,7 +350,9 @@ public class PlayerHelper {
         }
     }
 
-    private static boolean isMinimizeOnExitEnabled(@NonNull final Context context, final boolean b) {
-        return getPreferences(context).getBoolean(context.getString(R.string.minimize_on_exit_key), b);
+    private static String getMinimizeOnExitAction(@NonNull final Context context,
+                                                  final String key) {
+        return getPreferences(context).getString(context.getString(R.string.minimize_on_exit_key),
+                key);
     }
 }

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -24,6 +24,7 @@
     <string name="auto_queue_key" translatable="false">auto_queue_key</string>
     <string name="screen_brightness_key" translatable="false">screen_brightness_key</string>
     <string name="screen_brightness_timestamp_key" translatable="false">screen_brightness_timestamp_key</string>
+    <string name="minimize_on_exit_key" translatable="false">minimize_on_exit_key</string>
 
     <string name="default_resolution_key" translatable="false">default_resolution</string>
     <string name="default_resolution_value" translatable="false">360p</string>

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -24,7 +24,22 @@
     <string name="auto_queue_key" translatable="false">auto_queue_key</string>
     <string name="screen_brightness_key" translatable="false">screen_brightness_key</string>
     <string name="screen_brightness_timestamp_key" translatable="false">screen_brightness_timestamp_key</string>
+
     <string name="minimize_on_exit_key" translatable="false">minimize_on_exit_key</string>
+    <string name="minimize_on_exit_value" translatable="false">@string/minimize_on_exit_none_key</string>
+    <string name="minimize_on_exit_none_key" translatable="false">minimize_on_exit_none_key</string>
+    <string name="minimize_on_exit_background_key" translatable="false">minimize_on_exit_background_key</string>
+    <string name="minimize_on_exit_popup_key" translatable="false">minimize_on_exit_popup_key</string>
+    <string-array name="minimize_on_exit_action_key" translatable="false">
+        <item>@string/minimize_on_exit_none_key</item>
+        <item>@string/minimize_on_exit_background_key</item>
+        <item>@string/minimize_on_exit_popup_key</item>
+    </string-array>
+    <string-array name="minimize_on_exit_action_description" translatable="false">
+        <item>@string/minimize_on_exit_none_description</item>
+        <item>@string/minimize_on_exit_background_description</item>
+        <item>@string/minimize_on_exit_popup_description</item>
+    </string-array>
 
     <string name="default_resolution_key" translatable="false">default_resolution</string>
     <string name="default_resolution_value" translatable="false">360p</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -505,8 +505,8 @@
     </string-array>
 
     <!-- Minimize to exit action -->
-    <string name="minimize_on_exit_title">Minimize on exit</string>
-    <string name="minimize_on_exit_summary">Action when exiting main video player — %s</string>
+    <string name="minimize_on_exit_title">Minimize on application switch</string>
+    <string name="minimize_on_exit_summary">Action when switching to other application from main video player — %s</string>
     <string name="minimize_on_exit_none_description">None</string>
     <string name="minimize_on_exit_background_description">Minimize to background player</string>
     <string name="minimize_on_exit_popup_description">Minimize to popup player</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,6 +74,8 @@
     <string name="popup_remember_size_pos_summary">Remember last size and position of popup</string>
     <string name="use_inexact_seek_title">Use fast inexact seek</string>
     <string name="use_inexact_seek_summary">Inexact seek allows the player to seek to positions faster with reduced precision</string>
+    <string name="minimize_on_exit_title">Minimize on exit</string>
+    <string name="minimize_on_exit_summary">Experimental. Switch to play on popup player when exiting main video player</string>
     <string name="download_thumbnail_title">Load thumbnails</string>
     <string name="download_thumbnail_summary">Disable to stop all thumbnails from loading and save on data and memory usage. Changing this will clear both in-memory and on-disk image cache.</string>
     <string name="thumbnail_cache_wipe_complete_notice">Image cache wiped</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,8 +74,6 @@
     <string name="popup_remember_size_pos_summary">Remember last size and position of popup</string>
     <string name="use_inexact_seek_title">Use fast inexact seek</string>
     <string name="use_inexact_seek_summary">Inexact seek allows the player to seek to positions faster with reduced precision</string>
-    <string name="minimize_on_exit_title">Minimize on exit</string>
-    <string name="minimize_on_exit_summary">Experimental. Switch to play on popup player when exiting main video player</string>
     <string name="download_thumbnail_title">Load thumbnails</string>
     <string name="download_thumbnail_summary">Disable to stop all thumbnails from loading and save on data and memory usage. Changing this will clear both in-memory and on-disk image cache.</string>
     <string name="thumbnail_cache_wipe_complete_notice">Image cache wiped</string>
@@ -505,5 +503,12 @@
         <item>240p</item>
         <item>144p</item>
     </string-array>
+
+    <!-- Minimize to exit action -->
+    <string name="minimize_on_exit_title">Minimize on exit</string>
+    <string name="minimize_on_exit_summary">Action when exiting main video player — %s</string>
+    <string name="minimize_on_exit_none_description">None</string>
+    <string name="minimize_on_exit_background_description">Minimize to background player</string>
+    <string name="minimize_on_exit_popup_description">Minimize to popup player</string>
 
 </resources>

--- a/app/src/main/res/xml/video_audio_settings.xml
+++ b/app/src/main/res/xml/video_audio_settings.xml
@@ -90,6 +90,14 @@
             android:summary="@string/preferred_open_action_settings_summary"
             android:title="@string/preferred_open_action_settings_title"/>
 
+        <ListPreference
+            android:defaultValue="@string/minimize_on_exit_value"
+            android:entries="@array/minimize_on_exit_action_description"
+            android:entryValues="@array/minimize_on_exit_action_key"
+            android:key="@string/minimize_on_exit_key"
+            android:summary="@string/minimize_on_exit_summary"
+            android:title="@string/minimize_on_exit_title"/>
+
         <SwitchPreference
             android:defaultValue="false"
             android:key="@string/resume_on_audio_focus_gain_key"
@@ -113,11 +121,5 @@
             android:key="@string/use_inexact_seek_key"
             android:summary="@string/use_inexact_seek_summary"
             android:title="@string/use_inexact_seek_title"/>
-
-        <SwitchPreference
-            android:defaultValue="false"
-            android:key="@string/minimize_on_exit_key"
-            android:title="@string/minimize_on_exit_title"
-            android:summary="@string/minimize_on_exit_summary"/>
     </PreferenceCategory>
 </PreferenceScreen>

--- a/app/src/main/res/xml/video_audio_settings.xml
+++ b/app/src/main/res/xml/video_audio_settings.xml
@@ -113,5 +113,11 @@
             android:key="@string/use_inexact_seek_key"
             android:summary="@string/use_inexact_seek_summary"
             android:title="@string/use_inexact_seek_title"/>
+
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="@string/minimize_on_exit_key"
+            android:title="@string/minimize_on_exit_title"
+            android:summary="@string/minimize_on_exit_summary"/>
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
Here is a quick implementation for request #1334, added as toggleable in Settings -> Video & Audio.

However, I'm not particularly fond of this implementation as it performs the switch based on the `onStop` lifecycle event, which will occur on:
- back button pressed -- expected behavior
- home button pressed -- expected behavior
- screen turned off -- expected behavior
- other activity starts (open up settings) -- expected behavior
- navigation/overview button pressed -- maybe unexpected behavior
- entering multiwindow mode (long press overview button) -- unexpected behavior
- (many more possibilities, but mostly when the player activity is actively killed by the user)

Since this implementation uses the existing player switching method, the switching is just going to be as slow performance-wise. If anyone has any idea how this can be improved, please don't hesitate to make suggestions. That being said, I'd like to keep the expected behaviors intact.