### PR TITLE
Downloads: add switch for saf/legacy file picker

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -60,6 +60,7 @@ import org.schabi.newpipe.report.ErrorActivity;
 import org.schabi.newpipe.util.Constants;
 import org.schabi.newpipe.util.KioskTranslator;
 import org.schabi.newpipe.util.NavigationHelper;
+import org.schabi.newpipe.util.PermissionHelper;
 import org.schabi.newpipe.util.ServiceHelper;
 import org.schabi.newpipe.util.StateSaver;
 import org.schabi.newpipe.util.ThemeHelper;
@@ -420,6 +421,17 @@ public class MainActivity extends AppCompatActivity {
             if (i == PackageManager.PERMISSION_DENIED){
                 return;
             }
+        }
+        switch (requestCode) {
+            case PermissionHelper.DOWNLOADS_REQUEST_CODE:
+                NavigationHelper.openDownloads(this);
+                break;
+            case PermissionHelper.DOWNLOAD_DIALOG_REQUEST_CODE:
+                Fragment fragment = getSupportFragmentManager().findFragmentById(R.id.fragment_holder);
+                if (fragment instanceof VideoDetailFragment) {
+                    ((VideoDetailFragment) fragment).openDownloadDialog();
+                }
+                break;
         }
     }
 

--- a/app/src/main/java/org/schabi/newpipe/RouterActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/RouterActivity.java
@@ -74,10 +74,13 @@ import static org.schabi.newpipe.util.ThemeHelper.resolveResourceIdFromAttr;
  */
 public class RouterActivity extends AppCompatActivity {
 
-    @State protected int currentServiceId = -1;
+    @State
+    protected int currentServiceId = -1;
     private StreamingService currentService;
-    @State protected LinkType currentLinkType;
-    @State protected int selectedRadioPosition = -1;
+    @State
+    protected LinkType currentLinkType;
+    @State
+    protected int selectedRadioPosition = -1;
     protected int selectedPreviously = -1;
 
     protected String currentUrl;
@@ -257,7 +260,7 @@ public class RouterActivity extends AppCompatActivity {
                 .setNegativeButton(R.string.just_once, dialogButtonsClickListener)
                 .setPositiveButton(R.string.always, dialogButtonsClickListener)
                 .setOnDismissListener((dialog) -> {
-                    if(!selectionIsDownload) finish();
+                    if (!selectionIsDownload) finish();
                 })
                 .create();
 
@@ -358,13 +361,13 @@ public class RouterActivity extends AppCompatActivity {
         positiveButton.setEnabled(state);
     }
 
-    private void handleText(){
+    private void handleText() {
         String searchString = getIntent().getStringExtra(Intent.EXTRA_TEXT);
         int serviceId = getIntent().getIntExtra(Constants.KEY_SERVICE_ID, 0);
         Intent intent = new Intent(getThemeWrapperContext(), MainActivity.class);
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         startActivity(intent);
-        NavigationHelper.openSearch(getThemeWrapperContext(),serviceId,searchString);
+        NavigationHelper.openSearch(getThemeWrapperContext(), serviceId, searchString);
     }
 
     private void handleChoice(final String selectedChoiceKey) {
@@ -382,8 +385,10 @@ public class RouterActivity extends AppCompatActivity {
         }
 
         if (selectedChoiceKey.equals(getString(R.string.download_key))) {
-            selectionIsDownload = true;
-            openDownloadDialog();
+            if (PermissionHelper.checkStoragePermissions(this, PermissionHelper.DOWNLOAD_DIALOG_REQUEST_CODE)) {
+                selectionIsDownload = true;
+                openDownloadDialog();
+            }
             return;
         }
 
@@ -395,7 +400,7 @@ public class RouterActivity extends AppCompatActivity {
                     .subscribeOn(Schedulers.io())
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe(intent -> {
-                        if(!internalRoute){
+                        if (!internalRoute) {
                             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                             intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
                         }
@@ -445,17 +450,21 @@ public class RouterActivity extends AppCompatActivity {
 
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-        for (int i: grantResults){
-            if (i == PackageManager.PERMISSION_DENIED){
+        for (int i : grantResults) {
+            if (i == PackageManager.PERMISSION_DENIED) {
                 finish();
                 return;
             }
+        }
+        if (requestCode == PermissionHelper.DOWNLOAD_DIALOG_REQUEST_CODE) {
+            openDownloadDialog();
         }
     }
 
     private static class AdapterChoiceItem {
         final String description, key;
-        @DrawableRes final int icon;
+        @DrawableRes
+        final int icon;
 
         AdapterChoiceItem(String key, String description, int icon) {
             this.description = description;
@@ -553,7 +562,8 @@ public class RouterActivity extends AppCompatActivity {
 
                 final SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(this);
                 boolean isExtVideoEnabled = preferences.getBoolean(getString(R.string.use_external_video_player_key), false);
-                boolean isExtAudioEnabled = preferences.getBoolean(getString(R.string.use_external_audio_player_key), false);;
+                boolean isExtAudioEnabled = preferences.getBoolean(getString(R.string.use_external_audio_player_key), false);
+                ;
 
                 PlayQueue playQueue;
                 String playerChoice = choice.playerChoice;

--- a/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
@@ -569,7 +569,7 @@ public class DownloadDialog extends DialogFragment implements RadioGroup.OnCheck
             // This part is called if with SAF preferred:
             //  * older android version running
             //  * save path not defined (via download settings)
-            //  * the user as checked the "ask where to download" option
+            //  * the user checked the "ask where to download" option
 
             if (!askForSavePath)
                 Toast.makeText(context, getString(R.string.no_available_dir), Toast.LENGTH_LONG).show();
@@ -728,7 +728,7 @@ public class DownloadDialog extends DialogFragment implements RadioGroup.OnCheck
         try {
             if (storage.length() > 0) storage.truncate();
         } catch (IOException e) {
-            Log.e(TAG, "failed to overwrite the file: " + storage.getUri().toString(), e);
+            Log.e(TAG, "failed to truncate the file: " + storage.getUri().toString(), e);
             showFailedDialog(R.string.overwrite_failed);
             return;
         }

--- a/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
@@ -329,7 +329,7 @@ public class DownloadDialog extends DialogFragment implements RadioGroup.OnCheck
                 return;
             }
 
-            if (data.getData().getAuthority() != null && data.getData().getAuthority().startsWith(context.getPackageName())) {
+            if (FilePickerActivityHelper.isOwnFileUri(context, data.getData())) {
                 File file = Utils.getFileForUri(data.getData());
                 checkSelectedDownload(null, Uri.fromFile(file), file.getName(), StoredFileHelper.DEFAULT_MIME);
                 return;
@@ -592,7 +592,7 @@ public class DownloadDialog extends DialogFragment implements RadioGroup.OnCheck
             if (!askForSavePath)
                 Toast.makeText(context, getString(R.string.no_available_dir), Toast.LENGTH_LONG).show();
 
-            if (NewPipeSettings.hasCreateDocumentSupport) {
+            if (NewPipeSettings.useStorageAccessFramework(context)) {
                 StoredFileHelper.requestSafWithFileCreation(this, REQUEST_DOWNLOAD_SAVE_AS, filename, mime);
             } else {
                 File initialSavePath;

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -384,7 +384,10 @@ public class VideoDetailFragment
                 }
                 break;
             case R.id.detail_controls_download:
-                this.openDownloadDialog();
+                if (PermissionHelper.checkStoragePermissions(activity,
+                        PermissionHelper.DOWNLOAD_DIALOG_REQUEST_CODE)) {
+                    this.openDownloadDialog();
+                }
                 break;
             case R.id.detail_uploader_root_layout:
                 if (TextUtils.isEmpty(currentInfo.getUploaderUrl())) {

--- a/app/src/main/java/org/schabi/newpipe/settings/DownloadSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/DownloadSettingsFragment.java
@@ -35,8 +35,6 @@ public class DownloadSettingsFragment extends BasePreferenceFragment {
     private String DOWNLOAD_PATH_VIDEO_PREFERENCE;
     private String DOWNLOAD_PATH_AUDIO_PREFERENCE;
 
-    private String DOWNLOAD_STORAGE_ASK;
-
     private Preference prefPathVideo;
     private Preference prefPathAudio;
     private Preference prefStorageAsk;
@@ -49,14 +47,14 @@ public class DownloadSettingsFragment extends BasePreferenceFragment {
 
         DOWNLOAD_PATH_VIDEO_PREFERENCE = getString(R.string.download_path_video_key);
         DOWNLOAD_PATH_AUDIO_PREFERENCE = getString(R.string.download_path_audio_key);
-        DOWNLOAD_STORAGE_ASK = getString(R.string.downloads_storage_ask);
+        final String downloadStorageAsk = getString(R.string.downloads_storage_ask);
 
         prefPathVideo = findPreference(DOWNLOAD_PATH_VIDEO_PREFERENCE);
         prefPathAudio = findPreference(DOWNLOAD_PATH_AUDIO_PREFERENCE);
-        prefStorageAsk = findPreference(DOWNLOAD_STORAGE_ASK);
+        prefStorageAsk = findPreference(downloadStorageAsk);
 
         updatePreferencesSummary();
-        updatePathPickers(!defaultPreferences.getBoolean(DOWNLOAD_STORAGE_ASK, false));
+        updatePathPickers(!defaultPreferences.getBoolean(downloadStorageAsk, false));
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             prefStorageAsk.setSummary(R.string.downloads_storage_ask_summary);
@@ -180,7 +178,7 @@ public class DownloadSettingsFragment extends BasePreferenceFragment {
         }
 
         Intent i;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && NewPipeSettings.hasOpenDocumentTreeSupport) {
             i = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
                     .putExtra("android.content.extra.SHOW_ADVANCED", true)
                     .addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION | StoredDirectoryHelper.PERMISSION_FLAGS);
@@ -221,16 +219,17 @@ public class DownloadSettingsFragment extends BasePreferenceFragment {
             return;
         }
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            // steps:
-            //       1. revoke permissions on the old save path
-            //       2. acquire permissions on the new save path
-            //       3. save the new path, if step(2) was successful
-            final Context ctx = getContext();
-            if (ctx == null) throw new NullPointerException("getContext()");
 
-            forgetSAFTree(ctx, defaultPreferences.getString(key, ""));
+        // revoke permissions on the old save path (required for SAF only)
+        final Context ctx = getContext();
+        if (ctx == null) throw new NullPointerException("getContext()");
 
+        forgetSAFTree(ctx, defaultPreferences.getString(key, ""));
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && NewPipeSettings.hasOpenDocumentTreeSupport) {
+            // steps to acquire the selected path:
+            //     1. acquire permissions on the new save path
+            //     2. save the new path, if step(2) was successful
             try {
                 ctx.grantUriPermission(ctx.getPackageName(), uri, StoredDirectoryHelper.PERMISSION_FLAGS);
 

--- a/app/src/main/java/org/schabi/newpipe/settings/DownloadSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/DownloadSettingsFragment.java
@@ -178,7 +178,7 @@ public class DownloadSettingsFragment extends BasePreferenceFragment {
         }
 
         Intent i;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && NewPipeSettings.hasOpenDocumentTreeSupport) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && NewPipeSettings.useStorageAccessFramework(ctx)) {
             i = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
                     .putExtra("android.content.extra.SHOW_ADVANCED", true)
                     .addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION | StoredDirectoryHelper.PERMISSION_FLAGS);
@@ -226,7 +226,7 @@ public class DownloadSettingsFragment extends BasePreferenceFragment {
 
         forgetSAFTree(ctx, defaultPreferences.getString(key, ""));
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && NewPipeSettings.hasOpenDocumentTreeSupport) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && !FilePickerActivityHelper.isOwnFileUri(ctx, uri)) {
             // steps to acquire the selected path:
             //     1. acquire permissions on the new save path
             //     2. save the new path, if step(2) was successful
@@ -244,7 +244,7 @@ public class DownloadSettingsFragment extends BasePreferenceFragment {
                 return;
             }
         } else {
-            File target = Utils.getFileForUri(data.getData());
+            File target = Utils.getFileForUri(uri);
             if (!target.canWrite()) {
                 showMessageDialog(R.string.download_to_sdcard_error_title, R.string.download_to_sdcard_error_message);
                 return;

--- a/app/src/main/java/org/schabi/newpipe/settings/NewPipeSettings.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/NewPipeSettings.java
@@ -86,10 +86,10 @@ public class NewPipeSettings {
         PreferenceManager.setDefaultValues(context, R.xml.debug_settings, true);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            hasOpenDocumentTreeSupport = testFor(context, Intent.ACTION_OPEN_DOCUMENT_TREE);
+            hasOpenDocumentTreeSupport = testFor(context, Intent.ACTION_OPEN_DOCUMENT_TREE, false);
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-            hasCreateDocumentSupport = testFor(context, Intent.ACTION_CREATE_DOCUMENT);
+            hasCreateDocumentSupport = testFor(context, Intent.ACTION_CREATE_DOCUMENT, true);
         }
 
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP || !hasOpenDocumentTreeSupport) {
@@ -118,7 +118,7 @@ public class NewPipeSettings {
     }
 
     @NonNull
-    private static File getDir(String defaultDirectoryName) {
+    public static File getDir(String defaultDirectoryName) {
         return new File(Environment.getExternalStorageDirectory(), defaultDirectoryName);
     }
 
@@ -126,9 +126,14 @@ public class NewPipeSettings {
         return new File(dir, "NewPipe").toURI().toString();
     }
 
-    private static boolean testFor(@NonNull Context ctx, @NonNull String intentAction) {
-        Intent queryIntent = new Intent(intentAction);
-        queryIntent.addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
+    private static boolean testFor(@NonNull Context ctx, @NonNull String intentAction, boolean isFile) {
+        Intent queryIntent = new Intent(intentAction)
+                .addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
+
+        if (isFile) {
+            queryIntent.setType("*/*");
+            queryIntent.addCategory(Intent.CATEGORY_OPENABLE);
+        }
 
         List<ResolveInfo> infoList = ctx.getPackageManager()
                 .queryIntentActivities(queryIntent, PackageManager.MATCH_DEFAULT_ONLY);

--- a/app/src/main/java/org/schabi/newpipe/settings/NewPipeSettings.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/NewPipeSettings.java
@@ -140,7 +140,9 @@ public class NewPipeSettings {
 
         int availableProviders = 0;
         for (ResolveInfo info : infoList) {
-            if (info.activityInfo.exported) availableProviders++;
+            if (info.activityInfo != null && info.activityInfo.enabled && info.activityInfo.exported) {
+                availableProviders++;
+            }
         }
 
         return availableProviders > 0;

--- a/app/src/main/java/org/schabi/newpipe/util/FilePickerActivityHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/FilePickerActivityHelper.java
@@ -2,6 +2,7 @@ package org.schabi.newpipe.util;
 
 import android.content.Context;
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
 import android.os.Environment;
 import android.support.annotation.NonNull;
@@ -29,7 +30,7 @@ public class FilePickerActivityHelper extends com.nononsenseapps.filepicker.File
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        if(ThemeHelper.isLightThemeSelected(this)) {
+        if (ThemeHelper.isLightThemeSelected(this)) {
             this.setTheme(R.style.FilePickerThemeLight);
         } else {
             this.setTheme(R.style.FilePickerThemeDark);
@@ -71,6 +72,11 @@ public class FilePickerActivityHelper extends com.nononsenseapps.filepicker.File
                 .putExtra(FilePickerActivityHelper.EXTRA_ALLOW_EXISTING_FILE, true)
                 .putExtra(FilePickerActivityHelper.EXTRA_START_PATH, startPath)
                 .putExtra(FilePickerActivityHelper.EXTRA_MODE, FilePickerActivityHelper.MODE_NEW_FILE);
+    }
+
+    public static boolean isOwnFileUri(@NonNull Context context, @NonNull Uri uri) {
+        if (uri.getAuthority() == null) return false;
+        return uri.getAuthority().startsWith(context.getPackageName());
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
@@ -446,6 +446,9 @@ public class NavigationHelper {
     }
 
     public static boolean openDownloads(Activity activity) {
+        if (!PermissionHelper.checkStoragePermissions(activity, PermissionHelper.DOWNLOADS_REQUEST_CODE)) {
+            return false;
+        }
         Intent intent = new Intent(activity, DownloadActivity.class);
         activity.startActivity(intent);
         return true;

--- a/app/src/main/java/org/schabi/newpipe/util/PermissionHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/PermissionHelper.java
@@ -18,10 +18,12 @@ import android.widget.Toast;
 import org.schabi.newpipe.R;
 
 public class PermissionHelper {
+    public static final int DOWNLOAD_DIALOG_REQUEST_CODE = 778;
+    public static final int DOWNLOADS_REQUEST_CODE = 777;
 
     public static boolean checkStoragePermissions(Activity activity, int requestCode) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-            if(!checkReadStoragePermissions(activity, requestCode)) return false;
+            if (!checkReadStoragePermissions(activity, requestCode)) return false;
         }
         return checkWriteStoragePermissions(activity, requestCode);
     }
@@ -89,7 +91,7 @@ public class PermissionHelper {
             i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             context.startActivity(i);
             return false;
-        }else return true;
+        } else return true;
     }
 
     public static boolean isPopupEnabled(Context context) {

--- a/app/src/main/java/us/shandian/giga/service/DownloadManager.java
+++ b/app/src/main/java/us/shandian/giga/service/DownloadManager.java
@@ -35,8 +35,8 @@ public class DownloadManager {
     public final static int SPECIAL_PENDING = 1;
     public final static int SPECIAL_FINISHED = 2;
 
-    static final String TAG_AUDIO = "audio";
-    static final String TAG_VIDEO = "video";
+    public static final String TAG_AUDIO = "audio";
+    public static final String TAG_VIDEO = "video";
 
     private final FinishedMissionStore mFinishedMissionStore;
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -458,7 +458,9 @@ abrir en modo popup</string>
 
     <string name="downloads_storage_ask_title">Preguntar dónde descargar</string>
     <string name="downloads_storage_ask_summary">Se preguntará dónde guardar cada descarga</string>
-    <string name="downloads_storage_ask_summary_kitkat">Se preguntará dónde guardar cada descarga.\nHabilita esta opción si quieres descargar en la tarjeta SD externa</string>
+    <string name="downloads_storage_ask_summary_kitkat">Se preguntará dónde guardar cada descarga.\nHabilita esta opción junto con SAF si quieres descargar en la tarjeta SD externa</string>
+    <string name="downloads_storage_use_saf_title">Usar SAF</string>
+    <string name="downloads_storage_use_saf_summary">El Framework de Acceso al Almacenamiento permite descargar en la tarjeta SD externa.\nNota: Algunos los dispositivos no son compatibles</string>
 
     <string name="unsubscribe">Desuscribirse</string>
     <string name="tab_new">Nueva pestaña</string>

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -163,6 +163,7 @@
     <string name="clear_search_history_key" translatable="false">clear_search_history</string>
 
     <string name="downloads_storage_ask" translatable="false">downloads_storage_ask</string>
+    <string name="storage_use_saf" translatable="false">storage_use_saf</string>
 
     <!-- FileName Downloads  -->
     <string name="settings_file_charset_key" translatable="false">file_rename_charset</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -556,6 +556,8 @@
 
     <string name="downloads_storage_ask_title">Ask where to download</string>
     <string name="downloads_storage_ask_summary">You will be asked where to save each download</string>
-    <string name="downloads_storage_ask_summary_kitkat">You will be asked where to save each download.\nEnable this option if you want download to the external SD Card</string>
+    <string name="downloads_storage_ask_summary_kitkat">You will be asked where to save each download.\nEnable this option with SAF if you want download to the external SD Card</string>
+    <string name="downloads_storage_use_saf_title">Use SAF</string>
+    <string name="downloads_storage_use_saf_summary">The Storage Access Framework allow download to the external SD Card.\nNote: some devices are not compatible</string>
 
 </resources>

--- a/app/src/main/res/xml/download_settings.xml
+++ b/app/src/main/res/xml/download_settings.xml
@@ -12,6 +12,13 @@
         android:summary="@string/downloads_storage_ask_summary_kitkat"
         android:title="@string/downloads_storage_ask_title" />
 
+    <SwitchPreference
+        app:iconSpaceReserved="false"
+        android:defaultValue="false"
+        android:key="@string/storage_use_saf"
+        android:summary="@string/downloads_storage_use_saf_summary"
+        android:title="@string/downloads_storage_use_saf_title" />
+
     <Preference
         app:iconSpaceReserved="false"
         android:dialogTitle="@string/download_path_dialog_title"


### PR DESCRIPTION
Some ROMs are not [CTS](https://source.android.com/compatibility/cts/) compliant, in these cases the Storage Access Framework is not fully implemented or functional.
This PR checks whatever is SAF available, otherwise, the legacy API (Java I/O) will be used

changes:
* restore request permissions popups
* use legacy file/folder picker if necessary

fixes #2498 and fixes #2504 

- [ ✔ ] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
