### PR TITLE
show hidden directories in the file picker

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/util/FilePickerActivityHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/FilePickerActivityHelper.java
@@ -116,7 +116,7 @@ public class FilePickerActivityHelper extends com.nononsenseapps.filepicker.File
         }
 
         @Override
-        protected boolean isItemVisible(File file) {
+        protected boolean isItemVisible(@NonNull File file) {
             if (file.isDirectory() && file.isHidden()) return true;
             return super.isItemVisible(file);
         }

--- a/app/src/main/java/org/schabi/newpipe/util/FilePickerActivityHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/FilePickerActivityHelper.java
@@ -115,6 +115,12 @@ public class FilePickerActivityHelper extends com.nononsenseapps.filepicker.File
             super.onClickOk(view);
         }
 
+        @Override
+        protected boolean isItemVisible(File file) {
+            if (file.isDirectory() && file.isHidden()) return true;
+            return super.isItemVisible(file);
+        }
+
         public File getBackTop() {
             if (getArguments() == null) return Environment.getExternalStorageDirectory();
 


### PR DESCRIPTION
fixes https://github.com/TeamNewPipe/NewPipe/issues/2581 but allows NewPipe pick and navigate on hidden directories