### PR TITLE
Two-finger click to enqueue stream on background

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
@@ -190,6 +190,9 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I> implem
             public void held(StreamInfoItem selectedItem) {
                 showStreamDialog(selectedItem);
             }
+
+            @Override
+            public void twoFingerClick(StreamInfoItem selectedItem) { enqueueStreamOnBackgroundPlayer(selectedItem); }
         });
 
         infoListAdapter.setOnChannelSelectedListener(new OnClickGesture<ChannelInfoItem>() {
@@ -289,6 +292,11 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I> implem
         };
 
         new InfoItemDialog(getActivity(), item, commands, actions).show();
+    }
+
+    protected void enqueueStreamOnBackgroundPlayer(final StreamInfoItem item) {
+        final Context context = getContext();
+        NavigationHelper.enqueueOnBackgroundPlayer(context, new SinglePlayQueue(item));
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/app/src/main/java/org/schabi/newpipe/util/OnClickGesture.java
+++ b/app/src/main/java/org/schabi/newpipe/util/OnClickGesture.java
@@ -13,4 +13,8 @@ public abstract class OnClickGesture<T> {
     public void drag(T selectedItem, RecyclerView.ViewHolder viewHolder) {
         // Optional gesture
     }
+
+    public void twoFingerClick(T selectedItem) {
+        // Optional gesture
+    }
 }


### PR DESCRIPTION
- [X] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

Added a two-finger click gesture to the util.OnClickGesture class. It is triggered when the user touches a stream with two fingers, enabling him to quickly enqueue that stream on background.

I tested all the gestures in StreamMiniInfoItemHolder thoroughly and they work (after fixing some complications explained below). [test apk](https://github.com/TeamNewPipe/NewPipe/files/3144692/app-debug_1.zip)

The gesture detector in StreamMiniInfoItemHolder is not very readable, there probably is a way to make it better. The problem is it has to detect single clicks, held clicks and two-finger clicks: without manually handling every gesture there is no way (or at least I couldn't find it) not to block single clicks when a two-finger click or a held click is happening. I'm using the view.onTouchEvent() to detect normal clicks and two-finger clicks and delegating the work to a SimpleGestureDetector to detect held clicks.

Closes #2306