### PR TITLE
Added a warning about instability

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@
 <p align="center"><a href="https://newpipe.schabi.org">Website</a> &bull; <a href="https://newpipe.schabi.org/blog/">Blog</a>  &bull; <a href="https://newpipe.schabi.org/press/">Press</a></p>
 <hr>
 
-<b>WARNING: PUTTING NEWPIPE OR ANY FORK OF IT INTO GOOGLE PLAYSTORE VIOLATES THEIR TERMS OF CONDITIONS.</b>
+<b>WARNING: THIS IS A BETA VERSION, THEREFORE YOU MAY ENCOUNTER BUGS. IF YOU DO, OPEN AN ISSUE VIA OUR GITHUB REPOSITORY.</b>
+
+<b>PUTTING NEWPIPE OR ANY FORK OF IT INTO GOOGLE PLAYSTORE VIOLATES THEIR TERMS OF CONDITIONS.</b>
 
 ## Screenshots
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -209,6 +209,29 @@
                 <data android:pathPrefix="/user/"/>
             </intent-filter>
 
+            <!-- Invidious filter -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <action android:name="android.media.action.MEDIA_PLAY_FROM_SEARCH"/>
+                <action android:name="android.nfc.action.NDEF_DISCOVERED"/>
+
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+
+                <data android:scheme="http"/>
+                <data android:scheme="https"/>
+                <data android:host="invidio.us"/>
+                <data android:host="www.invidio.us"/>
+                <!-- video prefix -->
+                <data android:pathPrefix="/embed/"/>
+                <data android:pathPrefix="/watch"/>
+                <!-- channel prefix -->
+                <data android:pathPrefix="/channel/"/>
+                <data android:pathPrefix="/user/"/>
+                <!-- playlist prefix -->
+                <data android:pathPrefix="/playlist"/>
+            </intent-filter>
+
             <!-- Soundcloud filter -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>

--- a/app/src/main/java/org/schabi/newpipe/player/playback/BasePlayerMediaSession.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playback/BasePlayerMediaSession.java
@@ -1,7 +1,9 @@
 package org.schabi.newpipe.player.playback;
 
 import android.net.Uri;
+import android.os.Bundle;
 import android.support.v4.media.MediaDescriptionCompat;
+import android.support.v4.media.MediaMetadataCompat;
 
 import org.schabi.newpipe.player.BasePlayer;
 import org.schabi.newpipe.player.mediasession.MediaSessionCallback;
@@ -53,6 +55,12 @@ public class BasePlayerMediaSession implements MediaSessionCallback {
                 .setMediaId(String.valueOf(index))
                 .setTitle(item.getTitle())
                 .setSubtitle(item.getUploader());
+
+        // set additional metadata for A2DP/AVRCP
+        Bundle additionalMetadata = new Bundle();
+        additionalMetadata.putString(MediaMetadataCompat.METADATA_KEY_ARTIST, item.getUploader());
+        additionalMetadata.putLong(MediaMetadataCompat.METADATA_KEY_DURATION, item.getDuration());
+        descriptionBuilder.setExtras(additionalMetadata);
 
         final Uri thumbnailUri = Uri.parse(item.getThumbnailUrl());
         if (thumbnailUri != null) descriptionBuilder.setIconUri(thumbnailUri);


### PR DESCRIPTION
Fixes #2069. I've removed the "WARNING" from the second one as it looks a bit silly to have the same thing twice, when the user is already attracted to the first one, which means they will most probably read the second warning.

- [X] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.