### PR TITLE
Playlist thumbnail updates

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/dialog/PlaylistAppendDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/local/dialog/PlaylistAppendDialog.java
@@ -152,19 +152,15 @@ public final class PlaylistAppendDialog extends PlaylistDialog {
         final Toast successToast = Toast.makeText(getContext(),
                 R.string.playlist_add_stream_success, Toast.LENGTH_SHORT);
 
-        if(playlist.thumbnailUrl.equals("https://i.ytimg.com/")){   
-            playlistDisposables.add(manager.createPlaylist(playlist.name, streams)
-                    .observeOn(AndroidSchedulers.mainThread())
-                    .subscribe(ignored -> successToast.show()));
-            playlistDisposables.add(manager.deletePlaylist(playlist.uid)
+        if(playlist.thumbnailUrl.equals("drawable://" + R.drawable.dummy_thumbnail_playlist)){
+            playlistDisposables.add(manager.changePlaylistThumbnail(playlist.uid,streams.get(0).getThumbnailUrl())
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe(ignored -> successToast.show()));
         }
-        else {
-            playlistDisposables.add(manager.appendToPlaylist(playlist.uid, streams)
-                    .observeOn(AndroidSchedulers.mainThread())
-                    .subscribe(ignored -> successToast.show()));
-        }
+
+        playlistDisposables.add(manager.appendToPlaylist(playlist.uid, streams)
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(ignored -> successToast.show()));
 
         getDialog().dismiss();
     }

--- a/app/src/main/java/org/schabi/newpipe/local/dialog/PlaylistAppendDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/local/dialog/PlaylistAppendDialog.java
@@ -1,14 +1,15 @@
 package org.schabi.newpipe.local.dialog;
 
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 
 import org.schabi.newpipe.NewPipeDatabase;
 import org.schabi.newpipe.R;
@@ -152,8 +153,8 @@ public final class PlaylistAppendDialog extends PlaylistDialog {
         final Toast successToast = Toast.makeText(getContext(),
                 R.string.playlist_add_stream_success, Toast.LENGTH_SHORT);
 
-        if(playlist.thumbnailUrl.equals("drawable://" + R.drawable.dummy_thumbnail_playlist)){
-            playlistDisposables.add(manager.changePlaylistThumbnail(playlist.uid,streams.get(0).getThumbnailUrl())
+        if (playlist.thumbnailUrl.equals("drawable://" + R.drawable.dummy_thumbnail_playlist)) {
+            playlistDisposables.add(manager.changePlaylistThumbnail(playlist.uid, streams.get(0).getThumbnailUrl())
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe(ignored -> successToast.show()));
         }

--- a/app/src/main/java/org/schabi/newpipe/local/dialog/PlaylistAppendDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/local/dialog/PlaylistAppendDialog.java
@@ -152,9 +152,19 @@ public final class PlaylistAppendDialog extends PlaylistDialog {
         final Toast successToast = Toast.makeText(getContext(),
                 R.string.playlist_add_stream_success, Toast.LENGTH_SHORT);
 
-        playlistDisposables.add(manager.appendToPlaylist(playlist.uid, streams)
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(ignored -> successToast.show()));
+        if(playlist.thumbnailUrl.equals("https://i.ytimg.com/")){   //empty playlist
+            playlistDisposables.add(manager.createPlaylist(playlist.name, streams)
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .subscribe(ignored -> successToast.show()));
+            playlistDisposables.add(manager.deletePlaylist(playlist.uid)
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .subscribe(ignored -> successToast.show()));
+        }
+        else {
+            playlistDisposables.add(manager.appendToPlaylist(playlist.uid, streams)
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .subscribe(ignored -> successToast.show()));
+        }
 
         getDialog().dismiss();
     }

--- a/app/src/main/java/org/schabi/newpipe/local/dialog/PlaylistAppendDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/local/dialog/PlaylistAppendDialog.java
@@ -152,7 +152,7 @@ public final class PlaylistAppendDialog extends PlaylistDialog {
         final Toast successToast = Toast.makeText(getContext(),
                 R.string.playlist_add_stream_success, Toast.LENGTH_SHORT);
 
-        if(playlist.thumbnailUrl.equals("https://i.ytimg.com/")){   //empty playlist
+        if(playlist.thumbnailUrl.equals("https://i.ytimg.com/")){   
             playlistDisposables.add(manager.createPlaylist(playlist.name, streams)
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe(ignored -> successToast.show()));

--- a/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
@@ -413,10 +413,24 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
         disposables.add(disposable);
     }
 
+    private void updateThumbnailUrl() {
+        String newThumbnailUrl;
+
+        if(!itemListAdapter.getItemsList().isEmpty()){
+            newThumbnailUrl = ((PlaylistStreamEntry)itemListAdapter.getItemsList().get(0)).thumbnailUrl;
+        }
+        else newThumbnailUrl = "https://i.ytimg.com/";
+
+        changeThumbnailUrl(newThumbnailUrl);
+    }
+
     private void deleteItem(final PlaylistStreamEntry item) {
         if (itemListAdapter == null) return;
 
         itemListAdapter.removeItem(item);
+        if(playlistManager.getPlaylistThumbnail(playlistId).equals(item.thumbnailUrl)) // If yes change for the first thumbnail of the list
+            updateThumbnailUrl();
+
         setVideoCount(itemListAdapter.getItemsList().size());
         saveChanges();
     }

--- a/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
@@ -428,7 +428,7 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
         if (itemListAdapter == null) return;
 
         itemListAdapter.removeItem(item);
-        if(playlistManager.getPlaylistThumbnail(playlistId).equals(item.thumbnailUrl)) // If yes change for the first thumbnail of the list
+        if(playlistManager.getPlaylistThumbnail(playlistId).equals(item.thumbnailUrl)) 
             updateThumbnailUrl();
 
         setVideoCount(itemListAdapter.getItemsList().size());

--- a/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
@@ -419,7 +419,7 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
         if(!itemListAdapter.getItemsList().isEmpty()){
             newThumbnailUrl = ((PlaylistStreamEntry)itemListAdapter.getItemsList().get(0)).thumbnailUrl;
         }
-        else newThumbnailUrl = "https://i.ytimg.com/";
+        else newThumbnailUrl = "drawable://" + R.drawable.dummy_thumbnail_playlist;
 
         changeThumbnailUrl(newThumbnailUrl);
     }

--- a/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
@@ -4,11 +4,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.os.Bundle;
 import android.os.Parcelable;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.AlertDialog;
-import androidx.recyclerview.widget.RecyclerView;
-import androidx.recyclerview.widget.ItemTouchHelper;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -17,6 +12,12 @@ import android.view.ViewGroup;
 import android.widget.EditText;
 import android.widget.TextView;
 import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
+import androidx.recyclerview.widget.ItemTouchHelper;
+import androidx.recyclerview.widget.RecyclerView;
 
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -416,10 +417,11 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
     private void updateThumbnailUrl() {
         String newThumbnailUrl;
 
-        if(!itemListAdapter.getItemsList().isEmpty()){
-            newThumbnailUrl = ((PlaylistStreamEntry)itemListAdapter.getItemsList().get(0)).thumbnailUrl;
+        if (!itemListAdapter.getItemsList().isEmpty()) {
+            newThumbnailUrl = ((PlaylistStreamEntry) itemListAdapter.getItemsList().get(0)).thumbnailUrl;
+        } else {
+            newThumbnailUrl = "drawable://" + R.drawable.dummy_thumbnail_playlist;
         }
-        else newThumbnailUrl = "drawable://" + R.drawable.dummy_thumbnail_playlist;
 
         changeThumbnailUrl(newThumbnailUrl);
     }
@@ -428,7 +430,7 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
         if (itemListAdapter == null) return;
 
         itemListAdapter.removeItem(item);
-        if(playlistManager.getPlaylistThumbnail(playlistId).equals(item.thumbnailUrl)) 
+        if (playlistManager.getPlaylistThumbnail(playlistId).equals(item.thumbnailUrl))
             updateThumbnailUrl();
 
         setVideoCount(itemListAdapter.getItemsList().size());

--- a/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistManager.java
+++ b/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistManager.java
@@ -103,6 +103,10 @@ public class LocalPlaylistManager {
         return modifyPlaylist(playlistId, null, thumbnailUrl);
     }
 
+    public String getPlaylistThumbnail(final long playlistId) {
+        return playlistTable.getPlaylist(playlistId).blockingFirst().get(0).getThumbnailUrl();
+    }
+
     private Maybe<Integer> modifyPlaylist(final long playlistId,
                                           @Nullable final String name,
                                           @Nullable final String thumbnailUrl) {


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

I propose this solution for the issue #2759.
It corrects the use-case described in this issue : 

1. Select item, Add To Playlist -> New Playlist -> test1
    (Item Thumbnail will be used as Playlist Thumbnail)

2. Go to test1 playlist, Delete item.
    (Playlist Thumbnail ~~will remain, but it should be removed~~ is updated with the default thumbnail url : https://i.ytimg.com/ if the playlist is empty)

3. Select item, Add To Playlist -> test1
    (Playlist Thumbnail ~~will remain, but it should be updated~~ is updated with this item thumbnail if playlist was empty)

If the playlist isn't empty in step 2, we just update the playlist thumbnail with one of its item.
