### PR TITLE
[Closes #1772] change 'tab_bookmarks' string to 'Bookmarked Playlists' for UI clarity

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,7 +34,7 @@
 
     <string name="tab_main">Main</string>
     <string name="tab_subscriptions">Subscriptions</string>
-    <string name="tab_bookmarks">Bookmarks</string>
+    <string name="tab_bookmarks">Bookmarked Playlists</string>
     <string name="tab_new">New Tab</string>
     <string name="tab_choose">Choose Tab</string>
 


### PR DESCRIPTION
This change makes the heading of the "Bookmarks" tab more intuitive to the user by renaming it to "Bookmarked Playlists".  This addresses https://github.com/TeamNewPipe/NewPipe/issues/1772

Here is an example image of what this change looks like on an emulated Pixel XL:
![46259248-035eea00-c4a5-11e8-9c17-25e8649e3e91](https://user-images.githubusercontent.com/1891273/46570112-6cd87000-c95f-11e8-82ab-725ca2b0eb47.png)


- [X] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
