### PR TITLE
Enable linear layout in Downloads activity with full video names

### DIFF
--- a/app/src/main/java/us/shandian/giga/ui/fragment/MissionsFragment.java
+++ b/app/src/main/java/us/shandian/giga/ui/fragment/MissionsFragment.java
@@ -16,6 +16,8 @@ import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
@@ -144,17 +146,21 @@ public abstract class MissionsFragment extends Fragment {
     }
 
     @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        return super.onOptionsItemSelected(item);
+    public void onPrepareOptionsMenu(Menu menu) {
+        mSwitch = menu.findItem(R.id.switch_mode);
+        super.onPrepareOptionsMenu(menu);
+    }
 
-		/*switch (item.getItemId()) {
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
             case R.id.switch_mode:
 				mLinear = !mLinear;
 				updateList();
 				return true;
 			default:
 				return super.onOptionsItemSelected(item);
-		}*/
+		}
     }
 
     public void notifyChange() {

--- a/app/src/main/res/layout/mission_item_linear.xml
+++ b/app/src/main/res/layout/mission_item_linear.xml
@@ -9,7 +9,7 @@
 		android:layout_width="match_parent"
 		android:layout_margin="2dp"
 		android:background="@color/bluegray">
-		
+
 		<ImageView
 			android:id="@+id/item_icon"
 			android:layout_width="72dp"
@@ -19,59 +19,52 @@
 			android:gravity="center"
 			android:padding="15dp"
             android:contentDescription="TODO" />
-		
-		<LinearLayout
-			android:id="@+id/item_name_and_size"
+
+		<TextView
+			android:id="@+id/item_name"
 			android:layout_width="match_parent"
 			android:layout_height="wrap_content"
+			android:layout_toLeftOf="@+id/item_more"
 			android:layout_toRightOf="@id/item_icon"
-			android:layout_toLeftOf="@+id/item_status"
-			android:layout_centerVertical="true"
-			android:orientation="vertical">
+			android:ellipsize="end"
+			android:padding="6dp"
+			android:text="XXX.xx"
+			android:textColor="@color/white"
+			android:textSize="16sp"
+			android:textStyle="bold" />
 
-			<TextView
-				android:id="@+id/item_name"
-				android:layout_width="match_parent"
-				android:layout_height="wrap_content"
-				android:padding="6dp"
-				android:singleLine="true"
-				android:ellipsize="end"
-				android:text="XXX.xx"
-				android:textSize="16sp"
-				android:textStyle="bold"
-				android:textColor="@color/white"/>
-
-			<TextView
-				android:id="@+id/item_size"
-				android:layout_width="match_parent"
-				android:layout_height="wrap_content"
-                android:padding="6dp"
-				android:singleLine="true"
-				android:text="100.00MB"
-				android:textSize="12sp"
-				android:textColor="@color/white"/>
-		
-		</LinearLayout>
-		
+		<TextView
+			android:id="@+id/item_size"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_toRightOf="@id/item_icon"
+			android:layout_below="@+id/item_name"
+			android:padding="6dp"
+			android:singleLine="true"
+			android:text="100.00MB"
+			android:textSize="12sp"
+			android:textColor="@color/white"/>
 
 		<TextView
 			android:id="@+id/item_status"
 			android:layout_width="wrap_content"
 			android:layout_height="wrap_content"
-			android:layout_toLeftOf="@+id/item_more"
-			android:layout_centerVertical="true"
+			android:layout_below="@+id/item_name"
 			android:layout_marginLeft="6dp"
-			android:layout_marginRight="6dp"
+			android:layout_marginRight="5dp"
+			android:layout_toLeftOf="@+id/item_more"
+			android:layout_toRightOf="@id/item_size"
+			android:padding="6dp"
 			android:singleLine="true"
 			android:text="0%"
-			android:textSize="20sp"
-			android:textColor="@color/white"/>
+			android:textColor="@color/white"
+			android:textSize="12sp" />
 
 		<ImageView
 			style="?attr/buttonBarButtonStyle"
 			android:id="@+id/item_more"
-			android:layout_width="36dp"
-			android:layout_height="36dp"
+			android:layout_width="49dp"
+			android:layout_height="49dp"
 			android:layout_alignParentRight="true"
 			android:layout_centerVertical="true"
 			android:layout_marginRight="4dp"

--- a/app/src/main/res/menu/download_menu.xml
+++ b/app/src/main/res/menu/download_menu.xml
@@ -5,4 +5,7 @@
     <item android:id="@+id/action_settings"
         app:showAsAction="never"
         android:title="@string/settings"/>
+    <item android:id="@+id/switch_mode"
+        app:showAsAction="ifRoom"
+        android:title="@string/switch_view"/>
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -517,5 +517,6 @@
     <string name="minimize_on_exit_none_description">None</string>
     <string name="minimize_on_exit_background_description">Minimize to background player</string>
     <string name="minimize_on_exit_popup_description">Minimize to popup player</string>
+    <string name="switch_view">Switch View</string>
 
 </resources>


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

Hey NewPipe team, thanks for the great app. As an expat living in China, I really value the ability to download YT videos then play them later without having to stream them over a VPN. One issue I've had though is that the Downloads activity is pretty bareboned, and oftentimes I can't even read the full video title. I've enabled a toolbar item in the Downloads menu (most of the code was already there) to allow the user to switch between the grid and linear views. In the linear layout, the full video title should be displayed.

Do let me know if there are any issues - I'm certainly interested in continuing to contribute to NewPipe dev in the future.

![newpipe-update-linear-2018-09-30](https://user-images.githubusercontent.com/4959600/46251486-7d33ab00-c486-11e8-84e1-bd7dffcfe5a5.png)

![newpipe-update-grid-2018-09-30](https://user-images.githubusercontent.com/4959600/46251475-668d5400-c486-11e8-9c7c-b7f8decbdc0f.png)