### PR TITLE
check if last byte in the block is downloaded

### DIFF
--- a/app/src/main/java/us/shandian/giga/get/DownloadRunnable.java
+++ b/app/src/main/java/us/shandian/giga/get/DownloadRunnable.java
@@ -117,6 +117,8 @@ public class DownloadRunnable extends Thread {
                     byte[] buf = new byte[DownloadMission.BUFFER_SIZE];
                     int len;
 
+                    // use alwways start <= end
+                    // fixes a deadlock in DownloadRunnable because youtube is sending one byte alone after downloading 26MiB exactly
                     while (start <= end && mMission.running && (len = is.read(buf, 0, buf.length)) != -1) {
                         f.write(buf, 0, len);
                         start += len;

--- a/app/src/main/java/us/shandian/giga/get/DownloadRunnable.java
+++ b/app/src/main/java/us/shandian/giga/get/DownloadRunnable.java
@@ -117,7 +117,7 @@ public class DownloadRunnable extends Thread {
                     byte[] buf = new byte[DownloadMission.BUFFER_SIZE];
                     int len;
 
-                    while (start < end && mMission.running && (len = is.read(buf, 0, buf.length)) != -1) {
+                    while (start <= end && mMission.running && (len = is.read(buf, 0, buf.length)) != -1) {
                         f.write(buf, 0, len);
                         start += len;
                         block.done += len;

--- a/app/src/main/java/us/shandian/giga/get/DownloadRunnable.java
+++ b/app/src/main/java/us/shandian/giga/get/DownloadRunnable.java
@@ -117,7 +117,7 @@ public class DownloadRunnable extends Thread {
                     byte[] buf = new byte[DownloadMission.BUFFER_SIZE];
                     int len;
 
-                    // use alwways start <= end
+                    // use always start <= end
                     // fixes a deadlock in DownloadRunnable because youtube is sending one byte alone after downloading 26MiB exactly
                     while (start <= end && mMission.running && (len = is.read(buf, 0, buf.length)) != -1) {
                         f.write(buf, 0, len);


### PR DESCRIPTION
fixes a deadlock in `DownloadRunnable` because youtube is sending in some files one byte **alone** ~~after downloading 26MiB exactly, why... i dont know.~~
possible fix for #2406

- [ ✔ ] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
