### PR TITLE
Add move to next feature in play queue

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/ServicePlayerActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ServicePlayerActivity.java
@@ -32,6 +32,7 @@ import org.schabi.newpipe.fragments.OnScrollBelowItemsListener;
 import org.schabi.newpipe.local.dialog.PlaylistAppendDialog;
 import org.schabi.newpipe.player.event.PlayerEventListener;
 import org.schabi.newpipe.player.helper.PlaybackParameterDialog;
+import org.schabi.newpipe.player.playqueue.PlayQueue;
 import org.schabi.newpipe.player.playqueue.PlayQueueAdapter;
 import org.schabi.newpipe.player.playqueue.PlayQueueItem;
 import org.schabi.newpipe.player.playqueue.PlayQueueItemBuilder;
@@ -321,7 +322,6 @@ public abstract class ServicePlayerActivity extends AppCompatActivity
                 Menu.NONE, R.string.play_queue_remove);
         remove.setOnMenuItemClickListener(menuItem -> {
             if (player == null) return false;
-
             final int index = player.getPlayQueue().indexOf(item);
             if (index != -1) player.getPlayQueue().remove(index);
             return true;
@@ -345,6 +345,13 @@ public abstract class ServicePlayerActivity extends AppCompatActivity
                 Menu.NONE, R.string.share);
         share.setOnMenuItemClickListener(menuItem -> {
             shareUrl(item.getTitle(), item.getUrl());
+            return true;
+        });
+
+        final MenuItem moveToNext = menu.getMenu().add(RECYCLER_ITEM_POPUP_MENU_GROUP_ID, 4,
+                Menu.NONE, R.string.moveToNext);
+        moveToNext.setOnMenuItemClickListener(menuItem -> {
+            moveToNext(item);
             return true;
         });
 
@@ -535,6 +542,16 @@ public abstract class ServicePlayerActivity extends AppCompatActivity
         intent.putExtra(Intent.EXTRA_SUBJECT, subject);
         intent.putExtra(Intent.EXTRA_TEXT, url);
         startActivity(Intent.createChooser(intent, getString(R.string.share_dialog_title)));
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Move to Next
+    ////////////////////////////////////////////////////////////////////////////
+    private void moveToNext(PlayQueueItem item) {
+        int fromIndex = player.getPlayQueue().indexOf(item);
+        int toIndex = player.getPlayQueue().getIndex() + 1;
+
+        player.getPlayQueue().move(fromIndex, toIndex);
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -555,5 +555,6 @@
     <string name="downloads_storage_ask_title">Ask where to download</string>
     <string name="downloads_storage_ask_summary">You will be asked where to save each download</string>
     <string name="downloads_storage_ask_summary_kitkat">You will be asked where to save each download.\nEnable this option if you want download to the external SD Card</string>
+    <string name="moveToNext">Move to next</string>
 
 </resources>


### PR DESCRIPTION
- [X] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

In order to make organizing songs within a PlayQueue easier, I have added a "move to next" menu item.

### Feature added:
The move to next menu item appears when a PlayQueueItem is held down, bringing up the menu. The menu item will move this PlayQueueItem to the next-to-play position in the PlayQueue (that is, the index after the current playing song).

### Why? 
I use NewPipe often when commuting or at the gym and it's a wonderful application. One issue I've been running into, however, is organizing the play queue. Often I'll play a large public playlist with the intention of moving the songs I personally enjoy to the front. Furthermore, I'll also often enqueue songs not in the playlist to the queue. Currently this is a time-consuming task due to the time it takes to drag a song from the bottom to the top, not to mention bugs within the ItemTouchHelper that causes the drag to move way too fast after changing direction. By adding a menu option to move a PlayQueueItem to the next position in the PlayQueue, organizing songs can be more time efficient and less painful.