### PR TITLE
ExoPlayer 2.8.2 Update

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,7 +42,7 @@ android {
 
 ext {
     supportLibVersion = '27.1.1'
-    exoPlayerLibVersion = '2.8.1'
+    exoPlayerLibVersion = '2.8.2'
     roomDbLibVersion = '1.1.1'
     leakCanaryLibVersion = '1.5.4'
     okHttpLibVersion = '3.10.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,7 +42,7 @@ android {
 
 ext {
     supportLibVersion = '27.1.1'
-    exoPlayerLibVersion = '2.7.3'
+    exoPlayerLibVersion = '2.8.0'
     roomDbLibVersion = '1.1.1'
     leakCanaryLibVersion = '1.5.4'
     okHttpLibVersion = '3.10.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,7 +42,7 @@ android {
 
 ext {
     supportLibVersion = '27.1.1'
-    exoPlayerLibVersion = '2.8.0'
+    exoPlayerLibVersion = '2.8.1'
     roomDbLibVersion = '1.1.1'
     leakCanaryLibVersion = '1.5.4'
     okHttpLibVersion = '3.10.0'

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
@@ -289,7 +289,6 @@ public class PlaylistFragment extends BaseListInfoFragment<PlaylistInfo> {
         remotePlaylistManager.getPlaylist(result)
                 .flatMap(lists -> getUpdateProcessor(lists, result), (lists, id) -> lists)
                 .onBackpressureLatest()
-                .flatMap(lists -> getUpdateProcessor(lists, result), (lists, id) -> lists)
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(getPlaylistBookmarkSubscriber());
 
@@ -355,6 +354,7 @@ public class PlaylistFragment extends BaseListInfoFragment<PlaylistInfo> {
 
         final PlaylistRemoteEntity playlistEntity = playlists.get(0);
         if (playlistEntity.isIdenticalTo(result)) return noItemToUpdate;
+
         return remotePlaylistManager.onUpdate(playlists.get(0).getUid(), result).toFlowable();
     }
 

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
@@ -289,6 +289,7 @@ public class PlaylistFragment extends BaseListInfoFragment<PlaylistInfo> {
         remotePlaylistManager.getPlaylist(result)
                 .flatMap(lists -> getUpdateProcessor(lists, result), (lists, id) -> lists)
                 .onBackpressureLatest()
+                .flatMap(lists -> getUpdateProcessor(lists, result), (lists, id) -> lists)
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(getPlaylistBookmarkSubscriber());
 
@@ -354,7 +355,6 @@ public class PlaylistFragment extends BaseListInfoFragment<PlaylistInfo> {
 
         final PlaylistRemoteEntity playlistEntity = playlists.get(0);
         if (playlistEntity.isIdenticalTo(result)) return noItemToUpdate;
-
         return remotePlaylistManager.onUpdate(playlists.get(0).getUid(), result).toFlowable();
     }
 

--- a/app/src/main/java/org/schabi/newpipe/player/BackgroundPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/BackgroundPlayer.java
@@ -26,9 +26,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.graphics.Bitmap;
-import android.os.Build;
 import android.os.IBinder;
-import android.support.annotation.IntRange;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.NotificationCompat;
@@ -92,7 +90,6 @@ public final class BackgroundPlayer extends Service {
     private NotificationCompat.Builder notBuilder;
     private RemoteViews notRemoteView;
     private RemoteViews bigNotRemoteView;
-    private final String setAlphaMethodName = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) ? "setImageAlpha" : "setAlpha";
 
     private boolean shouldUpdateOnProgress;
 
@@ -246,16 +243,6 @@ public final class BackgroundPlayer extends Service {
         }
         notificationManager.notify(NOTIFICATION_ID, notBuilder.build());
     }
-
-    private void setControlsOpacity(@IntRange(from = 0, to = 255) int opacity) {
-        if (notRemoteView != null) notRemoteView.setInt(R.id.notificationPlayPause, setAlphaMethodName, opacity);
-        if (bigNotRemoteView != null) bigNotRemoteView.setInt(R.id.notificationPlayPause, setAlphaMethodName, opacity);
-        if (notRemoteView != null) notRemoteView.setInt(R.id.notificationFForward, setAlphaMethodName, opacity);
-        if (bigNotRemoteView != null) bigNotRemoteView.setInt(R.id.notificationFForward, setAlphaMethodName, opacity);
-        if (notRemoteView != null) notRemoteView.setInt(R.id.notificationFRewind, setAlphaMethodName, opacity);
-        if (bigNotRemoteView != null) bigNotRemoteView.setInt(R.id.notificationFRewind, setAlphaMethodName, opacity);
-    }
-
     /*//////////////////////////////////////////////////////////////////////////
     // Utils
     //////////////////////////////////////////////////////////////////////////*/
@@ -525,40 +512,26 @@ public final class BackgroundPlayer extends Service {
         public void changeState(int state) {
             super.changeState(state);
             updatePlayback();
-        }
-
-        @Override
-        public void onBlocked() {
-            super.onBlocked();
-
-            setControlsOpacity(77);
             updateNotification(-1);
         }
 
         @Override
         public void onPlaying() {
             super.onPlaying();
-
-            setControlsOpacity(255);
             updateNotification(R.drawable.ic_pause_white);
-
             lockManager.acquireWifiAndCpu();
         }
 
         @Override
         public void onPaused() {
             super.onPaused();
-
             updateNotification(R.drawable.ic_play_arrow_white);
-
             lockManager.releaseWifiAndCpu();
         }
 
         @Override
         public void onCompleted() {
             super.onCompleted();
-
-            setControlsOpacity(255);
 
             resetNotification();
             if (bigNotRemoteView != null) bigNotRemoteView.setProgressBar(R.id.notificationProgressBar, 100, 100, false);

--- a/app/src/main/java/org/schabi/newpipe/player/BackgroundPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/BackgroundPlayer.java
@@ -544,26 +544,29 @@ public final class BackgroundPlayer extends Service {
 
         @Override
         public void changeState(int state) {
+            resetNotification();
             super.changeState(state);
             updatePlayback();
-            updateNotification(-1);
         }
 
         @Override
         public void onBlocked() {
             super.onBlocked();
+            updateNotification(-1);
             startForeground(NOTIFICATION_ID, notBuilder.build());
         }
 
         @Override
         public void onBuffering() {
             super.onBuffering();
+            updateNotification(-1);
             startForeground(NOTIFICATION_ID, notBuilder.build());
         }
 
         @Override
         public void onPausedSeek() {
             super.onPausedSeek();
+            updateNotification(-1);
             startForeground(NOTIFICATION_ID, notBuilder.build());
         }
 
@@ -589,7 +592,6 @@ public final class BackgroundPlayer extends Service {
         public void onCompleted() {
             super.onCompleted();
 
-            resetNotification();
             if (bigNotRemoteView != null) bigNotRemoteView.setProgressBar(R.id.notificationProgressBar, 100, 100, false);
             if (notRemoteView != null) notRemoteView.setProgressBar(R.id.notificationProgressBar, 100, 100, false);
             updateNotification(R.drawable.ic_replay_white);

--- a/app/src/main/java/org/schabi/newpipe/player/BackgroundPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/BackgroundPlayer.java
@@ -199,7 +199,6 @@ public final class BackgroundPlayer extends Service {
 
         remoteViews.setTextViewText(R.id.notificationSongName, basePlayerImpl.getVideoTitle());
         remoteViews.setTextViewText(R.id.notificationArtist, basePlayerImpl.getUploaderName());
-        remoteViews.setImageViewBitmap(R.id.notificationCover, basePlayerImpl.getThumbnail());
 
         remoteViews.setOnClickPendingIntent(R.id.notificationPlayPause,
                 PendingIntent.getBroadcast(this, NOTIFICATION_ID, new Intent(ACTION_PLAY_PAUSE), PendingIntent.FLAG_UPDATE_CURRENT));
@@ -295,10 +294,22 @@ public final class BackgroundPlayer extends Service {
         // Thumbnail Loading
         //////////////////////////////////////////////////////////////////////////*/
 
+        private void updateNotificationThumbnail() {
+            if (notRemoteView != null) {
+                notRemoteView.setImageViewBitmap(R.id.notificationCover,
+                        basePlayerImpl.getThumbnail());
+            }
+            if (bigNotRemoteView != null) {
+                bigNotRemoteView.setImageViewBitmap(R.id.notificationCover,
+                        basePlayerImpl.getThumbnail());
+            }
+        }
+
         @Override
         public void onLoadingComplete(String imageUri, View view, Bitmap loadedImage) {
             super.onLoadingComplete(imageUri, view, loadedImage);
             resetNotification();
+            updateNotificationThumbnail();
             updateNotification(-1);
         }
 
@@ -306,13 +317,7 @@ public final class BackgroundPlayer extends Service {
         public void onLoadingFailed(String imageUri, View view, FailReason failReason) {
             super.onLoadingFailed(imageUri, view, failReason);
             resetNotification();
-            updateNotification(-1);
-        }
-
-        @Override
-        public void onLoadingCancelled(String imageUri, View view) {
-            super.onLoadingCancelled(imageUri, view);
-            resetNotification();
+            updateNotificationThumbnail();
             updateNotification(-1);
         }
         /*//////////////////////////////////////////////////////////////////////////
@@ -395,6 +400,7 @@ public final class BackgroundPlayer extends Service {
         protected void onMetadataChanged(@NonNull final MediaSourceTag tag) {
             super.onMetadataChanged(tag);
             resetNotification();
+            updateNotificationThumbnail();
             updateNotification(-1);
             updateMetadata();
         }
@@ -525,6 +531,7 @@ public final class BackgroundPlayer extends Service {
         public void onPlaying() {
             super.onPlaying();
             resetNotification();
+            updateNotificationThumbnail();
             updateNotification(R.drawable.ic_pause_white);
             lockManager.acquireWifiAndCpu();
         }
@@ -533,6 +540,7 @@ public final class BackgroundPlayer extends Service {
         public void onPaused() {
             super.onPaused();
             resetNotification();
+            updateNotificationThumbnail();
             updateNotification(R.drawable.ic_play_arrow_white);
             lockManager.releaseWifiAndCpu();
         }
@@ -547,6 +555,7 @@ public final class BackgroundPlayer extends Service {
             if (notRemoteView != null) {
                 notRemoteView.setProgressBar(R.id.notificationProgressBar, 100, 100, false);
             }
+            updateNotificationThumbnail();
             updateNotification(R.drawable.ic_replay_white);
             lockManager.releaseWifiAndCpu();
         }

--- a/app/src/main/java/org/schabi/newpipe/player/BackgroundPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/BackgroundPlayer.java
@@ -295,6 +295,7 @@ public final class BackgroundPlayer extends Service {
         //////////////////////////////////////////////////////////////////////////*/
 
         private void updateNotificationThumbnail() {
+            if (basePlayerImpl == null) return;
             if (notRemoteView != null) {
                 notRemoteView.setImageViewBitmap(R.id.notificationCover,
                         basePlayerImpl.getThumbnail());

--- a/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
@@ -285,9 +285,11 @@ public abstract class BasePlayer implements
         destroyPlayer();
         unregisterBroadcastReceiver();
 
+        if (mediaSessionManager != null) mediaSessionManager.dispose();
+
         trackSelector = null;
-        simpleExoPlayer = null;
         mediaSessionManager = null;
+        simpleExoPlayer = null;
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -494,22 +496,6 @@ public abstract class BasePlayer implements
                 (manifest == null ? "no manifest" : "available manifest") + ", " +
                 "timeline size = [" + timeline.getWindowCount() + "], " +
                 "reason = [" + reason + "]");
-        if (playQueue == null) return;
-
-        switch (reason) {
-            case Player.TIMELINE_CHANGE_REASON_RESET: // called after #block
-            case Player.TIMELINE_CHANGE_REASON_PREPARED: // called after #unblock
-            case Player.TIMELINE_CHANGE_REASON_DYNAMIC: // called after playlist changes
-                // Ensures MediaSourceManager#update is complete
-                final boolean isPlaylistStable = timeline.getWindowCount() == playQueue.size();
-                // Ensure dynamic/livestream timeline changes does not cause negative position
-                if (isPlaylistStable && !isCurrentWindowValid() && !isSynchronizing) {
-                    if (DEBUG) Log.d(TAG, "Playback - negative time position reached, " +
-                            "clamping to default position.");
-                    seekToDefault();
-                }
-                break;
-        }
     }
 
     @Override
@@ -598,7 +584,7 @@ public abstract class BasePlayer implements
         } else if (isSynchronizing && isLive()) {
             // Is still synchronizing?
             if (DEBUG) Log.d(TAG, "Playback - Synchronizing livestream to default time");
-            seekToDefault();
+            //seekToDefault();
 
         } else if (isSynchronizing && presetStartPositionMillis > 0L) {
             // Has another start position?

--- a/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
@@ -115,6 +115,7 @@ public abstract class BasePlayer implements
     public static final String REPEAT_MODE = "repeat_mode";
     public static final String PLAYBACK_PITCH = "playback_pitch";
     public static final String PLAYBACK_SPEED = "playback_speed";
+    public static final String PLAYBACK_SKIP_SILENCE = "playback_skip_silence";
     public static final String PLAYBACK_QUALITY = "playback_quality";
     public static final String PLAY_QUEUE_KEY = "play_queue_key";
     public static final String APPEND_ONLY = "append_only";
@@ -235,20 +236,23 @@ public abstract class BasePlayer implements
         final int repeatMode = intent.getIntExtra(REPEAT_MODE, getRepeatMode());
         final float playbackSpeed = intent.getFloatExtra(PLAYBACK_SPEED, getPlaybackSpeed());
         final float playbackPitch = intent.getFloatExtra(PLAYBACK_PITCH, getPlaybackPitch());
+        final boolean playbackSkipSilence = intent.getBooleanExtra(PLAYBACK_SKIP_SILENCE, false);
 
         // Good to go...
-        initPlayback(queue, repeatMode, playbackSpeed, playbackPitch, /*playOnInit=*/true);
+        initPlayback(queue, repeatMode, playbackSpeed, playbackPitch, playbackSkipSilence,
+                /*playOnInit=*/true);
     }
 
     protected void initPlayback(@NonNull final PlayQueue queue,
                                 @Player.RepeatMode final int repeatMode,
                                 final float playbackSpeed,
                                 final float playbackPitch,
+                                final boolean playbackSkipSilence,
                                 final boolean playOnReady) {
         destroyPlayer();
         initPlayer(playOnReady);
         setRepeatMode(repeatMode);
-        setPlaybackParameters(playbackSpeed, playbackPitch);
+        setPlaybackParameters(playbackSpeed, playbackPitch, playbackSkipSilence);
 
         playQueue = queue;
         playQueue.init();
@@ -1162,19 +1166,22 @@ public abstract class BasePlayer implements
         return getPlaybackParameters().pitch;
     }
 
+    public boolean getPlaybackSkipSilence() {
+        return getPlaybackParameters().skipSilence;
+    }
+
     public void setPlaybackSpeed(float speed) {
-        setPlaybackParameters(speed, getPlaybackPitch());
+        setPlaybackParameters(speed, getPlaybackPitch(), getPlaybackSkipSilence());
     }
 
     public PlaybackParameters getPlaybackParameters() {
-        final PlaybackParameters defaultParameters = new PlaybackParameters(1f, 1f);
-        if (simpleExoPlayer == null) return defaultParameters;
+        if (simpleExoPlayer == null) return PlaybackParameters.DEFAULT;
         final PlaybackParameters parameters = simpleExoPlayer.getPlaybackParameters();
-        return parameters == null ? defaultParameters : parameters;
+        return parameters == null ? PlaybackParameters.DEFAULT : parameters;
     }
 
-    public void setPlaybackParameters(float speed, float pitch) {
-        simpleExoPlayer.setPlaybackParameters(new PlaybackParameters(speed, pitch));
+    public void setPlaybackParameters(float speed, float pitch, boolean skipSilence) {
+        simpleExoPlayer.setPlaybackParameters(new PlaybackParameters(speed, pitch, skipSilence));
     }
 
     public PlayQueue getPlayQueue() {

--- a/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
@@ -236,7 +236,8 @@ public abstract class BasePlayer implements
         final int repeatMode = intent.getIntExtra(REPEAT_MODE, getRepeatMode());
         final float playbackSpeed = intent.getFloatExtra(PLAYBACK_SPEED, getPlaybackSpeed());
         final float playbackPitch = intent.getFloatExtra(PLAYBACK_PITCH, getPlaybackPitch());
-        final boolean playbackSkipSilence = intent.getBooleanExtra(PLAYBACK_SKIP_SILENCE, false);
+        final boolean playbackSkipSilence = intent.getBooleanExtra(PLAYBACK_SKIP_SILENCE,
+                getPlaybackSkipSilence());
 
         // Good to go...
         initPlayback(queue, repeatMode, playbackSpeed, playbackPitch, playbackSkipSilence,

--- a/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
@@ -1044,17 +1044,17 @@ public abstract class BasePlayer implements
 
     @NonNull
     public String getVideoUrl() {
-        return currentItem == null ? context.getString(R.string.unknown_content) : currentItem.getUrl();
+        return currentMetadata == null ? context.getString(R.string.unknown_content) : currentMetadata.getMetadata().getUrl();
     }
 
     @NonNull
     public String getVideoTitle() {
-        return currentItem == null ? context.getString(R.string.unknown_content) : currentItem.getTitle();
+        return currentMetadata == null ? context.getString(R.string.unknown_content) : currentMetadata.getMetadata().getName();
     }
 
     @NonNull
     public String getUploaderName() {
-        return currentItem == null ? context.getString(R.string.unknown_content) : currentItem.getUploader();
+        return currentMetadata == null ? context.getString(R.string.unknown_content) : currentMetadata.getMetadata().getUploaderName();
     }
 
     @Nullable

--- a/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
@@ -127,7 +127,7 @@ public final class MainVideoPlayer extends AppCompatActivity
 
         hideSystemUi();
         setContentView(R.layout.activity_main_player);
-        playerImpl = new VideoPlayerImpl(this);
+        playerImpl = new  VideoPlayerImpl(this);
         playerImpl.setup(findViewById(android.R.id.content));
 
         if (savedInstanceState != null && savedInstanceState.get(KEY_SAVED_STATE) != null) {
@@ -498,11 +498,11 @@ public final class MainVideoPlayer extends AppCompatActivity
         // Playback Listener
         //////////////////////////////////////////////////////////////////////////*/
 
-        protected void onMetadataChanged(@Nullable final MediaSourceTag tag) {
+        protected void onMetadataChanged(@NonNull final MediaSourceTag tag) {
             super.onMetadataChanged(tag);
 
-            titleTextView.setText(getVideoTitle());
-            channelTextView.setText(getUploaderName());
+            titleTextView.setText(tag.getMetadata().getName());
+            channelTextView.setText(tag.getMetadata().getUploaderName());
         }
 
         @Override

--- a/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
@@ -896,7 +896,6 @@ public final class MainVideoPlayer extends AppCompatActivity
         @Override
         public boolean onDoubleTap(MotionEvent e) {
             if (DEBUG) Log.d(TAG, "onDoubleTap() called with: e = [" + e + "]" + "rawXy = " + e.getRawX() + ", " + e.getRawY() + ", xy = " + e.getX() + ", " + e.getY());
-            if (!playerImpl.isPlaying()) return false;
 
             if (e.getX() > playerImpl.getRootView().getWidth() * 2 / 3) {
                 playerImpl.onFastForward();

--- a/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
@@ -181,7 +181,7 @@ public final class MainVideoPlayer extends AppCompatActivity
             playerImpl.setPlaybackQuality(playerState.getPlaybackQuality());
             playerImpl.initPlayback(playerState.getPlayQueue(), playerState.getRepeatMode(),
                     playerState.getPlaybackSpeed(), playerState.getPlaybackPitch(),
-                    playerState.wasPlaying());
+                    playerState.isPlaybackSkipSilence(), playerState.wasPlaying());
         }
     }
 
@@ -210,7 +210,8 @@ public final class MainVideoPlayer extends AppCompatActivity
         playerImpl.setRecovery();
         playerState = new PlayerState(playerImpl.getPlayQueue(), playerImpl.getRepeatMode(),
                 playerImpl.getPlaybackSpeed(), playerImpl.getPlaybackPitch(),
-                playerImpl.getPlaybackQuality(), playerImpl.isPlaying());
+                playerImpl.getPlaybackQuality(), playerImpl.getPlaybackSkipSilence(),
+                playerImpl.isPlaying());
         StateSaver.tryToSave(isChangingConfigurations(), null, outState, this);
     }
 
@@ -352,8 +353,11 @@ public final class MainVideoPlayer extends AppCompatActivity
     ////////////////////////////////////////////////////////////////////////////
 
     @Override
-    public void onPlaybackParameterChanged(float playbackTempo, float playbackPitch) {
-        if (playerImpl != null) playerImpl.setPlaybackParameters(playbackTempo, playbackPitch);
+    public void onPlaybackParameterChanged(float playbackTempo, float playbackPitch,
+                                           boolean playbackSkipSilence) {
+        if (playerImpl != null) {
+            playerImpl.setPlaybackParameters(playbackTempo, playbackPitch, playbackSkipSilence);
+        }
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -533,6 +537,7 @@ public final class MainVideoPlayer extends AppCompatActivity
                     this.getRepeatMode(),
                     this.getPlaybackSpeed(),
                     this.getPlaybackPitch(),
+                    this.getPlaybackSkipSilence(),
                     this.getPlaybackQuality()
             );
             context.startService(intent);
@@ -554,6 +559,7 @@ public final class MainVideoPlayer extends AppCompatActivity
                     this.getRepeatMode(),
                     this.getPlaybackSpeed(),
                     this.getPlaybackPitch(),
+                    this.getPlaybackSkipSilence(),
                     this.getPlaybackQuality()
             );
             context.startService(intent);
@@ -649,7 +655,8 @@ public final class MainVideoPlayer extends AppCompatActivity
 
         @Override
         public void onPlaybackSpeedClicked() {
-            PlaybackParameterDialog.newInstance(getPlaybackSpeed(), getPlaybackPitch())
+            PlaybackParameterDialog
+                    .newInstance(getPlaybackSpeed(), getPlaybackPitch(), getPlaybackSkipSilence())
                     .show(getSupportFragmentManager(), TAG);
         }
 

--- a/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
@@ -720,7 +720,6 @@ public final class MainVideoPlayer extends AppCompatActivity
         @Override
         public void onBuffering() {
             super.onBuffering();
-            animatePlayButtons(false, 100);
             getRootView().setKeepScreenOn(true);
         }
 

--- a/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
@@ -58,7 +58,6 @@ import com.google.android.exoplayer2.ui.AspectRatioFrameLayout;
 import com.google.android.exoplayer2.ui.SubtitleView;
 
 import org.schabi.newpipe.R;
-import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.extractor.stream.VideoStream;
 import org.schabi.newpipe.fragments.OnScrollBelowItemsListener;
 import org.schabi.newpipe.player.helper.PlaybackParameterDialog;
@@ -67,6 +66,8 @@ import org.schabi.newpipe.player.playqueue.PlayQueueItem;
 import org.schabi.newpipe.player.playqueue.PlayQueueItemBuilder;
 import org.schabi.newpipe.player.playqueue.PlayQueueItemHolder;
 import org.schabi.newpipe.player.playqueue.PlayQueueItemTouchCallback;
+import org.schabi.newpipe.player.resolver.MediaSourceTag;
+import org.schabi.newpipe.player.resolver.VideoPlaybackResolver;
 import org.schabi.newpipe.util.AnimationUtils;
 import org.schabi.newpipe.util.ListHelper;
 import org.schabi.newpipe.util.NavigationHelper;
@@ -497,11 +498,8 @@ public final class MainVideoPlayer extends AppCompatActivity
         // Playback Listener
         //////////////////////////////////////////////////////////////////////////*/
 
-        protected void onMetadataChanged(@NonNull final PlayQueueItem item,
-                                         @Nullable final StreamInfo info,
-                                         final int newPlayQueueIndex,
-                                         final boolean hasPlayQueueItemChanged) {
-            super.onMetadataChanged(item, info, newPlayQueueIndex, false);
+        protected void onMetadataChanged(@Nullable final MediaSourceTag tag) {
+            super.onMetadataChanged(tag);
 
             titleTextView.setText(getVideoTitle());
             channelTextView.setText(getUploaderName());
@@ -686,14 +684,19 @@ public final class MainVideoPlayer extends AppCompatActivity
         }
 
         @Override
-        protected int getDefaultResolutionIndex(final List<VideoStream> sortedVideos) {
-            return ListHelper.getDefaultResolutionIndex(context, sortedVideos);
-        }
+        protected VideoPlaybackResolver.QualityResolver getQualityResolver() {
+            return new VideoPlaybackResolver.QualityResolver() {
+                @Override
+                public int getDefaultResolutionIndex(List<VideoStream> sortedVideos) {
+                    return ListHelper.getDefaultResolutionIndex(context, sortedVideos);
+                }
 
-        @Override
-        protected int getOverrideResolutionIndex(final List<VideoStream> sortedVideos,
-                                                 final String playbackQuality) {
-            return ListHelper.getResolutionIndex(context, sortedVideos, playbackQuality);
+                @Override
+                public int getOverrideResolutionIndex(List<VideoStream> sortedVideos,
+                                                      String playbackQuality) {
+                    return ListHelper.getResolutionIndex(context, sortedVideos, playbackQuality);
+                }
+            };
         }
 
         /*//////////////////////////////////////////////////////////////////////////

--- a/app/src/main/java/org/schabi/newpipe/player/PlayerState.java
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayerState.java
@@ -14,21 +14,26 @@ public class PlayerState implements Serializable {
     private final float playbackSpeed;
     private final float playbackPitch;
     @Nullable private final String playbackQuality;
+    private final boolean playbackSkipSilence;
     private final boolean wasPlaying;
 
     PlayerState(@NonNull final PlayQueue playQueue, final int repeatMode,
-                 final float playbackSpeed, final float playbackPitch, final boolean wasPlaying) {
-        this(playQueue, repeatMode, playbackSpeed, playbackPitch, null, wasPlaying);
+                final float playbackSpeed, final float playbackPitch,
+                final boolean playbackSkipSilence, final boolean wasPlaying) {
+        this(playQueue, repeatMode, playbackSpeed, playbackPitch, null,
+                playbackSkipSilence, wasPlaying);
     }
 
     PlayerState(@NonNull final PlayQueue playQueue, final int repeatMode,
                 final float playbackSpeed, final float playbackPitch,
-                @Nullable final String playbackQuality, final boolean wasPlaying) {
+                @Nullable final String playbackQuality, final boolean playbackSkipSilence,
+                final boolean wasPlaying) {
         this.playQueue = playQueue;
         this.repeatMode = repeatMode;
         this.playbackSpeed = playbackSpeed;
         this.playbackPitch = playbackPitch;
         this.playbackQuality = playbackQuality;
+        this.playbackSkipSilence = playbackSkipSilence;
         this.wasPlaying = wasPlaying;
     }
 
@@ -60,6 +65,10 @@ public class PlayerState implements Serializable {
     @Nullable
     public String getPlaybackQuality() {
         return playbackQuality;
+    }
+
+    public boolean isPlaybackSkipSilence() {
+        return playbackSkipSilence;
     }
 
     public boolean wasPlaying() {

--- a/app/src/main/java/org/schabi/newpipe/player/PopupVideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/PopupVideoPlayer.java
@@ -191,14 +191,19 @@ public final class PopupVideoPlayer extends Service {
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
         popupWidth = popupRememberSizeAndPos ? sharedPreferences.getFloat(POPUP_SAVED_WIDTH, defaultSize) : defaultSize;
 
-        final int layoutParamType = Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.O ? WindowManager.LayoutParams.TYPE_PHONE : WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY;
+        final int layoutParamType = Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.O ?
+                WindowManager.LayoutParams.TYPE_PHONE :
+                WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY;
+        final int interactiveInputMethodLayout = WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE |
+                WindowManager.LayoutParams.FLAG_ALT_FOCUSABLE_IM;
 
         windowLayoutParams = new WindowManager.LayoutParams(
                 (int) popupWidth, (int) getMinimumVideoHeight(popupWidth),
                 layoutParamType,
-                WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE,
+                interactiveInputMethodLayout,
                 PixelFormat.TRANSLUCENT);
         windowLayoutParams.gravity = Gravity.LEFT | Gravity.TOP;
+        windowLayoutParams.softInputMode = WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE;
 
         int centerX = (int) (screenWidth / 2f - popupWidth / 2f);
         int centerY = (int) (screenHeight / 2f - popupHeight / 2f);
@@ -608,6 +613,8 @@ public final class PopupVideoPlayer extends Service {
 
         protected void onMetadataChanged(@NonNull final MediaSourceTag tag) {
             super.onMetadataChanged(tag);
+            resetNotification();
+            updateNotification(-1);
             updateMetadata();
         }
 

--- a/app/src/main/java/org/schabi/newpipe/player/PopupVideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/PopupVideoPlayer.java
@@ -59,13 +59,13 @@ import com.google.android.exoplayer2.ui.SubtitleView;
 
 import org.schabi.newpipe.BuildConfig;
 import org.schabi.newpipe.R;
-import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.extractor.stream.VideoStream;
 import org.schabi.newpipe.player.event.PlayerEventListener;
 import org.schabi.newpipe.player.helper.LockManager;
 import org.schabi.newpipe.player.helper.PlayerHelper;
 import org.schabi.newpipe.player.old.PlayVideoActivity;
-import org.schabi.newpipe.player.playqueue.PlayQueueItem;
+import org.schabi.newpipe.player.resolver.MediaSourceTag;
+import org.schabi.newpipe.player.resolver.VideoPlaybackResolver;
 import org.schabi.newpipe.util.ListHelper;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.ThemeHelper;
@@ -511,14 +511,20 @@ public final class PopupVideoPlayer extends Service {
         }
 
         @Override
-        protected int getDefaultResolutionIndex(final List<VideoStream> sortedVideos) {
-            return ListHelper.getPopupDefaultResolutionIndex(context, sortedVideos);
-        }
+        protected VideoPlaybackResolver.QualityResolver getQualityResolver() {
+            return new VideoPlaybackResolver.QualityResolver() {
+                @Override
+                public int getDefaultResolutionIndex(List<VideoStream> sortedVideos) {
+                    return ListHelper.getPopupDefaultResolutionIndex(context, sortedVideos);
+                }
 
-        @Override
-        protected int getOverrideResolutionIndex(final List<VideoStream> sortedVideos,
-                                                 final String playbackQuality) {
-            return ListHelper.getPopupResolutionIndex(context, sortedVideos, playbackQuality);
+                @Override
+                public int getOverrideResolutionIndex(List<VideoStream> sortedVideos,
+                                                      String playbackQuality) {
+                    return ListHelper.getPopupResolutionIndex(context, sortedVideos,
+                            playbackQuality);
+                }
+            };
         }
 
         /*//////////////////////////////////////////////////////////////////////////
@@ -539,8 +545,8 @@ public final class PopupVideoPlayer extends Service {
         }
 
         private void updateMetadata() {
-            if (activityListener != null && currentInfo != null) {
-                activityListener.onMetadataUpdate(currentInfo);
+            if (activityListener != null && getCurrentMetadata() != null) {
+                activityListener.onMetadataUpdate(getCurrentMetadata().getMetadata());
             }
         }
 
@@ -586,11 +592,8 @@ public final class PopupVideoPlayer extends Service {
         // Playback Listener
         //////////////////////////////////////////////////////////////////////////*/
 
-        protected void onMetadataChanged(@NonNull final PlayQueueItem item,
-                                         @Nullable final StreamInfo info,
-                                         final int newPlayQueueIndex,
-                                         final boolean hasPlayQueueItemChanged) {
-            super.onMetadataChanged(item, info, newPlayQueueIndex, false);
+        protected void onMetadataChanged(@Nullable final MediaSourceTag tag) {
+            super.onMetadataChanged(tag);
             updateMetadata();
         }
 

--- a/app/src/main/java/org/schabi/newpipe/player/PopupVideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/PopupVideoPlayer.java
@@ -729,7 +729,8 @@ public final class PopupVideoPlayer extends Service {
         /*package-private*/ void enableVideoRenderer(final boolean enable) {
             final int videoRendererIndex = getRendererIndex(C.TRACK_TYPE_VIDEO);
             if (trackSelector != null && videoRendererIndex != RENDERER_UNAVAILABLE) {
-                trackSelector.setRendererDisabled(videoRendererIndex, !enable);
+                trackSelector.setParameters(trackSelector.buildUponParameters()
+                        .setRendererDisabled(videoRendererIndex, !enable));
             }
         }
 

--- a/app/src/main/java/org/schabi/newpipe/player/PopupVideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/PopupVideoPlayer.java
@@ -459,6 +459,7 @@ public final class PopupVideoPlayer extends Service {
                         this.getRepeatMode(),
                         this.getPlaybackSpeed(),
                         this.getPlaybackPitch(),
+                        this.getPlaybackSkipSilence(),
                         this.getPlaybackQuality()
                 );
                 intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);

--- a/app/src/main/java/org/schabi/newpipe/player/PopupVideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/PopupVideoPlayer.java
@@ -683,9 +683,9 @@ public final class PopupVideoPlayer extends Service {
 
         @Override
         public void changeState(int state) {
+            resetNotification();
             super.changeState(state);
             updatePlayback();
-            updateNotification(-1);
         }
 
         @Override

--- a/app/src/main/java/org/schabi/newpipe/player/ServicePlayerActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ServicePlayerActivity.java
@@ -187,6 +187,7 @@ public abstract class ServicePlayerActivity extends AppCompatActivity
                 this.player.getRepeatMode(),
                 this.player.getPlaybackSpeed(),
                 this.player.getPlaybackPitch(),
+                this.player.getPlaybackSkipSilence(),
                 null
         ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
     }
@@ -466,13 +467,16 @@ public abstract class ServicePlayerActivity extends AppCompatActivity
 
     private void openPlaybackParameterDialog() {
         if (player == null) return;
-        PlaybackParameterDialog.newInstance(player.getPlaybackSpeed(),
-                player.getPlaybackPitch()).show(getSupportFragmentManager(), getTag());
+        PlaybackParameterDialog.newInstance(player.getPlaybackSpeed(), player.getPlaybackPitch(),
+                player.getPlaybackSkipSilence()).show(getSupportFragmentManager(), getTag());
     }
 
     @Override
-    public void onPlaybackParameterChanged(float playbackTempo, float playbackPitch) {
-        if (player != null) player.setPlaybackParameters(playbackTempo, playbackPitch);
+    public void onPlaybackParameterChanged(float playbackTempo, float playbackPitch,
+                                           boolean playbackSkipSilence) {
+        if (player != null) {
+            player.setPlaybackParameters(playbackTempo, playbackPitch, playbackSkipSilence);
+        }
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/app/src/main/java/org/schabi/newpipe/player/VideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/VideoPlayer.java
@@ -315,14 +315,13 @@ public abstract class VideoPlayer extends BasePlayer
         }
         captionPopupMenu.setOnDismissListener(this);
     }
-    /*//////////////////////////////////////////////////////////////////////////
-    // Playback Listener
-    //////////////////////////////////////////////////////////////////////////*/
 
-    protected abstract VideoPlaybackResolver.QualityResolver getQualityResolver();
 
-    protected void onMetadataChanged(@NonNull final MediaSourceTag tag) {
-        super.onMetadataChanged(tag);
+    private void updateStreamRelatedViews() {
+        if (getCurrentMetadata() == null) return;
+
+        final MediaSourceTag tag = getCurrentMetadata();
+        final StreamInfo metadata = tag.getMetadata();
 
         qualityTextView.setVisibility(View.GONE);
         playbackSpeedTextView.setVisibility(View.GONE);
@@ -330,7 +329,7 @@ public abstract class VideoPlayer extends BasePlayer
         playbackEndTime.setVisibility(View.GONE);
         playbackLiveSync.setVisibility(View.GONE);
 
-        switch (tag.getMetadata().getStreamType()) {
+        switch (metadata.getStreamType()) {
             case AUDIO_STREAM:
                 surfaceView.setVisibility(View.GONE);
                 endScreen.setVisibility(View.VISIBLE);
@@ -350,8 +349,8 @@ public abstract class VideoPlayer extends BasePlayer
                 break;
 
             case VIDEO_STREAM:
-                final StreamInfo info = tag.getMetadata();
-                if (info.getVideoStreams().size() + info.getVideoOnlyStreams().size() == 0) break;
+                if (metadata.getVideoStreams().size() + metadata.getVideoOnlyStreams().size() == 0)
+                    break;
 
                 availableStreams = tag.getSortedAvailableVideoStreams();
                 selectedStreamIndex = tag.getSelectedVideoStreamIndex();
@@ -367,6 +366,16 @@ public abstract class VideoPlayer extends BasePlayer
 
         buildPlaybackSpeedMenu();
         playbackSpeedTextView.setVisibility(View.VISIBLE);
+    }
+    /*//////////////////////////////////////////////////////////////////////////
+    // Playback Listener
+    //////////////////////////////////////////////////////////////////////////*/
+
+    protected abstract VideoPlaybackResolver.QualityResolver getQualityResolver();
+
+    protected void onMetadataChanged(@NonNull final MediaSourceTag tag) {
+        super.onMetadataChanged(tag);
+        updateStreamRelatedViews();
     }
 
     @Override
@@ -399,6 +408,8 @@ public abstract class VideoPlayer extends BasePlayer
     @Override
     public void onPlaying() {
         super.onPlaying();
+
+        updateStreamRelatedViews();
 
         showAndAnimateControl(-1, true);
 

--- a/app/src/main/java/org/schabi/newpipe/player/VideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/VideoPlayer.java
@@ -103,7 +103,7 @@ public abstract class VideoPlayer extends BasePlayer
 
     protected boolean wasPlaying = false;
 
-    @Nullable private VideoPlaybackResolver resolver;
+    @NonNull final private VideoPlaybackResolver resolver;
     /*//////////////////////////////////////////////////////////////////////////
     // Views
     //////////////////////////////////////////////////////////////////////////*/
@@ -154,6 +154,7 @@ public abstract class VideoPlayer extends BasePlayer
     public VideoPlayer(String debugTag, Context context) {
         super(context);
         this.TAG = debugTag;
+        this.resolver = new VideoPlaybackResolver(context, dataSource, getQualityResolver());
     }
 
     public void setup(View rootView) {
@@ -236,8 +237,6 @@ public abstract class VideoPlayer extends BasePlayer
             trackSelector.setParameters(trackSelector.buildUponParameters()
                     .setTunnelingAudioSessionId(C.generateAudioSessionIdV21(context)));
         }
-
-        resolver = new VideoPlaybackResolver(context, dataSource, getQualityResolver());
     }
 
     @Override
@@ -292,7 +291,7 @@ public abstract class VideoPlayer extends BasePlayer
                 0, Menu.NONE, R.string.caption_none);
         captionOffItem.setOnMenuItemClickListener(menuItem -> {
             final int textRendererIndex = getRendererIndex(C.TRACK_TYPE_TEXT);
-            if (trackSelector != null && textRendererIndex != RENDERER_UNAVAILABLE) {
+            if (textRendererIndex != RENDERER_UNAVAILABLE) {
                 trackSelector.setParameters(trackSelector.buildUponParameters()
                         .setRendererDisabled(textRendererIndex, true));
             }
@@ -306,7 +305,7 @@ public abstract class VideoPlayer extends BasePlayer
                     i + 1, Menu.NONE, captionLanguage);
             captionItem.setOnMenuItemClickListener(menuItem -> {
                 final int textRendererIndex = getRendererIndex(C.TRACK_TYPE_TEXT);
-                if (trackSelector != null && textRendererIndex != RENDERER_UNAVAILABLE) {
+                if (textRendererIndex != RENDERER_UNAVAILABLE) {
                     trackSelector.setPreferredTextLanguage(captionLanguage);
                     trackSelector.setParameters(trackSelector.buildUponParameters()
                             .setRendererDisabled(textRendererIndex, false));
@@ -369,7 +368,7 @@ public abstract class VideoPlayer extends BasePlayer
     @Override
     @Nullable
     public MediaSource sourceOf(final PlayQueueItem item, final StreamInfo info) {
-        return resolver == null ? null : resolver.resolve(info);
+        return resolver.resolve(info);
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -480,8 +479,7 @@ public abstract class VideoPlayer extends BasePlayer
         final int textRenderer = getRendererIndex(C.TRACK_TYPE_TEXT);
 
         if (captionTextView == null) return;
-        if (trackSelector == null || trackSelector.getCurrentMappedTrackInfo() == null ||
-                textRenderer == RENDERER_UNAVAILABLE) {
+        if (trackSelector.getCurrentMappedTrackInfo() == null || textRenderer == RENDERER_UNAVAILABLE) {
             captionTextView.setVisibility(View.GONE);
             return;
         }
@@ -833,12 +831,12 @@ public abstract class VideoPlayer extends BasePlayer
     //////////////////////////////////////////////////////////////////////////*/
 
     public void setPlaybackQuality(final String quality) {
-        if (resolver != null) resolver.setPlaybackQuality(quality);
+        this.resolver.setPlaybackQuality(quality);
     }
 
     @Nullable
     public String getPlaybackQuality() {
-        return resolver == null ? null : resolver.getPlaybackQuality();
+        return resolver.getPlaybackQuality();
     }
 
     public AspectRatioFrameLayout getAspectRatioFrameLayout() {

--- a/app/src/main/java/org/schabi/newpipe/player/VideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/VideoPlayer.java
@@ -241,7 +241,8 @@ public abstract class VideoPlayer extends BasePlayer
 
         // Setup audio session with onboard equalizer
         if (Build.VERSION.SDK_INT >= 21) {
-            trackSelector.setTunnelingAudioSessionId(C.generateAudioSessionIdV21(context));
+            trackSelector.setParameters(trackSelector.buildUponParameters()
+                    .setTunnelingAudioSessionId(C.generateAudioSessionIdV21(context)));
         }
     }
 
@@ -298,7 +299,8 @@ public abstract class VideoPlayer extends BasePlayer
         captionOffItem.setOnMenuItemClickListener(menuItem -> {
             final int textRendererIndex = getRendererIndex(C.TRACK_TYPE_TEXT);
             if (trackSelector != null && textRendererIndex != RENDERER_UNAVAILABLE) {
-                trackSelector.setRendererDisabled(textRendererIndex, true);
+                trackSelector.setParameters(trackSelector.buildUponParameters()
+                        .setRendererDisabled(textRendererIndex, true));
             }
             return true;
         });
@@ -312,7 +314,8 @@ public abstract class VideoPlayer extends BasePlayer
                 final int textRendererIndex = getRendererIndex(C.TRACK_TYPE_TEXT);
                 if (trackSelector != null && textRendererIndex != RENDERER_UNAVAILABLE) {
                     trackSelector.setPreferredTextLanguage(captionLanguage);
-                    trackSelector.setRendererDisabled(textRendererIndex, false);
+                    trackSelector.setParameters(trackSelector.buildUponParameters()
+                            .setRendererDisabled(textRendererIndex, false));
                 }
                 return true;
             });
@@ -575,8 +578,8 @@ public abstract class VideoPlayer extends BasePlayer
 
         // Build UI
         buildCaptionMenu(availableLanguages);
-        if (trackSelector.getRendererDisabled(textRenderer) || preferredLanguage == null ||
-                !availableLanguages.contains(preferredLanguage)) {
+        if (trackSelector.getParameters().getRendererDisabled(textRenderer) ||
+                preferredLanguage == null || !availableLanguages.contains(preferredLanguage)) {
             captionTextView.setText(R.string.caption_none);
         } else {
             captionTextView.setText(preferredLanguage);

--- a/app/src/main/java/org/schabi/newpipe/player/VideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/VideoPlayer.java
@@ -333,16 +333,19 @@ public abstract class VideoPlayer extends BasePlayer
         switch (tag.getMetadata().getStreamType()) {
             case AUDIO_STREAM:
                 surfaceView.setVisibility(View.GONE);
+                endScreen.setVisibility(View.VISIBLE);
                 playbackEndTime.setVisibility(View.VISIBLE);
                 break;
 
             case AUDIO_LIVE_STREAM:
                 surfaceView.setVisibility(View.GONE);
+                endScreen.setVisibility(View.VISIBLE);
                 playbackLiveSync.setVisibility(View.VISIBLE);
                 break;
 
             case LIVE_STREAM:
                 surfaceView.setVisibility(View.VISIBLE);
+                endScreen.setVisibility(View.GONE);
                 playbackLiveSync.setVisibility(View.VISIBLE);
                 break;
 
@@ -357,6 +360,7 @@ public abstract class VideoPlayer extends BasePlayer
                 qualityTextView.setVisibility(View.VISIBLE);
                 surfaceView.setVisibility(View.VISIBLE);
             default:
+                endScreen.setVisibility(View.GONE);
                 playbackEndTime.setVisibility(View.VISIBLE);
                 break;
         }
@@ -387,7 +391,6 @@ public abstract class VideoPlayer extends BasePlayer
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN)
             playbackSeekBar.getThumb().setColorFilter(Color.RED, PorterDuff.Mode.SRC_IN);
 
-        animateView(endScreen, false, 0);
         loadingPanel.setBackgroundColor(Color.BLACK);
         animateView(loadingPanel, true, 0);
         animateView(surfaceForeground, true, 100);
@@ -407,14 +410,12 @@ public abstract class VideoPlayer extends BasePlayer
         loadingPanel.setVisibility(View.GONE);
 
         animateView(currentDisplaySeek, AnimationUtils.Type.SCALE_AND_ALPHA, false, 200);
-        animateView(endScreen, false, 0);
     }
 
     @Override
     public void onBuffering() {
         if (DEBUG) Log.d(TAG, "onBuffering() called");
         loadingPanel.setBackgroundColor(Color.TRANSPARENT);
-        animateView(loadingPanel, true, 500);
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/player/helper/MediaSessionManager.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/MediaSessionManager.java
@@ -39,10 +39,13 @@ public class MediaSessionManager {
         return MediaButtonReceiver.handleIntent(mediaSession, intent);
     }
 
+    /**
+     * Should be called on player destruction to prevent leakage.
+     * */
     public void dispose() {
         this.sessionConnector.setPlayer(null, null);
         this.sessionConnector.setQueueNavigator(null);
         this.mediaSession.setActive(false);
         this.mediaSession.release();
-    }
+	}
 }

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlaybackParameterDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlaybackParameterDialog.java
@@ -27,7 +27,13 @@ public class PlaybackParameterDialog extends DialogFragment {
 
     public static final char STEP_UP_SIGN = '+';
     public static final char STEP_DOWN_SIGN = '-';
-    public static final double DEFAULT_PLAYBACK_STEP_VALUE = 0.05f;
+
+    public static final double STEP_ONE_PERCENT_VALUE = 0.01f;
+    public static final double STEP_FIVE_PERCENT_VALUE = 0.05f;
+    public static final double STEP_TEN_PERCENT_VALUE = 0.10f;
+    public static final double STEP_TWENTY_FIVE_PERCENT_VALUE = 0.25f;
+    public static final double STEP_ONE_HUNDRED_PERCENT_VALUE = 1.00f;
+    public static final double DEFAULT_PLAYBACK_STEP_VALUE = STEP_TWENTY_FIVE_PERCENT_VALUE;
 
     public static final double DEFAULT_TEMPO = 1.00f;
     public static final double DEFAULT_PITCH = 1.00f;
@@ -244,35 +250,33 @@ public class PlaybackParameterDialog extends DialogFragment {
         stepSizeOneHundredPercentText = rootView.findViewById(R.id.stepSizeOneHundredPercent);
 
         if (stepSizeOnePercentText != null) {
-            final double onePercent = 0.01f;
-            stepSizeOnePercentText.setText(getPercentString(onePercent));
-            stepSizeOnePercentText.setOnClickListener(view -> setupStepSize(onePercent));
+            stepSizeOnePercentText.setText(getPercentString(STEP_ONE_PERCENT_VALUE));
+            stepSizeOnePercentText.setOnClickListener(view ->
+                    setupStepSize(STEP_ONE_PERCENT_VALUE));
         }
 
         if (stepSizeFivePercentText != null) {
-            final double fivePercent = 0.05f;
-            stepSizeFivePercentText.setText(getPercentString(fivePercent));
-            stepSizeFivePercentText.setOnClickListener(view -> setupStepSize(fivePercent));
+            stepSizeFivePercentText.setText(getPercentString(STEP_FIVE_PERCENT_VALUE));
+            stepSizeFivePercentText.setOnClickListener(view ->
+                    setupStepSize(STEP_FIVE_PERCENT_VALUE));
         }
 
         if (stepSizeTenPercentText != null) {
-            final double tenPercent = 0.10f;
-            stepSizeTenPercentText.setText(getPercentString(tenPercent));
-            stepSizeTenPercentText.setOnClickListener(view -> setupStepSize(tenPercent));
+            stepSizeTenPercentText.setText(getPercentString(STEP_TEN_PERCENT_VALUE));
+            stepSizeTenPercentText.setOnClickListener(view ->
+                    setupStepSize(STEP_TEN_PERCENT_VALUE));
         }
 
         if (stepSizeTwentyFivePercentText != null) {
-            final double twentyFivePercent = 0.25f;
-            stepSizeTwentyFivePercentText.setText(getPercentString(twentyFivePercent));
+            stepSizeTwentyFivePercentText.setText(getPercentString(STEP_TWENTY_FIVE_PERCENT_VALUE));
             stepSizeTwentyFivePercentText.setOnClickListener(view ->
-                    setupStepSize(twentyFivePercent));
+                    setupStepSize(STEP_TWENTY_FIVE_PERCENT_VALUE));
         }
 
         if (stepSizeOneHundredPercentText != null) {
-            final double oneHundredPercent = 1.00f;
-            stepSizeOneHundredPercentText.setText(getPercentString(oneHundredPercent));
+            stepSizeOneHundredPercentText.setText(getPercentString(STEP_ONE_HUNDRED_PERCENT_VALUE));
             stepSizeOneHundredPercentText.setOnClickListener(view ->
-                    setupStepSize(oneHundredPercent));
+                    setupStepSize(STEP_ONE_HUNDRED_PERCENT_VALUE));
         }
     }
 

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlaybackParameterDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlaybackParameterDialog.java
@@ -21,7 +21,7 @@ import static org.schabi.newpipe.player.BasePlayer.DEBUG;
 public class PlaybackParameterDialog extends DialogFragment {
     @NonNull private static final String TAG = "PlaybackParameterDialog";
 
-    // Maximum allowable range in ExoPlayer
+    // Minimum allowable range in ExoPlayer
     public static final double MINIMUM_PLAYBACK_VALUE = 0.10f;
     public static final double MAXIMUM_PLAYBACK_VALUE = 3.00f;
 

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
@@ -252,7 +252,7 @@ public class PlayerHelper {
     }
 
     public static int getShutdownFlingVelocity(@NonNull final Context context) {
-        return 10000;
+        return 6000;
     }
 
     public static int getTossFlingVelocity(@NonNull final Context context) {

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
@@ -241,7 +241,6 @@ public class PlayerHelper {
     public static TrackSelection.Factory getQualitySelector(@NonNull final Context context,
                                                             @NonNull final BandwidthMeter meter) {
         return new AdaptiveTrackSelection.Factory(meter,
-                AdaptiveTrackSelection.DEFAULT_MAX_INITIAL_BITRATE,
                 /*bufferDurationRequiredForQualityIncrease=*/1000,
                 AdaptiveTrackSelection.DEFAULT_MAX_DURATION_FOR_QUALITY_DECREASE_MS,
                 AdaptiveTrackSelection.DEFAULT_MIN_DURATION_TO_RETAIN_AFTER_DISCARD_MS,

--- a/app/src/main/java/org/schabi/newpipe/player/mediasource/FailedMediaSource.java
+++ b/app/src/main/java/org/schabi/newpipe/player/mediasource/FailedMediaSource.java
@@ -4,6 +4,7 @@ import android.support.annotation.NonNull;
 import android.util.Log;
 
 import com.google.android.exoplayer2.ExoPlayer;
+import com.google.android.exoplayer2.source.BaseMediaSource;
 import com.google.android.exoplayer2.source.MediaPeriod;
 import com.google.android.exoplayer2.upstream.Allocator;
 
@@ -11,7 +12,7 @@ import org.schabi.newpipe.player.playqueue.PlayQueueItem;
 
 import java.io.IOException;
 
-public class FailedMediaSource implements ManagedMediaSource {
+public class FailedMediaSource extends BaseMediaSource implements ManagedMediaSource {
     private final String TAG = "FailedMediaSource@" + Integer.toHexString(hashCode());
 
     public static class FailedMediaSourceException extends Exception {
@@ -73,11 +74,6 @@ public class FailedMediaSource implements ManagedMediaSource {
     }
 
     @Override
-    public void prepareSource(ExoPlayer player, boolean isTopLevelSource, Listener listener) {
-        Log.e(TAG, "Loading failed source: ", error);
-    }
-
-    @Override
     public void maybeThrowSourceInfoRefreshError() throws IOException {
         throw new IOException(error);
     }
@@ -90,8 +86,14 @@ public class FailedMediaSource implements ManagedMediaSource {
     @Override
     public void releasePeriod(MediaPeriod mediaPeriod) {}
 
+
     @Override
-    public void releaseSource() {}
+    protected void prepareSourceInternal(ExoPlayer player, boolean isTopLevelSource) {
+        Log.e(TAG, "Loading failed source: ", error);
+    }
+
+    @Override
+    protected void releaseSourceInternal() {}
 
     @Override
     public boolean shouldBeReplacedWith(@NonNull final PlayQueueItem newIdentity,

--- a/app/src/main/java/org/schabi/newpipe/player/mediasource/LoadedMediaSource.java
+++ b/app/src/main/java/org/schabi/newpipe/player/mediasource/LoadedMediaSource.java
@@ -1,10 +1,12 @@
 package org.schabi.newpipe.player.mediasource;
 
+import android.os.Handler;
 import android.support.annotation.NonNull;
 
 import com.google.android.exoplayer2.ExoPlayer;
 import com.google.android.exoplayer2.source.MediaPeriod;
 import com.google.android.exoplayer2.source.MediaSource;
+import com.google.android.exoplayer2.source.MediaSourceEventListener;
 import com.google.android.exoplayer2.upstream.Allocator;
 
 import org.schabi.newpipe.player.playqueue.PlayQueueItem;
@@ -34,7 +36,8 @@ public class LoadedMediaSource implements ManagedMediaSource {
     }
 
     @Override
-    public void prepareSource(ExoPlayer player, boolean isTopLevelSource, Listener listener) {
+    public void prepareSource(ExoPlayer player, boolean isTopLevelSource,
+                              SourceInfoRefreshListener listener) {
         source.prepareSource(player, isTopLevelSource, listener);
     }
 
@@ -54,8 +57,18 @@ public class LoadedMediaSource implements ManagedMediaSource {
     }
 
     @Override
-    public void releaseSource() {
-        source.releaseSource();
+    public void releaseSource(SourceInfoRefreshListener listener) {
+        source.releaseSource(listener);
+    }
+
+    @Override
+    public void addEventListener(Handler handler, MediaSourceEventListener eventListener) {
+        source.addEventListener(handler, eventListener);
+    }
+
+    @Override
+    public void removeEventListener(MediaSourceEventListener eventListener) {
+        source.removeEventListener(eventListener);
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/player/mediasource/ManagedMediaSourcePlaylist.java
+++ b/app/src/main/java/org/schabi/newpipe/player/mediasource/ManagedMediaSourcePlaylist.java
@@ -3,14 +3,14 @@ package org.schabi.newpipe.player.mediasource;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-import com.google.android.exoplayer2.source.DynamicConcatenatingMediaSource;
+import com.google.android.exoplayer2.source.ConcatenatingMediaSource;
 import com.google.android.exoplayer2.source.ShuffleOrder;
 
 public class ManagedMediaSourcePlaylist {
-    @NonNull private final DynamicConcatenatingMediaSource internalSource;
+    @NonNull private final ConcatenatingMediaSource internalSource;
 
     public ManagedMediaSourcePlaylist() {
-        internalSource = new DynamicConcatenatingMediaSource(/*isPlaylistAtomic=*/false,
+        internalSource = new ConcatenatingMediaSource(/*isPlaylistAtomic=*/false,
                 new ShuffleOrder.UnshuffledShuffleOrder(0));
     }
 
@@ -32,12 +32,8 @@ public class ManagedMediaSourcePlaylist {
                 null : (ManagedMediaSource) internalSource.getMediaSource(index);
     }
 
-    public void dispose() {
-        internalSource.releaseSource();
-    }
-
     @NonNull
-    public DynamicConcatenatingMediaSource getParentMediaSource() {
+    public ConcatenatingMediaSource getParentMediaSource() {
         return internalSource;
     }
 
@@ -46,7 +42,7 @@ public class ManagedMediaSourcePlaylist {
     //////////////////////////////////////////////////////////////////////////*/
 
     /**
-     * Expands the {@link DynamicConcatenatingMediaSource} by appending it with a
+     * Expands the {@link ConcatenatingMediaSource} by appending it with a
      * {@link PlaceholderMediaSource}.
      *
      * @see #append(ManagedMediaSource)
@@ -56,17 +52,17 @@ public class ManagedMediaSourcePlaylist {
     }
 
     /**
-     * Appends a {@link ManagedMediaSource} to the end of {@link DynamicConcatenatingMediaSource}.
-     * @see DynamicConcatenatingMediaSource#addMediaSource
+     * Appends a {@link ManagedMediaSource} to the end of {@link ConcatenatingMediaSource}.
+     * @see ConcatenatingMediaSource#addMediaSource
      * */
     public synchronized void append(@NonNull final ManagedMediaSource source) {
         internalSource.addMediaSource(source);
     }
 
     /**
-     * Removes a {@link ManagedMediaSource} from {@link DynamicConcatenatingMediaSource}
+     * Removes a {@link ManagedMediaSource} from {@link ConcatenatingMediaSource}
      * at the given index. If this index is out of bound, then the removal is ignored.
-     * @see DynamicConcatenatingMediaSource#removeMediaSource(int)
+     * @see ConcatenatingMediaSource#removeMediaSource(int)
      * */
     public synchronized void remove(final int index) {
         if (index < 0 || index > internalSource.getSize()) return;
@@ -75,10 +71,10 @@ public class ManagedMediaSourcePlaylist {
     }
 
     /**
-     * Moves a {@link ManagedMediaSource} in {@link DynamicConcatenatingMediaSource}
+     * Moves a {@link ManagedMediaSource} in {@link ConcatenatingMediaSource}
      * from the given source index to the target index. If either index is out of bound,
      * then the call is ignored.
-     * @see DynamicConcatenatingMediaSource#moveMediaSource(int, int)
+     * @see ConcatenatingMediaSource#moveMediaSource(int, int)
      * */
     public synchronized void move(final int source, final int target) {
         if (source < 0 || target < 0) return;
@@ -99,7 +95,7 @@ public class ManagedMediaSourcePlaylist {
     }
 
     /**
-     * Updates the {@link ManagedMediaSource} in {@link DynamicConcatenatingMediaSource}
+     * Updates the {@link ManagedMediaSource} in {@link ConcatenatingMediaSource}
      * at the given index with a given {@link ManagedMediaSource}.
      * @see #update(int, ManagedMediaSource, Runnable)
      * */
@@ -108,11 +104,11 @@ public class ManagedMediaSourcePlaylist {
     }
 
     /**
-     * Updates the {@link ManagedMediaSource} in {@link DynamicConcatenatingMediaSource}
+     * Updates the {@link ManagedMediaSource} in {@link ConcatenatingMediaSource}
      * at the given index with a given {@link ManagedMediaSource}. If the index is out of bound,
      * then the replacement is ignored.
-     * @see DynamicConcatenatingMediaSource#addMediaSource
-     * @see DynamicConcatenatingMediaSource#removeMediaSource(int, Runnable)
+     * @see ConcatenatingMediaSource#addMediaSource
+     * @see ConcatenatingMediaSource#removeMediaSource(int, Runnable)
      * */
     public synchronized void update(final int index, @NonNull final ManagedMediaSource source,
                                     @Nullable final Runnable finalizingAction) {

--- a/app/src/main/java/org/schabi/newpipe/player/mediasource/PlaceholderMediaSource.java
+++ b/app/src/main/java/org/schabi/newpipe/player/mediasource/PlaceholderMediaSource.java
@@ -3,20 +3,19 @@ package org.schabi.newpipe.player.mediasource;
 import android.support.annotation.NonNull;
 
 import com.google.android.exoplayer2.ExoPlayer;
+import com.google.android.exoplayer2.source.BaseMediaSource;
 import com.google.android.exoplayer2.source.MediaPeriod;
 import com.google.android.exoplayer2.upstream.Allocator;
 
 import org.schabi.newpipe.player.playqueue.PlayQueueItem;
 
-import java.io.IOException;
-
-public class PlaceholderMediaSource implements ManagedMediaSource {
+public class PlaceholderMediaSource extends BaseMediaSource implements ManagedMediaSource {
     // Do nothing, so this will stall the playback
-    @Override public void prepareSource(ExoPlayer player, boolean isTopLevelSource, Listener listener) {}
-    @Override public void maybeThrowSourceInfoRefreshError() throws IOException {}
+    @Override public void maybeThrowSourceInfoRefreshError() {}
     @Override public MediaPeriod createPeriod(MediaPeriodId id, Allocator allocator) { return null; }
     @Override public void releasePeriod(MediaPeriod mediaPeriod) {}
-    @Override public void releaseSource() {}
+    @Override protected void prepareSourceInternal(ExoPlayer player, boolean isTopLevelSource) {}
+    @Override protected void releaseSourceInternal() {}
 
     @Override
     public boolean shouldBeReplacedWith(@NonNull PlayQueueItem newIdentity,

--- a/app/src/main/java/org/schabi/newpipe/player/playback/MediaSourceManager.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playback/MediaSourceManager.java
@@ -172,7 +172,6 @@ public class MediaSourceManager {
         playQueueReactor.cancel();
         loaderReactor.dispose();
         syncReactor.dispose();
-        playlist.dispose();
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -481,8 +480,6 @@ public class MediaSourceManager {
 
     private void resetSources() {
         if (DEBUG) Log.d(TAG, "resetSources() called.");
-
-        playlist.dispose();
         playlist = new ManagedMediaSourcePlaylist();
     }
 

--- a/app/src/main/java/org/schabi/newpipe/player/playback/MediaSourceManager.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playback/MediaSourceManager.java
@@ -5,12 +5,10 @@ import android.support.annotation.Nullable;
 import android.support.v4.util.ArraySet;
 import android.util.Log;
 
-import com.google.android.exoplayer2.source.DynamicConcatenatingMediaSource;
 import com.google.android.exoplayer2.source.MediaSource;
 
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
-import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.player.mediasource.FailedMediaSource;
 import org.schabi.newpipe.player.mediasource.LoadedMediaSource;
 import org.schabi.newpipe.player.mediasource.ManagedMediaSource;
@@ -24,10 +22,8 @@ import org.schabi.newpipe.player.playqueue.events.RemoveEvent;
 import org.schabi.newpipe.player.playqueue.events.ReorderEvent;
 import org.schabi.newpipe.util.ServiceHelper;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -37,8 +33,6 @@ import io.reactivex.Single;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.disposables.SerialDisposable;
-import io.reactivex.functions.Consumer;
 import io.reactivex.internal.subscriptions.EmptySubscription;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.PublishSubject;
@@ -104,7 +98,6 @@ public class MediaSourceManager {
     private final static int MAXIMUM_LOADER_SIZE = WINDOW_SIZE * 2 + 1;
     @NonNull private final CompositeDisposable loaderReactor;
     @NonNull private final Set<PlayQueueItem> loadingItems;
-    @NonNull private final SerialDisposable syncReactor;
 
     @NonNull private final AtomicBoolean isBlocked;
 
@@ -144,7 +137,6 @@ public class MediaSourceManager {
 
         this.playQueueReactor = EmptySubscription.INSTANCE;
         this.loaderReactor = new CompositeDisposable();
-        this.syncReactor = new SerialDisposable();
 
         this.isBlocked = new AtomicBoolean(false);
 
@@ -171,7 +163,6 @@ public class MediaSourceManager {
 
         playQueueReactor.cancel();
         loaderReactor.dispose();
-        syncReactor.dispose();
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -310,21 +301,7 @@ public class MediaSourceManager {
         final PlayQueueItem currentItem = playQueue.getItem();
         if (isBlocked.get() || currentItem == null) return;
 
-        final Consumer<StreamInfo> onSuccess = info -> syncInternal(currentItem, info);
-        final Consumer<Throwable> onError = throwable -> syncInternal(currentItem, null);
-
-        final Disposable sync = currentItem.getStream()
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(onSuccess, onError);
-        syncReactor.set(sync);
-    }
-
-    private void syncInternal(@NonNull final PlayQueueItem item,
-                              @Nullable final StreamInfo info) {
-        // Ensure the current item is up to date with the play queue
-        if (playQueue.getItem() == item) {
-            playbackListener.onPlaybackSynchronize(item, info);
-        }
+        playbackListener.onPlaybackSynchronize(currentItem);
     }
 
     private synchronized void maybeSynchronizePlayer() {
@@ -423,7 +400,8 @@ public class MediaSourceManager {
     }
 
     /**
-     * Checks if the corresponding MediaSource in {@link DynamicConcatenatingMediaSource}
+     * Checks if the corresponding MediaSource in
+     * {@link com.google.android.exoplayer2.source.ConcatenatingMediaSource}
      * for a given {@link PlayQueueItem} needs replacement, either due to gapless playback
      * readiness or playlist desynchronization.
      * <br><br>

--- a/app/src/main/java/org/schabi/newpipe/player/playback/PlaybackListener.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playback/PlaybackListener.java
@@ -45,7 +45,7 @@ public interface PlaybackListener {
      *
      * May be called anytime at any amount once unblock is called.
      * */
-    void onPlaybackSynchronize(@NonNull final PlayQueueItem item, @Nullable final StreamInfo info);
+    void onPlaybackSynchronize(@NonNull final PlayQueueItem item);
 
     /**
      * Requests the listener to resolve a stream info into a media source

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/AudioPlaybackResolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/AudioPlaybackResolver.java
@@ -2,6 +2,7 @@ package org.schabi.newpipe.player.resolver;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.google.android.exoplayer2.source.MediaSource;
 
@@ -24,6 +25,7 @@ public class AudioPlaybackResolver implements PlaybackResolver {
     }
 
     @Override
+    @Nullable
     public MediaSource resolve(@NonNull StreamInfo info) {
         final MediaSource liveSource = maybeBuildLiveMediaSource(dataSource, info);
         if (liveSource != null) return liveSource;

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/AudioPlaybackResolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/AudioPlaybackResolver.java
@@ -1,0 +1,39 @@
+package org.schabi.newpipe.player.resolver;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+
+import com.google.android.exoplayer2.source.MediaSource;
+
+import org.schabi.newpipe.extractor.MediaFormat;
+import org.schabi.newpipe.extractor.stream.AudioStream;
+import org.schabi.newpipe.extractor.stream.StreamInfo;
+import org.schabi.newpipe.player.helper.PlayerDataSource;
+import org.schabi.newpipe.player.helper.PlayerHelper;
+import org.schabi.newpipe.util.ListHelper;
+
+public class AudioPlaybackResolver implements PlaybackResolver {
+
+    @NonNull private final Context context;
+    @NonNull private final PlayerDataSource dataSource;
+
+    public AudioPlaybackResolver(@NonNull final Context context,
+                                 @NonNull final PlayerDataSource dataSource) {
+        this.context = context;
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public MediaSource resolve(@NonNull StreamInfo info) {
+        final MediaSource liveSource = maybeBuildLiveMediaSource(dataSource, info);
+        if (liveSource != null) return liveSource;
+
+        final int index = ListHelper.getDefaultAudioFormat(context, info.getAudioStreams());
+        if (index < 0 || index >= info.getAudioStreams().size()) return null;
+
+        final AudioStream audio = info.getAudioStreams().get(index);
+        final MediaSourceTag tag = new MediaSourceTag(info);
+        return buildMediaSource(dataSource, audio.getUrl(), PlayerHelper.cacheKeyOf(info, audio),
+                MediaFormat.getSuffixById(audio.getFormatId()), tag);
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/MediaSourceTag.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/MediaSourceTag.java
@@ -1,0 +1,51 @@
+package org.schabi.newpipe.player.resolver;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import org.schabi.newpipe.extractor.stream.StreamInfo;
+import org.schabi.newpipe.extractor.stream.VideoStream;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
+
+public class MediaSourceTag implements Serializable {
+    @NonNull private final StreamInfo metadata;
+
+    @NonNull private final List<VideoStream> sortedAvailableVideoStreams;
+    private final int selectedVideoStreamIndex;
+
+    public MediaSourceTag(@NonNull final StreamInfo metadata,
+                          @NonNull final List<VideoStream> sortedAvailableVideoStreams,
+                          final int selectedVideoStreamIndex) {
+        this.metadata = metadata;
+        this.sortedAvailableVideoStreams = sortedAvailableVideoStreams;
+        this.selectedVideoStreamIndex = selectedVideoStreamIndex;
+    }
+
+    public MediaSourceTag(@NonNull final StreamInfo metadata) {
+        this(metadata, Collections.emptyList(), /*indexNotAvailable=*/-1);
+    }
+
+    @NonNull
+    public StreamInfo getMetadata() {
+        return metadata;
+    }
+
+    @NonNull
+    public List<VideoStream> getSortedAvailableVideoStreams() {
+        return sortedAvailableVideoStreams;
+    }
+
+    public int getSelectedVideoStreamIndex() {
+        return selectedVideoStreamIndex;
+    }
+
+    @Nullable
+    public VideoStream getSelectedVideoStream() {
+        return selectedVideoStreamIndex < 0 ||
+                selectedVideoStreamIndex >= sortedAvailableVideoStreams.size() ? null :
+                sortedAvailableVideoStreams.get(selectedVideoStreamIndex);
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/PlaybackResolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/PlaybackResolver.java
@@ -1,0 +1,84 @@
+package org.schabi.newpipe.player.resolver;
+
+import android.net.Uri;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.text.TextUtils;
+
+import com.google.android.exoplayer2.C;
+import com.google.android.exoplayer2.source.MediaSource;
+import com.google.android.exoplayer2.util.Util;
+
+import org.schabi.newpipe.extractor.stream.StreamInfo;
+import org.schabi.newpipe.extractor.stream.StreamType;
+import org.schabi.newpipe.player.helper.PlayerDataSource;
+
+public interface PlaybackResolver extends Resolver<StreamInfo, MediaSource> {
+
+    @Nullable
+    default MediaSource maybeBuildLiveMediaSource(@NonNull final PlayerDataSource dataSource,
+                                                  @NonNull final StreamInfo info) {
+        final StreamType streamType = info.getStreamType();
+        if (!(streamType == StreamType.AUDIO_LIVE_STREAM || streamType == StreamType.LIVE_STREAM)) {
+            return null;
+        }
+
+        final MediaSourceTag tag = new MediaSourceTag(info);
+        if (!info.getHlsUrl().isEmpty()) {
+            return buildLiveMediaSource(dataSource, info.getHlsUrl(), C.TYPE_HLS, tag);
+        } else if (!info.getDashMpdUrl().isEmpty()) {
+            return buildLiveMediaSource(dataSource, info.getDashMpdUrl(), C.TYPE_DASH, tag);
+        }
+
+        return null;
+    }
+
+    @NonNull
+    default MediaSource buildLiveMediaSource(@NonNull final PlayerDataSource dataSource,
+                                             @NonNull final String sourceUrl,
+                                             @C.ContentType final int type,
+                                             @NonNull final MediaSourceTag metadata) {
+        final Uri uri = Uri.parse(sourceUrl);
+        switch (type) {
+            case C.TYPE_SS:
+                return dataSource.getLiveSsMediaSourceFactory().setTag(metadata)
+                        .createMediaSource(uri);
+            case C.TYPE_DASH:
+                return dataSource.getLiveDashMediaSourceFactory().setTag(metadata)
+                        .createMediaSource(uri);
+            case C.TYPE_HLS:
+                return dataSource.getLiveHlsMediaSourceFactory().setTag(metadata)
+                        .createMediaSource(uri);
+            default:
+                throw new IllegalStateException("Unsupported type: " + type);
+        }
+    }
+
+    @NonNull
+    default MediaSource buildMediaSource(@NonNull final PlayerDataSource dataSource,
+                                         @NonNull final String sourceUrl,
+                                         @NonNull final String cacheKey,
+                                         @NonNull final String overrideExtension,
+                                         @NonNull final MediaSourceTag metadata) {
+        final Uri uri = Uri.parse(sourceUrl);
+        @C.ContentType final int type = TextUtils.isEmpty(overrideExtension) ?
+                Util.inferContentType(uri) : Util.inferContentType("." + overrideExtension);
+
+        switch (type) {
+            case C.TYPE_SS:
+                return dataSource.getLiveSsMediaSourceFactory().setTag(metadata)
+                        .createMediaSource(uri);
+            case C.TYPE_DASH:
+                return dataSource.getDashMediaSourceFactory().setTag(metadata)
+                        .createMediaSource(uri);
+            case C.TYPE_HLS:
+                return dataSource.getHlsMediaSourceFactory().setTag(metadata)
+                        .createMediaSource(uri);
+            case C.TYPE_OTHER:
+                return dataSource.getExtractorMediaSourceFactory(cacheKey).setTag(metadata)
+                        .createMediaSource(uri);
+            default:
+                throw new IllegalStateException("Unsupported type: " + type);
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/Resolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/Resolver.java
@@ -1,7 +1,8 @@
 package org.schabi.newpipe.player.resolver;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 public interface Resolver<Source, Product> {
-    Product resolve(@NonNull Source source);
+    @Nullable Product resolve(@NonNull Source source);
 }

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/Resolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/Resolver.java
@@ -2,6 +2,6 @@ package org.schabi.newpipe.player.resolver;
 
 import android.support.annotation.NonNull;
 
-public interface Resolver<Source, Produce> {
-    Produce resolve(@NonNull Source source);
+public interface Resolver<Source, Product> {
+    Product resolve(@NonNull Source source);
 }

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/Resolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/Resolver.java
@@ -1,0 +1,7 @@
+package org.schabi.newpipe.player.resolver;
+
+import android.support.annotation.NonNull;
+
+public interface Resolver<Source, Produce> {
+    Produce resolve(@NonNull Source source);
+}

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/VideoPlaybackResolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/VideoPlaybackResolver.java
@@ -47,6 +47,7 @@ public class VideoPlaybackResolver implements PlaybackResolver {
     }
 
     @Override
+    @Nullable
     public MediaSource resolve(@NonNull StreamInfo info) {
         final MediaSource liveSource = maybeBuildLiveMediaSource(dataSource, info);
         if (liveSource != null) return liveSource;

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/VideoPlaybackResolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/VideoPlaybackResolver.java
@@ -1,0 +1,122 @@
+package org.schabi.newpipe.player.resolver;
+
+import android.content.Context;
+import android.net.Uri;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.google.android.exoplayer2.Format;
+import com.google.android.exoplayer2.source.MediaSource;
+import com.google.android.exoplayer2.source.MergingMediaSource;
+
+import org.schabi.newpipe.extractor.MediaFormat;
+import org.schabi.newpipe.extractor.Subtitles;
+import org.schabi.newpipe.extractor.stream.AudioStream;
+import org.schabi.newpipe.extractor.stream.StreamInfo;
+import org.schabi.newpipe.extractor.stream.VideoStream;
+import org.schabi.newpipe.player.helper.PlayerDataSource;
+import org.schabi.newpipe.player.helper.PlayerHelper;
+import org.schabi.newpipe.util.ListHelper;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.google.android.exoplayer2.C.SELECTION_FLAG_AUTOSELECT;
+import static com.google.android.exoplayer2.C.TIME_UNSET;
+
+public class VideoPlaybackResolver implements PlaybackResolver {
+
+    public interface QualityResolver {
+        int getDefaultResolutionIndex(final List<VideoStream> sortedVideos);
+        int getOverrideResolutionIndex(final List<VideoStream> sortedVideos,
+                                       final String playbackQuality);
+    }
+
+    @NonNull private final Context context;
+    @NonNull private final PlayerDataSource dataSource;
+    @NonNull private final QualityResolver qualityResolver;
+
+    @Nullable private String playbackQuality;
+
+    public VideoPlaybackResolver(@NonNull final Context context,
+                                 @NonNull final PlayerDataSource dataSource,
+                                 @NonNull final QualityResolver qualityResolver) {
+        this.context = context;
+        this.dataSource = dataSource;
+        this.qualityResolver = qualityResolver;
+    }
+
+    @Override
+    public MediaSource resolve(@NonNull StreamInfo info) {
+        final MediaSource liveSource = maybeBuildLiveMediaSource(dataSource, info);
+        if (liveSource != null) return liveSource;
+
+        List<MediaSource> mediaSources = new ArrayList<>();
+
+        // Create video stream source
+        final List<VideoStream> videos = ListHelper.getSortedStreamVideosList(context,
+                info.getVideoStreams(), info.getVideoOnlyStreams(), false);
+        final int index;
+        if (videos.isEmpty()) {
+            index = -1;
+        } else if (playbackQuality == null) {
+            index = qualityResolver.getDefaultResolutionIndex(videos);
+        } else {
+            index = qualityResolver.getOverrideResolutionIndex(videos, getPlaybackQuality());
+        }
+        final MediaSourceTag tag = new MediaSourceTag(info, videos, index);
+        @Nullable final VideoStream video = tag.getSelectedVideoStream();
+
+        if (video != null) {
+            final MediaSource streamSource = buildMediaSource(dataSource, video.getUrl(),
+                    PlayerHelper.cacheKeyOf(info, video),
+                    MediaFormat.getSuffixById(video.getFormatId()), tag);
+            mediaSources.add(streamSource);
+        }
+
+        // Create optional audio stream source
+        final List<AudioStream> audioStreams = info.getAudioStreams();
+        final AudioStream audio = audioStreams.isEmpty() ? null : audioStreams.get(
+                ListHelper.getDefaultAudioFormat(context, audioStreams));
+        // Use the audio stream if there is no video stream, or
+        // Merge with audio stream in case if video does not contain audio
+        if (audio != null && ((video != null && video.isVideoOnly) || video == null)) {
+            final MediaSource audioSource = buildMediaSource(dataSource, audio.getUrl(),
+                    PlayerHelper.cacheKeyOf(info, audio),
+                    MediaFormat.getSuffixById(audio.getFormatId()), tag);
+            mediaSources.add(audioSource);
+        }
+
+        // If there is no audio or video sources, then this media source cannot be played back
+        if (mediaSources.isEmpty()) return null;
+        // Below are auxiliary media sources
+
+        // Create subtitle sources
+        for (final Subtitles subtitle : info.getSubtitles()) {
+            final String mimeType = PlayerHelper.mimeTypesOf(subtitle.getFileType());
+            if (mimeType == null) continue;
+
+            final Format textFormat = Format.createTextSampleFormat(null, mimeType,
+                    SELECTION_FLAG_AUTOSELECT, PlayerHelper.captionLanguageOf(context, subtitle));
+            final MediaSource textSource = dataSource.getSampleMediaSourceFactory()
+                    .createMediaSource(Uri.parse(subtitle.getURL()), textFormat, TIME_UNSET);
+            mediaSources.add(textSource);
+        }
+
+        if (mediaSources.size() == 1) {
+            return mediaSources.get(0);
+        } else {
+            return new MergingMediaSource(mediaSources.toArray(
+                    new MediaSource[mediaSources.size()]));
+        }
+    }
+
+    @Nullable
+    public String getPlaybackQuality() {
+        return playbackQuality;
+    }
+
+    public void setPlaybackQuality(@Nullable String playbackQuality) {
+        this.playbackQuality = playbackQuality;
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
@@ -277,6 +277,7 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
                 newpipe_db_shm.delete();
 
             } else {
+
                 Toast.makeText(getContext(), R.string.could_not_import_all_files, Toast.LENGTH_LONG)
                         .show();
             }

--- a/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
@@ -100,11 +100,13 @@ public class NavigationHelper {
                                          final int repeatMode,
                                          final float playbackSpeed,
                                          final float playbackPitch,
+                                         final boolean playbackSkipSilence,
                                          @Nullable final String playbackQuality) {
         return getPlayerIntent(context, targetClazz, playQueue, playbackQuality)
                 .putExtra(BasePlayer.REPEAT_MODE, repeatMode)
                 .putExtra(BasePlayer.PLAYBACK_SPEED, playbackSpeed)
-                .putExtra(BasePlayer.PLAYBACK_PITCH, playbackPitch);
+                .putExtra(BasePlayer.PLAYBACK_PITCH, playbackPitch)
+                .putExtra(BasePlayer.PLAYBACK_SKIP_SILENCE, playbackSkipSilence);
     }
 
     public static void playOnMainPlayer(final Context context, final PlayQueue queue) {

--- a/app/src/main/res/layout/activity_main_player.xml
+++ b/app/src/main/res/layout/activity_main_player.xml
@@ -41,7 +41,6 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_gravity="center"
-        android:scaleType="centerInside"
         android:visibility="gone"
         tools:background="@android:color/white"
         tools:ignore="ContentDescription"

--- a/app/src/main/res/layout/dialog_playback_parameter.xml
+++ b/app/src/main/res/layout/dialog_playback_parameter.xml
@@ -260,43 +260,19 @@
         </RelativeLayout>
 
         <View
-            android:id="@+id/separatorCheckbox"
+            android:id="@+id/separatorStepSizeSelector"
             android:layout_width="match_parent"
             android:layout_height="1dp"
             android:layout_below="@+id/pitchControl"
             android:layout_margin="@dimen/video_item_search_padding"
             android:background="?attr/separator_color"/>
 
-        <CheckBox
-            android:id="@+id/unhookCheckbox"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:checked="false"
-            android:clickable="true"
-            android:focusable="true"
-            android:text="@string/unhook_checkbox"
-            android:maxLines="1"
-            android:layout_centerHorizontal="true"
-            android:layout_below="@id/separatorCheckbox"/>
-
-        <CheckBox
-            android:id="@+id/skipSilenceCheckbox"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:checked="false"
-            android:clickable="true"
-            android:focusable="true"
-            android:text="@string/skip_silence_checkbox"
-            android:maxLines="1"
-            android:layout_centerHorizontal="true"
-            android:layout_below="@id/unhookCheckbox"/>
-
         <LinearLayout
             android:id="@+id/stepSizeSelector"
             android:layout_width="match_parent"
             android:layout_height="40dp"
             android:orientation="horizontal"
-            android:layout_below="@id/skipSilenceCheckbox">
+            android:layout_below="@id/separatorStepSizeSelector">
 
             <TextView
                 android:id="@+id/stepSizeText"
@@ -364,6 +340,38 @@
                 android:background="?attr/selectableItemBackground"
                 android:textColor="?attr/colorAccent"/>
         </LinearLayout>
+
+        <View
+            android:id="@+id/separatorCheckbox"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_below="@+id/stepSizeSelector"
+            android:layout_margin="@dimen/video_item_search_padding"
+            android:background="?attr/separator_color"/>
+
+        <CheckBox
+            android:id="@+id/unhookCheckbox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:checked="false"
+            android:clickable="true"
+            android:focusable="true"
+            android:text="@string/unhook_checkbox"
+            android:maxLines="1"
+            android:layout_centerHorizontal="true"
+            android:layout_below="@id/separatorCheckbox"/>
+
+        <CheckBox
+            android:id="@+id/skipSilenceCheckbox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:checked="false"
+            android:clickable="true"
+            android:focusable="true"
+            android:text="@string/skip_silence_checkbox"
+            android:maxLines="1"
+            android:layout_centerHorizontal="true"
+            android:layout_below="@id/unhookCheckbox"/>
 
         <!-- END HERE -->
 

--- a/app/src/main/res/layout/dialog_playback_parameter.xml
+++ b/app/src/main/res/layout/dialog_playback_parameter.xml
@@ -279,30 +279,88 @@
             android:layout_centerHorizontal="true"
             android:layout_below="@id/separatorCheckbox"/>
 
+        <CheckBox
+            android:id="@+id/skipSilenceCheckbox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:checked="false"
+            android:clickable="true"
+            android:focusable="true"
+            android:text="@string/skip_silence_checkbox"
+            android:maxLines="1"
+            android:layout_centerHorizontal="true"
+            android:layout_below="@id/unhookCheckbox"/>
+
         <LinearLayout
-            android:id="@+id/presetSelector"
+            android:id="@+id/stepSizeSelector"
             android:layout_width="match_parent"
             android:layout_height="40dp"
             android:orientation="horizontal"
-            android:layout_below="@id/unhookCheckbox">
+            android:layout_below="@id/skipSilenceCheckbox">
 
             <TextView
-                android:id="@+id/presetNightcore"
+                android:id="@+id/stepSizeText"
                 android:layout_width="0dp"
                 android:layout_height="match_parent"
                 android:layout_weight="1"
                 android:gravity="center"
-                android:text="@string/playback_nightcore"
+                android:text="@string/playback_step"
+                android:textStyle="bold"
+                android:clickable="false"
+                android:textColor="?attr/colorAccent"/>
+
+            <TextView
+                android:id="@+id/stepSizeOnePercent"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:gravity="center"
+                android:clickable="true"
+                android:focusable="true"
                 android:background="?attr/selectableItemBackground"
                 android:textColor="?attr/colorAccent"/>
 
             <TextView
-                android:id="@+id/presetReset"
+                android:id="@+id/stepSizeFivePercent"
                 android:layout_width="0dp"
                 android:layout_height="match_parent"
                 android:layout_weight="1"
                 android:gravity="center"
-                android:text="@string/playback_default"
+                android:clickable="true"
+                android:focusable="true"
+                android:background="?attr/selectableItemBackground"
+                android:textColor="?attr/colorAccent"/>
+
+            <TextView
+                android:id="@+id/stepSizeTenPercent"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:gravity="center"
+                android:clickable="true"
+                android:focusable="true"
+                android:background="?attr/selectableItemBackground"
+                android:textColor="?attr/colorAccent"/>
+
+            <TextView
+                android:id="@+id/stepSizeTwentyFivePercent"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:gravity="center"
+                android:clickable="true"
+                android:focusable="true"
+                android:background="?attr/selectableItemBackground"
+                android:textColor="?attr/colorAccent"/>
+
+            <TextView
+                android:id="@+id/stepSizeOneHundredPercent"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:gravity="center"
+                android:clickable="true"
+                android:focusable="true"
                 android:background="?attr/selectableItemBackground"
                 android:textColor="?attr/colorAccent"/>
         </LinearLayout>

--- a/app/src/main/res/layout/player_popup.xml
+++ b/app/src/main/res/layout/player_popup.xml
@@ -111,7 +111,7 @@
 
                 <TextView
                     android:id="@+id/resizeTextView"
-                    android:layout_width="match_parent"
+                    android:layout_width="wrap_content"
                     android:layout_height="match_parent"
                     android:layout_alignParentLeft="true"
                     android:background="?attr/selectableItemBackground"

--- a/app/src/main/res/layout/statistic_playlist_control.xml
+++ b/app/src/main/res/layout/statistic_playlist_control.xml
@@ -4,7 +4,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="?attr/selectableItemBackground"
     android:orientation="vertical">
 
     <RelativeLayout
@@ -12,7 +11,9 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:clickable="true"
-        android:focusable="true">
+        android:focusable="true"
+        android:background="?attr/selectableItemBackground">
+
         <ImageView
             android:id="@+id/sortButtonIcon"
             android:layout_width="48dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -479,9 +479,10 @@
     <string name="playback_speed_control">Playback Speed Controls</string>
     <string name="playback_tempo">Tempo</string>
     <string name="playback_pitch">Pitch</string>
-    <string name="unhook_checkbox">Unhook (may cause distortion)</string>
-    <string name="playback_nightcore">Nightcore</string>
-    <string name="playback_default">Default</string>
+    <string name="unhook_checkbox">Unlink (may cause distortion)</string>
+    <string name="skip_silence_checkbox">Fast-forward during silence</string>
+    <string name="playback_step">Step</string>
+    <string name="playback_reset">Reset</string>
 
     <!-- GDPR dialog -->
     <string name="start_accept_privacy_policy">In order to comply with the European General Data Protection Regulation (GDPR), we herby draw your attention to NewPipe\'s privacy policy. Please read it carefully.\nYou must accept it to send us the bug report.</string>


### PR DESCRIPTION
This update bumps the player library version and:

- Reworked the playback speed control dialog to support different step sizes for faster speed change.
- Added a toggle to fast-forward during silences in playback speed control. This should be helpful for audiobooks and certain music genres, and can bring a true seamless experience (and can break a song with lots of silences =\\).  
- Refactored media source resolution to allow passing metadata alongside media internally in the player, rather than doing so manually. Now we have a single source of metadata and is directly available when playback starts.
- Fixed remote playlist metadata not updating when new metadata is available when playlist fragment is opened.
- Various UI fixes: #1383, background player notification controls now always white, easier to shutdown popup player through flinging

However, there is a potential bug in the current release that breaks livestreams, so we will need to wait until a bugfix or resolution is found before merging.

I've also tried to integrate our players to use the new notification UI, which can reduce all notification code on the background and popup players to about 20 lines and provide dynamic notification coloring from thumbnail on Oreo. Unfortunately, the library hardcoded the broadcast intent strings, which means we can't have two players at the same time. Maybe we can later refactor the notification controls and roll our own solution.

If anyone is interested, [here](https://www.youtube.com/watch?v=svdq1BWl4r8) is the link to the new ExoPlayer Google IO talk. 
