### PR TITLE
Allow a BasePlayer to start paused

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/BackgroundPlayerActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/player/BackgroundPlayerActivity.java
@@ -57,7 +57,10 @@ public final class BackgroundPlayerActivity extends ServicePlayerActivity {
 
             this.player.setRecovery();
             getApplicationContext().sendBroadcast(getPlayerShutdownIntent());
-            getApplicationContext().startService(getSwitchIntent(PopupVideoPlayer.class));
+            getApplicationContext().startService(
+                getSwitchIntent(PopupVideoPlayer.class)
+                    .putExtra(BasePlayer.START_PAUSED, !this.player.isPlaying())
+            );
             return true;
         }
         return false;

--- a/app/src/main/java/org/schabi/newpipe/player/BackgroundPlayerActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/player/BackgroundPlayerActivity.java
@@ -55,13 +55,7 @@ public final class BackgroundPlayerActivity extends ServicePlayerActivity {
                 return true;
             }
 
-            this.player.setRecovery();
-            getApplicationContext().sendBroadcast(getPlayerShutdownIntent());
-            getApplicationContext().startService(
-                getSwitchIntent(PopupVideoPlayer.class)
-                    .putExtra(BasePlayer.START_PAUSED, !this.player.isPlaying())
-            );
-            return true;
+            return switchTo(PopupVideoPlayer.class);
         }
         return false;
     }

--- a/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
@@ -150,6 +150,8 @@ public abstract class BasePlayer implements
     @NonNull
     public static final String RESUME_PLAYBACK = "resume_playback";
     @NonNull
+    public static final String START_PAUSED = "start_paused";
+    @NonNull
     public static final String SELECT_ON_APPEND = "select_on_append";
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -304,7 +306,7 @@ public abstract class BasePlayer implements
         }
         // Good to go...
         initPlayback(queue, repeatMode, playbackSpeed, playbackPitch, playbackSkipSilence,
-                /*playOnInit=*/true);
+                /*playOnInit=*/!intent.getBooleanExtra(START_PAUSED, false));
     }
 
     protected void initPlayback(@NonNull final PlayQueue queue,

--- a/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
@@ -946,10 +946,10 @@ public abstract class BasePlayer implements
     public void onPlayPause() {
         if (DEBUG) Log.d(TAG, "onPlayPause() called");
 
-        if (!isPlaying()) {
-            onPlay();
-        } else {
+        if (isPlaying()) {
             onPause();
+        } else {
+            onPlay();
         }
     }
 

--- a/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
@@ -614,7 +614,8 @@ public final class MainVideoPlayer extends AppCompatActivity
                     this.getPlaybackPitch(),
                     this.getPlaybackSkipSilence(),
                     this.getPlaybackQuality(),
-                    false
+                    false,
+                    !isPlaying()
             );
             context.startService(intent);
 
@@ -637,7 +638,8 @@ public final class MainVideoPlayer extends AppCompatActivity
                     this.getPlaybackPitch(),
                     this.getPlaybackSkipSilence(),
                     this.getPlaybackQuality(),
-                    false
+                    false,
+                    !isPlaying()
             );
             context.startService(intent);
 

--- a/app/src/main/java/org/schabi/newpipe/player/PopupVideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/PopupVideoPlayer.java
@@ -567,7 +567,8 @@ public final class PopupVideoPlayer extends Service {
                     this.getPlaybackPitch(),
                     this.getPlaybackSkipSilence(),
                     this.getPlaybackQuality(),
-                    false
+                    false,
+                    !isPlaying()
             );
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             context.startActivity(intent);

--- a/app/src/main/java/org/schabi/newpipe/player/PopupVideoPlayerActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/player/PopupVideoPlayerActivity.java
@@ -50,7 +50,10 @@ public final class PopupVideoPlayerActivity extends ServicePlayerActivity {
         if (item.getItemId() == R.id.action_switch_background) {
             this.player.setRecovery();
             getApplicationContext().sendBroadcast(getPlayerShutdownIntent());
-            getApplicationContext().startService(getSwitchIntent(BackgroundPlayer.class));
+            getApplicationContext().startService(
+                getSwitchIntent(BackgroundPlayer.class)
+                    .putExtra(BasePlayer.START_PAUSED, !this.player.isPlaying())
+            );
             return true;
         }
         return false;

--- a/app/src/main/java/org/schabi/newpipe/player/PopupVideoPlayerActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/player/PopupVideoPlayerActivity.java
@@ -48,13 +48,7 @@ public final class PopupVideoPlayerActivity extends ServicePlayerActivity {
     @Override
     public boolean onPlayerOptionSelected(MenuItem item) {
         if (item.getItemId() == R.id.action_switch_background) {
-            this.player.setRecovery();
-            getApplicationContext().sendBroadcast(getPlayerShutdownIntent());
-            getApplicationContext().startService(
-                getSwitchIntent(BackgroundPlayer.class)
-                    .putExtra(BasePlayer.START_PAUSED, !this.player.isPlaying())
-            );
-            return true;
+            return switchTo(BackgroundPlayer.class);
         }
         return false;
     }

--- a/app/src/main/java/org/schabi/newpipe/player/ServicePlayerActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ServicePlayerActivity.java
@@ -167,7 +167,10 @@ public abstract class ServicePlayerActivity extends AppCompatActivity
             case R.id.action_switch_main:
                 this.player.setRecovery();
                 getApplicationContext().sendBroadcast(getPlayerShutdownIntent());
-                getApplicationContext().startActivity(getSwitchIntent(MainVideoPlayer.class));
+                getApplicationContext().startActivity(
+                    getSwitchIntent(MainVideoPlayer.class)
+                        .putExtra(BasePlayer.START_PAUSED, !this.player.isPlaying())
+                );
                 return true;
         }
         return onPlayerOptionSelected(item) || super.onOptionsItemSelected(item);
@@ -189,6 +192,7 @@ public abstract class ServicePlayerActivity extends AppCompatActivity
                 this.player.getPlaybackPitch(),
                 this.player.getPlaybackSkipSilence(),
                 null,
+                false,
                 false
         ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
     }

--- a/app/src/main/java/org/schabi/newpipe/player/ServicePlayerActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ServicePlayerActivity.java
@@ -165,13 +165,7 @@ public abstract class ServicePlayerActivity extends AppCompatActivity
                 startActivity(new Intent(Settings.ACTION_SOUND_SETTINGS));
                 return true;
             case R.id.action_switch_main:
-                this.player.setRecovery();
-                getApplicationContext().sendBroadcast(getPlayerShutdownIntent());
-                getApplicationContext().startActivity(
-                    getSwitchIntent(MainVideoPlayer.class)
-                        .putExtra(BasePlayer.START_PAUSED, !this.player.isPlaying())
-                );
-                return true;
+                return switchTo(MainVideoPlayer.class);
         }
         return onPlayerOptionSelected(item) || super.onOptionsItemSelected(item);
     }
@@ -194,7 +188,15 @@ public abstract class ServicePlayerActivity extends AppCompatActivity
                 null,
                 false,
                 false
-        ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        .putExtra(BasePlayer.START_PAUSED, !this.player.isPlaying());
+    }
+
+    protected boolean switchTo(final Class clazz) {
+        this.player.setRecovery();
+        getApplicationContext().sendBroadcast(getPlayerShutdownIntent());
+        getApplicationContext().startActivity(getSwitchIntent(clazz));
+        return true;
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
@@ -109,12 +109,14 @@ public class NavigationHelper {
                                          final float playbackPitch,
                                          final boolean playbackSkipSilence,
                                          @Nullable final String playbackQuality,
-                                         final boolean resumePlayback) {
+                                         final boolean resumePlayback,
+                                         final boolean startPaused) {
         return getPlayerIntent(context, targetClazz, playQueue, playbackQuality, resumePlayback)
                 .putExtra(BasePlayer.REPEAT_MODE, repeatMode)
                 .putExtra(BasePlayer.PLAYBACK_SPEED, playbackSpeed)
                 .putExtra(BasePlayer.PLAYBACK_PITCH, playbackPitch)
-                .putExtra(BasePlayer.PLAYBACK_SKIP_SILENCE, playbackSkipSilence);
+                .putExtra(BasePlayer.PLAYBACK_SKIP_SILENCE, playbackSkipSilence)
+                .putExtra(BasePlayer.START_PAUSED, startPaused);
     }
 
     public static void playOnMainPlayer(final Context context, final PlayQueue queue, final boolean resumePlayback) {


### PR DESCRIPTION
This commit fixes the situation where NewPipe is set up to play in the background when minimizing its window.

1) A video is playing
2) The video is paused
3) NewPipe is minimized (of the screen is turned of)

In this situation, without this pull request, the video is incorrectly resumed in the background.

I hesitated whether I would set the default value to true of false. I chose  to pick true to be closer to the current behavior, please let me know if it would be better to use false or fill free to edit. 

[X] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
