### PR TITLE
Downloader: Fix crash on loading unfinished downloads from .giga files (Fixup for release builds)

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -42,3 +42,9 @@
 -dontwarn javax.annotation.**
 # A resource is loaded with a relative path so the package of this class must be preserved.
 -keepnames class okhttp3.internal.publicsuffix.PublicSuffixDatabase
+-keepclassmembers class * implements java.io.Serializable {
+    static final long serialVersionUID;
+    !static !transient <fields>;
+    private void writeObject(java.io.ObjectOutputStream);
+    private void readObject(java.io.ObjectInputStream);
+}


### PR DESCRIPTION
- [X] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

This is a fixup for #1407 , which fixes the crash in release builds, too. It keeps Proguard from removing the new method "private void readObject(java.io.ObjectInputStream)", which is only called by the VM, but not from the code, and therefore considered useless by Proguard in release (minify) mode.

This PR adds some new Proguard rules to keep class members related to serialization for Serializable classes like DownloadMission.