### PR TITLE
Fix for player access out of its creation thread

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/playback/MediaSourceManager.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playback/MediaSourceManager.java
@@ -319,6 +319,7 @@ public class MediaSourceManager {
 
     private Observable<Long> getEdgeIntervalSignal() {
         return Observable.interval(progressUpdateIntervalMillis, TimeUnit.MILLISECONDS)
+                .observeOn(AndroidSchedulers.mainThread())
                 .filter(ignored ->
                         playbackListener.isApproachingPlaybackEdge(playbackNearEndGapMillis));
     }


### PR DESCRIPTION
Some code was running in a RxComputation thread (default of `Observable#interval`).

This PR fixes it by always delivering the result in the main thread, which the player was created on.

Should be the only case where this happens, checked using a watch point on the player field to compare in which thread access occurred on.

---

Fixes #2376.