### PR TITLE
Downgrade build tools version to fix F-Droid builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ android:
   components:
     # The BuildTools version used by NewPipe
     - tools
-    - build-tools-28.0.3
+    - build-tools-28.0.2
 
     # The SDK version used to compile NewPipe
     - android-28

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 28
-    buildToolsVersion '28.0.3'
+    buildToolsVersion '28.0.2'
 
     defaultConfig {
         applicationId "org.schabi.newpipe"


### PR DESCRIPTION
Android broke some licensing stuff related to the SDK and the build
tools. I was told that downgrading to 28.0.2 potentially fixes the
issue.

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
