### PR TITLE
Cache duration String to improve performance

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/BackgroundPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/BackgroundPlayer.java
@@ -275,6 +275,8 @@ public final class BackgroundPlayer extends Service {
     protected class BasePlayerImpl extends BasePlayer {
 
         @NonNull final private AudioPlaybackResolver resolver;
+        private int cachedDuration;
+        private String cachedDurationString;
 
         BasePlayerImpl(Context context) {
             super(context);
@@ -351,8 +353,12 @@ public final class BackgroundPlayer extends Service {
             resetNotification();
             if(Build.VERSION.SDK_INT >= 26 /*Oreo*/) updateNotificationThumbnail();
             if (bigNotRemoteView != null) {
+                if(cachedDuration != duration) {
+                    cachedDuration = duration;
+                    cachedDurationString = getTimeString(duration);
+                }
                 bigNotRemoteView.setProgressBar(R.id.notificationProgressBar, duration, currentProgress, false);
-                bigNotRemoteView.setTextViewText(R.id.notificationTime, getTimeString(currentProgress) + " / " + getTimeString(duration));
+                bigNotRemoteView.setTextViewText(R.id.notificationTime, getTimeString(currentProgress) + " / " + cachedDurationString);
             }
             if (notRemoteView != null) {
                 notRemoteView.setProgressBar(R.id.notificationProgressBar, duration, currentProgress, false);

--- a/app/src/main/java/org/schabi/newpipe/player/BackgroundPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/BackgroundPlayer.java
@@ -351,7 +351,7 @@ public final class BackgroundPlayer extends Service {
 
             if (!shouldUpdateOnProgress) return;
             resetNotification();
-            if(Build.VERSION.SDK_INT >= 26 /*Oreo*/) updateNotificationThumbnail();
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O /*Oreo*/) updateNotificationThumbnail();
             if (bigNotRemoteView != null) {
                 if(cachedDuration != duration) {
                     cachedDuration = duration;


### PR DESCRIPTION
This pull requests intents to improve performance on Backgroundplayer while the screen is on.

In VideoPlayer the Duration String is cached effectively with the help of the playbackSeekBar(getMax() and setMax(). As the playbackSeekBar doesn't exist in BackgroundPlayer, using two additional variables will reduce performance impact of notification updates by almost 50% and thus perform similar to VideoPlayer.

This addresses issue #2170 and issue #1941.

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
