### PR TITLE
Add "share at current time" button to the main video player

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/BaseStateFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/BaseStateFragment.java
@@ -230,21 +230,4 @@ public abstract class BaseStateFragment<I> extends BaseFragment implements ViewC
         ErrorActivity.reportError(getContext(), exception, MainActivity.class, rootView,
                 ErrorActivity.ErrorInfo.make(userAction, serviceName, request, errorId));
     }
-
-    /*//////////////////////////////////////////////////////////////////////////
-    // Utils
-    //////////////////////////////////////////////////////////////////////////*/
-
-    protected void openUrlInBrowser(String url) {
-        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-        startActivity(Intent.createChooser(intent, activity.getString(R.string.share_dialog_title)));
-    }
-
-    protected void shareUrl(String subject, String url) {
-        Intent intent = new Intent(Intent.ACTION_SEND);
-        intent.setType("text/plain");
-        intent.putExtra(Intent.EXTRA_SUBJECT, subject);
-        intent.putExtra(Intent.EXTRA_TEXT, url);
-        startActivity(Intent.createChooser(intent, getString(R.string.share_dialog_title)));
-    }
 }

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -86,6 +86,7 @@ import org.schabi.newpipe.util.ListHelper;
 import org.schabi.newpipe.util.Localization;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.PermissionHelper;
+import org.schabi.newpipe.util.ShareUtils;
 import org.schabi.newpipe.util.StreamItemAdapter;
 import org.schabi.newpipe.util.StreamItemAdapter.StreamSizeWrapper;
 
@@ -547,7 +548,7 @@ public class VideoDetailFragment
                     }
                     break;
                 case 3:
-                    shareUrl(item.getName(), item.getUrl());
+                    ShareUtils.shareUrl(this.getContext(), item.getName(), item.getUrl());
                     break;
                 default:
                     break;
@@ -636,13 +637,13 @@ public class VideoDetailFragment
         switch (id) {
             case R.id.menu_item_share: {
                 if (currentInfo != null) {
-                    shareUrl(currentInfo.getName(), currentInfo.getOriginalUrl());
+                    ShareUtils.shareUrl(this.getContext(), currentInfo.getName(), currentInfo.getOriginalUrl());
                 }
                 return true;
             }
             case R.id.menu_item_openInBrowser: {
                 if (currentInfo != null) {
-                    openUrlInBrowser(currentInfo.getOriginalUrl());
+                    ShareUtils.openUrlInBrowser(this.getContext(), currentInfo.getOriginalUrl());
                 }
                 return true;
             }

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
@@ -34,6 +34,7 @@ import org.schabi.newpipe.player.playqueue.SinglePlayQueue;
 import org.schabi.newpipe.report.ErrorActivity;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.OnClickGesture;
+import org.schabi.newpipe.util.ShareUtils;
 import org.schabi.newpipe.util.StateSaver;
 
 import java.util.Collections;
@@ -280,7 +281,7 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I> implem
                     }
                     break;
                 case 4:
-                    shareUrl(item.getName(), item.getUrl());
+                    ShareUtils.shareUrl(this.getContext(), item.getName(), item.getUrl());
                     break;
                 default:
                     break;

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
@@ -46,6 +46,7 @@ import org.schabi.newpipe.util.ExtractorHelper;
 import org.schabi.newpipe.util.ImageDisplayConstants;
 import org.schabi.newpipe.util.Localization;
 import org.schabi.newpipe.util.NavigationHelper;
+import org.schabi.newpipe.util.ShareUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -190,7 +191,7 @@ public class ChannelFragment extends BaseListInfoFragment<ChannelInfo> {
                     }
                     break;
                 case 6:
-                    shareUrl(item.getName(), item.getUrl());
+                    ShareUtils.shareUrl(this.getContext(), item.getName(), item.getUrl());
                     break;
                 default:
                     break;
@@ -233,10 +234,10 @@ public class ChannelFragment extends BaseListInfoFragment<ChannelInfo> {
                 openRssFeed();
                 break;
             case R.id.menu_item_openInBrowser:
-                openUrlInBrowser(currentInfo.getOriginalUrl());
+                ShareUtils.openUrlInBrowser(this.getContext(), currentInfo.getOriginalUrl());
                 break;
             case R.id.menu_item_share:
-                shareUrl(name, currentInfo.getOriginalUrl());
+                ShareUtils.shareUrl(this.getContext(), name, currentInfo.getOriginalUrl());
                 break;
             default:
                 return super.onOptionsItemSelected(item);

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
@@ -40,6 +40,7 @@ import org.schabi.newpipe.report.UserAction;
 import org.schabi.newpipe.util.ExtractorHelper;
 import org.schabi.newpipe.util.ImageDisplayConstants;
 import org.schabi.newpipe.util.NavigationHelper;
+import org.schabi.newpipe.util.ShareUtils;
 import org.schabi.newpipe.util.ThemeHelper;
 
 import java.util.ArrayList;
@@ -168,7 +169,7 @@ public class PlaylistFragment extends BaseListInfoFragment<PlaylistInfo> {
                     NavigationHelper.playOnPopupPlayer(activity, getPlayQueue(index));
                     break;
                 case 5:
-                    shareUrl(item.getName(), item.getUrl());
+                    ShareUtils.shareUrl(this.getContext(), item.getName(), item.getUrl());
                     break;
                 default:
                     break;
@@ -230,10 +231,10 @@ public class PlaylistFragment extends BaseListInfoFragment<PlaylistInfo> {
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case R.id.menu_item_openInBrowser:
-                openUrlInBrowser(url);
+                ShareUtils.openUrlInBrowser(this.getContext(), url);
                 break;
             case R.id.menu_item_share:
-                shareUrl(name, url);
+                ShareUtils.shareUrl(this.getContext(), name, url);
                 break;
             case R.id.menu_item_bookmark:
                 onBookmarkClicked();

--- a/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
@@ -34,6 +34,7 @@ import org.schabi.newpipe.report.UserAction;
 import org.schabi.newpipe.settings.SettingsActivity;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.OnClickGesture;
+import org.schabi.newpipe.util.ShareUtils;
 import org.schabi.newpipe.util.ThemeHelper;
 
 import java.util.ArrayList;
@@ -394,7 +395,7 @@ public class StatisticsPlaylistFragment
                     deleteEntry(index);
                     break;
                 case 6:
-                    shareUrl(item.toStreamInfoItem().getName(), item.toStreamInfoItem().getUrl());
+                    ShareUtils.shareUrl(this.getContext(), item.toStreamInfoItem().getName(), item.toStreamInfoItem().getUrl());
                     break;
                 default:
                     break;

--- a/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
@@ -34,6 +34,7 @@ import org.schabi.newpipe.report.UserAction;
 import org.schabi.newpipe.util.Localization;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.OnClickGesture;
+import org.schabi.newpipe.util.ShareUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -555,7 +556,7 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
                     deleteItem(item);
                     break;
                 case 7:
-                    shareUrl(item.toStreamInfoItem().getName(), item.toStreamInfoItem().getUrl());
+                    ShareUtils.shareUrl(this.getContext(), item.toStreamInfoItem().getName(), item.toStreamInfoItem().getUrl());
                     break;
                 default:
                     break;

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.java
@@ -57,6 +57,7 @@ import org.schabi.newpipe.util.FilePickerActivityHelper;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.OnClickGesture;
 import org.schabi.newpipe.util.ServiceHelper;
+import org.schabi.newpipe.util.ShareUtils;
 import org.schabi.newpipe.util.ThemeHelper;
 import org.schabi.newpipe.views.CollapsibleView;
 
@@ -425,7 +426,7 @@ public class SubscriptionFragment extends BaseStateFragment<List<SubscriptionEnt
     }
 
     private void shareChannel (ChannelInfoItem selectedItem) {
-        shareUrl(selectedItem.getName(), selectedItem.getUrl());
+        ShareUtils.shareUrl(this.getContext(), selectedItem.getName(), selectedItem.getUrl());
     }
 
     @SuppressLint("CheckResult")

--- a/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
@@ -75,6 +75,7 @@ import org.schabi.newpipe.util.AnimationUtils;
 import org.schabi.newpipe.util.ListHelper;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.PermissionHelper;
+import org.schabi.newpipe.util.ShareUtils;
 import org.schabi.newpipe.util.StateSaver;
 import org.schabi.newpipe.util.ThemeHelper;
 
@@ -283,8 +284,8 @@ public final class MainVideoPlayer extends AppCompatActivity
         if (playerImpl != null && playerImpl.queueVisible) return;
 
         final int visibility = View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                    | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                    | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION;
+                | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION;
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             @ColorInt final int systenUiColor =
@@ -402,6 +403,7 @@ public final class MainVideoPlayer extends AppCompatActivity
         private boolean queueVisible;
 
         private ImageButton moreOptionsButton;
+        private ImageButton shareButton;
         private ImageButton toggleOrientationButton;
         private ImageButton switchPopupButton;
         private ImageButton switchBackgroundButton;
@@ -436,6 +438,7 @@ public final class MainVideoPlayer extends AppCompatActivity
 
             this.moreOptionsButton = rootView.findViewById(R.id.moreOptionsButton);
             this.secondaryControls = rootView.findViewById(R.id.secondaryControls);
+            this.shareButton = rootView.findViewById(R.id.share);
             this.toggleOrientationButton = rootView.findViewById(R.id.toggleOrientation);
             this.switchBackgroundButton = rootView.findViewById(R.id.switchBackground);
             this.switchPopupButton = rootView.findViewById(R.id.switchPopup);
@@ -481,6 +484,7 @@ public final class MainVideoPlayer extends AppCompatActivity
             playNextButton.setOnClickListener(this);
 
             moreOptionsButton.setOnClickListener(this);
+            shareButton.setOnClickListener(this);
             toggleOrientationButton.setOnClickListener(this);
             switchBackgroundButton.setOnClickListener(this);
             switchPopupButton.setOnClickListener(this);
@@ -631,6 +635,9 @@ public final class MainVideoPlayer extends AppCompatActivity
             } else if (v.getId() == moreOptionsButton.getId()) {
                 onMoreOptionsClicked();
 
+            } else if (v.getId() == shareButton.getId()) {
+                onShareClicked();
+
             } else if (v.getId() == toggleOrientationButton.getId()) {
                 onScreenRotationClicked();
 
@@ -682,6 +689,13 @@ public final class MainVideoPlayer extends AppCompatActivity
             animateView(secondaryControls, SLIDE_AND_ALPHA, !isMoreControlsVisible,
                     DEFAULT_CONTROLS_DURATION);
             showControls(DEFAULT_CONTROLS_DURATION);
+        }
+
+        private void onShareClicked() {
+            // share video at the current time (youtube.com/watch?v=ID&t=SECONDS)
+            ShareUtils.shareUrl(MainVideoPlayer.this,
+                    playerImpl.getVideoTitle(),
+                    playerImpl.getVideoUrl() + "&t=" + String.valueOf(playerImpl.getPlaybackSeekBar().getProgress()/1000));
         }
 
         private void onScreenRotationClicked() {
@@ -847,8 +861,8 @@ public final class MainVideoPlayer extends AppCompatActivity
             if (DEBUG) Log.d(TAG, "hideControls() called with: delay = [" + delay + "]");
             getControlsVisibilityHandler().removeCallbacksAndMessages(null);
             getControlsVisibilityHandler().postDelayed(() ->
-                    animateView(getControlsRoot(), false, duration, 0,
-                            MainVideoPlayer.this::hideSystemUi),
+                            animateView(getControlsRoot(), false, duration, 0,
+                                    MainVideoPlayer.this::hideSystemUi),
                     /*delayMillis=*/delay
             );
         }
@@ -1052,9 +1066,9 @@ public final class MainVideoPlayer extends AppCompatActivity
 
                 final int resId =
                         currentProgressPercent <= 0 ? R.drawable.ic_volume_off_white_72dp
-                        : currentProgressPercent < 0.25 ? R.drawable.ic_volume_mute_white_72dp
-                        : currentProgressPercent < 0.75 ? R.drawable.ic_volume_down_white_72dp
-                        : R.drawable.ic_volume_up_white_72dp;
+                                : currentProgressPercent < 0.25 ? R.drawable.ic_volume_mute_white_72dp
+                                : currentProgressPercent < 0.75 ? R.drawable.ic_volume_down_white_72dp
+                                : R.drawable.ic_volume_up_white_72dp;
 
                 playerImpl.getVolumeImageView().setImageDrawable(
                         AppCompatResources.getDrawable(getApplicationContext(), resId)
@@ -1078,8 +1092,8 @@ public final class MainVideoPlayer extends AppCompatActivity
 
                 final int resId =
                         currentProgressPercent < 0.25 ? R.drawable.ic_brightness_low_white_72dp
-                        : currentProgressPercent < 0.75 ? R.drawable.ic_brightness_medium_white_72dp
-                        : R.drawable.ic_brightness_high_white_72dp;
+                                : currentProgressPercent < 0.75 ? R.drawable.ic_brightness_medium_white_72dp
+                                : R.drawable.ic_brightness_high_white_72dp;
 
                 playerImpl.getBrightnessImageView().setImageDrawable(
                         AppCompatResources.getDrawable(getApplicationContext(), resId)

--- a/app/src/main/java/org/schabi/newpipe/util/ShareUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ShareUtils.java
@@ -1,0 +1,22 @@
+package org.schabi.newpipe.util;
+
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+
+import org.schabi.newpipe.R;
+
+public class ShareUtils {
+    public static void openUrlInBrowser(Context context, String url) {
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+        context.startActivity(Intent.createChooser(intent, context.getString(R.string.share_dialog_title)));
+    }
+
+    public static void shareUrl(Context context, String subject, String url) {
+        Intent intent = new Intent(Intent.ACTION_SEND);
+        intent.setType("text/plain");
+        intent.putExtra(Intent.EXTRA_SUBJECT, subject);
+        intent.putExtra(Intent.EXTRA_TEXT, url);
+        context.startActivity(Intent.createChooser(intent, context.getString(R.string.share_dialog_title)));
+    }
+}

--- a/app/src/main/res/layout-large-land/activity_main_player.xml
+++ b/app/src/main/res/layout-large-land/activity_main_player.xml
@@ -249,7 +249,7 @@
                     android:layout_height="wrap_content"
                     android:layout_alignParentRight="true"
                     android:layout_marginLeft="2dp"
-					android:padding="5dp"
+                    android:padding="5dp"
                     android:clickable="true"
                     android:focusable="true"
                     android:scaleType="fitXY"
@@ -305,12 +305,29 @@
                     tools:text="English" />
 
                 <ImageButton
-                    android:id="@+id/toggleOrientation"
+                    android:id="@+id/share"
                     android:layout_width="30dp"
                     android:layout_height="30dp"
                     android:layout_marginLeft="4dp"
                     android:layout_marginRight="2dp"
                     android:layout_alignParentRight="true"
+                    android:layout_centerVertical="true"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:padding="5dp"
+                    android:scaleType="fitXY"
+                    android:src="@drawable/ic_share_white_24dp"
+                    android:background="?attr/selectableItemBackground"
+                    android:contentDescription="@string/share"
+                    tools:ignore="RtlHardcoded"/>
+
+                <ImageButton
+                    android:id="@+id/toggleOrientation"
+                    android:layout_width="30dp"
+                    android:layout_height="30dp"
+                    android:layout_marginLeft="4dp"
+                    android:layout_marginRight="4dp"
+                    android:layout_toLeftOf="@id/share"
                     android:layout_centerVertical="true"
                     android:clickable="true"
                     android:focusable="true"

--- a/app/src/main/res/layout/activity_main_player.xml
+++ b/app/src/main/res/layout/activity_main_player.xml
@@ -247,7 +247,7 @@
                     android:layout_height="wrap_content"
                     android:layout_alignParentRight="true"
                     android:layout_marginLeft="2dp"
-					android:padding="5dp"
+                    android:padding="5dp"
                     android:clickable="true"
                     android:focusable="true"
                     android:scaleType="fitXY"
@@ -303,12 +303,29 @@
                     tools:text="English" />
 
                 <ImageButton
-                    android:id="@+id/toggleOrientation"
+                    android:id="@+id/share"
                     android:layout_width="30dp"
                     android:layout_height="30dp"
                     android:layout_marginLeft="4dp"
                     android:layout_marginRight="2dp"
                     android:layout_alignParentRight="true"
+                    android:layout_centerVertical="true"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:padding="5dp"
+                    android:scaleType="fitXY"
+                    android:src="@drawable/ic_share_white_24dp"
+                    android:background="?attr/selectableItemBackground"
+                    android:contentDescription="@string/share"
+                    tools:ignore="RtlHardcoded"/>
+
+                <ImageButton
+                    android:id="@+id/toggleOrientation"
+                    android:layout_width="30dp"
+                    android:layout_height="30dp"
+                    android:layout_marginLeft="4dp"
+                    android:layout_marginRight="4dp"
+                    android:layout_toLeftOf="@id/share"
                     android:layout_centerVertical="true"
                     android:clickable="true"
                     android:focusable="true"


### PR DESCRIPTION
The button is placed in the upper right corner, under "more settings". No changes has been made to the popup video player (as for other things, there is no space for a share button).
![main player share button](https://user-images.githubusercontent.com/36421898/55673749-701bcc80-58ac-11e9-8bc4-ffdd33670b81.jpg)
The share button generates this text (for the video above at the current time):
```
TEST VIDEO
https://www.youtube.com/watch?v=C0DPdy98e4c&t=3
```
This implements #2000, but it does not give a chance of choosing whether to share the url normally or to at the current time. But as discussed in #2000 this is not a problem because there are already many other ways to do that.

The share utilities (i.e. `shareUrl()` and `openUrlInBrowser()`) were placed under the BaseStateFragment class. But since they have nothing to do with fragments, I moved them to a separate utilities class: `utils.ShareUtils`. This way they can be accessed from anywhere. I could not find any way to access them from the MainVideoPlayer, using the previous setup.

I tested the feature both from a phone (Huawei P9 lite, where the used layout is normal) and from a tablet (Amazon Kindle, where the layout is large-land, I think). Also, since I moved the sharing functions, I tested the "share" buttons in the app and they work as they did before.

Please note that this is my first pull request ever, so if I did something wrong I'm sorry :-)

- [X] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.