### PR TITLE
Add preference option for unlimited search history

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/list/search/SearchFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/search/SearchFragment.java
@@ -128,6 +128,7 @@ public class SearchFragment
     private String nextPageUrl;
     private String contentCountry;
     private boolean isSuggestionsEnabled = true;
+    private boolean isUnlimitedSearchHistory = false;
 
     private final PublishSubject<String> suggestionPublisher = PublishSubject.create();
     private Disposable searchDisposable;
@@ -190,6 +191,7 @@ public class SearchFragment
 
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(activity);
         isSuggestionsEnabled = preferences.getBoolean(getString(R.string.show_search_suggestions_key), true);
+        isUnlimitedSearchHistory = preferences.getBoolean(getString(R.string.unlimited_search_history_key), false);
         contentCountry = preferences.getString(getString(R.string.content_country_key), getString(R.string.default_country_value));
     }
 
@@ -637,7 +639,9 @@ public class SearchFragment
         suggestionDisposable = observable
                 .switchMap(query -> {
                     final Flowable<List<SearchHistoryEntry>> flowable = historyRecordManager
-                            .getRelatedSearches(query, 3, 25);
+                            .getRelatedSearches(query,
+                                    isUnlimitedSearchHistory ? -1 : 3,
+                                    isUnlimitedSearchHistory ? -1 : 25);
                     final Observable<List<SuggestionItem>> local = flowable.toObservable()
                             .map(searchHistoryEntries -> {
                                 List<SuggestionItem> result = new ArrayList<>();

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -143,6 +143,8 @@
     <string name="show_search_suggestions_summary">Vis søkeforslag ved søk</string>
     <string name="enable_search_history_title">Søkehistorikk</string>
     <string name="enable_search_history_summary">Lagre søkemønster lokalt</string>
+    <string name="unlimited_search_history_title">Ubegrenset søkehistorikk</string>
+    <string name="unlimited_search_history_summary">Ubegrenset antall føringer i søkehistorikken</string>
     <string name="enable_watch_history_title">Visningshistorikk</string>
     <string name="enable_watch_history_summary">Lagre visningshistorikk</string>
     <string name="settings_category_popup_title">Oppsprett</string>

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -148,6 +148,7 @@
     <string name="show_age_restricted_content" translatable="false">show_age_restricted_content</string>
     <string name="use_tor_key" translatable="false">use_tor</string>
     <string name="enable_search_history_key" translatable="false">enable_search_history</string>
+    <string name="unlimited_search_history_key" translatable="false">unlimited_search_history</string>
     <string name="enable_watch_history_key" translatable="false">enable_watch_history</string>
     <string name="main_page_content_key" translatable="false">main_page_content</string>
     <string name="enable_playback_resume_key" translatable="false">enable_playback_resume</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,6 +90,8 @@
     <string name="show_search_suggestions_summary">Show suggestions when searching</string>
     <string name="enable_search_history_title">Search history</string>
     <string name="enable_search_history_summary">Store search queries locally</string>
+    <string name="unlimited_search_history_title">Unlimited search history</string>
+    <string name="unlimited_search_history_summary">Unlimited search history entries</string>
     <string name="enable_watch_history_title">Watch history</string>
     <string name="enable_playback_resume_title">Resume playback</string>
     <string name="enable_playback_resume_summary">Restore last playback position</string>

--- a/app/src/main/res/xml/history_settings.xml
+++ b/app/src/main/res/xml/history_settings.xml
@@ -34,6 +34,14 @@
         android:title="@string/enable_search_history_title"
         app:iconSpaceReserved="false" />
 
+    <SwitchPreference
+        android:defaultValue="false"
+        android:key="@string/unlimited_search_history_key"
+        android:summary="@string/unlimited_search_history_summary"
+        android:title="@string/unlimited_search_history_title"
+        android:dependency="@string/enable_search_history_key"
+        app:iconSpaceReserved="false" />
+
     <PreferenceCategory
         android:layout="@layout/settings_category_header_layout"
         android:title="@string/settings_category_clear_data_title"


### PR DESCRIPTION
- [X] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

This branch adds an option to turn on unlimited search history.

Current behavior: search history is capped at 25 entries when opened, and 3 entries when typing.
New behavior, preference is on: no caps when opening search and no caps when typing.
New behavior, preference is off: as current behavior.
Also, when turning off search history altogether, the new option is disabled.

I have tested and confirmed it works as intended on a virtual device and on my phone.

![Screenshot_1569616343](https://user-images.githubusercontent.com/16323830/65800609-3058e200-e177-11e9-9376-6c81ec484df5.png)

