### PR TITLE
Fix italian translation

### DIFF
--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -564,7 +564,7 @@
     <string name="max_retry_msg">Tentativi massimi</string>
     <string name="max_retry_desc">Tentativi massimi prima di cancellare il download</string>
     <string name="pause_downloads_on_mobile">Metti in pausa quando si usano i dati mobili</string>
-    <string name="pause_downloads_on_mobile_desc">I download che non possono essere messi in pausa verranno ravviati</string>
+    <string name="pause_downloads_on_mobile_desc">I download che non possono essere messi in pausa verranno riavviati</string>
     <string name="events">Eventi</string>
     <string name="conferences">Conferenze</string>
 </resources>


### PR DESCRIPTION
Word "ravviati" is wrong.
The correct one is "riavviati".

https://www.collinsdictionary.com/dictionary/italian-english/riavviare

I already subscribed to weblate.org, and suggested the change there. But maybe it takes time to integrate and get lost.

- [X ] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
