### PR TITLE
Fix ":00" being erroneously recognized as a timestamp in comments

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/info_list/holder/CommentsMiniInfoItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/holder/CommentsMiniInfoItemHolder.java
@@ -34,7 +34,7 @@ public class CommentsMiniInfoItemHolder extends InfoItemHolder {
     private String commentText;
     private String streamUrl;
 
-    private static final Pattern pattern = Pattern.compile("(\\d+:)?(\\d+)?:(\\d+)");
+    private static final Pattern pattern = Pattern.compile("(\\d+:)?(\\d+):(\\d+)");
 
     private final Linkify.TransformFilter timestampLink = new Linkify.TransformFilter() {
         @Override
@@ -43,9 +43,9 @@ public class CommentsMiniInfoItemHolder extends InfoItemHolder {
             String hours = match.group(1);
             String minutes = match.group(2);
             String seconds = match.group(3);
-            if(hours != null) timestamp += (Integer.parseInt(hours.replace(":", ""))*3600);
-            if(minutes != null) timestamp += (Integer.parseInt(minutes.replace(":", ""))*60);
-            if(seconds != null) timestamp += (Integer.parseInt(seconds));
+            if(hours != null) timestamp += Integer.parseInt(hours.replace(":", ""))*3600;
+            if(minutes != null) timestamp += Integer.parseInt(minutes)*60;
+            if(seconds != null) timestamp += Integer.parseInt(seconds);
             return streamUrl + url.replace(match.group(0), "#timestamp=" + timestamp);
         }
     };


### PR DESCRIPTION
On Youtube's web interface, in comments (and descriptions), :00 is not recognized as a timestamp in comments, while 0:00 is.

This does not solve the minor issue that 000:000 is recognized as a comment in NewPipe, but not YouTube.

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
