### PR TITLE
Enabling TLS1.1/1.2 on Android 4.4 devices (API 19/KitKat)

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/DownloaderImpl.java
+++ b/app/src/main/java/org/schabi/newpipe/DownloaderImpl.java
@@ -173,12 +173,14 @@ public class DownloaderImpl extends Downloader {
     /**
      * Enable TLS 1.2 and 1.1 on Android Kitkat. This function is mostly taken from the documentation of
      * OkHttpClient.Builder.sslSocketFactory(_,_)
+     * <p>
+     * If there is an error, the function will safely fall back to doing nothing and printing the error to the console.
      *
-     * If there is an error, It will safely fall back to doing nothing and printing the Error to the console.
      * @param builder The HTTPClient Builder on which TLS is enabled on (will be modified in-place)
      */
     private static void enableModernTLS(OkHttpClient.Builder builder) {
         try {
+            // get the default TrustManager
             TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(
                     TrustManagerFactory.getDefaultAlgorithm());
             trustManagerFactory.init((KeyStore) null);
@@ -189,9 +191,7 @@ public class DownloaderImpl extends Downloader {
             }
             X509TrustManager trustManager = (X509TrustManager) trustManagers[0];
 
-            SSLContext sslContext = SSLContext.getInstance("TLS");
-            sslContext.init(null, new TrustManager[] { trustManager }, null);
-            //SSLSocketFactory sslSocketFactory = sslContext.getSocketFactory();
+            // insert our own TLSSocketFactory
             SSLSocketFactory sslSocketFactory = TLSSocketFactoryCompat.getInstance();
 
             builder.sslSocketFactory(sslSocketFactory, trustManager);

--- a/app/src/main/java/org/schabi/newpipe/DownloaderImpl.java
+++ b/app/src/main/java/org/schabi/newpipe/DownloaderImpl.java
@@ -35,6 +35,8 @@ import okhttp3.OkHttpClient;
 import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
 
+import static org.schabi.newpipe.MainActivity.DEBUG;
+
 public class DownloaderImpl extends Downloader {
     public static final String USER_AGENT = "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:43.0) Gecko/20100101 Firefox/43.0";
 
@@ -211,7 +213,7 @@ public class DownloaderImpl extends Downloader {
 
             builder.connectionSpecs(Arrays.asList(legacyTLS, ConnectionSpec.CLEARTEXT));
         } catch (KeyManagementException | NoSuchAlgorithmException | KeyStoreException e) {
-            e.printStackTrace();
+            if (DEBUG) e.printStackTrace();
         }
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -72,6 +72,7 @@ import org.schabi.newpipe.util.PeertubeHelper;
 import org.schabi.newpipe.util.PermissionHelper;
 import org.schabi.newpipe.util.ServiceHelper;
 import org.schabi.newpipe.util.StateSaver;
+import org.schabi.newpipe.util.TLSSocketFactoryCompat;
 import org.schabi.newpipe.util.ThemeHelper;
 
 import java.util.ArrayList;
@@ -107,6 +108,10 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         if (DEBUG) Log.d(TAG, "onCreate() called with: savedInstanceState = [" + savedInstanceState + "]");
+
+        //enable TLS1.1/1.2 for kitkat devices, to fix download and play for mediaCCC sources
+        if (Build.VERSION.SDK_INT == Build.VERSION_CODES.KITKAT)
+            TLSSocketFactoryCompat.setAsDefault();
 
         ThemeHelper.setTheme(this, ServiceHelper.getSelectedServiceId(this));
 

--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -109,9 +109,10 @@ public class MainActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         if (DEBUG) Log.d(TAG, "onCreate() called with: savedInstanceState = [" + savedInstanceState + "]");
 
-        //enable TLS1.1/1.2 for kitkat devices, to fix download and play for mediaCCC sources
-        if (Build.VERSION.SDK_INT == Build.VERSION_CODES.KITKAT)
+        // enable TLS1.1/1.2 for kitkat devices, to fix download and play for mediaCCC sources
+        if (Build.VERSION.SDK_INT == Build.VERSION_CODES.KITKAT) {
             TLSSocketFactoryCompat.setAsDefault();
+        }
 
         ThemeHelper.setTheme(this, ServiceHelper.getSelectedServiceId(this));
 

--- a/app/src/main/java/org/schabi/newpipe/util/TLSSocketFactoryCompat.java
+++ b/app/src/main/java/org/schabi/newpipe/util/TLSSocketFactoryCompat.java
@@ -21,14 +21,15 @@ import javax.net.ssl.TrustManager;
 public class TLSSocketFactoryCompat extends SSLSocketFactory {
 
 
-    private static TLSSocketFactoryCompat instance=null;
+    private static TLSSocketFactoryCompat instance = null;
 
     private SSLSocketFactory internalSSLSocketFactory;
 
     public static TLSSocketFactoryCompat getInstance() throws NoSuchAlgorithmException, KeyManagementException {
-        if(instance!=null)
+        if (instance != null) {
             return instance;
-        return instance=new TLSSocketFactoryCompat();
+        }
+        return instance = new TLSSocketFactoryCompat();
     }
 
 
@@ -93,7 +94,7 @@ public class TLSSocketFactoryCompat extends SSLSocketFactory {
     }
 
     private Socket enableTLSOnSocket(Socket socket) {
-        if(socket != null && (socket instanceof SSLSocket)) {
+        if (socket != null && (socket instanceof SSLSocket)) {
             /*
             //Create list of supported protocols
             ArrayList<String> supportedProtocols = new ArrayList<>();
@@ -119,7 +120,7 @@ public class TLSSocketFactoryCompat extends SSLSocketFactory {
             //((SSLSocket)socket).setEnabledProtocols(protocolArray);
             */
             // OR: only enable TLS 1.1 and 1.2!
-            ((SSLSocket)socket).setEnabledProtocols(new String[] {"TLSv1.1", "TLSv1.2"});
+            ((SSLSocket) socket).setEnabledProtocols(new String[]{"TLSv1.1", "TLSv1.2"});
 
         }
         return socket;

--- a/app/src/main/java/org/schabi/newpipe/util/TLSSocketFactoryCompat.java
+++ b/app/src/main/java/org/schabi/newpipe/util/TLSSocketFactoryCompat.java
@@ -13,6 +13,8 @@ import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 
+import static org.schabi.newpipe.MainActivity.DEBUG;
+
 
 /**
  * This is an extension of the SSLSocketFactory which enables TLS 1.2 and 1.1.
@@ -49,7 +51,7 @@ public class TLSSocketFactoryCompat extends SSLSocketFactory {
         try {
             HttpsURLConnection.setDefaultSSLSocketFactory(getInstance());
         } catch (NoSuchAlgorithmException | KeyManagementException e) {
-            e.printStackTrace();
+            if (DEBUG) e.printStackTrace();
         }
     }
 
@@ -95,33 +97,7 @@ public class TLSSocketFactoryCompat extends SSLSocketFactory {
 
     private Socket enableTLSOnSocket(Socket socket) {
         if (socket != null && (socket instanceof SSLSocket)) {
-            /*
-            //Create list of supported protocols
-            ArrayList<String> supportedProtocols = new ArrayList<>();
-            for (String protocol : ((SSLSocket)socket).getEnabledProtocols()) {
-
-                //Log.d("TLSSocketFactory", "Supported protocol:" + protocol);
-                //Only add TLS protocols (don't want ot support older SSL versions)
-                if (protocol.toUpperCase().contains("TLS")) {
-                    supportedProtocols.add(protocol);
-                }
-            }
-            //Force add TLSv1.1 and 1.2 if not already added
-            if (!supportedProtocols.contains("TLSv1.1")) {
-                supportedProtocols.add("TLSv1.1");
-            }
-            if (!supportedProtocols.contains("TLSv1.2")) {
-                supportedProtocols.add("TLSv1.2");
-            }
-
-            String[] protocolArray = supportedProtocols.toArray(new String[supportedProtocols.size()]);
-
-            //enable protocols in our list
-            //((SSLSocket)socket).setEnabledProtocols(protocolArray);
-            */
-            // OR: only enable TLS 1.1 and 1.2!
             ((SSLSocket) socket).setEnabledProtocols(new String[]{"TLSv1.1", "TLSv1.2"});
-
         }
         return socket;
     }

--- a/app/src/main/java/org/schabi/newpipe/util/TLSSocketFactoryCompat.java
+++ b/app/src/main/java/org/schabi/newpipe/util/TLSSocketFactoryCompat.java
@@ -1,0 +1,127 @@
+package org.schabi.newpipe.util;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+
+
+/**
+ * This is an extension of the SSLSocketFactory which enables TLS 1.2 and 1.1.
+ * Created for usage on Android 4.1-4.4 devices, which haven't enabled those by default.
+ */
+public class TLSSocketFactoryCompat extends SSLSocketFactory {
+
+
+    private static TLSSocketFactoryCompat instance=null;
+
+    private SSLSocketFactory internalSSLSocketFactory;
+
+    public static TLSSocketFactoryCompat getInstance() throws NoSuchAlgorithmException, KeyManagementException {
+        if(instance!=null)
+            return instance;
+        return instance=new TLSSocketFactoryCompat();
+    }
+
+
+    public TLSSocketFactoryCompat() throws KeyManagementException, NoSuchAlgorithmException {
+        SSLContext context = SSLContext.getInstance("TLS");
+        context.init(null, null, null);
+        internalSSLSocketFactory = context.getSocketFactory();
+    }
+
+    public TLSSocketFactoryCompat(TrustManager[] tm) throws KeyManagementException, NoSuchAlgorithmException {
+        SSLContext context = SSLContext.getInstance("TLS");
+        context.init(null, tm, new java.security.SecureRandom());
+        internalSSLSocketFactory = context.getSocketFactory();
+    }
+
+    public static void setAsDefault() {
+        try {
+            HttpsURLConnection.setDefaultSSLSocketFactory(getInstance());
+        } catch (NoSuchAlgorithmException | KeyManagementException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public String[] getDefaultCipherSuites() {
+        return internalSSLSocketFactory.getDefaultCipherSuites();
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+        return internalSSLSocketFactory.getSupportedCipherSuites();
+    }
+
+    @Override
+    public Socket createSocket() throws IOException {
+        return enableTLSOnSocket(internalSSLSocketFactory.createSocket());
+    }
+
+    @Override
+    public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException {
+        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(s, host, port, autoClose));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException, UnknownHostException {
+        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException, UnknownHostException {
+        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(host, port, localHost, localPort));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress host, int port) throws IOException {
+        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) throws IOException {
+        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(address, port, localAddress, localPort));
+    }
+
+    private Socket enableTLSOnSocket(Socket socket) {
+        if(socket != null && (socket instanceof SSLSocket)) {
+            /*
+            //Create list of supported protocols
+            ArrayList<String> supportedProtocols = new ArrayList<>();
+            for (String protocol : ((SSLSocket)socket).getEnabledProtocols()) {
+
+                //Log.d("TLSSocketFactory", "Supported protocol:" + protocol);
+                //Only add TLS protocols (don't want ot support older SSL versions)
+                if (protocol.toUpperCase().contains("TLS")) {
+                    supportedProtocols.add(protocol);
+                }
+            }
+            //Force add TLSv1.1 and 1.2 if not already added
+            if (!supportedProtocols.contains("TLSv1.1")) {
+                supportedProtocols.add("TLSv1.1");
+            }
+            if (!supportedProtocols.contains("TLSv1.2")) {
+                supportedProtocols.add("TLSv1.2");
+            }
+
+            String[] protocolArray = supportedProtocols.toArray(new String[supportedProtocols.size()]);
+
+            //enable protocols in our list
+            //((SSLSocket)socket).setEnabledProtocols(protocolArray);
+            */
+            // OR: only enable TLS 1.1 and 1.2!
+            ((SSLSocket)socket).setEnabledProtocols(new String[] {"TLSv1.1", "TLSv1.2"});
+
+        }
+        return socket;
+    }
+}


### PR DESCRIPTION
This is an attempt to fix #2777 . I already got the Downloader and the Extractor parts working. What I may need some help on is the player. I simply don't know how to approach this and where to start.

Please give me some feedback on the "finished" parts, too.

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.