### PR TITLE
Customizing default action when clicking on audio/video item. 

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
@@ -181,7 +181,8 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I> implem
         infoListAdapter.setOnStreamSelectedListener(new OnClickGesture<StreamInfoItem>() {
             @Override
             public void selected(StreamInfoItem selectedItem) {
-                onStreamSelected(selectedItem);
+                onItemSelected(selectedItem);
+                NavigationHelper.playBasedOnUserPreference(BaseListFragment.this, selectedItem);
             }
 
             @Override
@@ -227,34 +228,6 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I> implem
                 onScrollToBottom();
             }
         });
-    }
-
-    private void onStreamSelected(StreamInfoItem selectedItem) {
-        onItemSelected(selectedItem);
-        final String actionChoice = getStreamSelectedActionChoice();
-        final String openVideoDetailChoice = getString(R.string.video_player_key);
-        final String openPopupPlayerChoice = getString(R.string.popup_player_key);
-        final String openBackgroundPlayerChoice = getString(R.string.background_player_key);
-        if(actionChoice.equals(openVideoDetailChoice)) {
-            openVideoDetailsFragment(selectedItem);
-        } else if(actionChoice.equals(openPopupPlayerChoice)) {
-            NavigationHelper.playOnPopupPlayer(getContext(), new SinglePlayQueue(selectedItem));
-        } else if(actionChoice.equals(openBackgroundPlayerChoice)) {
-            NavigationHelper.playOnBackgroundPlayer(getContext(), new SinglePlayQueue(selectedItem));
-        } else {
-            Log.e(TAG, "onStreamSelected(): unknown actionChoice found = " + actionChoice + ", going with default and opening video detail");
-            openVideoDetailsFragment(selectedItem);
-        }
-    }
-
-    private void openVideoDetailsFragment(StreamInfoItem streamInfoItem) {
-        NavigationHelper.openVideoDetailFragment(getFM(),
-          streamInfoItem.getServiceId(), streamInfoItem.getUrl(), streamInfoItem.getName());
-    }
-
-    private String getStreamSelectedActionChoice() {
-        final SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(getContext());
-        return sharedPreferences.getString(getString(R.string.preferred_click_action_key), getString(R.string.preferred_click_action_default));
     }
 
     protected void onScrollToBottom() {

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
@@ -231,8 +231,30 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I> implem
 
     private void onStreamSelected(StreamInfoItem selectedItem) {
         onItemSelected(selectedItem);
+        final String actionChoice = getStreamSelectedActionChoice();
+        final String openVideoDetailChoice = getString(R.string.video_player_key);
+        final String openPopupPlayerChoice = getString(R.string.popup_player_key);
+        final String openBackgroundPlayerChoice = getString(R.string.background_player_key);
+        if(actionChoice.equals(openVideoDetailChoice)) {
+            openVideoDetailsFragment(selectedItem);
+        } else if(actionChoice.equals(openPopupPlayerChoice)) {
+            NavigationHelper.playOnPopupPlayer(getContext(), new SinglePlayQueue(selectedItem));
+        } else if(actionChoice.equals(openBackgroundPlayerChoice)) {
+            NavigationHelper.playOnBackgroundPlayer(getContext(), new SinglePlayQueue(selectedItem));
+        } else {
+            Log.e(TAG, "onStreamSelected(): unknown actionChoice found = " + actionChoice + ", going with default and opening video detail");
+            openVideoDetailsFragment(selectedItem);
+        }
+    }
+
+    private void openVideoDetailsFragment(StreamInfoItem streamInfoItem) {
         NavigationHelper.openVideoDetailFragment(getFM(),
-                selectedItem.getServiceId(), selectedItem.getUrl(), selectedItem.getName());
+          streamInfoItem.getServiceId(), streamInfoItem.getUrl(), streamInfoItem.getName());
+    }
+
+    private String getStreamSelectedActionChoice() {
+        final SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(getContext());
+        return sharedPreferences.getString(getString(R.string.preferred_click_action_key), getString(R.string.preferred_click_action_default));
     }
 
     protected void onScrollToBottom() {

--- a/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
@@ -3,11 +3,14 @@ package org.schabi.newpipe.local.history;
 import android.app.Activity;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.os.Parcelable;
+import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.design.widget.Snackbar;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -139,10 +142,13 @@ public class StatisticsPlaylistFragment
             public void selected(LocalItem selectedItem) {
                 if (selectedItem instanceof StreamStatisticsEntry) {
                     final StreamStatisticsEntry item = (StreamStatisticsEntry) selectedItem;
-                    NavigationHelper.openVideoDetailFragment(getFM(),
-                            item.serviceId,
-                            item.url,
-                            item.title);
+                    final StreamInfoItem streamInfoItem = new StreamInfoItem(
+                      item.serviceId,
+                      item.url,
+                      item.title,
+                      item.streamType
+                    );
+                    NavigationHelper.playBasedOnUserPreference(StatisticsPlaylistFragment.this, streamInfoItem);
                 }
             }
 

--- a/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
@@ -165,8 +165,13 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
             public void selected(LocalItem selectedItem) {
                 if (selectedItem instanceof PlaylistStreamEntry) {
                     final PlaylistStreamEntry item = (PlaylistStreamEntry) selectedItem;
-                    NavigationHelper.openVideoDetailFragment(getFragmentManager(),
-                            item.serviceId, item.url, item.title);
+                    final StreamInfoItem streamInfoItem = new StreamInfoItem(
+                      item.serviceId,
+                      item.url,
+                      item.title,
+                      item.streamType
+                    );
+                    NavigationHelper.playBasedOnUserPreference(LocalPlaylistFragment.this, streamInfoItem);
                 }
             }
 

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -180,6 +180,21 @@
     <string name="preferred_open_action_default" translatable="false">@string/always_ask_open_action_key</string>
     <string name="preferred_open_action_last_selected_key" translatable="false">preferred_open_action_last_selected</string>
 
+    <!-- region: Preferred action on clicking an audio/video item -->
+    <string name="preferred_click_action_key" translatable="false">preferred_click_action_key</string>
+    <string name="preferred_click_action_default" translatable="false">@string/video_player_key</string>
+
+    <string-array name="preferred_click_action_description_list" translatable="false">
+        <item>@string/video_player</item>
+        <item>@string/background_player</item>
+        <item>@string/popup_player</item>
+    </string-array>
+    <string-array name="preferred_click_action_values_list" translatable="false">
+        <item>@string/video_player_key</item>
+        <item>@string/background_player_key</item>
+        <item>@string/popup_player_key</item>
+    </string-array>
+    <!-- endregion -->
     <string name="show_info_key" translatable="false">show_info</string>
     <string name="video_player_key" translatable="false">video_player</string>
     <string name="background_player_key" translatable="false">background_player</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -426,6 +426,11 @@
     <string name="preferred_player_fetcher_notification_title">Getting info…</string>
     <string name="preferred_player_fetcher_notification_message">"Loading requested content"</string>
 
+    <!-- region: Preferred click action -->
+    <string name="preferred_click_action_settings_title">Preferred \'click\' action</string>
+    <string name="preferred_click_action_settings_summary">Default action when clicking on audio/video item — %s</string>
+    <!-- endregion -->
+
     <!-- Local Playlist -->
     <string name="create_playlist">New Playlist</string>
     <string name="delete_playlist">Delete</string>

--- a/app/src/main/res/xml/video_audio_settings.xml
+++ b/app/src/main/res/xml/video_audio_settings.xml
@@ -91,6 +91,14 @@
             android:title="@string/preferred_open_action_settings_title"/>
 
         <ListPreference
+            android:defaultValue="@string/preferred_click_action_default"
+            android:entries="@array/preferred_click_action_description_list"
+            android:entryValues="@array/preferred_click_action_values_list"
+            android:key="@string/preferred_click_action_key"
+            android:summary="@string/preferred_click_action_settings_summary"
+            android:title="@string/preferred_click_action_settings_title"/>
+
+        <ListPreference
             android:defaultValue="@string/minimize_on_exit_value"
             android:entries="@array/minimize_on_exit_action_description"
             android:entryValues="@array/minimize_on_exit_action_key"


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

This takes care of #1875. Essentially users can now customize the default action they wish to take when clicking on a YouTube/Soundcloud video/song. By default clicking on such an item will open the item details screen but they can set it so as to play it in the background or as a popup by going in the video and audio settings page.

