### PR TITLE
Downloader: Fix crash on loading unfinished downloads from .giga files

### DIFF
--- a/app/src/main/java/us/shandian/giga/get/DownloadMission.java
+++ b/app/src/main/java/us/shandian/giga/get/DownloadMission.java
@@ -5,6 +5,7 @@ import android.os.Looper;
 import android.util.Log;
 
 import java.io.File;
+import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
@@ -310,6 +311,13 @@ public class DownloadMission implements Serializable {
         synchronized (blockState) {
             Utility.writeToFile(getMetaFilename(), this);
         }
+    }
+
+    private void readObject(ObjectInputStream inputStream)
+    throws java.io.IOException, ClassNotFoundException
+    {
+        inputStream.defaultReadObject();
+        mListeners = new ArrayList<>();
     }
 
     private void deleteThisFromFile() {

--- a/app/src/main/java/us/shandian/giga/util/Utility.java
+++ b/app/src/main/java/us/shandian/giga/util/Utility.java
@@ -12,6 +12,7 @@ import android.widget.Toast;
 import org.schabi.newpipe.R;
 
 import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -59,17 +60,17 @@ public class Utility {
         ObjectOutputStream objectOutputStream = null;
 
         try {
-            objectOutputStream = new ObjectOutputStream(new FileOutputStream(fileName));
+            objectOutputStream = new ObjectOutputStream(new BufferedOutputStream(new FileOutputStream(fileName)));
             objectOutputStream.writeObject(serializable);
         } catch (Exception e) {
             //nothing to do
-        }
-
-        if(objectOutputStream != null) {
-            try {
-                objectOutputStream.close();
-            } catch (Exception e) {
-                //nothing to do
+        } finally {
+            if(objectOutputStream != null) {
+                try {
+                    objectOutputStream.close();
+                } catch (Exception e) {
+                    //nothing to do
+                }
             }
         }
     }


### PR DESCRIPTION
- [X] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

#1355 introduced a bug, which results in a crash, when you open the "Downloads" Activity with paused, unfinished items:
When a DownloadMission gets written to a file via the Serialization API, the member mListeners is not serialized, because it is marked as _transient_. After restoring, mListeners is null, resulting in a NullPointerException in DownloadMission.java:234.

This Pull Request also improves the performance of downloads by wrapping the FileOutputStream in Utility.writeToFile in a BufferedOutputStream, resulting in less system calls.