### PR TITLE
Remove old player from the manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,12 +35,6 @@
             </intent-filter>
         </receiver>
 
-        <activity
-            android:name=".player.old.PlayVideoActivity"
-            android:configChanges="orientation|keyboardHidden|screenSize"
-            android:theme="@style/OldVideoPlayerTheme"
-            tools:ignore="UnusedAttribute"/>
-
         <service
             android:name=".player.BackgroundPlayer"
             android:exported="false">


### PR DESCRIPTION
The old player has been removed some time ago, but it was still in the manifest.
See https://github.com/TeamNewPipe/NewPipe/pull/1884 for more info on dropping support for Android 4.1 - 4.3.

CC @friendlyanon I guess you need to revert this commit in the legacy repo