### PR TITLE
Enqueuing now triggers video playing if the play queue has already ended

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
@@ -230,7 +230,8 @@ public abstract class BasePlayer implements
             int sizeBeforeAppend = playQueue.size();
             playQueue.append(queue.getStreams());
 
-            if (intent.getBooleanExtra(SELECT_ON_APPEND, false) &&
+            if ((intent.getBooleanExtra(SELECT_ON_APPEND, false) ||
+                    getCurrentState() == STATE_COMPLETED) &&
                     queue.getStreams().size() > 0) {
                 playQueue.setIndex(sizeBeforeAppend);
             }


### PR DESCRIPTION
- [X] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

 This fixes #1775.