### PR TITLE
Fixed issues #2838 #2797 #2773

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
@@ -369,7 +369,7 @@ public class DownloadDialog extends DialogFragment implements RadioGroup.OnCheck
         toolbar.setOnMenuItemClickListener(item -> {
             if (item.getItemId() == R.id.okay) {
                 prepareSelectedDownload();
-                if (getActivity() instanceof RouterActivity){
+                if (getActivity() instanceof RouterActivity) {
                     getActivity().finish();
                 }
                 return true;

--- a/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
@@ -38,6 +38,7 @@ import com.nononsenseapps.filepicker.Utils;
 
 import org.schabi.newpipe.MainActivity;
 import org.schabi.newpipe.R;
+import org.schabi.newpipe.RouterActivity;
 import org.schabi.newpipe.extractor.MediaFormat;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.localization.Localization;
@@ -368,6 +369,9 @@ public class DownloadDialog extends DialogFragment implements RadioGroup.OnCheck
         toolbar.setOnMenuItemClickListener(item -> {
             if (item.getItemId() == R.id.okay) {
                 prepareSelectedDownload();
+                if (getActivity() instanceof RouterActivity){
+                    getActivity().finish();
+                }
                 return true;
             }
             return false;


### PR DESCRIPTION
- [✓] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

I found a way to solve issue #2838  together with issue #2773 and issue #2797 . Youtube seems to freeze as the NewPipe activity is not correctly closed. I added an if statement in DownloadDialog to close the activity when ok is clicked if the activity does not come from the app itself:

As it finishes the activity, when downloading a second video, the name is reset so it also fixes issue #2797 

Fixes #2838
Fixes #2773
Fixes #2797