### PR TITLE
seek on clicking timestamp links in comments

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/info_list/holder/CommentsMiniInfoItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/holder/CommentsMiniInfoItemHolder.java
@@ -118,9 +118,9 @@ public class CommentsMiniInfoItemHolder extends InfoItemHolder {
     private void ellipsize() {
         if (itemContentView.getLineCount() > commentDefaultLines){
             int endOfLastLine = itemContentView.getLayout().getLineEnd(commentDefaultLines - 1);
-            int end = itemContentView.getText().toString().lastIndexOf(' ', endOfLastLine -3);
-            if(end == -1) end = Math.max(endOfLastLine -3, 0);
-            String newVal = itemContentView.getText().subSequence(0, end) + "...";
+            int end = itemContentView.getText().toString().lastIndexOf(' ', endOfLastLine -2);
+            if(end == -1) end = Math.max(endOfLastLine -2, 0);
+            String newVal = itemContentView.getText().subSequence(0, end) + " …";
             itemContentView.setText(newVal);
         }
         linkify();

--- a/app/src/main/java/org/schabi/newpipe/info_list/holder/CommentsMiniInfoItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/holder/CommentsMiniInfoItemHolder.java
@@ -91,15 +91,14 @@ public class CommentsMiniInfoItemHolder extends InfoItemHolder {
 
         streamUrl = item.getUrl();
 
-        itemContentView.setMaxLines(commentDefaultLines);
+        itemContentView.setLines(commentDefaultLines);
         commentText = item.getCommentText();
         itemContentView.setText(commentText);
-        linkify();
         itemContentView.setOnTouchListener(CommentTextOnTouchListener.INSTANCE);
 
-        if(itemContentView.getLineCount() == 0){
+        if (itemContentView.getLineCount() == 0) {
             itemContentView.post(() -> ellipsize());
-        }else{
+        } else {
             ellipsize();
         }
 
@@ -119,15 +118,17 @@ public class CommentsMiniInfoItemHolder extends InfoItemHolder {
     private void ellipsize() {
         if (itemContentView.getLineCount() > commentDefaultLines){
             int endOfLastLine = itemContentView.getLayout().getLineEnd(commentDefaultLines - 1);
-            String newVal = itemContentView.getText().subSequence(0, endOfLastLine - 3) + "...";
+            int end = itemContentView.getText().toString().lastIndexOf(' ', endOfLastLine -3);
+            if(end == -1) end = Math.max(endOfLastLine -3, 0);
+            String newVal = itemContentView.getText().subSequence(0, end) + "...";
             itemContentView.setText(newVal);
-            linkify();
         }
+        linkify();
     }
 
     private void toggleEllipsize() {
         if (itemContentView.getText().toString().equals(commentText)) {
-            ellipsize();
+            if (itemContentView.getLineCount() > commentDefaultLines) ellipsize();
         } else {
             expand();
         }

--- a/app/src/main/java/org/schabi/newpipe/info_list/holder/CommentsMiniInfoItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/holder/CommentsMiniInfoItemHolder.java
@@ -45,7 +45,7 @@ public class CommentsMiniInfoItemHolder extends InfoItemHolder {
             if(hours != null) timestamp += (Integer.parseInt(hours.replace(":", ""))*3600);
             if(minutes != null) timestamp += (Integer.parseInt(minutes.replace(":", ""))*60);
             if(seconds != null) timestamp += (Integer.parseInt(seconds));
-            return streamUrl + url.replace(match.group(0), "&t=" + String.valueOf(timestamp));
+            return streamUrl + url.replace(match.group(0), "#timestamp=" + String.valueOf(timestamp));
         }
     };
 

--- a/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
@@ -269,6 +269,18 @@ public abstract class BasePlayer implements
         final boolean playbackSkipSilence = intent.getBooleanExtra(PLAYBACK_SKIP_SILENCE,
                 getPlaybackSkipSilence());
 
+        // seek to timestamp if stream is already playing
+        if (simpleExoPlayer != null
+                && queue.size() == 1
+                && playQueue != null
+                && playQueue.getItem() != null
+                && queue.getItem().getUrl().equals(playQueue.getItem().getUrl())
+                && queue.getItem().getRecoveryPosition() != PlayQueueItem.RECOVERY_UNSET
+                ) {
+            simpleExoPlayer.seekTo(playQueue.getIndex(), queue.getItem().getRecoveryPosition());
+            return;
+        }
+
         // Good to go...
         initPlayback(queue, repeatMode, playbackSpeed, playbackPitch, playbackSkipSilence,
                 /*playOnInit=*/true);

--- a/app/src/main/java/org/schabi/newpipe/player/playqueue/SinglePlayQueue.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playqueue/SinglePlayQueue.java
@@ -16,6 +16,11 @@ public final class SinglePlayQueue extends PlayQueue {
         super(0, Collections.singletonList(new PlayQueueItem(info)));
     }
 
+    public SinglePlayQueue(final StreamInfo info, final long startPosition) {
+        super(0, Collections.singletonList(new PlayQueueItem(info)));
+        getItem().setRecoveryPosition(startPosition);
+    }
+
     public SinglePlayQueue(final List<StreamInfoItem> items, final int index) {
         super(index, playQueueItemsOf(items));
     }

--- a/app/src/main/java/org/schabi/newpipe/util/CommentTextOnTouchListener.java
+++ b/app/src/main/java/org/schabi/newpipe/util/CommentTextOnTouchListener.java
@@ -31,7 +31,7 @@ public class CommentTextOnTouchListener implements View.OnTouchListener {
 
     public static final CommentTextOnTouchListener INSTANCE = new CommentTextOnTouchListener();
 
-    private static final Pattern timestampPattern = Pattern.compile(".*&t=(\\d+)");
+    private static final Pattern timestampPattern = Pattern.compile("(.*)#timestamp=(\\d+)");
 
     @Override
     public boolean onTouch(View v, MotionEvent event) {
@@ -86,6 +86,12 @@ public class CommentTextOnTouchListener implements View.OnTouchListener {
 
     private boolean handleUrl(Context context, URLSpan urlSpan) {
         String url = urlSpan.getURL();
+        int seconds = -1;
+        Matcher matcher = timestampPattern.matcher(url);
+        if(matcher.matches()){
+            url = matcher.group(1);
+            seconds = Integer.parseInt(matcher.group(2));
+        }
         StreamingService service;
         StreamingService.LinkType linkType;
         try {
@@ -97,9 +103,7 @@ public class CommentTextOnTouchListener implements View.OnTouchListener {
         if(linkType == StreamingService.LinkType.NONE){
             return false;
         }
-        Matcher matcher = timestampPattern.matcher(url);
-        if(linkType == StreamingService.LinkType.STREAM && matcher.matches()){
-            int seconds = Integer.parseInt(matcher.group(1));
+        if(linkType == StreamingService.LinkType.STREAM && seconds != -1){
             return playOnPopup(context, url, service, seconds);
         }else{
             NavigationHelper.openRouterActivity(context, url);
@@ -119,9 +123,8 @@ public class CommentTextOnTouchListener implements View.OnTouchListener {
         single.subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(info -> {
-                    PlayQueue playQueue = new SinglePlayQueue((StreamInfo) info);
-                    ((StreamInfo) info).setStartPosition(seconds);
-                    NavigationHelper.enqueueOnPopupPlayer(context, playQueue, true);
+                    PlayQueue playQueue = new SinglePlayQueue((StreamInfo) info, seconds*1000);
+                    NavigationHelper.playOnPopupPlayer(context, playQueue);
                 });
         return true;
     }


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

Fixes https://github.com/TeamNewPipe/NewPipe/pull/1968#pullrequestreview-212928929

> There are some problems with the popup player:
> 
> 1. start a video in popup mode by clicking on a timestep-link in a video description or comment
> 2. Notice the video repeating the first miliseconds again and again until some more of the video stream is buffered.
> 3. Let the video play for some seconds
> 4. Pause the video. Notice the current playback position is reset back to the point from where we started in 1.
> 
> In some cases this problem is even bigger.
> 
>  1. start a video in popup mode by clicking on a timestep-link in a video description or comment
>  2. start another video in popup mode by clicking on a timestep-link in a video description or comment
>  3. let the first video finish or skip it (to skip it, click on the popup notification and then press the control to get to the next video
>  4. You'll be in an endless loop of the first frames. The only way the interrupt the loop is pressing the pause button. after pressing play again, the video is played properly.
> 
