### PR TITLE
Fix random Popup player crash

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/PopupVideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/PopupVideoPlayer.java
@@ -626,6 +626,7 @@ public final class PopupVideoPlayer extends Service {
         @Override
         public void onLoadingComplete(String imageUri, View view, Bitmap loadedImage) {
             super.onLoadingComplete(imageUri, view, loadedImage);
+            if (playerImpl == null) return;
             // rebuild notification here since remote view does not release bitmaps,
             // causing memory leaks
             resetNotification();


### PR DESCRIPTION
This happens while switching from pop-up to full-screen player. The reason is the thumbnail was loaded while the pop-up player is closed

- [ ✔ ] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
