### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 <p align="center"><a href="#screenshots">Screenshots</a> &bull; <a href="#description">Description</a> &bull; <a href="#features">Features</a> &bull; <a href="#contribution">Contribution</a> &bull; <a href="#donate">Donate</a> &bull; <a href="#license">License</a></p>
 <p align="center"><a href="https://newpipe.schabi.org">Website</a> &bull; <a href="https://newpipe.schabi.org/blog/">Blog</a>  &bull; <a href="https://newpipe.schabi.org/press/">Press</a></p>
 <hr />
-WARNING: PUTTING NEWPIPE OR ANY FORK OF IT INTO GOOGLE PLAYSTORE VIOLATES THEIR TERMS OF CONDITIONS.
+**WARNING: PUTTING NEWPIPE OR ANY FORK OF IT INTO GOOGLE PLAYSTORE VIOLATES THEIR TERMS OF CONDITIONS.**
 
 ## Screenshots
 
@@ -61,11 +61,11 @@ NewPipe does not use any Google framework libraries, or the YouTube API. It only
 * Queuing videos
 * Local playlists
 * Subtitles
-* Multi-service support (eg. SoundCloud in NewPipe Beta)
+* Multi-service support (eg. SoundCloud \[beta\])
+* Livestream support
 
 ### Coming Features
 
-* Livestream support
 * Cast to UPnP and Cast
 * Show comments
 * ... and many more


### PR DESCRIPTION
- [ yes ] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

Livestreaming has been included, as on 0.14.1 for me, and probably earlier, though I may be wrong, Thanks

Also highlighted text in bold and changed soundcloud to included in newpipe app (i think it left the beta app to the stable newpipe app)