### PR TITLE
Solving issue #2797 by changing RouterActivity

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/RouterActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/RouterActivity.java
@@ -119,6 +119,14 @@ public class RouterActivity extends AppCompatActivity {
         Icepick.saveInstanceState(this, outState);
     }
 
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+
+        currentUrl = getUrl(intent);
+    }
+
     @Override
     protected void onStart() {
         super.onStart();


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

I managed to fix #2797 which caused the video downloaded by sharing from the YouTube application to be the wrong one.

The problem can be reproduced by following these steps:
1) Downloading a video by sharing from the YouTube app
2) Switching back to YouTube app
3) Sharing a new YouTube video to NewPipe

After adding a OnNewIntend method in RouterActivity, the problem is gone.