### PR TITLE
Fix crash with default resolution set to best and limited mobile data resolution

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
@@ -110,7 +110,8 @@ public final class ListHelper {
                 : context.getString(R.string.best_resolution_key);
 
         String maxResolution = getResolutionLimit(context);
-        if (maxResolution != null && compareVideoStreamResolution(maxResolution, resolution) < 1){
+        if (maxResolution != null && (resolution.equals(context.getString(R.string.best_resolution_key))
+                || compareVideoStreamResolution(maxResolution, resolution) < 1)) {
             resolution = maxResolution;
         }
         return resolution;


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

Fixes #1829.

When default resolution is set to best. The value of `resolution` is set to `best_resolution` here:
https://github.com/TeamNewPipe/NewPipe/blob/6fe3fdce112a617ed94d6b113146df8747ad74bb/app/src/main/java/org/schabi/newpipe/util/ListHelper.java#L108-L116

In the `if` branch however, `compareVideoStreamResolution` function expects values like `144p`, `480p`, etc. (but instead, the string `best_resolution` gets passed in `resolution`) and it is unable to parse it to an integer:
https://github.com/TeamNewPipe/NewPipe/blob/6fe3fdce112a617ed94d6b113146df8747ad74bb/app/src/main/java/org/schabi/newpipe/util/ListHelper.java#L393-L399

This PR workarounds it by checking whether the value of `resolution` is set to `best_resolution` before calling `compareVideoStreamResolution` in the `if` condition.