### PR TITLE
Fix #1440 Broken Video Info Layout

### DIFF
--- a/app/src/main/res/layout/fragment_video_detail.xml
+++ b/app/src/main/res/layout/fragment_video_detail.xml
@@ -101,7 +101,8 @@
             <RelativeLayout
                 android:id="@+id/detail_content_root_layout"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent">
+                android:layout_height="match_parent"
+                android:background="?android:windowBackground">
 
                 <!-- TITLE -->
                 <FrameLayout


### PR DESCRIPTION
- [X] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

This fixes bug #1440 Broken Video Info Layout and partially reverts pull request #1371 Reduce Overdraw in doing so.
