### PR TITLE
Add foreground service permission for API 28+ devices

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,8 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    
 
     <application
         android:name=".App"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,6 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
-    
 
     <application
         android:name=".App"


### PR DESCRIPTION
As discussed here https://developer.android.com/about/versions/pie/android-9.0-changes-28
Apps which target API 28+ must include foreground permission in the manifest. I first noted this issue today after trying NewPipe master on the Pixel 3 device. Confirmed exists also with API 28 in emulator.

 - Fix foreground playback in android Pie API 28. Tested in emulator & Pixel 3 device.



- [ x ] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
