### PR TITLE
Fixed build failing to resolve the exoplayer dependancy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,5 +19,6 @@ allprojects {
         google()
         maven { url "https://jitpack.io" }
         maven { url "https://clojars.org/repo" }
+        maven { url 'https://google.bintray.com/exoplayer/' }
     }
 }


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

It seems like the version of exoPlayerLib 2.8.4 couldn't be resolved. 

It seems like this is an issue for others:
https://stackoverflow.com/questions/53718291/failed-to-resolve-com-google-android-exoplayerextension-mediasession2-8-4

The issue can be fixed by adding this link to the build. https://google.bintray.com/exoplayer/