### PR TITLE
Android TV compatibility (fixes #1363, #899)

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -20,6 +20,7 @@
 
 package org.schabi.newpipe;
 
+import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
@@ -39,6 +40,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import android.util.Log;
 import android.view.Gravity;
+import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -58,6 +60,7 @@ import org.schabi.newpipe.fragments.detail.VideoDetailFragment;
 import org.schabi.newpipe.fragments.list.search.SearchFragment;
 import org.schabi.newpipe.report.ErrorActivity;
 import org.schabi.newpipe.util.Constants;
+import org.schabi.newpipe.util.FireTvUtils;
 import org.schabi.newpipe.util.KioskTranslator;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.PermissionHelper;
@@ -407,12 +410,19 @@ public class MainActivity extends AppCompatActivity {
     public void onBackPressed() {
         if (DEBUG) Log.d(TAG, "onBackPressed() called");
 
+        if (FireTvUtils.isFireTv()) {
+            View drawerPanel = findViewById(R.id.navigation_layout);
+            if (drawer.isDrawerOpen(drawerPanel)) {
+                drawer.closeDrawers();
+                return;
+            }
+        }
+
         Fragment fragment = getSupportFragmentManager().findFragmentById(R.id.fragment_holder);
         // If current fragment implements BackPressable (i.e. can/wanna handle back press) delegate the back press to it
         if (fragment instanceof BackPressable) {
             if (((BackPressable) fragment).onBackPressed()) return;
         }
-
 
         if (getSupportFragmentManager().getBackStackEntryCount() == 1) {
             finish();

--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -67,6 +67,7 @@ import org.schabi.newpipe.util.PermissionHelper;
 import org.schabi.newpipe.util.ServiceHelper;
 import org.schabi.newpipe.util.StateSaver;
 import org.schabi.newpipe.util.ThemeHelper;
+import org.schabi.newpipe.views.FocusOverlayView;
 
 public class MainActivity extends AppCompatActivity {
     private static final String TAG = "MainActivity";
@@ -103,6 +104,10 @@ public class MainActivity extends AppCompatActivity {
 
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+
+        if (FireTvUtils.isFireTv()) {
+            FocusOverlayView.setupFocusObserver(this);
+        }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             Window w = getWindow();

--- a/app/src/main/java/org/schabi/newpipe/download/DownloadActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadActivity.java
@@ -13,7 +13,9 @@ import android.view.ViewTreeObserver;
 
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.settings.SettingsActivity;
+import org.schabi.newpipe.util.FireTvUtils;
 import org.schabi.newpipe.util.ThemeHelper;
+import org.schabi.newpipe.views.FocusOverlayView;
 
 import us.shandian.giga.service.DownloadManagerService;
 import us.shandian.giga.ui.fragment.MissionsFragment;
@@ -32,6 +34,10 @@ public class DownloadActivity extends AppCompatActivity {
         ThemeHelper.setTheme(this);
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_downloader);
+
+        if (FireTvUtils.isFireTv()) {
+            FocusOverlayView.setupFocusObserver(this);
+        }
 
         Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -505,7 +505,7 @@ public class VideoDetailFragment
 
         setHeightThumbnail();
 
-
+        thumbnailBackgroundButton.requestFocus();
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
@@ -35,6 +35,7 @@ import org.schabi.newpipe.util.OnClickGesture;
 import org.schabi.newpipe.util.StateSaver;
 import org.schabi.newpipe.util.StreamDialogEntry;
 import org.schabi.newpipe.views.SuperScrollLayoutManager;
+import org.schabi.newpipe.views.FixedGridLayoutManager;
 
 import java.util.List;
 import java.util.Queue;
@@ -156,7 +157,7 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I> implem
         int width = resources.getDimensionPixelSize(R.dimen.video_item_grid_thumbnail_image_width);
         width += (24 * resources.getDisplayMetrics().density);
         final int spanCount = (int) Math.floor(resources.getDisplayMetrics().widthPixels / (double)width);
-        final GridLayoutManager lm = new GridLayoutManager(activity, spanCount);
+        final GridLayoutManager lm = new FixedGridLayoutManager(activity, spanCount);
         lm.setSpanSizeLookup(infoListAdapter.getSpanSizeLookup(spanCount));
         return lm;
     }

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
@@ -34,6 +34,7 @@ import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.OnClickGesture;
 import org.schabi.newpipe.util.StateSaver;
 import org.schabi.newpipe.util.StreamDialogEntry;
+import org.schabi.newpipe.views.SuperScrollLayoutManager;
 
 import java.util.List;
 import java.util.Queue;
@@ -147,7 +148,7 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I> implem
     }
 
     protected RecyclerView.LayoutManager getListLayoutManager() {
-        return new LinearLayoutManager(activity);
+        return new SuperScrollLayoutManager(activity);
     }
 
     protected RecyclerView.LayoutManager getGridLayoutManager() {

--- a/app/src/main/java/org/schabi/newpipe/info_list/holder/CommentsMiniInfoItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/holder/CommentsMiniInfoItemHolder.java
@@ -1,6 +1,9 @@
 package org.schabi.newpipe.info_list.holder;
 
 import androidx.appcompat.app.AppCompatActivity;
+
+import android.text.method.LinkMovementMethod;
+import android.text.style.URLSpan;
 import android.text.util.Linkify;
 import android.view.ViewGroup;
 import android.widget.TextView;
@@ -114,15 +117,35 @@ public class CommentsMiniInfoItemHolder extends InfoItemHolder {
         });
     }
 
+    private void allowLinkFocus() {
+        if (itemView.isInTouchMode()) {
+             return;
+        }
+
+        URLSpan[] urls = itemContentView.getUrls();
+
+        if (urls != null && urls.length != 0) {
+            itemContentView.setMovementMethod(LinkMovementMethod.getInstance());
+        }
+    }
+
     private void ellipsize() {
+        boolean hasEllipsis = false;
+
         if (itemContentView.getLineCount() > commentDefaultLines){
             int endOfLastLine = itemContentView.getLayout().getLineEnd(commentDefaultLines - 1);
             int end = itemContentView.getText().toString().lastIndexOf(' ', endOfLastLine -2);
             if(end == -1) end = Math.max(endOfLastLine -2, 0);
             String newVal = itemContentView.getText().subSequence(0, end) + " …";
             itemContentView.setText(newVal);
+            hasEllipsis = true;
         }
+
         linkify();
+
+        if (!hasEllipsis) {
+            allowLinkFocus();
+        }
     }
 
     private void toggleEllipsize() {
@@ -137,11 +160,13 @@ public class CommentsMiniInfoItemHolder extends InfoItemHolder {
         itemContentView.setMaxLines(commentExpandedLines);
         itemContentView.setText(commentText);
         linkify();
+        allowLinkFocus();
     }
 
     private void linkify(){
         Linkify.addLinks(itemContentView, Linkify.WEB_URLS);
         Linkify.addLinks(itemContentView, pattern, null, null, timestampLink);
+
         itemContentView.setMovementMethod(null);
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/local/BaseLocalListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/BaseLocalListFragment.java
@@ -18,6 +18,7 @@ import android.view.View;
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.fragments.BaseStateFragment;
 import org.schabi.newpipe.fragments.list.ListViewContract;
+import org.schabi.newpipe.views.FixedGridLayoutManager;
 
 import static org.schabi.newpipe.util.AnimationUtils.animateView;
 
@@ -95,7 +96,7 @@ public abstract class BaseLocalListFragment<I, N> extends BaseStateFragment<I>
         int width = resources.getDimensionPixelSize(R.dimen.video_item_grid_thumbnail_image_width);
         width += (24 * resources.getDisplayMetrics().density);
         final int spanCount = (int) Math.floor(resources.getDisplayMetrics().widthPixels / (double)width);
-        final GridLayoutManager lm = new GridLayoutManager(activity, spanCount);
+        final GridLayoutManager lm = new FixedGridLayoutManager(activity, spanCount);
         lm.setSpanSizeLookup(itemListAdapter.getSpanSizeLookup(spanCount));
         return lm;
     }

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.java
@@ -57,6 +57,7 @@ import org.schabi.newpipe.util.ServiceHelper;
 import org.schabi.newpipe.util.ShareUtils;
 import org.schabi.newpipe.util.ThemeHelper;
 import org.schabi.newpipe.views.CollapsibleView;
+import org.schabi.newpipe.views.FixedGridLayoutManager;
 
 import java.io.File;
 import java.text.SimpleDateFormat;
@@ -192,7 +193,7 @@ public class SubscriptionFragment extends BaseStateFragment<List<SubscriptionEnt
         int width = resources.getDimensionPixelSize(R.dimen.video_item_grid_thumbnail_image_width);
         width += (24 * resources.getDisplayMetrics().density);
         final int spanCount = (int) Math.floor(resources.getDisplayMetrics().widthPixels / (double)width);
-        final GridLayoutManager lm = new GridLayoutManager(activity, spanCount);
+        final GridLayoutManager lm = new FixedGridLayoutManager(activity, spanCount);
         lm.setSpanSizeLookup(infoListAdapter.getSpanSizeLookup(spanCount));
         return lm;
     }

--- a/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
@@ -84,6 +84,7 @@ import org.schabi.newpipe.util.PermissionHelper;
 import org.schabi.newpipe.util.ShareUtils;
 import org.schabi.newpipe.util.StateSaver;
 import org.schabi.newpipe.util.ThemeHelper;
+import org.schabi.newpipe.views.FocusOverlayView;
 
 import java.util.List;
 import java.util.Queue;
@@ -141,6 +142,11 @@ public final class MainVideoPlayer extends AppCompatActivity
 
         hideSystemUi();
         setContentView(R.layout.activity_main_player);
+
+        if (FireTvUtils.isFireTv()) {
+            FocusOverlayView.setupFocusObserver(this);
+        }
+
         playerImpl = new  VideoPlayerImpl(this);
         playerImpl.setup(findViewById(android.R.id.content));
 

--- a/app/src/main/java/org/schabi/newpipe/player/VideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/VideoPlayer.java
@@ -97,6 +97,7 @@ public abstract class VideoPlayer extends BasePlayer
     protected static final int RENDERER_UNAVAILABLE = -1;
     public static final int DEFAULT_CONTROLS_DURATION = 300; // 300 millis
     public static final int DEFAULT_CONTROLS_HIDE_TIME = 2000;  // 2 Seconds
+    public static final int DPAD_CONTROLS_HIDE_TIME = 7000;  // 7 Seconds
 
     private List<VideoStream> availableStreams;
     private int selectedStreamIndex;
@@ -825,14 +826,26 @@ public abstract class VideoPlayer extends BasePlayer
 
     public void showControlsThenHide() {
         if (DEBUG) Log.d(TAG, "showControlsThenHide() called");
+
+        final int hideTime = controlsRoot.isInTouchMode() ? DEFAULT_CONTROLS_HIDE_TIME : DPAD_CONTROLS_HIDE_TIME;
+
         animateView(controlsRoot, true, DEFAULT_CONTROLS_DURATION, 0,
-                () -> hideControls(DEFAULT_CONTROLS_DURATION, DEFAULT_CONTROLS_HIDE_TIME));
+                () -> hideControls(DEFAULT_CONTROLS_DURATION, hideTime));
     }
 
     public void showControls(long duration) {
         if (DEBUG) Log.d(TAG, "showControls() called");
         controlsVisibilityHandler.removeCallbacksAndMessages(null);
         animateView(controlsRoot, true, duration);
+    }
+
+    public void safeHideControls(final long duration, long delay) {
+        if (DEBUG) Log.d(TAG, "safeHideControls() called with: delay = [" + delay + "]");
+        if (rootView.isInTouchMode()) {
+            controlsVisibilityHandler.removeCallbacksAndMessages(null);
+            controlsVisibilityHandler.postDelayed(
+                    () -> animateView(controlsRoot, false, duration), delay);
+        }
     }
 
     public void hideControls(final long duration, long delay) {

--- a/app/src/main/java/org/schabi/newpipe/util/FireTvUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/FireTvUtils.java
@@ -1,10 +1,18 @@
 package org.schabi.newpipe.util;
 
+import android.annotation.SuppressLint;
+import android.content.pm.PackageManager;
+
 import org.schabi.newpipe.App;
 
 public class FireTvUtils {
+    @SuppressLint("InlinedApi")
     public static boolean isFireTv(){
         final String AMAZON_FEATURE_FIRE_TV = "amazon.hardware.fire_tv";
-        return App.getApp().getPackageManager().hasSystemFeature(AMAZON_FEATURE_FIRE_TV);
+
+        PackageManager pm =  App.getApp().getPackageManager();
+
+        return pm.hasSystemFeature(AMAZON_FEATURE_FIRE_TV)
+                || pm.hasSystemFeature(PackageManager.FEATURE_LEANBACK);
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/views/FixedGridLayoutManager.java
+++ b/app/src/main/java/org/schabi/newpipe/views/FixedGridLayoutManager.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) Eltex ltd 2019 <eltex@eltex-co.ru>
+ * FixedGridLayoutManager.java is part of NewPipe.
+ *
+ * NewPipe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NewPipe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NewPipe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.schabi.newpipe.views;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.FocusFinder;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.recyclerview.widget.GridLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+// Version of GridLayoutManager that works around https://issuetracker.google.com/issues/37067220
+public class FixedGridLayoutManager extends GridLayoutManager {
+    public FixedGridLayoutManager(Context context, int spanCount) {
+        super(context, spanCount);
+    }
+
+    public FixedGridLayoutManager(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+    }
+
+    public FixedGridLayoutManager(Context context, int spanCount, int orientation, boolean reverseLayout) {
+        super(context, spanCount, orientation, reverseLayout);
+    }
+
+    @Override
+    public View onFocusSearchFailed(View focused, int focusDirection, RecyclerView.Recycler recycler, RecyclerView.State state) {
+        FocusFinder ff = FocusFinder.getInstance();
+
+        View result = ff.findNextFocus((ViewGroup) focused.getParent(), focused, focusDirection);
+        if (result != null) {
+            return super.onFocusSearchFailed(focused, focusDirection, recycler, state);
+        }
+
+        if (focusDirection == View.FOCUS_DOWN) {
+            scrollVerticallyBy(10, recycler, state);
+            return null;
+        }
+
+        return super.onFocusSearchFailed(focused, focusDirection, recycler, state);
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/views/FocusAwareCoordinator.java
+++ b/app/src/main/java/org/schabi/newpipe/views/FocusAwareCoordinator.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) Eltex ltd 2019 <eltex@eltex-co.ru>
+ * FocusAwareCoordinator.java is part of NewPipe.
+ *
+ * NewPipe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NewPipe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NewPipe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.schabi.newpipe.views;
+
+import android.content.Context;
+import android.graphics.Rect;
+import android.util.AttributeSet;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
+
+public final class FocusAwareCoordinator extends CoordinatorLayout {
+    private final Rect childFocus = new Rect();
+
+    public FocusAwareCoordinator(@NonNull Context context) {
+        super(context);
+    }
+
+    public FocusAwareCoordinator(@NonNull Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public FocusAwareCoordinator(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @Override
+    public void requestChildFocus(View child, View focused) {
+        if (!isInTouchMode()) {
+            if (child instanceof ViewGroup) {
+                focused.getHitRect(childFocus);
+
+                ((ViewGroup) child).offsetDescendantRectToMyCoords((View) focused.getParent(), childFocus);
+            } else {
+                child.getFocusedRect(childFocus);
+            }
+
+            requestChildRectangleOnScreen(child, childFocus, false);
+        }
+
+        super.requestChildFocus(child, focused);
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/views/FocusAwareDrawerLayout.java
+++ b/app/src/main/java/org/schabi/newpipe/views/FocusAwareDrawerLayout.java
@@ -17,8 +17,10 @@
  */
 package org.schabi.newpipe.views;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.util.AttributeSet;
+import android.view.Gravity;
 import android.view.View;
 
 import androidx.annotation.NonNull;
@@ -65,5 +67,36 @@ public final class FocusAwareDrawerLayout extends DrawerLayout {
         if (content != null && !hasOpenPanels) {
             content.addFocusables(views, direction, focusableMode);
         }
+    }
+
+    // this override isn't strictly necessary, but it is helpful when DrawerLayout isn't the topmost
+    // view in hierarchy (such as when system or builtin appcompat ActionBar is used)
+    @Override
+    @SuppressLint("RtlHardcoded")
+    public void openDrawer(@NonNull View drawerView, boolean animate) {
+        super.openDrawer(drawerView, animate);
+
+        LayoutParams params = (LayoutParams) drawerView.getLayoutParams();
+
+        int gravity = GravityCompat.getAbsoluteGravity(params.gravity, ViewCompat.getLayoutDirection(this));
+
+        int direction = 0;
+
+        switch (gravity) {
+            case Gravity.LEFT:
+                direction = FOCUS_LEFT;
+                break;
+            case Gravity.RIGHT:
+                direction = FOCUS_RIGHT;
+                break;
+            case Gravity.TOP:
+                direction = FOCUS_UP;
+                break;
+            case Gravity.BOTTOM:
+                direction = FOCUS_DOWN;
+                break;
+        }
+
+        drawerView.requestFocus(direction);
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/views/FocusAwareDrawerLayout.java
+++ b/app/src/main/java/org/schabi/newpipe/views/FocusAwareDrawerLayout.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) Eltex ltd 2019 <eltex@eltex-co.ru>
+ * FocusAwareDrawerLayout.java is part of NewPipe.
+ *
+ * NewPipe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NewPipe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NewPipe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.schabi.newpipe.views;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.view.GravityCompat;
+import androidx.core.view.ViewCompat;
+import androidx.drawerlayout.widget.DrawerLayout;
+
+import java.util.ArrayList;
+
+public final class FocusAwareDrawerLayout extends DrawerLayout {
+    public FocusAwareDrawerLayout(@NonNull Context context) {
+        super(context);
+    }
+
+    public FocusAwareDrawerLayout(@NonNull Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public FocusAwareDrawerLayout(@NonNull Context context, @Nullable AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+    }
+
+    @Override
+    public void addFocusables(ArrayList<View> views, int direction, int focusableMode) {
+        boolean hasOpenPanels = false;
+        View content = null;
+
+        for (int i = 0; i < getChildCount(); ++i) {
+            View child = getChildAt(i);
+
+            DrawerLayout.LayoutParams lp = (DrawerLayout.LayoutParams) child.getLayoutParams();
+
+            if (lp.gravity == 0) {
+                content = child;
+            } else {
+                if (isDrawerVisible(child)) {
+                    hasOpenPanels = true;
+                    child.addFocusables(views, direction, focusableMode);
+                }
+            }
+        }
+
+        if (content != null && !hasOpenPanels) {
+            content.addFocusables(views, direction, focusableMode);
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/views/FocusAwareSeekBar.java
+++ b/app/src/main/java/org/schabi/newpipe/views/FocusAwareSeekBar.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) Eltex ltd 2019 <eltex@eltex-co.ru>
+ * FocusAwareDrawerLayout.java is part of NewPipe.
+ *
+ * NewPipe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NewPipe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NewPipe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.schabi.newpipe.views;
+
+import android.content.Context;
+import android.graphics.Rect;
+import android.util.AttributeSet;
+import android.view.KeyEvent;
+import android.view.ViewTreeObserver;
+import android.widget.SeekBar;
+
+import androidx.appcompat.widget.AppCompatSeekBar;
+
+/**
+ * SeekBar, adapted for directional navigation. It emulates touch-related callbacks
+ * (onStartTrackingTouch/onStopTrackingTouch), so existing code does not need to be changed to
+ * work with it.
+  */
+public final class FocusAwareSeekBar extends AppCompatSeekBar {
+    private NestedListener listener;
+
+    private ViewTreeObserver treeObserver;
+
+    public FocusAwareSeekBar(Context context) {
+        super(context);
+    }
+
+    public FocusAwareSeekBar(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public FocusAwareSeekBar(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @Override
+    public void setOnSeekBarChangeListener(OnSeekBarChangeListener l) {
+        this.listener = l == null ? null : new NestedListener(l);
+
+        super.setOnSeekBarChangeListener(listener);
+    }
+
+    @Override
+    public boolean onKeyDown(int keyCode, KeyEvent event) {
+        if (!isInTouchMode() && keyCode == KeyEvent.KEYCODE_DPAD_CENTER) {
+            releaseTrack();
+        }
+
+        return super.onKeyDown(keyCode, event);
+    }
+
+    @Override
+    protected void onFocusChanged(boolean gainFocus, int direction, Rect previouslyFocusedRect) {
+        super.onFocusChanged(gainFocus, direction, previouslyFocusedRect);
+
+        if (!isInTouchMode() && !gainFocus) {
+            releaseTrack();
+        }
+    }
+
+    private final ViewTreeObserver.OnTouchModeChangeListener touchModeListener = isInTouchMode -> { if (isInTouchMode) releaseTrack(); };
+
+    @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+
+        treeObserver = getViewTreeObserver();
+        treeObserver.addOnTouchModeChangeListener(touchModeListener);
+    }
+
+    @Override
+    protected void onDetachedFromWindow() {
+        if (treeObserver == null || !treeObserver.isAlive()) {
+            treeObserver = getViewTreeObserver();
+        }
+
+        treeObserver.removeOnTouchModeChangeListener(touchModeListener);
+        treeObserver = null;
+
+        super.onDetachedFromWindow();
+    }
+
+    private void releaseTrack() {
+        if (listener != null && listener.isSeeking) {
+            listener.onStopTrackingTouch(this);
+        }
+    }
+
+    private final class NestedListener implements OnSeekBarChangeListener {
+        private final OnSeekBarChangeListener delegate;
+
+        boolean isSeeking;
+
+        private NestedListener(OnSeekBarChangeListener delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
+            if (!seekBar.isInTouchMode() && !isSeeking && fromUser) {
+                isSeeking = true;
+
+                onStartTrackingTouch(seekBar);
+            }
+
+            delegate.onProgressChanged(seekBar, progress, fromUser);
+        }
+
+        @Override
+        public void onStartTrackingTouch(SeekBar seekBar) {
+            isSeeking = true;
+
+            delegate.onStartTrackingTouch(seekBar);
+        }
+
+        @Override
+        public void onStopTrackingTouch(SeekBar seekBar) {
+            isSeeking = false;
+
+            delegate.onStopTrackingTouch(seekBar);
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/views/FocusOverlayView.java
+++ b/app/src/main/java/org/schabi/newpipe/views/FocusOverlayView.java
@@ -1,0 +1,150 @@
+package org.schabi.newpipe.views;
+
+import android.app.Activity;
+import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.ColorFilter;
+import android.graphics.Paint;
+import android.graphics.PixelFormat;
+import android.graphics.Rect;
+import android.graphics.drawable.Drawable;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.Message;
+import android.util.DisplayMetrics;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewTreeObserver;
+import android.view.Window;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
+
+import org.schabi.newpipe.R;
+
+import java.lang.ref.WeakReference;
+
+public final class FocusOverlayView extends Drawable implements
+        ViewTreeObserver.OnGlobalFocusChangeListener,
+        ViewTreeObserver.OnDrawListener,
+        ViewTreeObserver.OnGlobalLayoutListener,
+        ViewTreeObserver.OnScrollChangedListener {
+
+    private final Rect focusRect = new Rect();
+
+    private final Paint rectPaint = new Paint();
+
+    private final Handler animator = new Handler(Looper.getMainLooper()) {
+        @Override
+        public void handleMessage(Message msg) {
+            updateRect();
+        }
+    };
+
+    private WeakReference<View> focused;
+
+    public FocusOverlayView(Context context) {
+        rectPaint.setStyle(Paint.Style.STROKE);
+        rectPaint.setStrokeWidth(2);
+        rectPaint.setColor(context.getResources().getColor(R.color.white));
+    }
+
+    @Override
+    public void onGlobalFocusChanged(View oldFocus, View newFocus) {
+        int l = focusRect.left;
+        int r = focusRect.right;
+        int t = focusRect.top;
+        int b = focusRect.bottom;
+
+        if (newFocus != null && newFocus.getWidth() > 0 && newFocus.getHeight() > 0) {
+            newFocus.getGlobalVisibleRect(focusRect);
+
+            focused = new WeakReference<>(newFocus);
+        } else {
+            focusRect.setEmpty();
+
+            focused = null;
+        }
+
+        if (l != focusRect.left || r != focusRect.right || t != focusRect.top || b != focusRect.bottom) {
+            invalidateSelf();
+        }
+
+        focused = new WeakReference<>(newFocus);
+    }
+
+    private void updateRect() {
+        if (focused == null) {
+            return;
+        }
+
+        View focused = this.focused.get();
+
+        int l = focusRect.left;
+        int r = focusRect.right;
+        int t = focusRect.top;
+        int b = focusRect.bottom;
+
+        if (focused != null) {
+            focused.getGlobalVisibleRect(focusRect);
+        } else {
+            focusRect.setEmpty();
+        }
+
+        if (l != focusRect.left || r != focusRect.right || t != focusRect.top || b != focusRect.bottom) {
+            invalidateSelf();
+        }
+    }
+
+    @Override
+    public void onDraw() {
+        updateRect();
+    }
+
+    @Override
+    public void onScrollChanged() {
+        updateRect();
+    }
+
+    @Override
+    public void onGlobalLayout() {
+        updateRect();
+
+        animator.sendEmptyMessageDelayed(0, 1000);
+    }
+
+    @Override
+    public void draw(@NonNull Canvas canvas) {
+        if (focusRect.width() != 0) {
+            canvas.drawRect(focusRect, rectPaint);
+        }
+    }
+
+    @Override
+    public int getOpacity() {
+        return PixelFormat.TRANSPARENT;
+    }
+
+    @Override
+    public void setAlpha(int alpha) {
+    }
+
+    @Override
+    public void setColorFilter(ColorFilter colorFilter) {
+    }
+
+    public static void setupFocusObserver(Activity activity) {
+        DisplayMetrics display = activity.getResources().getDisplayMetrics();
+        FocusOverlayView overlay = new FocusOverlayView(activity);
+        overlay.setBounds(0, 0, display.widthPixels, display.heightPixels);
+
+        Window window = activity.getWindow();
+        ViewGroup decor = (ViewGroup) window.getDecorView();
+        decor.getOverlay().add(overlay);
+
+        ViewTreeObserver observer = decor.getViewTreeObserver();
+        observer.addOnScrollChangedListener(overlay);
+        observer.addOnGlobalFocusChangeListener(overlay);
+        observer.addOnGlobalLayoutListener(overlay);
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/views/NewPipeRecyclerView.java
+++ b/app/src/main/java/org/schabi/newpipe/views/NewPipeRecyclerView.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) Eltex ltd 2019 <eltex@eltex-co.ru>
+ * NewPipeRecyclerView.java is part of NewPipe.
+ *
+ * NewPipe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NewPipe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NewPipe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.schabi.newpipe.views;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.recyclerview.widget.RecyclerView;
+
+public class NewPipeRecyclerView extends RecyclerView {
+    private static final String TAG = "FixedRecyclerView";
+
+    public NewPipeRecyclerView(@NonNull Context context) {
+        super(context);
+    }
+
+    public NewPipeRecyclerView(@NonNull Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public NewPipeRecyclerView(@NonNull Context context, @Nullable AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+    }
+
+    @Override
+    public View focusSearch(int direction) {
+        return null;
+    }
+
+    @Override
+    public View focusSearch(View focused, int direction) {
+        return null;
+    }
+
+    @Override
+    public boolean dispatchUnhandledMove(View focused, int direction) {
+        View found = super.focusSearch(focused, direction);
+        if (found != null) {
+            found.requestFocus(direction);
+            return true;
+        }
+
+        if (direction == View.FOCUS_UP) {
+            if (canScrollVertically(-1)) {
+                scrollBy(0, -10);
+                return true;
+            }
+
+            return false;
+        }
+
+        return super.dispatchUnhandledMove(focused, direction);
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/views/SuperScrollLayoutManager.java
+++ b/app/src/main/java/org/schabi/newpipe/views/SuperScrollLayoutManager.java
@@ -62,10 +62,39 @@ public final class SuperScrollLayoutManager extends LinearLayoutManager {
         }
 
         if (focusDirection == View.FOCUS_DOWN) {
-            scrollVerticallyBy(10, recycler, state);
+            int scrollAmount = 1 + getScrollExtra(focused);
+            scrollVerticallyBy(scrollAmount, recycler, state);
             return null;
         }
 
         return super.onFocusSearchFailed(focused, focusDirection, recycler, state);
+    }
+
+    private int getScrollExtra(View focused) {
+        if (focused == null) {
+            return 0;
+        }
+
+        View container = findContainingItemView(focused);
+        if (container == focused) {
+            return 0;
+        }
+
+        if (!(container instanceof ViewGroup)) {
+            return 0;
+        }
+
+        ViewGroup vg = (ViewGroup) container;
+
+        Rect rect = new Rect();
+
+        focused.getHitRect(rect);
+
+        ViewGroup parent = (ViewGroup) focused.getParent();
+        if (container != parent) {
+            vg.offsetDescendantRectToMyCoords(parent, rect);
+        }
+
+        return container.getHeight() - rect.bottom;
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/views/SuperScrollLayoutManager.java
+++ b/app/src/main/java/org/schabi/newpipe/views/SuperScrollLayoutManager.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) Eltex ltd 2019 <eltex@eltex-co.ru>
+ * SuperScrollLayoutManager.java is part of NewPipe.
+ *
+ * NewPipe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NewPipe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NewPipe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.schabi.newpipe.views;
+
+import android.content.Context;
+import android.graphics.Rect;
+import android.view.FocusFinder;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+public final class SuperScrollLayoutManager extends LinearLayoutManager {
+    private final Rect handy = new Rect();
+
+    public SuperScrollLayoutManager(Context context) {
+        super(context);
+    }
+
+    @Override
+    public boolean requestChildRectangleOnScreen(@NonNull RecyclerView parent, @NonNull View child, @NonNull Rect rect, boolean immediate, boolean focusedChildVisible) {
+        if (!parent.isInTouchMode()) {
+            // only activate when in directional navigation mode (Android TV etc) — fine grained
+            // touch scrolling is better served by nested scroll system
+
+            if (!focusedChildVisible || getFocusedChild() == child) {
+                handy.set(rect);
+
+                parent.offsetDescendantRectToMyCoords(child, handy);
+
+                parent.requestRectangleOnScreen(handy, immediate);
+            }
+        }
+
+        return super.requestChildRectangleOnScreen(parent, child, rect, immediate, focusedChildVisible);
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/views/SuperScrollLayoutManager.java
+++ b/app/src/main/java/org/schabi/newpipe/views/SuperScrollLayoutManager.java
@@ -21,6 +21,7 @@ import android.content.Context;
 import android.graphics.Rect;
 import android.view.FocusFinder;
 import android.view.View;
+import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -49,5 +50,22 @@ public final class SuperScrollLayoutManager extends LinearLayoutManager {
         }
 
         return super.requestChildRectangleOnScreen(parent, child, rect, immediate, focusedChildVisible);
+    }
+
+    @Override
+    public View onFocusSearchFailed(View focused, int focusDirection, RecyclerView.Recycler recycler, RecyclerView.State state) {
+        FocusFinder ff = FocusFinder.getInstance();
+
+        View result = ff.findNextFocus((ViewGroup) focused.getParent(), focused, focusDirection);
+        if (result != null) {
+            return super.onFocusSearchFailed(focused, focusDirection, recycler, state);
+        }
+
+        if (focusDirection == View.FOCUS_DOWN) {
+            scrollVerticallyBy(10, recycler, state);
+            return null;
+        }
+
+        return super.onFocusSearchFailed(focused, focusDirection, recycler, state);
     }
 }

--- a/app/src/main/java/us/shandian/giga/ui/fragment/MissionsFragment.java
+++ b/app/src/main/java/us/shandian/giga/ui/fragment/MissionsFragment.java
@@ -30,6 +30,7 @@ import org.schabi.newpipe.R;
 import org.schabi.newpipe.settings.NewPipeSettings;
 import org.schabi.newpipe.util.FilePickerActivityHelper;
 import org.schabi.newpipe.util.ThemeHelper;
+import org.schabi.newpipe.views.FixedGridLayoutManager;
 
 import java.io.File;
 import java.io.IOException;
@@ -108,7 +109,7 @@ public class MissionsFragment extends Fragment {
         mList = v.findViewById(R.id.mission_recycler);
 
         // Init layouts managers
-        mGridManager = new GridLayoutManager(getActivity(), SPAN_SIZE);
+        mGridManager = new FixedGridLayoutManager(getActivity(), SPAN_SIZE);
         mGridManager.setSpanSizeLookup(new GridLayoutManager.SpanSizeLookup() {
             @Override
             public int getSpanSize(int position) {

--- a/app/src/main/res/layout-large-land/activity_main_player.xml
+++ b/app/src/main/res/layout-large-land/activity_main_player.xml
@@ -196,8 +196,9 @@
                         tools:text="The Video Artist  LONG very LONG very Long"/>
                 </LinearLayout>
 
-                <TextView
+                <Button
                     android:id="@+id/qualityTextView"
+                    style="@style/Widget.AppCompat.Button.Borderless"
                     android:layout_width="wrap_content"
                     android:layout_height="35dp"
                     android:layout_marginLeft="2dp"
@@ -208,11 +209,13 @@
                     android:text="720p"
                     android:textColor="@android:color/white"
                     android:textStyle="bold"
-                    android:background="?attr/selectableItemBackground"
+                    android:textAllCaps="false"
+                    android:padding="5dp"
                     tools:ignore="HardcodedText,RtlHardcoded"/>
 
-                <TextView
+                <Button
                     android:id="@+id/playbackSpeed"
+                    style="@style/Widget.AppCompat.Button.Borderless"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginRight="2dp"
@@ -222,7 +225,8 @@
                     android:minWidth="40dp"
                     android:textColor="@android:color/white"
                     android:textStyle="bold"
-                    android:background="?attr/selectableItemBackground"
+                    android:textAllCaps="false"
+                    android:padding="5dp"
                     tools:ignore="RtlHardcoded,RtlSymmetry"
                     tools:text="1x" />
 
@@ -268,8 +272,9 @@
                 tools:ignore="RtlHardcoded"
                 tools:visibility="visible">
 
-                <TextView
+                <Button
                     android:id="@+id/resizeTextView"
+                    style="@style/Widget.AppCompat.Button.Borderless"
                     android:layout_width="wrap_content"
                     android:layout_height="35dp"
                     android:layout_marginLeft="8dp"
@@ -279,11 +284,13 @@
                     android:minWidth="50dp"
                     android:textColor="@android:color/white"
                     android:textStyle="bold"
+                    android:textAllCaps="false"
                     android:background="?attr/selectableItemBackground"
                     tools:ignore="HardcodedText,RtlHardcoded"
                     tools:text="FIT"/>
 
-                <TextView
+                <Button
+                    style="@style/Widget.AppCompat.Button.Borderless"
                     android:id="@+id/captionTextView"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -298,6 +305,7 @@
                     android:paddingRight="2dp"
                     android:textColor="@android:color/white"
                     android:textStyle="bold"
+                    android:textAllCaps="false"
                     android:background="?attr/selectableItemBackground"
                     tools:ignore="RelativeOverlap,RtlHardcoded"
                     tools:text="English" />

--- a/app/src/main/res/layout-large-land/activity_main_player.xml
+++ b/app/src/main/res/layout-large-land/activity_main_player.xml
@@ -178,7 +178,6 @@
                         android:textSize="15sp"
                         android:textStyle="bold"
                         android:clickable="true"
-                        android:focusable="true"
                         tools:ignore="RtlHardcoded"
                         tools:text="The Video Title LONG very LONG"/>
 
@@ -194,7 +193,6 @@
                         android:textColor="@android:color/white"
                         android:textSize="12sp"
                         android:clickable="true"
-                        android:focusable="true"
                         tools:text="The Video Artist  LONG very LONG very Long"/>
                 </LinearLayout>
 

--- a/app/src/main/res/layout-large-land/activity_main_player.xml
+++ b/app/src/main/res/layout-large-land/activity_main_player.xml
@@ -401,7 +401,7 @@
                     tools:text="1:06:29"/>
 
 
-                <androidx.appcompat.widget.AppCompatSeekBar
+                <org.schabi.newpipe.views.FocusAwareSeekBar
                     android:id="@+id/playbackSeekBar"
                     style="@style/Widget.AppCompat.SeekBar"
                     android:layout_width="0dp"

--- a/app/src/main/res/layout-large-land/fragment_video_detail.xml
+++ b/app/src/main/res/layout-large-land/fragment_video_detail.xml
@@ -490,6 +490,7 @@
 							android:textAppearance="?android:attr/textAppearanceMedium"
 							android:textIsSelectable="true"
 							android:textSize="@dimen/video_item_detail_description_text_size"
+							android:focusable="true"
 							tools:text="Description Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed a ultricies ex. Integer sit amet sodales risus. Duis non mi et urna pretium bibendum." />
 
 						<View

--- a/app/src/main/res/layout-large-land/fragment_video_detail.xml
+++ b/app/src/main/res/layout-large-land/fragment_video_detail.xml
@@ -10,7 +10,7 @@
 	android:orientation="horizontal"
 	android:baselineAligned="false">
 
-	<androidx.coordinatorlayout.widget.CoordinatorLayout
+	<org.schabi.newpipe.views.FocusAwareCoordinator
 		android:id="@+id/detail_main_content"
 		android:layout_width="0dp"
 		android:layout_height="match_parent"
@@ -526,7 +526,7 @@
 
 		</com.google.android.material.tabs.TabLayout>
 
-	</androidx.coordinatorlayout.widget.CoordinatorLayout>
+	</org.schabi.newpipe.views.FocusAwareCoordinator>
 
 	<FrameLayout
 		android:id="@+id/relatedStreamsLayout"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.drawerlayout.widget.DrawerLayout
+<org.schabi.newpipe.views.FocusAwareDrawerLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/drawer_layout"
@@ -24,4 +24,4 @@
 
     <include layout="@layout/drawer_layout"/>
 
-</androidx.drawerlayout.widget.DrawerLayout>
+</org.schabi.newpipe.views.FocusAwareDrawerLayout>

--- a/app/src/main/res/layout/fragment_comments.xml
+++ b/app/src/main/res/layout/fragment_comments.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.recyclerview.widget.RecyclerView
+    <org.schabi.newpipe.views.NewPipeRecyclerView
         android:id="@+id/items_list"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/app/src/main/res/layout/fragment_kiosk.xml
+++ b/app/src/main/res/layout/fragment_kiosk.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.recyclerview.widget.RecyclerView
+    <org.schabi.newpipe.views.NewPipeRecyclerView
         android:id="@+id/items_list"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/app/src/main/res/layout/toolbar_search_layout.xml
+++ b/app/src/main/res/layout/toolbar_search_layout.xml
@@ -19,6 +19,7 @@
         android:drawablePadding="8dp"
         android:focusable="true"
         android:focusableInTouchMode="true"
+        android:nextFocusDown="@+id/suggestions_list"
         android:hint="@string/search"
         android:imeOptions="actionSearch|flagNoFullscreen"
         android:inputType="textFilter|textNoSuggestions"


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

Most development for Android TV is done with "Leanback" support library. There are two issues with it:
1. it kind-of sucks (won't delve deeply into that here)
2. retrofitting an existing application with it is virtually impossible  

In absence of Leanback one has to directly face challenges of designing for TV devices: handling focus and TV-friendly design.

Focus-based (aka "directional") navigation is a must because TV devices are remote-driven. Many standard View/ViewGroup subclasses are poorly suited for directional navigation and must be heavily augmented to work with it. Some components have notional support for focus handling but contain annoying bugs due to code rot or lack of testing.

TV-friendly design means two things: clearly highlighting focused element and using big readable fonts everywhere (since most big TV screens have low resolution and questionable LCD panel quality). This pull request does not address font size issues, but does contain a workaround to visually distinguish currently focused element.

There are many known issues with this PR:

1. There is a fix for bug in RecyclerView, that makes it largely unusable with focus-based navigation, but the fix is applied only to couple of RecyclerView instances: initial screen with videos and comments list
2. Focus highlight overlay is unsuitable for light theme (should be easy to fix)
3. Inconsistent use of isFireTV/isInTouchMode (more on that further down)
4. Drawer is still a bit buggy
5. When focus reaches a bottom of comments list (and "loading more" progress bar appears) pressing DOWN again moves it elsewhere. This will likely require a bit more customization to fix.
6. When focus moves from video preview to comments list, the transition is not smooth (this is result of architectural flaw in AppBarLayout)
7. Popup player still can't be interacted with

In order to apply fix from 3c4d62c everywhere, every RecyclerView in NewPipe and every adapter must be replaces with NewPipeRecyclerView and FixedGridAdapter/SuperScrollAdapter. I avoided doing so to reduce number of conflicts during rebasing, so please do it yourself if you merge this PR

Regarding focus-based navigation, — it needs extra explanation.

The general approach to handling focus in Android is to call isInTouchMode(), and make decisions depending on returned value. Ideally, there should be no need to distinguish between Android TV devices, Android Auto, Android phones with dpad and other kinds of devices — directional navigation should work that same way everywhere. In real world this is not so simple: for example, hiding side drawer on back press might not be useful on most Android devices with touchscreens (because it is easier to dismiss it with finger), but is absolutely mandatory on TV devices, controlled with IR remote. And we can't easily check if device has touchsreen — some devices lie that they have it, because apps refuse to work or install otherwise, but in reality they have some kind of less-that-perfect touchscreen emulator. So there are still some checks for isFireTV() (which now detects any TV devices) and some checks for isInTouchMode().

fixes #1363, #899