### PR TITLE
Fixed setPlayWhenReady behaviour inconsistency

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
@@ -889,27 +889,22 @@ public abstract class BasePlayer implements
 
     public void onPlay() {
         if (DEBUG) Log.d(TAG, "onPlay() called");
-        if (audioReactor == null || playQueue == null || simpleExoPlayer == null) return;
 
-        audioReactor.requestAudioFocus();
+        if (audioReactor != null) audioReactor.requestAudioFocus();
 
-        if (getCurrentState() == STATE_COMPLETED) {
+        if (playQueue != null && getCurrentState() == STATE_COMPLETED) {
             if (playQueue.getIndex() == 0) {
                 seekToDefault();
             } else {
                 playQueue.setIndex(0);
             }
         }
-
-        simpleExoPlayer.setPlayWhenReady(true);
     }
 
     public void onPause() {
         if (DEBUG) Log.d(TAG, "onPause() called");
-        if (audioReactor == null || simpleExoPlayer == null) return;
 
-        audioReactor.abandonAudioFocus();
-        simpleExoPlayer.setPlayWhenReady(false);
+        if (audioReactor != null) audioReactor.abandonAudioFocus();
     }
 
     public void onPlayPause() {


### PR DESCRIPTION
this commit aims to fix multiple possible issues by simplifcation:
- multi null checks to return a method early could result in actual available object not being used
- audioreactor request and abandon of audio focus are both leading to setPlayWhenReady calls, so doubled calls have been removed
- simpleExoPlayer.setPlayWhenReady(true) was not respecting isResumeAfterAudioFocusGain (see AudioReactor). It is gone now, as explained in list point above.

Might fix #2331

- [X] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
