### PR TITLE
[feature request] Forward/backward buttons in background mode

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "org.schabi.newpipe"
         minSdkVersion 19
         targetSdkVersion 28
-        versionCode 780
-        versionName "0.17.3"
+        versionCode 790
+        versionName "0.17.4"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/fastlane/metadata/android/en-US/changelogs/790.txt
+++ b/fastlane/metadata/android/en-US/changelogs/790.txt
@@ -1,0 +1,13 @@
+Improved
+• Add more titles to improve accessibility for blind people #2655
+• Make language of download folder setting more consistent and less ambiguous #2637
+
+Fixed
+• Check if last byte in the block is downloaded #2646
+• Fixed scrolling in video detail fragment #2672
+• Remove double search clear box animations to one #2695
+
+Development
+• Add missing dependencies inherited from NewPipeExtractor into NewPipe #2535
+• Migrate to AndroidX #2685
+• Update to ExoPlayer 2.10.5 #2697


### PR DESCRIPTION
In background mode:
implementation of buttons or gestures that permits to go forward or backward of some seconds, like it's yet developed in standard mode tapping twice on left (-10") or right (+10") screen side
As is implemented in podcasts apps there are 2 main buttons:
+30 seconds
-10 seconds
That should be useful to resume easily some audio content that is lost during the listening.

Another helpful implementation could be a finest scrolling of timeline for long contents, putting time in manual mode or timebar in widescreen when mobile is tilted..

Thanks and btw... AMAZING APP!!

![Screenshot_2019-10-11-11-21-22-324_com google android googlequicksearchbox](https://user-images.githubusercontent.com/56430866/66640580-81f27980-ec19-11e9-81ba-d132461ab30a.png)
