### PR TITLE
Fix ReCaptchaActivity

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,7 +57,7 @@ dependencies {
         exclude module: 'support-annotations'
     })
 
-    implementation 'com.github.TeamNewPipe:NewPipeExtractor:5f65788a2f89e'
+    implementation 'com.github.Stypox:NewPipeExtractor:06689a2f27edfe83bd4605a1cceed86c06a5ebf8'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.23.0'

--- a/app/src/main/java/org/schabi/newpipe/Downloader.java
+++ b/app/src/main/java/org/schabi/newpipe/Downloader.java
@@ -164,7 +164,7 @@ public class Downloader implements org.schabi.newpipe.extractor.Downloader {
         final ResponseBody body = response.body();
 
         if (response.code() == 429) {
-            throw new ReCaptchaException("reCaptcha Challenge requested");
+            throw new ReCaptchaException("reCaptcha Challenge requested", siteUrl);
         }
 
         if (body == null) {
@@ -214,7 +214,7 @@ public class Downloader implements org.schabi.newpipe.extractor.Downloader {
         final ResponseBody body = response.body();
 
         if (response.code() == 429) {
-            throw new ReCaptchaException("reCaptcha Challenge requested");
+            throw new ReCaptchaException("reCaptcha Challenge requested", siteUrl);
         }
 
         if (body == null) {
@@ -268,7 +268,7 @@ public class Downloader implements org.schabi.newpipe.extractor.Downloader {
         final ResponseBody body = response.body();
 
         if (response.code() == 429) {
-            throw new ReCaptchaException("reCaptcha Challenge requested");
+            throw new ReCaptchaException("reCaptcha Challenge requested", siteUrl);
         }
 
         if (body == null) {

--- a/app/src/main/java/org/schabi/newpipe/ReCaptchaActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/ReCaptchaActivity.java
@@ -37,14 +37,23 @@ import android.webkit.WebViewClient;
  */
 public class ReCaptchaActivity extends AppCompatActivity {
     public static final int RECAPTCHA_REQUEST = 10;
+    public static final String RECAPTCHA_URL_EXTRA = "recaptcha_url_extra";
 
     public static final String TAG = ReCaptchaActivity.class.toString();
     public static final String YT_URL = "https://www.youtube.com";
+
+    private String url;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_recaptcha);
+
+        url = getIntent().getStringExtra(RECAPTCHA_URL_EXTRA);
+        if (url == null || url.isEmpty()) {
+            url = YT_URL;
+        }
+
 
         // Set return to Cancel by default
         setResult(RESULT_CANCELED);
@@ -73,15 +82,12 @@ public class ReCaptchaActivity extends AppCompatActivity {
         myWebView.clearHistory();
         android.webkit.CookieManager cookieManager = CookieManager.getInstance();
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            cookieManager.removeAllCookies(new ValueCallback<Boolean>() {
-                @Override
-                public void onReceiveValue(Boolean aBoolean) {}
-            });
+            cookieManager.removeAllCookies(aBoolean -> {});
         } else {
             cookieManager.removeAllCookie();
         }
 
-        myWebView.loadUrl(YT_URL);
+        myWebView.loadUrl(url);
     }
 
     private class ReCaptchaWebViewClient extends WebViewClient {

--- a/app/src/main/java/org/schabi/newpipe/fragments/BaseStateFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/BaseStateFragment.java
@@ -180,7 +180,7 @@ public abstract class BaseStateFragment<I> extends BaseFragment implements ViewC
         }
 
         if (exception instanceof ReCaptchaException) {
-            onReCaptchaException();
+            onReCaptchaException((ReCaptchaException) exception);
             return true;
         } else if (exception instanceof IOException) {
             showError(getString(R.string.network_error), true);
@@ -190,11 +190,13 @@ public abstract class BaseStateFragment<I> extends BaseFragment implements ViewC
         return false;
     }
 
-    public void onReCaptchaException() {
+    public void onReCaptchaException(ReCaptchaException exception) {
         if (DEBUG) Log.d(TAG, "onReCaptchaException() called");
         Toast.makeText(activity, R.string.recaptcha_request_toast, Toast.LENGTH_LONG).show();
         // Starting ReCaptcha Challenge Activity
-        startActivityForResult(new Intent(activity, ReCaptchaActivity.class), ReCaptchaActivity.RECAPTCHA_REQUEST);
+        Intent intent = new Intent(activity, ReCaptchaActivity.class);
+        intent.putExtra(ReCaptchaActivity.RECAPTCHA_URL_EXTRA, exception.getUrl());
+        startActivityForResult(intent, ReCaptchaActivity.RECAPTCHA_REQUEST);
 
         showError(getString(R.string.recaptcha_request_toast), false);
     }

--- a/app/src/main/res/layout/activity_recaptcha.xml
+++ b/app/src/main/res/layout/activity_recaptcha.xml
@@ -1,16 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
+
+    <android.support.v7.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        android:gravity="center_vertical"
+        android:minHeight="?attr/actionBarSize"
+        android:theme="@style/ThemeOverlay.AppCompat.ActionBar"
+        app:popupTheme="@style/ThemeOverlay.AppCompat.ActionBar"
+        app:titleTextAppearance="@style/Toolbar.Title">
+
+    </android.support.v7.widget.Toolbar>
 
     <WebView
         android:id="@+id/reCaptchaWebView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_marginTop="?attr/actionBarSize"/>
-
-    <include layout="@layout/toolbar_layout"/>
 
 </RelativeLayout>


### PR DESCRIPTION
- [y] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

This pr fixes two problems with the ReCaptchaActivity:
- it crashes on activity startup due to a hidden EditText, see #2484
- it always shows youtube's main page ("https://www.youtube.com"), even though the ReCaptchaException was thrown while loading a different page. The main page sometimes contains the ReCaptcha (so there is no problem), but other times it does not since YouTube only blocks a specific page. The specific page that requested a ReCaptcha challenge is now loaded instead, so that the ReCaptcha is always shown.

Fixes #2484
Corresponding extractor pr: TeamNewPipe/NewPipeExtractor#186
Testing apk: [app-debug_2.zip](https://github.com/TeamNewPipe/NewPipe/files/3511787/app-debug_2.zip)
