### PR TITLE
Fixed selected subtitle track name not being shown

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/VideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/VideoPlayer.java
@@ -297,6 +297,7 @@ public abstract class VideoPlayer extends BasePlayer
             return true;
         });
 
+        // Add all available captions
         for (int i = 0; i < availableLanguages.size(); i++) {
             final String captionLanguage = availableLanguages.get(i);
             MenuItem captionItem = captionPopupMenu.getMenu().add(captionPopupMenuGroupId,
@@ -506,7 +507,7 @@ public abstract class VideoPlayer extends BasePlayer
         }
 
         // Normalize mismatching language strings
-        final String preferredLanguage = trackSelector.getParameters().preferredTextLanguage;
+        final String preferredLanguage = trackSelector.getPreferredTextLanguage();
         // Build UI
         buildCaptionMenu(availableLanguages);
         if (trackSelector.getParameters().getRendererDisabled(textRenderer) ||


### PR DESCRIPTION
closes #2393
this amends my obviously incomplete fix in PR #2311.

This is just an UI issue. Subtitle track selection and display of subtitle works. It just shows "No Captions" instead of the actual selected subtitle track name.

Sorry.

- [X] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
