### PR TITLE
Fix broken video count text translations

### DIFF
--- a/app/src/main/res/values-b+ast/strings.xml
+++ b/app/src/main/res/values-b+ast/strings.xml
@@ -176,10 +176,6 @@
         <item quantity="other">%s visualizaciones</item>
     </plurals>
     <string name="no_videos"/>
-    <plurals name="videos">
-        <item quantity="one">Vídeos</item>
-        <item quantity="other"></item>
-    </plurals>
     <string name="settings_category_downloads_title">Descarga</string>
     <string name="settings_file_charset_title"/>
     <string name="settings_file_replacement_character_summary"/>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -217,9 +217,9 @@
     </plurals>
     <string name="no_videos">Няма відэа</string>
     <plurals name="videos">
-        <item quantity="one">Відэа</item>
-        <item quantity="few">відэа</item>
-        <item quantity="many">відэа</item>
+        <item quantity="one">%s Відэа</item>
+        <item quantity="few">%s відэа</item>
+        <item quantity="many">%s відэа</item>
     </plurals>
     <string name="start">Пачаць</string>
     <string name="pause">Паўза</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -153,8 +153,8 @@
     </plurals>
     <string name="no_videos">Няма клипове</string>
     <plurals name="videos">
-        <item quantity="one">Клип</item>
-        <item quantity="other">Клипове</item>
+        <item quantity="one">%s Клип</item>
+        <item quantity="other">%s Клипове</item>
     </plurals>
     <string name="pause">Пауза</string>
     <string name="view">Начало</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -223,8 +223,8 @@
     </plurals>
     <string name="no_videos">Sense vídeos</string>
     <plurals name="videos">
-        <item quantity="one">Vídeo</item>
-        <item quantity="other">Vídeos</item>
+        <item quantity="one">%s vídeo</item>
+        <item quantity="other">%s vídeos</item>
     </plurals>
     <string name="pause">Pausa</string>
     <string name="view">Reprodueix</string>

--- a/app/src/main/res/values-cmn/strings.xml
+++ b/app/src/main/res/values-cmn/strings.xml
@@ -253,10 +253,6 @@
         <item quantity="other"/>
     </plurals>
     <string name="no_videos">没有视频</string>
-    <plurals name="videos">
-        <item quantity="one">部视频</item>
-        <item quantity="other"/>
-    </plurals>
     <string name="delete_one">删除</string>
     <string name="checksum">校验</string>
     <string name="dismiss">退出</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -123,8 +123,8 @@
     <string name="playlist">Playliste</string>
     <string name="playlists">Playlister</string>
     <plurals name="videos">
-        <item quantity="one">Video</item>
-        <item quantity="other">Videoer</item>
+        <item quantity="one">Én video</item>
+        <item quantity="other">%s videoer</item>
     </plurals>
     <string name="tracks">Numre</string>
     <string name="users">Brugere</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -202,8 +202,8 @@
     </plurals>
     <string name="no_videos">Keine Videos</string>
     <plurals name="videos">
-        <item quantity="one">Video</item>
-        <item quantity="other">Videos</item>
+        <item quantity="one">%s Video</item>
+        <item quantity="other">%s Videos</item>
     </plurals>
     <string name="charset_most_special_characters">Die meisten Sonderzeichen</string>
     <string name="item_deleted">Element gelöscht</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -227,8 +227,8 @@
     </plurals>
     <string name="no_videos">Κανένα βίντεο</string>
     <plurals name="videos">
-        <item quantity="one">Βίντεο</item>
-        <item quantity="other">Βίντεο</item>
+        <item quantity="one">%s Βίντεο</item>
+        <item quantity="other">%s Βίντεο</item>
     </plurals>
     <string name="start">Εκκίνηση</string>
     <string name="view">Αναπαραγωγή</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -207,8 +207,8 @@ abrir en modo popup</string>
     </plurals>
     <string name="no_videos">Sin vídeos</string>
     <plurals name="videos">
-        <item quantity="one">Vídeo</item>
-        <item quantity="other">Vídeos</item>
+        <item quantity="one">%s vídeo</item>
+        <item quantity="other">%s vídeos</item>
     </plurals>
     <string name="item_deleted">Elemento eliminado</string>
     <string name="delete_item_search_history">¿Desea eliminar este elemento del historial de búsqueda?</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -199,8 +199,8 @@
     </plurals>
     <string name="no_videos">Bideorik ez</string>
     <plurals name="videos">
-        <item quantity="one">Bideoa</item>
-        <item quantity="other">Bideoak</item>
+        <item quantity="one">%s Bideoa</item>
+        <item quantity="other">%s Bideoak</item>
     </plurals>
     <string name="title_activity_history">Historiala</string>
     <string name="title_history_search">Bilatuta</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -200,8 +200,8 @@
     </plurals>
     <string name="no_videos">بدون ویدئو</string>
     <plurals name="videos">
-        <item quantity="one">ویدئو</item>
-        <item quantity="other">ویدئو</item>
+        <item quantity="one">%s ویدئو</item>
+        <item quantity="other">%s ویدئو</item>
     </plurals>
     <string name="create">ایجاد</string>
     <string name="delete_one">پاک کردن یک مورد</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -205,8 +205,8 @@
     </plurals>
     <string name="no_videos">Aucune vidéo</string>
     <plurals name="videos">
-        <item quantity="one">Vidéo</item>
-        <item quantity="other">Vidéos</item>
+        <item quantity="one">%s vidéo</item>
+        <item quantity="other">%s vidéos</item>
     </plurals>
     <string name="charset_most_special_characters">Caractères spéciaux</string>
     <string name="item_deleted">Élément supprimé</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -167,10 +167,10 @@
     </plurals>
     <string name="no_videos">אין סרטונים</string>
     <plurals name="videos">
-        <item quantity="one">סרטון</item>
-        <item quantity="two">סרטונים</item>
-        <item quantity="many">סרטונים</item>
-        <item quantity="other">סרטונים</item>
+        <item quantity="one">%s סרטון</item>
+        <item quantity="two">%s סרטונים</item>
+        <item quantity="many">%s סרטונים</item>
+        <item quantity="other">%s סרטונים</item>
     </plurals>
     <string name="start">התחלה</string>
     <string name="pause">השהיה</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -224,8 +224,8 @@
     </plurals>
     <string name="no_videos">Nincs videó</string>
     <plurals name="videos">
-        <item quantity="one">Videó</item>
-        <item quantity="other">Videók</item>
+        <item quantity="one">%s videó</item>
+        <item quantity="other">%s videók</item>
     </plurals>
     <string name="create">Létrehozás</string>
     <string name="delete_one">Egy törlése</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -235,9 +235,6 @@
         <item quantity="other">%s ditonton</item>
     </plurals>
     <string name="no_videos">Tidak ada video</string>
-    <plurals name="videos">
-        <item quantity="other">Video</item>
-    </plurals>
     <string name="create">Buat</string>
     <string name="delete_one">Hapus Satu</string>
     <string name="delete_all">Hapus Semua</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -205,8 +205,8 @@
     </plurals>
     <string name="no_videos">Nessun video</string>
     <plurals name="videos">
-        <item quantity="one">Video</item>
-        <item quantity="other">Video</item>
+        <item quantity="one">%s video</item>
+        <item quantity="other">%s video</item>
     </plurals>
     <string name="item_deleted">Elemento eliminato</string>
     <string name="empty_subscription_feed_subtitle">Nulla da mostrare</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -336,9 +336,6 @@
     <plurals name="views">
         <item quantity="other">視聴回数 %s 回</item>
     </plurals>
-    <plurals name="videos">
-        <item quantity="other">動画</item>
-    </plurals>
     <string name="one_item_deleted">1 つのアイテムが削除されました。</string>
     <string name="give_back">支援する</string>
     <string name="privacy_policy_encouragement">NewPipe プロジェクトはあなたのプライバシーを非常に大切にしています。あなたの同意がない限り、アプリはいかなるデータも収集しません。NewPipe のプライバシー・ポリシーでは、クラッシュリポート送信時にどのような種類のデータが送信・記録されるかを詳細に説明しています。</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -164,9 +164,6 @@
         <item quantity="other">%s 시청 횟수</item>
     </plurals>
     <string name="no_videos">비디오 없음</string>
-    <plurals name="videos">
-        <item quantity="other">비디오</item>
-    </plurals>
     <string name="view">재생</string>
     <string name="add">새로운 미션</string>
     <string name="finish">OK</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -122,9 +122,6 @@
     <string name="channels">Saluran</string>
     <string name="playlist">Senarai main</string>
     <string name="playlists">Senarai main</string>
-    <plurals name="videos">
-    <item quantity="other">Video</item>
-</plurals>
     <string name="tracks">Trek</string>
     <string name="users">Pengguna</string>
     <string name="events">Peristiwa</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -194,8 +194,8 @@
     </plurals>
     <string name="no_videos">Ingen videoer</string>
     <plurals name="videos">
-        <item quantity="one">Video</item>
-        <item quantity="other">Videoer</item>
+        <item quantity="one">Én video</item>
+        <item quantity="other">%s videoer</item>
     </plurals>
     <string name="view_on_github">Vis på GitHub</string>
     <string name="app_license_title">NewPipe sin lisens</string>

--- a/app/src/main/res/values-nl-rBE/strings.xml
+++ b/app/src/main/res/values-nl-rBE/strings.xml
@@ -203,8 +203,8 @@
     </plurals>
     <string name="no_videos">Geen video’s</string>
     <plurals name="videos">
-        <item quantity="one">Video</item>
-        <item quantity="other">Video’s</item>
+        <item quantity="one">%s video</item>
+        <item quantity="other">%s video’s</item>
     </plurals>
     <string name="start">Begin</string>
     <string name="pause">Pauzeren</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -206,8 +206,8 @@
     </plurals>
     <string name="no_videos">Geen video\'s</string>
     <plurals name="videos">
-        <item quantity="one">Video</item>
-        <item quantity="other">Video’s</item>
+        <item quantity="one">%s video</item>
+        <item quantity="other">%s video’s</item>
     </plurals>
     <string name="item_deleted">Item verwijderd</string>
     <string name="delete_item_search_history">Wil je dit item verwijderen uit je zoekgeschiedenis?</string>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -209,8 +209,8 @@
     </plurals>
     <string name="no_videos">ਕੋਈ ਵੀਡੀਓ ਨਹੀਂ</string>
     <plurals name="videos">
-        <item quantity="one">ਵੀਡੀਓਜ਼</item>
-        <item quantity="other">ਵੀਡੀਓਜ਼</item>
+        <item quantity="one">%s ਵੀਡੀਓ ਹੈ</item>
+        <item quantity="other">%s ਵੀਡੀਓ ਹਨ</item>
     </plurals>
     <string name="start">ਸ਼ੁਰੂ ਕਰੋ</string>
     <string name="pause">ਰੋਕੋ</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -216,9 +216,9 @@
     </plurals>
     <string name="no_videos">Brak filmów</string>
     <plurals name="videos">
-        <item quantity="one">Film</item>
-        <item quantity="few">Filmy</item>
-        <item quantity="many">Filmów</item>
+        <item quantity="one">%s film</item>
+        <item quantity="few">%s filmy</item>
+        <item quantity="many">%s filmów</item>
     </plurals>
     <string name="charset_most_special_characters">Większość znaków specjalnych</string>
     <string name="donation_title">Dotacja</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -205,8 +205,8 @@ abrir em modo popup</string>
     </plurals>
     <string name="no_videos">Nenhum vídeo</string>
     <plurals name="videos">
-        <item quantity="one">Vídeo</item>
-        <item quantity="other">Vídeos</item>
+        <item quantity="one">%s vídeo</item>
+        <item quantity="other">%s vídeos</item>
     </plurals>
     <string name="item_deleted">Item excluído</string>
     <string name="settings_category_player_title">Player</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -193,8 +193,8 @@
     </plurals>
     <string name="no_videos">Sem vídeos</string>
     <plurals name="videos">
-        <item quantity="one">Vídeo</item>
-        <item quantity="other">Vídeos</item>
+        <item quantity="one">%s vídeo</item>
+        <item quantity="other">%s vídeos</item>
     </plurals>
     <string name="settings_category_downloads_title">Transferir</string>
     <string name="settings_file_charset_title">Carateres permitidos nos nomes de ficheiros</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -208,9 +208,9 @@
     </plurals>
     <string name="no_videos">Žiadne videá</string>
     <plurals name="videos">
-        <item quantity="one">Video</item>
-        <item quantity="few">Videá</item>
-        <item quantity="other">Videí</item>
+        <item quantity="one">%s video</item>
+        <item quantity="few">%s videá</item>
+        <item quantity="other">%s videí</item>
     </plurals>
     <string name="item_deleted">Položka bola odstránená</string>
     <string name="no_player_found_toast">Nebol nájdený žiadny prehrávač pre stream (môžete si nainštalovať napr. VLC)</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -121,12 +121,6 @@
     <string name="channels">ช่อง</string>
     <string name="playlist">เพลย์ลิสต์</string>
     <string name="playlists">เพลย์ลิสต์</string>
-    <plurals name="videos">
-        <item quantity="other">วิดีโอ</item>
-    </plurals>
-    <plurals name="comments">
-        <item quantity="other">ความคิดเห็น</item>
-    </plurals>
     <string name="tracks">แทร็ค</string>
     <string name="users">ผู้ใช้</string>
     <string name="events">เหตุการณ์</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -198,10 +198,6 @@
         <item quantity="other">%s görüntüleme</item>
     </plurals>
     <string name="no_videos">Video yok</string>
-    <plurals name="videos">
-        <item quantity="one">Video</item>
-        <item quantity="other">Videolar</item>
-    </plurals>
     <string name="title_activity_history">Geçmiş</string>
     <string name="title_history_search">Aranan</string>
     <string name="title_history_view">İzlenen</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -233,9 +233,9 @@
         <item quantity="many">%s підписників</item>
     </plurals>
     <plurals name="videos">
-        <item quantity="one">Відео</item>
-        <item quantity="few">Відео</item>
-        <item quantity="many">Відео</item>
+        <item quantity="one">%s Відео</item>
+        <item quantity="few">%s Відео</item>
+        <item quantity="many">%s Відео</item>
     </plurals>
     <string name="create">Створити</string>
     <string name="delete_one">Видалити одне</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -252,7 +252,7 @@
     </plurals>
     <string name="no_videos">Không có video nào</string>
     <plurals name="videos">
-        <item quantity="other">Videos</item>
+        <item quantity="other">%s video</item>
     </plurals>
     <string name="create">Tạo nên</string>
     <string name="delete_one">Xóa một</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -173,9 +173,6 @@
         <item quantity="other">%s 次觀看</item>
     </plurals>
     <string name="no_videos">沒有影片</string>
-    <plurals name="videos">
-        <item quantity="other">影片</item>
-    </plurals>
     <string name="settings_category_downloads_title">下載</string>
     <string name="settings_file_charset_title">檔案名稱中允許的字元</string>
     <string name="settings_file_replacement_character_summary">不符合設定的字元將會被替換為此字串</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -265,8 +265,8 @@
     </plurals>
     <string name="no_videos">No videos</string>
     <plurals name="videos">
-        <item quantity="one">Videos</item>
-        <item quantity="other">Videos</item>
+        <item quantity="one">%s video</item>
+        <item quantity="other">%s videos</item>
     </plurals>
     <string name="no_comments">No comments</string>
     <plurals name="comments">


### PR DESCRIPTION
Someone removed the string arguments, giving the wrong example for other translators in the process. 

This PR fixes this either by correcting it (comparing to YouTube) or, in cases where I'm uncertain, deleting the wrong translation.

@TobiGr I think this should make it to the next release (#2710).