### PR TITLE
Custom share url (ex.: invidio instead of youtube)

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -608,13 +608,13 @@ public class VideoDetailFragment
         switch (id) {
             case R.id.menu_item_share: {
                 if (currentInfo != null) {
-                    ShareUtils.shareUrl(this.getContext(), currentInfo.getName(), currentInfo.getOriginalUrl());
+                    ShareUtils.shareUrl(this.getContext(), currentInfo.getName(), currentInfo.getUrl());
                 }
                 return true;
             }
             case R.id.menu_item_openInBrowser: {
                 if (currentInfo != null) {
-                    ShareUtils.openUrlInBrowser(this.getContext(), currentInfo.getOriginalUrl());
+                    ShareUtils.openUrlInBrowser(this.getContext(), currentInfo.getUrl());
                 }
                 return true;
             }

--- a/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.util.Patterns;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.preference.EditTextPreference;
@@ -94,10 +95,19 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
         EditTextPreference shareWebsitePreference = (EditTextPreference) findPreference("custom_share_website");
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getContext());
         shareWebsitePreference.setSummary(prefs.getString("custom_share_website", "Not set"));
-        shareWebsitePreference.setOnPreferenceChangeListener(((preference, newValue) -> {
-            preference.setSummary((String) newValue);
-            return true;
-        }));
+        shareWebsitePreference.setOnPreferenceChangeListener((preference, newValue) -> {
+            if (Patterns.WEB_URL.matcher((String) newValue).matches()) {
+                preference.setSummary((String) newValue);
+                return true;
+            } else {
+                Toast toast = Toast.makeText(
+                    getContext(),
+                    getContext().getString(R.string.custom_share_website_invalid_url),
+                    Toast.LENGTH_SHORT);
+                toast.show();
+                return false;
+            }
+        });
 
         Preference importDataPreference = findPreference(getString(R.string.import_data));
         importDataPreference.setOnPreferenceClickListener((Preference p) -> {

--- a/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
@@ -9,6 +9,7 @@ import android.os.Bundle;
 import android.preference.PreferenceManager;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.preference.EditTextPreference;
 import androidx.preference.Preference;
 import android.util.Log;
 import android.widget.Toast;
@@ -88,6 +89,15 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
         newpipe_settings.delete();
 
         addPreferencesFromResource(R.xml.content_settings);
+
+        //Display currently set website as summary and update it when changed
+        EditTextPreference shareWebsitePreference = (EditTextPreference) findPreference("custom_share_website");
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getContext());
+        shareWebsitePreference.setSummary(prefs.getString("custom_share_website", "Not set"));
+        shareWebsitePreference.setOnPreferenceChangeListener(((preference, newValue) -> {
+            preference.setSummary((String) newValue);
+            return true;
+        }));
 
         Preference importDataPreference = findPreference(getString(R.string.import_data));
         importDataPreference.setOnPreferenceClickListener((Preference p) -> {

--- a/app/src/main/java/org/schabi/newpipe/util/ShareUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ShareUtils.java
@@ -2,13 +2,19 @@ package org.schabi.newpipe.util;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.net.Uri;
 
+import android.preference.PreferenceManager;
 import org.schabi.newpipe.R;
+
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 
 public class ShareUtils {
     public static void openUrlInBrowser(Context context, String url) {
-        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+        String shareUrl = getShareUrl(PreferenceManager.getDefaultSharedPreferences(context), url);
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(shareUrl));
         context.startActivity(Intent.createChooser(intent, context.getString(R.string.share_dialog_title)));
     }
 
@@ -16,7 +22,24 @@ public class ShareUtils {
         Intent intent = new Intent(Intent.ACTION_SEND);
         intent.setType("text/plain");
         intent.putExtra(Intent.EXTRA_SUBJECT, subject);
-        intent.putExtra(Intent.EXTRA_TEXT, url);
+        String shareUrl = getShareUrl(PreferenceManager.getDefaultSharedPreferences(context), url);
+        intent.putExtra(Intent.EXTRA_TEXT, shareUrl);
         context.startActivity(Intent.createChooser(intent, context.getString(R.string.share_dialog_title)));
+    }
+
+    private static String getShareUrl(SharedPreferences prefs, String url) {
+        if (prefs.getBoolean("use_custom_share_website", false)) {
+            return prefs.getString("custom_share_website", "https://youtube.com")
+                + extractWatchParameter(url);
+        } else {
+            return url;
+        }
+    }
+
+    private static String extractWatchParameter(String url) {
+        Pattern pattern = Pattern.compile("(watch\\?v=[^&]+)");
+        Matcher matcher = pattern.matcher(url);
+        matcher.find();
+        return matcher.group(1);
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/util/ShareUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ShareUtils.java
@@ -8,38 +8,46 @@ import android.net.Uri;
 import android.preference.PreferenceManager;
 import org.schabi.newpipe.R;
 
-import java.util.regex.Pattern;
-import java.util.regex.Matcher;
+import java.net.MalformedURLException;
+import java.net.URL;
 
 public class ShareUtils {
     public static void openUrlInBrowser(Context context, String url) {
-        String shareUrl = getShareUrl(PreferenceManager.getDefaultSharedPreferences(context), url);
-        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(shareUrl));
-        context.startActivity(Intent.createChooser(intent, context.getString(R.string.share_dialog_title)));
-    }
+        try {
+            String shareUrl = getShareUrl(PreferenceManager.getDefaultSharedPreferences(context), url);
+            Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(shareUrl));
+            context.startActivity(Intent.createChooser(intent, context.getString(R.string.share_dialog_title)));
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+        }
+        }
 
     public static void shareUrl(Context context, String subject, String url) {
-        Intent intent = new Intent(Intent.ACTION_SEND);
-        intent.setType("text/plain");
-        intent.putExtra(Intent.EXTRA_SUBJECT, subject);
-        String shareUrl = getShareUrl(PreferenceManager.getDefaultSharedPreferences(context), url);
-        intent.putExtra(Intent.EXTRA_TEXT, shareUrl);
-        context.startActivity(Intent.createChooser(intent, context.getString(R.string.share_dialog_title)));
+        try {
+            String shareUrl = getShareUrl(PreferenceManager.getDefaultSharedPreferences(context), url);
+            Intent intent = new Intent(Intent.ACTION_SEND);
+            intent.setType("text/plain");
+            intent.putExtra(Intent.EXTRA_SUBJECT, subject);
+            intent.putExtra(Intent.EXTRA_TEXT, shareUrl);
+            context.startActivity(Intent.createChooser(intent, context.getString(R.string.share_dialog_title)));
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+        }
+
     }
 
-    private static String getShareUrl(SharedPreferences prefs, String url) {
+    private static String getShareUrl(SharedPreferences prefs, String url)
+        throws MalformedURLException {
         if (prefs.getBoolean("use_custom_share_website", false)) {
             return prefs.getString("custom_share_website", "https://youtube.com")
-                + "/" + extractWatchParameter(url);
+                + extractPathAndQuery(url);
         } else {
             return url;
         }
     }
 
-    private static String extractWatchParameter(String url) {
-        Pattern pattern = Pattern.compile("(watch\\?v=[^&]+)");
-        Matcher matcher = pattern.matcher(url);
-        matcher.find();
-        return matcher.group(1);
+    private static String extractPathAndQuery(String link) throws MalformedURLException {
+        URL url = new URL(link);
+       return url.getPath() + "?" + url.getQuery();
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/util/ShareUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ShareUtils.java
@@ -30,7 +30,7 @@ public class ShareUtils {
     private static String getShareUrl(SharedPreferences prefs, String url) {
         if (prefs.getBoolean("use_custom_share_website", false)) {
             return prefs.getString("custom_share_website", "https://youtube.com")
-                + extractWatchParameter(url);
+                + "/" + extractWatchParameter(url);
         } else {
             return url;
         }

--- a/app/src/main/res/layout/preference_url_edit_text.xml
+++ b/app/src/main/res/layout/preference_url_edit_text.xml
@@ -8,7 +8,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:inputType="textUri"
-    android:hint="@string/default_invidio_url"
+    android:hint="@string/default_custom_share_url"
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintTop_toTopOf="parent"

--- a/app/src/main/res/layout/preference_url_edit_text.xml
+++ b/app/src/main/res/layout/preference_url_edit_text.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  xmlns:app="http://schemas.android.com/apk/res-auto">
+
+  <EditText android:id="@android:id/edit"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:inputType="textUri"
+    android:hint="@string/default_invidio_url"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintTop_toTopOf="parent"
+    app:layout_constraintBottom_toBottomOf="parent"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -152,6 +152,8 @@
     <string name="main_page_content_key" translatable="false">main_page_content</string>
     <string name="enable_playback_resume_key" translatable="false">enable_playback_resume</string>
     <string name="enable_playback_state_lists_key" translatable="false">enable_playback_state_lists</string>
+    <string name="use_custom_share_website_key" translatable="false">use_custom_share_website</string>
+    <string name="custom_share_website_key" translatable="false">custom_share_website</string>
 
     <string name="import_data" translatable="false">import_data</string>
     <string name="export_data" translatable="false">export_data</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -379,6 +379,9 @@
     <string name="override_current_data">This will override your current setup.</string>
     <string name="import_settings">Do you want to also import settings?</string>
     <string name="error_unable_to_load_comments">Could not load comments</string>
+    <string name="custom_share_website_title">Custom share Website</string>
+    <string name="use_custom_share_website_title">Use custom share website</string>
+    <string name="default_invidio_url" translatable="false">https://invidio.us/</string>
     <!-- Kiosk Names -->
     <string name="kiosk">Kiosk</string>
     <string name="trending">Trending</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -382,6 +382,7 @@
     <string name="custom_share_website_title">Custom share Website</string>
     <string name="use_custom_share_website_title">Use custom share website</string>
     <string name="default_invidio_url" translatable="false">https://invidio.us/</string>
+    <string name="use_custom_share_website_summary">Links created by share function will use the provided website</string>
     <!-- Kiosk Names -->
     <string name="kiosk">Kiosk</string>
     <string name="trending">Trending</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -379,9 +379,9 @@
     <string name="override_current_data">This will override your current setup.</string>
     <string name="import_settings">Do you want to also import settings?</string>
     <string name="error_unable_to_load_comments">Could not load comments</string>
-    <string name="custom_share_website_title">Custom share Website</string>
+    <string name="custom_share_website_title">Custom share website</string>
     <string name="use_custom_share_website_title">Use custom share website</string>
-    <string name="default_invidio_url" translatable="false">https://invidio.us</string>
+    <string name="default_custom_share_url" translatable="false">https://invidio.us</string>
     <string name="use_custom_share_website_summary">Links created by share function will use the provided website</string>
     <string name="custom_share_website_invalid_url">Invalid url</string>
     <!-- Kiosk Names -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -381,8 +381,9 @@
     <string name="error_unable_to_load_comments">Could not load comments</string>
     <string name="custom_share_website_title">Custom share Website</string>
     <string name="use_custom_share_website_title">Use custom share website</string>
-    <string name="default_invidio_url" translatable="false">https://invidio.us/</string>
+    <string name="default_invidio_url" translatable="false">https://invidio.us</string>
     <string name="use_custom_share_website_summary">Links created by share function will use the provided website</string>
+    <string name="custom_share_website_invalid_url">Invalid url</string>
     <!-- Kiosk Names -->
     <string name="kiosk">Kiosk</string>
     <string name="trending">Trending</string>

--- a/app/src/main/res/xml/content_settings.xml
+++ b/app/src/main/res/xml/content_settings.xml
@@ -48,6 +48,23 @@
         android:title="@string/show_comments_title"
         android:summary="@string/show_comments_summary"/>
 
+    <SwitchPreference
+      app:iconSpaceReserved="false"
+      android:defaultValue="false"
+      android:key="@string/use_custom_share_website_key"
+      android:title="@string/use_custom_share_website_title"
+      android:summary="Links created by share function will use the provided website"/>
+
+    <EditTextPreference
+      app:iconSpaceReserved="false"
+      android:defaultValue="@string/default_invidio_url"
+      android:key="@string/custom_share_website_key"
+      android:title="@string/custom_share_website_title"
+      android:summary="@string/default_invidio_url"
+      android:dependency="@string/use_custom_share_website_key"
+      android:dialogLayout="@layout/preference_url_edit_text"
+      />
+
     <Preference
         app:iconSpaceReserved="false"
         android:summary="@string/import_data_summary"

--- a/app/src/main/res/xml/content_settings.xml
+++ b/app/src/main/res/xml/content_settings.xml
@@ -57,10 +57,10 @@
 
     <EditTextPreference
       app:iconSpaceReserved="false"
-      android:defaultValue="@string/default_invidio_url"
+      android:defaultValue="@string/default_custom_share_url"
       android:key="@string/custom_share_website_key"
       android:title="@string/custom_share_website_title"
-      android:summary="@string/default_invidio_url"
+      android:summary="@string/default_custom_share_url"
       android:dependency="@string/use_custom_share_website_key"
       android:dialogLayout="@layout/preference_url_edit_text"
       />

--- a/app/src/main/res/xml/content_settings.xml
+++ b/app/src/main/res/xml/content_settings.xml
@@ -53,7 +53,7 @@
       android:defaultValue="false"
       android:key="@string/use_custom_share_website_key"
       android:title="@string/use_custom_share_website_title"
-      android:summary="Links created by share function will use the provided website"/>
+      android:summary="@string/use_custom_share_website_summary"/>
 
     <EditTextPreference
       app:iconSpaceReserved="false"


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

Added an option for user to select the way the url are generated for the "share" function. If the custom option is activated then the url will be generated with the given base.
For example: "https://invidio.us/watch?v=abcdefg" instead of "https://youtube.com/watch?v=abcdefg" 

By default turned off. When turned on the default custom website is "https://invidio.us", but can be changed.

Related issue: #2351

<img src="https://user-images.githubusercontent.com/41164160/67238941-54de6c00-f44e-11e9-92be-c27238a0becc.png" width="250"><img src="https://user-images.githubusercontent.com/41164160/67238943-55770280-f44e-11e9-91b9-40c9667de98e.png" width="250"><img src="https://user-images.githubusercontent.com/41164160/67238942-55770280-f44e-11e9-9701-115b3a677e22.png" width="250">

