### PR TITLE
Change the display cutout behaviour

### DIFF
--- a/app/src/main/res/values-v28/styles.xml
+++ b/app/src/main/res/values-v28/styles.xml
@@ -1,0 +1,5 @@
+<style name="ActivityTheme">
+  <item name="android:windowLayoutInDisplayCutoutMode">
+    shortEdges
+  </item>
+</style>


### PR DESCRIPTION
Should change the behaviour of the app to fill the screen/render information on the cutout/notch area

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
