### PR TITLE
make main page tabs scrollable and hide when there is only a single tab

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/MainFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/MainFragment.java
@@ -30,6 +30,7 @@ import org.schabi.newpipe.settings.tabs.Tab;
 import org.schabi.newpipe.settings.tabs.TabsManager;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.ServiceHelper;
+import org.schabi.newpipe.views.ScrollableTabLayout;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,7 +38,7 @@ import java.util.List;
 public class MainFragment extends BaseFragment implements TabLayout.OnTabSelectedListener {
     private ViewPager viewPager;
     private SelectedTabsPagerAdapter pagerAdapter;
-    private TabLayout tabLayout;
+    private ScrollableTabLayout tabLayout;
 
     private List<Tab> tabsList = new ArrayList<>();
     private TabsManager tabsManager;

--- a/app/src/main/java/org/schabi/newpipe/views/ScrollableTabLayout.java
+++ b/app/src/main/java/org/schabi/newpipe/views/ScrollableTabLayout.java
@@ -14,6 +14,7 @@ import com.google.android.material.tabs.TabLayout.Tab;
 
 /**
  * A TabLayout that is scrollable when tabs exceed its width.
+ * Hides when there are less than 2 tabs.
  */
 public class ScrollableTabLayout extends TabLayout {
     private static final String TAG = ScrollableTabLayout.class.getSimpleName();
@@ -60,6 +61,13 @@ public class ScrollableTabLayout extends TabLayout {
     }
 
     private void resetMode() {
+        if (getTabCount() < 2) {
+            setVisibility(View.GONE);
+            return;
+        } else {
+            setVisibility(View.VISIBLE);
+        }
+
         if (getTabCount() == 0 || getTabAt(0).view == null) return;
         setTabMode(TabLayout.MODE_FIXED);
 

--- a/app/src/main/java/org/schabi/newpipe/views/ScrollableTabLayout.java
+++ b/app/src/main/java/org/schabi/newpipe/views/ScrollableTabLayout.java
@@ -25,18 +25,21 @@ public class ScrollableTabLayout extends TabLayout {
 
     public ScrollableTabLayout(Context context, AttributeSet attrs) {
         super(context, attrs);
+        setTabMode(TabLayout.MODE_FIXED);
     }
 
     public ScrollableTabLayout(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
+        setTabMode(TabLayout.MODE_FIXED);
     }
 
     @Override
-    protected void onAttachedToWindow() {
-        super.onAttachedToWindow();
+    protected void onLayout(boolean changed, int l, int t, int r, int b) {
+        super.onLayout(changed, l, t, r, b);
 
-        setTabMode(TabLayout.MODE_FIXED);
-        resetMode();
+        if (changed) {
+            resetMode();
+        }
     }
 
     @Override
@@ -68,21 +71,15 @@ public class ScrollableTabLayout extends TabLayout {
             setVisibility(View.VISIBLE);
         }
 
-        if (getTabCount() == 0 || getTabAt(0).view == null) return;
+        int layoutWidth = getWidth();
+        if (layoutWidth == 0) return;
+
         setTabMode(TabLayout.MODE_FIXED);
 
-        int layoutWidth = getWidth();
-        int minimumWidth = ((View) getTabAt(0).view).getMinimumWidth();
-        if (minimumWidth * getTabCount() > layoutWidth) {
-            setTabMode(TabLayout.MODE_SCROLLABLE);
-            return;
-        }
-
-        int actualWidth = 0;
+        int tabsRequestedWidth = 0;
         for (int i = 0; i < getTabCount(); ++i) {
-            if (getTabAt(i).view == null) return;
-            actualWidth += ((View) getTabAt(i).view).getWidth();
-            if (actualWidth > layoutWidth) {
+            tabsRequestedWidth += ((View) getTabAt(i).view).getMinimumWidth();
+            if (tabsRequestedWidth > layoutWidth) {
                 setTabMode(TabLayout.MODE_SCROLLABLE);
                 return;
             }

--- a/app/src/main/java/org/schabi/newpipe/views/ScrollableTabLayout.java
+++ b/app/src/main/java/org/schabi/newpipe/views/ScrollableTabLayout.java
@@ -106,7 +106,7 @@ public class ScrollableTabLayout extends TabLayout {
      * Calculate minimal width required by tabs and set tabMode accordingly
      */
     private void remeasureTabs() {
-        if (getVisibility() != View.VISIBLE) return;
+        if (prevVisibility != View.VISIBLE) return;
         if (layoutWidth == 0) return;
 
         final int count = getTabCount();

--- a/app/src/main/java/org/schabi/newpipe/views/ScrollableTabLayout.java
+++ b/app/src/main/java/org/schabi/newpipe/views/ScrollableTabLayout.java
@@ -1,0 +1,83 @@
+package org.schabi.newpipe.views;
+
+import android.content.Context;
+import android.os.Build;
+import android.util.AttributeSet;
+import android.util.Log;
+import android.view.View;
+import android.view.ViewTreeObserver.OnGlobalLayoutListener;
+
+import androidx.annotation.NonNull;
+
+import com.google.android.material.tabs.TabLayout;
+import com.google.android.material.tabs.TabLayout.Tab;
+
+/**
+ * A TabLayout that is scrollable when tabs exceed its width.
+ */
+public class ScrollableTabLayout extends TabLayout {
+    private static final String TAG = ScrollableTabLayout.class.getSimpleName();
+
+    public ScrollableTabLayout(Context context) {
+        super(context);
+    }
+
+    public ScrollableTabLayout(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public ScrollableTabLayout(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+
+        setTabMode(TabLayout.MODE_FIXED);
+        resetMode();
+    }
+
+    @Override
+    protected void onSizeChanged(int w, int h, int oldw, int oldh) {
+        super.onSizeChanged(w, h, oldw, oldh);
+
+        resetMode();
+    }
+
+    @Override
+    public void addTab(@NonNull Tab tab, int position, boolean setSelected) {
+        super.addTab(tab, position, setSelected);
+
+        resetMode();
+    }
+
+    @Override
+    public void removeTabAt(int position) {
+        super.removeTabAt(position);
+
+        resetMode();
+    }
+
+    private void resetMode() {
+        if (getTabCount() == 0 || getTabAt(0).view == null) return;
+        setTabMode(TabLayout.MODE_FIXED);
+
+        int layoutWidth = getWidth();
+        int minimumWidth = ((View) getTabAt(0).view).getMinimumWidth();
+        if (minimumWidth * getTabCount() > layoutWidth) {
+            setTabMode(TabLayout.MODE_SCROLLABLE);
+            return;
+        }
+
+        int actualWidth = 0;
+        for (int i = 0; i < getTabCount(); ++i) {
+            if (getTabAt(i).view == null) return;
+            actualWidth += ((View) getTabAt(i).view).getWidth();
+            if (actualWidth > layoutWidth) {
+                setTabMode(TabLayout.MODE_SCROLLABLE);
+                return;
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -6,12 +6,13 @@
     android:layout_height="match_parent">
 
 
-    <com.google.android.material.tabs.TabLayout
+    <org.schabi.newpipe.views.ScrollableTabLayout
         android:id="@+id/main_tab_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentTop="true"
         android:background="?attr/colorPrimary"
+        app:tabMinWidth="60dp"
         app:tabGravity="fill"/>
 
     <androidx.viewpager.widget.ViewPager


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

This PR makes tabs scrollable so they don't get squeezed if there are too many of them and hides tab selector if there is only a single tab. Adds and closes #1647 

Before | After
:---:|:---:
![single tab before][single-pre] | ![single tab after][single-post]
![multiple tabs before][multi-pre] | ![multiple tabs after][multi-post]

Created separate ScrollableTabLayout class to avoid cluttering MainFragment with switching between scrollable and fixed modes.

[single-pre]: https://user-images.githubusercontent.com/10105131/70863722-e647f700-1f42-11ea-95d5-17268d883ad6.jpg "Single tab"
[single-post]: https://user-images.githubusercontent.com/10105131/70863727-efd15f00-1f42-11ea-8ef8-d1edf501fa23.jpg "Single tab"
[multi-pre]: https://user-images.githubusercontent.com/10105131/70863729-f5c74000-1f42-11ea-9064-5aa63f83ffd0.jpg "Multiple tabs"
[multi-post]: https://user-images.githubusercontent.com/10105131/70863733-f9f35d80-1f42-11ea-9445-2ed78edb57fb.jpg "Multiple tabs"