### PR TITLE
Black navigation bar for black theme

### DIFF
--- a/app/src/main/res/values-v27/styles.xml
+++ b/app/src/main/res/values-v27/styles.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Base.V21.DarkTheme" parent="Base.V7.DarkTheme">
+    <style name="Base.V27.DarkTheme" parent="Base.V7.DarkTheme">
         <item name="android:navigationBarColor">@color/dark_background_color</item>
         <item name="android:windowLightNavigationBar">false</item>
     </style>
-    <style name="Base.DarkTheme" parent="Base.V21.DarkTheme" />
+    <style name="Base.DarkTheme" parent="Base.V27.DarkTheme" />
 
-    <style name="Base.V21.BlackTheme" parent="Base.V7.BlackTheme">
+    <style name="Base.V27.BlackTheme" parent="Base.V7.BlackTheme">
         <item name="android:navigationBarColor">@android:color/black</item>
     </style>
-    <style name="Base.BlackTheme" parent="Base.V21.BlackTheme" />
+    <style name="Base.BlackTheme" parent="Base.V27.BlackTheme" />
 </resources>

--- a/app/src/main/res/values-v27/styles.xml
+++ b/app/src/main/res/values-v27/styles.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="BlackTheme" parent="DarkTheme">
+        <item name="android:windowBackground">@color/black_background_color</item>
+        <item name="windowBackground">@color/black_background_color</item>
+        <item name="android:navigationBarColor">@android:color/black</item>
+        <item name="android:windowLightNavigationBar">false</item>
+
+        <item name="separator_color">@color/black_separator_color</item>
+        <item name="contrast_background_color">@color/black_contrast_background_color</item>
+    </style>
+</resources>

--- a/app/src/main/res/values-v27/styles.xml
+++ b/app/src/main/res/values-v27/styles.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="BlackTheme" parent="DarkTheme">
-        <item name="android:windowBackground">@color/black_background_color</item>
-        <item name="windowBackground">@color/black_background_color</item>
-        <item name="android:navigationBarColor">@android:color/black</item>
+    <style name="Base.V21.DarkTheme" parent="Base.V7.DarkTheme">
+        <item name="android:navigationBarColor">@color/dark_background_color</item>
         <item name="android:windowLightNavigationBar">false</item>
-
-        <item name="separator_color">@color/black_separator_color</item>
-        <item name="contrast_background_color">@color/black_contrast_background_color</item>
     </style>
+    <style name="Base.DarkTheme" parent="Base.V21.DarkTheme" />
+
+    <style name="Base.V21.BlackTheme" parent="Base.V7.BlackTheme">
+        <item name="android:navigationBarColor">@android:color/black</item>
+    </style>
+    <style name="Base.BlackTheme" parent="Base.V21.BlackTheme" />
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -77,7 +77,9 @@
         <item name="android:windowAnimationStyle">@style/SwitchAnimation</item>
     </style>
 
-    <style name="DarkTheme" parent="Theme.AppCompat.NoActionBar">
+    <style name="Base.V7.DarkTheme" parent="Theme.AppCompat.NoActionBar" />
+    <style name="Base.DarkTheme" parent="Base.V7.DarkTheme" />
+    <style name="DarkTheme" parent="Base.DarkTheme">
         <item name="colorPrimary">@color/dark_youtube_primary_color</item>
         <item name="colorPrimaryDark">@color/dark_youtube_dark_color</item>
         <item name="colorAccent">@color/dark_youtube_accent_color</item>
@@ -144,7 +146,9 @@
         <item name="android:windowAnimationStyle">@style/SwitchAnimation</item>
     </style>
 
-    <style name="BlackTheme" parent="DarkTheme">
+    <style name="Base.V7.BlackTheme" parent="DarkTheme"/>
+    <style name="Base.BlackTheme" parent="Base.V7.BlackTheme"/>
+    <style name="BlackTheme" parent="Base.BlackTheme">
         <item name="android:windowBackground">@color/black_background_color</item>
         <item name="windowBackground">@color/black_background_color</item>
 


### PR DESCRIPTION
As discussed in https://github.com/TeamNewPipe/NewPipe/issues/1494, this changes the software navigation bar to black with light buttons if all of the following points are fulfilled:
1. The black theme is enabled (maybe this should apply to the dark theme as well?)
2. The device supports setting a custom navigation bar color (API Level 21).
3. The device supports setting the navigation buttons color to dark mode (API Level 27).

Fixes #1494

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
