### PR TITLE
Revert Buffering Strategy

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/helper/LoadController.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/LoadController.java
@@ -18,7 +18,6 @@ public class LoadController implements LoadControl {
 
     public static final String TAG = "LoadController";
 
-    private final long initialPlaybackBufferUs;
     private final LoadControl internalLoadControl;
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -27,15 +26,15 @@ public class LoadController implements LoadControl {
 
     public LoadController(final Context context) {
         this(PlayerHelper.getPlaybackStartBufferMs(context),
+                PlayerHelper.getPlaybackRebufferMs(context),
                 PlayerHelper.getPlaybackMinimumBufferMs(context),
                 PlayerHelper.getPlaybackOptimalBufferMs(context));
     }
 
     private LoadController(final int initialPlaybackBufferMs,
+                           final int rebufferPlaybackBufferMs,
                            final int minimumPlaybackbufferMs,
                            final int optimalPlaybackBufferMs) {
-        this.initialPlaybackBufferUs = initialPlaybackBufferMs * 1000;
-
         final DefaultAllocator allocator = new DefaultAllocator(true,
                 C.DEFAULT_BUFFER_SEGMENT_SIZE);
 
@@ -43,7 +42,7 @@ public class LoadController implements LoadControl {
                 /*minBufferMs=*/minimumPlaybackbufferMs,
                 /*maxBufferMs=*/optimalPlaybackBufferMs,
                 /*bufferForPlaybackMs=*/initialPlaybackBufferMs,
-                /*bufferForPlaybackAfterRebufferMs=*/initialPlaybackBufferMs,
+                /*bufferForPlaybackAfterRebufferMs=*/rebufferPlaybackBufferMs,
                 DEFAULT_TARGET_BUFFER_BYTES, DEFAULT_PRIORITIZE_TIME_OVER_SIZE_THRESHOLDS);
     }
 
@@ -95,10 +94,7 @@ public class LoadController implements LoadControl {
     @Override
     public boolean shouldStartPlayback(long bufferedDurationUs, float playbackSpeed,
                                        boolean rebuffering) {
-        final boolean isInitialPlaybackBufferFilled = bufferedDurationUs >=
-                this.initialPlaybackBufferUs * playbackSpeed;
-        final boolean isInternalStartingPlayback = internalLoadControl.shouldStartPlayback(
-                bufferedDurationUs, playbackSpeed, rebuffering);
-        return isInitialPlaybackBufferFilled || isInternalStartingPlayback;
+        return internalLoadControl.shouldStartPlayback(bufferedDurationUs, playbackSpeed,
+                rebuffering);
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
@@ -190,7 +190,14 @@ public class PlayerHelper {
      * Returns the number of milliseconds the player buffers for before starting playback.
      * */
     public static int getPlaybackStartBufferMs(@NonNull final Context context) {
-        return 500;
+        return 2500;
+    }
+
+    /**
+     * Returns the number of milliseconds the player buffers for before starting playback.
+     * */
+    public static int getPlaybackRebufferMs(@NonNull final Context context) {
+        return 5000;
     }
 
     /**
@@ -198,7 +205,7 @@ public class PlayerHelper {
      * playback.
      * */
     public static int getPlaybackMinimumBufferMs(@NonNull final Context context) {
-        return 25000;
+        return 15000;
     }
 
     /**
@@ -206,7 +213,7 @@ public class PlayerHelper {
      * hits the point of {@link #getPlaybackMinimumBufferMs(Context)}.
      * */
     public static int getPlaybackOptimalBufferMs(@NonNull final Context context) {
-        return 60000;
+        return 30000;
     }
 
     public static TrackSelection.Factory getQualitySelector(@NonNull final Context context,


### PR DESCRIPTION
This PR is in response to #1388 and #1294, to revert the buffering strategy and parameter changes to load controller. 

Though after testing on my own device, this only prolongs the slow buffering problem from playing and buffering every second to playing and buffering every several seconds, which, IMO delivers worse user experience. 