### PR TITLE
Improve performance of getTimeString

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
@@ -70,10 +70,10 @@ public class PlayerHelper {
     ////////////////////////////////////////////////////////////////////////////
 
     public static String getTimeString(int milliSeconds) {
-        long seconds = (milliSeconds % 60000L) / 1000L;
-        long minutes = (milliSeconds % 3600000L) / 60000L;
-        long hours = (milliSeconds % 86400000L) / 3600000L;
-        long days = (milliSeconds % (86400000L * 7L)) / 86400000L;
+        int seconds = (milliSeconds % 60000) / 1000;
+        int minutes = (milliSeconds % 3600000) / 60000;
+        int hours = (milliSeconds % 86400000) / 3600000;
+        int days = (milliSeconds % (86400000 * 7)) / 86400000;
 
         stringBuilder.setLength(0);
         return days > 0 ? stringFormatter.format("%d:%02d:%02d:%02d", days, hours, minutes, seconds).toString()


### PR DESCRIPTION
This pull requests complements pull request  #2178 by reducing general computational time for the method getTimeString.

On my local machine (Desktop PC with Java) my tests with a sample size of 10000 calls to the method with param 86400001 showed an average performance improvement of about 50%.

See sample code below to reproduce:

    private static final StringBuilder stringBuilder = new StringBuilder();
    private static final Formatter stringFormatter = new Formatter(stringBuilder, Locale.getDefault());
    
    public static String getTimeString(int milliSeconds) {
        int seconds = (milliSeconds % 60000) / 1000;
        int minutes = (milliSeconds % 3600000) / 60000;
        int hours = (milliSeconds % 86400000) / 3600000;
        int days = (milliSeconds % (86400000 * 7)) / 86400000;

        stringBuilder.setLength(0);
        return days > 0 ? stringFormatter.format("%d:%02d:%02d:%02d", days, hours, minutes, seconds).toString()
                : hours > 0 ? stringFormatter.format("%d:%02d:%02d", hours, minutes, seconds).toString()
                : stringFormatter.format("%02d:%02d", minutes, seconds).toString();
    }
    
    public static String getTimeStringL(int milliSeconds) {
        long seconds = (milliSeconds % 60000L) / 1000L;
        long minutes = (milliSeconds % 3600000L) / 60000L;
        long hours = (milliSeconds % 86400000L) / 3600000L;
        long days = (milliSeconds % (86400000L * 7L)) / 86400000L;

        stringBuilder.setLength(0);
        return days > 0 ? stringFormatter.format("%d:%02d:%02d:%02d", days, hours, minutes, seconds).toString()
                : hours > 0 ? stringFormatter.format("%d:%02d:%02d", hours, minutes, seconds).toString()
                : stringFormatter.format("%02d:%02d", minutes, seconds).toString();
    }
    
	public static void main(String[] args) throws Exception {
		final int SAMPLE_SIZE = 10000;
		long[] results = new long[SAMPLE_SIZE];
		for(int i = 0; i < SAMPLE_SIZE; i++) {
			long now = System.nanoTime();
			getTimeString(86400001);
			results[i] = System.nanoTime() - now;
		}
		long sum = 0;
		for(int i = 0; i < SAMPLE_SIZE; i++) {
			sum += results[i];
		}
		System.out.println("Average execution time: " + (sum/SAMPLE_SIZE));
		results = new long[SAMPLE_SIZE];
		for(int i = 0; i < SAMPLE_SIZE; i++) {
			long now = System.nanoTime();
			getTimeStringL(86400001);
			results[i] = System.nanoTime() - now;
		}
		sum = 0;
		for(int i = 0; i < SAMPLE_SIZE; i++) {
			sum += results[i];
		}
		System.out.println("Average execution time: " + (sum/SAMPLE_SIZE));
	}
- [X] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
