### PR TITLE
Clear search box has now only one animation - issue #2644 solved

### DIFF
--- a/app/src/main/res/layout/toolbar_search_layout.xml
+++ b/app/src/main/res/layout/toolbar_search_layout.xml
@@ -31,8 +31,7 @@
         android:layout_height="48dp"
         android:layout_gravity="right|center_vertical"
         android:focusable="true"
-        tools:ignore="RtlHardcoded"
-        android:background="?attr/selectableItemBackground">
+        tools:ignore="RtlHardcoded">
 
         <View
             android:layout_width="28dp"


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

Fixes #2644 
The selectableItemBackground has been deleted to show only the circle animation on the search box.