### PR TITLE
Playback resume

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -163,6 +163,7 @@ public class VideoDetailFragment
     private TextView detailControlsDownload;
     private TextView appendControlsDetail;
     private TextView detailDurationView;
+    private TextView detailPlaybackResumeView;
 
     private LinearLayout videoDescriptionRootLayout;
     private TextView videoUploadDateView;
@@ -182,6 +183,9 @@ public class VideoDetailFragment
     private LinearLayout relatedStreamRootLayout;
     private LinearLayout relatedStreamsView;
     private ImageButton relatedStreamExpandButton;
+
+    private SharedPreferences playbackPreferences;
+    private boolean isVideoPlaybackResumeEnabled;
 
 
     /*////////////////////////////////////////////////////////////////////////*/
@@ -205,6 +209,9 @@ public class VideoDetailFragment
                 .getBoolean(getString(R.string.show_next_video_key), true);
         PreferenceManager.getDefaultSharedPreferences(activity)
                 .registerOnSharedPreferenceChangeListener(this);
+
+        this.playbackPreferences = activity.getSharedPreferences(Constants.KEY_VIDEO_PLAYBACK_POSITION_PREFS,0);
+        this.isVideoPlaybackResumeEnabled = PreferenceManager.getDefaultSharedPreferences(activity).getBoolean(getString(R.string.enable_video_playback_resume_key), false);
     }
 
     @Override
@@ -480,6 +487,7 @@ public class VideoDetailFragment
         detailControlsDownload = rootView.findViewById(R.id.detail_controls_download);
         appendControlsDetail = rootView.findViewById(R.id.touch_append_detail);
         detailDurationView = rootView.findViewById(R.id.detail_duration_view);
+        detailPlaybackResumeView = rootView.findViewById(R.id.detail_playback_resume_view);
 
         videoDescriptionRootLayout = rootView.findViewById(R.id.detail_description_root_layout);
         videoUploadDateView = rootView.findViewById(R.id.detail_upload_date_view);
@@ -1108,6 +1116,7 @@ public class VideoDetailFragment
         animateView(spinnerToolbar, false, 200);
         animateView(thumbnailPlayButton, false, 50);
         animateView(detailDurationView, false, 100);
+        animateView(detailPlaybackResumeView, false, 100);
 
         videoTitleTextView.setText(name != null ? name : "");
         videoTitleTextView.setMaxLines(1);
@@ -1182,12 +1191,22 @@ public class VideoDetailFragment
             detailDurationView.setText(Localization.getDurationString(info.getDuration()));
             detailDurationView.setBackgroundColor(ContextCompat.getColor(activity, R.color.duration_background_color));
             animateView(detailDurationView, true, 100);
+            if(isVideoPlaybackResumeEnabled){
+                int playback = (int) playbackPreferences.getLong(info.getOriginalUrl(), 0);
+                if(playback > 0){
+                    detailPlaybackResumeView.setVisibility(View.VISIBLE);
+                    detailPlaybackResumeView.setText(PlayerHelper.getTimeString(playback));
+                    animateView(detailPlaybackResumeView, true, 100);
+                }
+            }
         } else if (info.getStreamType() == StreamType.LIVE_STREAM) {
             detailDurationView.setText(R.string.duration_live);
             detailDurationView.setBackgroundColor(ContextCompat.getColor(activity, R.color.live_duration_background_color));
             animateView(detailDurationView, true, 100);
+            detailPlaybackResumeView.setVisibility(View.GONE);
         } else {
             detailDurationView.setVisibility(View.GONE);
+            detailPlaybackResumeView.setVisibility(View.GONE);
         }
 
         videoTitleRoot.setClickable(true);

--- a/app/src/main/java/org/schabi/newpipe/util/Constants.java
+++ b/app/src/main/java/org/schabi/newpipe/util/Constants.java
@@ -11,5 +11,7 @@ public class Constants {
     public static final String KEY_THEME_CHANGE = "key_theme_change";
     public static final String KEY_MAIN_PAGE_CHANGE = "key_main_page_change";
 
+    public static final String KEY_VIDEO_PLAYBACK_POSITION_PREFS = "key_saved_video_positions";
+
     public static final int NO_SERVICE_ID = -1;
 }

--- a/app/src/main/res/layout/fragment_video_detail.xml
+++ b/app/src/main/res/layout/fragment_video_detail.xml
@@ -57,19 +57,19 @@
                     android:id="@+id/touch_append_detail"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_gravity="center"
                     android:background="#64000000"
                     android:paddingBottom="10dp"
                     android:paddingLeft="30dp"
                     android:paddingRight="30dp"
                     android:paddingTop="10dp"
-                    android:layout_gravity="center"
+                    android:text="@string/hold_to_append"
                     android:textColor="@android:color/white"
                     android:textSize="20sp"
                     android:textStyle="bold"
-                    android:text="@string/hold_to_append"
                     android:visibility="gone"
                     tools:ignore="RtlHardcoded"
-                    tools:visibility="visible"/>
+                    tools:visibility="visible" />
 
                 <TextView
                     android:id="@+id/detail_duration_view"
@@ -95,6 +95,31 @@
                     tools:ignore="RtlHardcoded"
                     tools:text="12:38"
                     tools:visibility="visible"/>
+
+                <TextView
+                    android:id="@+id/detail_playback_resume_view"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="bottom|left"
+                    android:layout_marginBottom="8dp"
+                    android:layout_marginLeft="12dp"
+                    android:layout_marginRight="12dp"
+                    android:layout_marginTop="8dp"
+                    android:alpha=".6"
+                    android:background="@android:color/holo_red_dark"
+                    android:gravity="center"
+                    android:paddingBottom="2dp"
+                    android:paddingLeft="6dp"
+                    android:paddingRight="6dp"
+                    android:paddingTop="2dp"
+                    android:textAllCaps="true"
+                    android:textColor="@android:color/white"
+                    android:textSize="12sp"
+                    android:textStyle="bold"
+                    android:visibility="gone"
+                    tools:ignore="RtlHardcoded"
+                    tools:text="12:38"
+                    tools:visibility="visible" />
             </FrameLayout>
 
             <!-- CONTENT -->
@@ -127,7 +152,7 @@
                         android:textAppearance="?android:attr/textAppearanceLarge"
                         android:textSize="@dimen/video_item_detail_title_text_size"
                         tools:ignore="RtlHardcoded"
-                        tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed a ultricies ex. Integer sit amet sodales risus. Duis non mi et urna pretium bibendum. Nunc eleifend est quis ipsum porttitor egestas. Sed facilisis, nisl quis eleifend pellentesque, orci metus egestas dolor, at accumsan eros metus quis libero."/>
+                        tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed a ultricies ex. Integer sit amet sodales risus. Duis non mi et urna pretium bibendum. Nunc eleifend est quis ipsum porttitor egestas. Sed facilisis, nisl quis eleifend pellentesque, orci metus egestas dolor, at accumsan eros metus quis libero." />
 
                     <ImageView
                         android:id="@+id/detail_toggle_description_view"

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -168,6 +168,8 @@
     <string name="clear_views_history_key" translatable="false">clear_play_history</string>
     <string name="clear_search_history_key" translatable="false">clear_search_history</string>
 
+    <string name="enable_video_playback_resume_key" translatable="false">enable_video_playback_resume</string>
+
     <!-- FileName Downloads  -->
     <string name="settings_file_charset_key" translatable="false">file_rename</string>
     <string name="settings_file_replacement_character_key" translatable="false">file_replacement_character</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -164,6 +164,8 @@
     <string name="view_history_deleted">Watch history deleted.</string>
     <string name="clear_search_history_title">Clear search history</string>
     <string name="clear_search_history_summary">Deletes history of search keywords.</string>
+    <string name="enable_video_playback_resume_title">Playback Resume</string>
+    <string name="enable_video_playback_resume_summary">Continue playing back videos where you left off</string>
     <string name="delete_search_history_alert">Delete whole search history.</string>
     <string name="search_history_deleted">Search history deleted.</string>
     <!-- error strings -->

--- a/app/src/main/res/xml/history_settings.xml
+++ b/app/src/main/res/xml/history_settings.xml
@@ -16,6 +16,12 @@
         android:summary="@string/enable_search_history_summary"
         android:title="@string/enable_search_history_title"/>
 
+    <SwitchPreference
+        android:defaultValue="false"
+        android:key="@string/enable_video_playback_resume_key"
+        android:summary="@string/enable_video_playback_resume_summary"
+        android:title="@string/enable_video_playback_resume_title" />
+
     <Preference
         android:key="@string/metadata_cache_wipe_key"
         android:summary="@string/metadata_cache_wipe_summary"


### PR DESCRIPTION
Hey!
First things first,
- [X] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

This is my first android and open source project that I've ever worked on. I implement a video playback resume feature that I've been using on my own. I would like to ask some questions regarding my developed feature and give some feedback. Any feedback regarding android development and open source in general is helpful.

### The motivation behind the feature
I think it would make a great addition to the project since something very similar is already implemented in Youtube cross platform. I developed this for my own use at first, but this could be a really handy feature for every user.

### The current implementation.

- The feature currently resides in the classes MainVideoPlayer and PopupVideoPlayer respectively. Wouldn't it be just easier to move it to the abstract class VideoPlayer so that every implementing video player gets this feature? I wasn't sure where to put it.

- The option the turn this feature on and off currently can be found in Settings > History. Is this an appropriate place for it?

- I'm currently using SharedPreferences to store video URL/playback time pairs. These pairs have to own preferences and I'm not using the default one that is given back by PreferenceManager. Is there a better way to store this info?