### PR TITLE
Double-tap the middle of the player screen to pause the video

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
@@ -847,10 +847,12 @@ public final class MainVideoPlayer extends AppCompatActivity
             if (DEBUG) Log.d(TAG, "onDoubleTap() called with: e = [" + e + "]" + "rawXy = " + e.getRawX() + ", " + e.getRawY() + ", xy = " + e.getX() + ", " + e.getY());
             if (!playerImpl.isPlaying()) return false;
 
-            if (e.getX() > playerImpl.getRootView().getWidth() / 2) {
+            if (e.getX() > playerImpl.getRootView().getWidth() * 2 / 3) {
                 playerImpl.onFastForward();
-            } else {
+            } else if (e.getX() < playerImpl.getRootView().getWidth() / 3) {
                 playerImpl.onFastRewind();
+            } else {
+                playerImpl.getPlayPauseButton().performClick();
             }
 
             return true;


### PR DESCRIPTION
- [X] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

This PR changes how double-tap for the main player works:
Now, double-tapping the middle third of the screen will pause the video, while rewind / fast forward are on the left third / right third of the screen, respectively.
The reason is, that currently there is no practical way to pause the video fast: When you want to pause playback, you need to tap the screen, wait for the controls to fade in, and then finally press pause. But if you tap the center (where the pause button fades in) too fast, it will be recognized as a double-tap gesture, which will trigger a **seek**, although you tapped the center of the screen and actually wanted to pause the video. This is probably not what you expect, so this PR attempts to change this behaviour to something more natural.
Another idea, which I did not yet implement, was to allow a double-tap while being paused to resume playback.

Feel free to comment wether this change reflects NewPipe's user experience principles. I am open to any suggestions.