### PR TITLE
Fixed bug #640 - Screen timeout in case of video playing in pop-up mode.

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/PopupVideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/PopupVideoPlayer.java
@@ -662,7 +662,8 @@ public final class PopupVideoPlayer extends Service {
             videoPlayPause.setBackgroundResource(R.drawable.ic_pause_white);
             lockManager.acquireWifiAndCpu();
 
-            hideControls(DEFAULT_CONTROLS_DURATION, DEFAULT_CONTROLS_HIDE_TIME);
+            windowLayoutParams.flags = WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON;
+            windowManager.updateViewLayout(playerImpl.getRootView(), windowLayoutParams);
         }
 
         @Override
@@ -677,6 +678,9 @@ public final class PopupVideoPlayer extends Service {
             updateNotification(R.drawable.ic_play_arrow_white);
             videoPlayPause.setBackgroundResource(R.drawable.ic_play_arrow_white);
             lockManager.releaseWifiAndCpu();
+
+            windowLayoutParams.flags = 0;
+            windowManager.updateViewLayout(playerImpl.getRootView(), windowLayoutParams);
         }
 
         @Override


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

The screen will now remain active if the video is playing. In case the video is paused, the screen will be allowed to time out. 
