### PR TITLE
Fix padding in settings layout (Fixes #1866)

### DIFF
--- a/app/src/main/res/xml/appearance_settings.xml
+++ b/app/src/main/res/xml/appearance_settings.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:title="@string/settings_category_appearance_title">
 
     <ListPreference
+        app:iconSpaceReserved="false"
         android:defaultValue="@string/default_theme_value"
         android:entries="@array/theme_description_list"
         android:entryValues="@array/theme_values_list"
@@ -12,17 +14,20 @@
         android:title="@string/theme_title"/>
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:defaultValue="true"
         android:key="@string/show_next_video_key"
         android:title="@string/show_next_and_similar_title"/>
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:defaultValue="true"
         android:key="@string/show_hold_to_append_key"
         android:title="@string/show_hold_to_append_title"
         android:summary="@string/show_hold_to_append_summary"/>
 
     <ListPreference
+        app:iconSpaceReserved="false"
         android:defaultValue="@string/list_view_mode_value"
         android:entries="@array/list_view_mode_description"
         android:entryValues="@array/list_view_mode_values"
@@ -31,11 +36,13 @@
         android:title="@string/list_view_mode"/>
 
     <Preference
+        app:iconSpaceReserved="false"
         android:key="@string/caption_settings_key"
         android:title="@string/caption_setting_title"
         android:summary="@string/caption_setting_description"/>
 
     <PreferenceScreen
+        app:iconSpaceReserved="false"
         android:fragment="org.schabi.newpipe.settings.tabs.ChooseTabsFragment"
         android:summary="@string/main_page_content_summary"
         android:key="@string/main_page_content_key"

--- a/app/src/main/res/xml/content_settings.xml
+++ b/app/src/main/res/xml/content_settings.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:title="@string/content">
     <ListPreference
+        app:iconSpaceReserved="false"
         android:defaultValue="@string/default_country_value"
         android:entries="@array/country_names"
         android:entryValues="@array/country_codes"
@@ -11,6 +13,7 @@
         android:title="@string/default_content_country_title"/>
 
     <ListPreference
+        app:iconSpaceReserved="false"
         android:defaultValue="@string/default_language_value"
         android:entries="@array/language_names"
         android:entryValues="@array/language_codes"
@@ -19,28 +22,33 @@
         android:title="@string/content_language_title"/>
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:defaultValue="false"
         android:key="@string/show_age_restricted_content"
         android:title="@string/show_age_restricted_content_title"/>
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:defaultValue="true"
         android:key="@string/show_search_suggestions_key"
         android:summary="@string/show_search_suggestions_summary"
         android:title="@string/show_search_suggestions_title"/>
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:defaultValue="true"
         android:key="@string/download_thumbnail_key"
         android:title="@string/download_thumbnail_title"
         android:summary="@string/download_thumbnail_summary"/>
 
     <Preference
+        app:iconSpaceReserved="false"
         android:summary="@string/import_data_summary"
         android:key="@string/import_data"
         android:title="@string/import_data_title"/>
 
     <Preference
+        app:iconSpaceReserved="false"
         android:title="@string/export_data_title"
         android:key="@string/export_data"
         android:summary="@string/export_data_summary"/>

--- a/app/src/main/res/xml/debug_settings.xml
+++ b/app/src/main/res/xml/debug_settings.xml
@@ -1,16 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:key="general_preferences"
     android:title="@string/settings_category_debug_title">
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:defaultValue="false"
         android:key="@string/allow_heap_dumping_key"
         android:title="@string/enable_leak_canary_title"
         android:summary="@string/enable_leak_canary_summary"/>
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:defaultValue="false"
         android:key="@string/allow_disposed_exceptions_key"
         android:title="@string/enable_disposed_exceptions_title"

--- a/app/src/main/res/xml/download_settings.xml
+++ b/app/src/main/res/xml/download_settings.xml
@@ -1,21 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:title="@string/settings_category_downloads_title">
 
     <Preference
+        app:iconSpaceReserved="false"
         android:dialogTitle="@string/download_path_dialog_title"
         android:key="@string/download_path_key"
         android:summary="@string/download_path_summary"
         android:title="@string/download_path_title"/>
 
     <Preference
+        app:iconSpaceReserved="false"
         android:dialogTitle="@string/download_path_audio_dialog_title"
         android:key="@string/download_path_audio_key"
         android:summary="@string/download_path_audio_summary"
         android:title="@string/download_path_audio_title"/>
 
     <ListPreference
+        app:iconSpaceReserved="false"
         android:defaultValue="@string/default_file_charset_value"
         android:entries="@array/settings_filename_charset_name"
         android:entryValues="@array/settings_filename_charset"
@@ -24,12 +28,14 @@
         android:title="@string/settings_file_charset_title"/>
 
     <EditTextPreference
+        app:iconSpaceReserved="false"
         android:defaultValue="@string/settings_file_replacement_character_default_value"
         android:key="@string/settings_file_replacement_character_key"
         android:summary="@string/settings_file_replacement_character_summary"
         android:title="@string/settings_file_replacement_character_title"/>
 
     <ListPreference
+        app:iconSpaceReserved="false"
         android:defaultValue="@string/downloads_maximum_retry_default"
         android:entries="@array/downloads_maximum_retry_list"
         android:entryValues="@array/downloads_maximum_retry_list"
@@ -38,6 +44,7 @@
         android:title="@string/max_retry_msg" />
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:defaultValue="false"
         android:key="@string/downloads_cross_network"
         android:summary="@string/pause_downloads_on_mobile_desc"

--- a/app/src/main/res/xml/history_settings.xml
+++ b/app/src/main/res/xml/history_settings.xml
@@ -1,32 +1,38 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:key="general_preferences"
     android:title="@string/settings_category_history_title">
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:defaultValue="true"
         android:key="@string/enable_watch_history_key"
         android:summary="@string/enable_watch_history_summary"
         android:title="@string/enable_watch_history_title"/>
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:defaultValue="true"
         android:key="@string/enable_search_history_key"
         android:summary="@string/enable_search_history_summary"
         android:title="@string/enable_search_history_title"/>
 
     <Preference
+        app:iconSpaceReserved="false"
         android:key="@string/metadata_cache_wipe_key"
         android:summary="@string/metadata_cache_wipe_summary"
         android:title="@string/metadata_cache_wipe_title"/>
 
     <Preference
+        app:iconSpaceReserved="false"
         android:key="@string/clear_views_history_key"
         android:title="@string/clear_views_history_title"
         android:summary="@string/clear_views_history_summary"/>
 
     <Preference
+        app:iconSpaceReserved="false"
         android:key="@string/clear_search_history_key"
         android:title="@string/clear_search_history_title"
         android:summary="@string/clear_search_history_summary"/>

--- a/app/src/main/res/xml/main_settings.xml
+++ b/app/src/main/res/xml/main_settings.xml
@@ -1,41 +1,49 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:key="general_preferences"
     android:title="@string/settings">
 
     <PreferenceScreen
+        app:iconSpaceReserved="false"
         android:fragment="org.schabi.newpipe.settings.VideoAudioSettingsFragment"
         android:icon="?attr/audio"
         android:title="@string/settings_category_video_audio_title"/>
 
     <PreferenceScreen
+        app:iconSpaceReserved="false"
         android:fragment="org.schabi.newpipe.settings.DownloadSettingsFragment"
         android:icon="?attr/download"
         android:title="@string/settings_category_downloads_title"/>
 
     <PreferenceScreen
+        app:iconSpaceReserved="false"
         android:fragment="org.schabi.newpipe.settings.AppearanceSettingsFragment"
         android:icon="?attr/palette"
         android:title="@string/settings_category_appearance_title"/>
 
     <PreferenceScreen
+        app:iconSpaceReserved="false"
         android:fragment="org.schabi.newpipe.settings.HistorySettingsFragment"
         android:icon="?attr/history"
         android:title="@string/settings_category_history_title"/>
 
     <PreferenceScreen
+        app:iconSpaceReserved="false"
         android:fragment="org.schabi.newpipe.settings.ContentSettingsFragment"
         android:icon="?attr/language"
         android:title="@string/content"/>
 
     <PreferenceScreen
+        app:iconSpaceReserved="false"
         android:fragment="org.schabi.newpipe.settings.UpdateSettingsFragment"
         android:icon="?attr/ic_settings_update"
         android:title="@string/settings_category_updates_title"
         android:key="update_pref_screen_key"/>
 
     <PreferenceScreen
+        app:iconSpaceReserved="false"
         android:fragment="org.schabi.newpipe.settings.DebugSettingsFragment"
         android:icon="?attr/bug"
         android:title="@string/settings_category_debug_title"

--- a/app/src/main/res/xml/update_settings.xml
+++ b/app/src/main/res/xml/update_settings.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:key="general_preferences"
     android:title="@string/settings_category_updates_title">
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:defaultValue="true"
         android:key="@string/update_app_key"
         android:title="@string/updates_setting_title"

--- a/app/src/main/res/xml/video_audio_settings.xml
+++ b/app/src/main/res/xml/video_audio_settings.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:title="@string/settings_category_video_audio_title">
 
     <ListPreference
+        app:iconSpaceReserved="false"
         android:defaultValue="@string/default_resolution_value"
         android:entries="@array/resolution_list_description"
         android:entryValues="@array/resolution_list_values"
@@ -12,6 +14,7 @@
         android:title="@string/default_resolution_title"/>
 
     <ListPreference
+        app:iconSpaceReserved="false"
         android:defaultValue="@string/default_popup_resolution_value"
         android:entries="@array/resolution_list_description"
         android:entryValues="@array/resolution_list_values"
@@ -20,6 +23,7 @@
         android:title="@string/default_popup_resolution_title"/>
 
     <ListPreference
+        app:iconSpaceReserved="false"
         android:defaultValue="@string/limit_mobile_data_usage_value"
         android:entries="@array/limit_data_usage_description_list"
         android:entryValues="@array/limit_data_usage_values_list"
@@ -28,12 +32,14 @@
         android:title="@string/limit_mobile_data_usage_title" />
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:defaultValue="false"
         android:key="@string/show_higher_resolutions_key"
         android:summary="@string/show_higher_resolutions_summary"
         android:title="@string/show_higher_resolutions_title"/>
 
     <ListPreference
+        app:iconSpaceReserved="false"
         android:defaultValue="@string/default_video_format_value"
         android:entries="@array/video_format_description_list"
         android:entryValues="@array/video_format_values_list"
@@ -42,6 +48,7 @@
         android:title="@string/default_video_format_title"/>
 
     <ListPreference
+        app:iconSpaceReserved="false"
         android:defaultValue="@string/default_audio_format_value"
         android:entries="@array/audio_format_description_list"
         android:entryValues="@array/audio_format_values_list"
@@ -50,21 +57,25 @@
         android:title="@string/default_audio_format_title" />
 
     <PreferenceCategory
+        app:iconSpaceReserved="false"
         android:layout="@layout/settings_category_header_layout"
         android:title="@string/settings_category_player_title">
 
         <SwitchPreference
+            app:iconSpaceReserved="false"
             android:defaultValue="false"
             android:key="@string/use_external_video_player_key"
             android:summary="@string/use_external_video_player_summary"
             android:title="@string/use_external_video_player_title"/>
 
         <SwitchPreference
+            app:iconSpaceReserved="false"
             android:defaultValue="false"
             android:key="@string/use_external_audio_player_key"
             android:title="@string/use_external_audio_player_title"/>
 
         <SwitchPreference
+            app:iconSpaceReserved="false"
             android:defaultValue="false"
             android:key="@string/show_play_with_kodi_key"
             android:summary="@string/show_play_with_kodi_summary"
@@ -77,6 +88,7 @@
         android:title="@string/settings_category_player_behavior_title">
 
         <ListPreference
+            app:iconSpaceReserved="false"
             android:defaultValue="@string/preferred_open_action_default"
             android:entries="@array/preferred_open_action_description_list"
             android:entryValues="@array/preferred_open_action_values_list"
@@ -85,6 +97,7 @@
             android:title="@string/preferred_open_action_settings_title"/>
 
         <ListPreference
+            app:iconSpaceReserved="false"
             android:defaultValue="@string/minimize_on_exit_value"
             android:entries="@array/minimize_on_exit_action_description"
             android:entryValues="@array/minimize_on_exit_action_key"
@@ -93,36 +106,42 @@
             android:title="@string/minimize_on_exit_title"/>
 
         <SwitchPreference
+            app:iconSpaceReserved="false"
             android:defaultValue="false"
             android:key="@string/auto_queue_key"
             android:summary="@string/auto_queue_summary"
             android:title="@string/auto_queue_title"/>
 
         <SwitchPreference
+            app:iconSpaceReserved="false"
             android:defaultValue="false"
             android:key="@string/resume_on_audio_focus_gain_key"
             android:summary="@string/resume_on_audio_focus_gain_summary"
             android:title="@string/resume_on_audio_focus_gain_title"/>
 
         <SwitchPreference
+            app:iconSpaceReserved="false"
             android:defaultValue="true"
             android:key="@string/volume_gesture_control_key"
             android:summary="@string/volume_gesture_control_summary"
             android:title="@string/volume_gesture_control_title"/>
 
         <SwitchPreference
+            app:iconSpaceReserved="false"
             android:defaultValue="true"
             android:key="@string/brightness_gesture_control_key"
             android:summary="@string/brightness_gesture_control_summary"
             android:title="@string/brightness_gesture_control_title"/>
 
         <SwitchPreference
+            app:iconSpaceReserved="false"
             android:defaultValue="true"
             android:key="@string/popup_remember_size_pos_key"
             android:summary="@string/popup_remember_size_pos_summary"
             android:title="@string/popup_remember_size_pos_title"/>
 
         <SwitchPreference
+            app:iconSpaceReserved="false"
             android:defaultValue="false"
             android:key="@string/use_inexact_seek_key"
             android:summary="@string/use_inexact_seek_summary"


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
   
There was previously a gap before every setting option (#1866).
Here's how it looks now:  

![52512280-aa792e00-2bc9-11e9-91e1-1dfe60634d55](https://user-images.githubusercontent.com/1891273/52518384-2dda6400-2c4a-11e9-81b7-e16946e95f3d.png)

