### PR TITLE
Library version update and database backup fix

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,7 +43,7 @@ android {
 ext {
     supportLibVersion = '27.1.1'
     exoPlayerLibVersion = '2.7.3'
-    roomDbLibVersion = '1.0.0'
+    roomDbLibVersion = '1.1.1'
     leakCanaryLibVersion = '1.5.4'
     okHttpLibVersion = '3.10.0'
     icepickLibVersion = '3.2.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,7 +45,7 @@ ext {
     exoPlayerLibVersion = '2.7.3'
     roomDbLibVersion = '1.0.0'
     leakCanaryLibVersion = '1.5.4'
-    okHttpLibVersion = '1.5.0'
+    okHttpLibVersion = '3.10.0'
     icepickLibVersion = '3.2.0'
     stethoLibVersion = '1.5.0'
 }
@@ -57,7 +57,7 @@ dependencies {
     implementation 'com.github.TeamNewPipe:NewPipeExtractor:bf1c771'
 
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:1.10.19'
+    testImplementation 'org.mockito:mockito-core:2.8.9'
 
     implementation "com.android.support:appcompat-v7:$supportLibVersion"
     implementation "com.android.support:support-v4:$supportLibVersion"
@@ -79,7 +79,7 @@ dependencies {
     debugImplementation "com.facebook.stetho:stetho-urlconnection:$stethoLibVersion"
     debugImplementation 'com.android.support:multidex:1.0.3'
 
-    implementation 'io.reactivex.rxjava2:rxjava:2.1.10'
+    implementation 'io.reactivex.rxjava2:rxjava:2.1.14'
     implementation 'io.reactivex.rxjava2:rxandroid:2.0.2'
     implementation 'com.jakewharton.rxbinding2:rxbinding:2.1.1'
 
@@ -93,6 +93,6 @@ dependencies {
     debugImplementation "com.squareup.leakcanary:leakcanary-android:$leakCanaryLibVersion"
     releaseImplementation "com.squareup.leakcanary:leakcanary-android-no-op:$leakCanaryLibVersion"
 
-    implementation 'com.squareup.okhttp3:okhttp:3.9.1'
-    debugImplementation "com.facebook.stetho:stetho-okhttp3:$okHttpLibVersion"
+    implementation "com.squareup.okhttp3:okhttp:$okHttpLibVersion"
+    debugImplementation "com.facebook.stetho:stetho-okhttp3:$stethoLibVersion"
 }

--- a/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
@@ -56,6 +56,8 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
     private File databasesDir;
     private File newpipe_db;
     private File newpipe_db_journal;
+    private File newpipe_db_shm;
+    private File newpipe_db_wal;
     private File newpipe_settings;
 
     private String thumbnailLoadToggleKey;
@@ -88,6 +90,9 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
         databasesDir = new File(homeDir + "/databases");
         newpipe_db = new File(homeDir + "/databases/newpipe.db");
         newpipe_db_journal = new File(homeDir + "/databases/newpipe.db-journal");
+        newpipe_db_shm = new File(homeDir + "/databases/newpipe.db-shm");
+        newpipe_db_wal = new File(homeDir + "/databases/newpipe.db-wal");
+
         newpipe_settings = new File(homeDir + "/databases/newpipe.settings");
         newpipe_settings.delete();
 
@@ -207,7 +212,7 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
                     new BufferedOutputStream(
                             new FileOutputStream(path)));
             ZipHelper.addFileToZip(outZip, newpipe_db.getPath(), "newpipe.db");
-            ZipHelper.addFileToZip(outZip, newpipe_db_journal.getPath(), "newpipe.db-journal");
+
             saveSharedPreferencesToFile(newpipe_settings);
             ZipHelper.addFileToZip(outZip, newpipe_settings.getPath(), "newpipe.settings");
 
@@ -263,8 +268,15 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
                 throw new Exception("Could not create databases dir");
             }
 
-            if(!(ZipHelper.extractFileFromZip(filePath, newpipe_db.getPath(), "newpipe.db")
-                    && ZipHelper.extractFileFromZip(filePath, newpipe_db_journal.getPath(), "newpipe.db-journal"))) {
+            final boolean isDbFileExtracted = ZipHelper.extractFileFromZip(filePath,
+                    newpipe_db.getPath(), "newpipe.db");
+
+            if (isDbFileExtracted) {
+                newpipe_db_journal.delete();
+                newpipe_db_wal.delete();
+                newpipe_db_shm.delete();
+
+            } else {
                 Toast.makeText(getContext(), R.string.could_not_import_all_files, Toast.LENGTH_LONG)
                         .show();
             }


### PR DESCRIPTION
This updates bumps the version of a few libraries and was part of #1392, but since it is isolated enough, I've decided to pull it out.

Starting from version 1.1.0, Room db changes its journal file into two separate accessory files, namely db-wal and db-shm. These files do not store any important data after a checkpoint or db connection closes. However, when importing new databases, if any of the accessory files do not match, the existing core database will be wiped. So, in order to provide backward compatibility, I've decided to remove all accessory files when a database is imported. 

The only problem is that, if the database of a newer version needs to be imported to a version before this PR, then the user needs to manually clear the app data from the system settings. @theScrabi What do you think about this?