### PR TITLE
Fix Hebrew translation on some devices

### DIFF
--- a/app/src/main/res/values-iw
+++ b/app/src/main/res/values-iw
@@ -1,0 +1,1 @@
+values-he/


### PR DESCRIPTION
Hebrew on android uses two locale codes (iw and he).
See details here: https://stackoverflow.com/a/8470980

For example, Nexus 7 (2013) uses iw, so it shows the English UI even when configuring the tablet to use Hebrew.

Add a symbolic link from values-iw to values-he so both use the same strings.

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
