### PR TITLE
Make reCAPTCHA string untranslatable

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -304,7 +304,7 @@
     <!-- Checksum types -->
     <string name="md5" translatable="false">MD5</string>
     <string name="sha1" translatable="false">SHA-1</string>
-    <string name="reCaptchaActivity">reCAPTCHA</string>
+    <string name="reCaptchaActivity" translatable="false">reCAPTCHA</string>
     <string name="reCaptcha_title">reCAPTCHA challenge</string>
     <string name="recaptcha_request_toast">reCAPTCHA challenge requested</string>
     <!-- End of GigaGet's Strings -->


### PR DESCRIPTION
I updated reCaptchaActivity string and made it untranslatable, because it's causing "Failed check: Unchanged translation" on Weblate.

This would fix the last paragraph of #2794 (the main reason why I created the issue is not fixed)