### PR TITLE
Fix delayed ducking of Audio

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/helper/AudioReactor.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/AudioReactor.java
@@ -131,7 +131,7 @@ public class AudioReactor implements AudioManager.OnAudioFocusChangeListener,
     private void onAudioFocusLossCanDuck() {
         Log.d(TAG, "onAudioFocusLossCanDuck() called");
         // Set the volume to 1/10 on ducking
-        animateAudio(player.getVolume(), DUCK_AUDIO_TO);
+        player.setVolume(DUCK_AUDIO_TO);
     }
 
     private void animateAudio(final float from, final float to) {


### PR DESCRIPTION
Scenario: listening to a video on NewPipe over Bluetooth and a Notification Sound causes audio focus event AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK.

Problem: With the current implementation animateAudio does cause the audio to reach the DUCK_AUDIO_TO volume AFTER the notification sound is played, which is irritating and annoying.

Solution: animateAudio should just be used on focusGain where it is sensible to increase audio gradually. On ducking event the reaction should be immediate.

This very simple fix does this. Please approve.

- [X] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
