### PR TITLE
Fixed English translations for Play/Enqueue commands

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -419,12 +419,12 @@
     <string name="play_queue_stream_detail">Details</string>
     <string name="play_queue_audio_settings">Audio Settings</string>
     <string name="hold_to_append">Hold To enqueue</string>
-    <string name="direct_on_background">Play directly in Background</string>
-    <string name="enqueue_on_background">Enqueue when backgrounded</string>
-    <string name="enqueue_on_popup">Enqueue on new popup</string>
+    <string name="direct_on_background">Play directly in background</string>
+    <string name="enqueue_on_background">Enqueue in the background</string>
+    <string name="enqueue_on_popup">Enqueue in a new popup</string>
     <string name="start_here_on_main">Start playing here</string>
-    <string name="start_here_on_background">Start here when backgrounded</string>
-    <string name="start_here_on_popup">Start here on new popup</string>
+    <string name="start_here_on_background">Start playing in the background</string>
+    <string name="start_here_on_popup">Start playing in a new popup</string>
 
     <!-- Drawer -->
     <string name="drawer_open">Open Drawer</string>


### PR DESCRIPTION
The wording for the Play/Enqueue commands is currently a little odd (introduced in commit 6167d5dbfc6de63c50d24fdbfa524ada48432c05):

```diff
-    <string name="enqueue_on_background">Enqueue on Background</string>
+    <string name="enqueue_on_background">Enqueue when backgrounded</string>

-    <string name="enqueue_on_popup">Enqueue on Popup</string>
+    <string name="enqueue_on_popup">Enqueue on new popup</string>

-    <string name="start_here_on_background">Start Here on Background</string>
+    <string name="start_here_on_background">Start here when backgrounded</string>

-    <string name="start_here_on_popup">Start Here on Popup</string>
+    <string name="start_here_on_popup">Start here on new popup</string>
```

This commit fixes them (eg: "Enqueue when backgrounded" is changed to "Enqueue in the background", etc.)