### PR TITLE
Downloader: Improve performance for weaker CPUs

### DIFF
--- a/app/src/main/java/us/shandian/giga/get/DownloadRunnable.java
+++ b/app/src/main/java/us/shandian/giga/get/DownloadRunnable.java
@@ -2,7 +2,6 @@ package us.shandian.giga.get;
 
 import android.util.Log;
 
-import java.io.BufferedInputStream;
 import java.io.RandomAccessFile;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -104,11 +103,11 @@ public class DownloadRunnable implements Runnable {
 
                 RandomAccessFile f = new RandomAccessFile(mMission.location + "/" + mMission.name, "rw");
                 f.seek(start);
-                BufferedInputStream ipt = new BufferedInputStream(conn.getInputStream());
-                byte[] buf = new byte[512];
+                java.io.InputStream ipt = conn.getInputStream();
+                byte[] buf = new byte[64*1024];
 
                 while (start < end && mMission.running) {
-                    int len = ipt.read(buf, 0, 512);
+                    int len = ipt.read(buf, 0, buf.length);
 
                     if (len == -1) {
                         break;


### PR DESCRIPTION
- [X] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

This improves downloading performance dramatically when the download is cpu bound:
For example, a Galaxy S4 with its 2013 high-end CPU only reaches around 1MB/s, with all cores running at its maximum (and overheating).
By inreasing the chunk size, at which download threads notify its progress (and persist its current state) from only 512 Bytes to 64 KiB, the S4 can easily saturate a 50 MBit/s connection (the maximum I could test).
