### PR TITLE
add «Always expand description» in appearance settings, closes #1113

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -974,6 +974,11 @@ public class VideoDetailFragment
 
     private void showContent() {
         contentRootLayoutHiding.setVisibility(View.VISIBLE);
+        final boolean showDescriptionOnLoad = PreferenceManager.getDefaultSharedPreferences(activity)
+                .getBoolean(getString(R.string.always_expand_description_key), false);
+        if (showDescriptionOnLoad) {
+            toggleTitleAndDescription();
+        }
     }
 
     protected void setInitialData(int serviceId, String url, String name) {

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -1125,5 +1125,5 @@
         <item>@string/list</item>
         <item>@string/grid</item>
     </string-array>
-
+    <string name="always_expand_description_key" translatable="false">always_expand_description</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -644,4 +644,5 @@
     <string name="feed_use_dedicated_fetch_method_enable_button">Enable fast mode</string>
     <string name="feed_use_dedicated_fetch_method_disable_button">Disable fast mode</string>
     <string name="feed_use_dedicated_fetch_method_help_text">Do you think feed loading is too slow? If so, try enabling fast loading (you can change it in settings or by pressing the button below).\n\nNewPipe offers two feed loading strategies:\n• Fetching the whole subscription channel, which is slow but complete.\n• Using a dedicated service endpoint, which is fast but usually not complete.\n\nThe difference between the two is that the fast one usually lacks some information, like the item\'s duration or type (can\'t distinguish between live videos and normal ones) and it may return less items.\n\nYouTube is an example of a service that offers this fast method with its RSS feed.\n\nSo the choice boils down to what you prefer: speed or precise information.</string>
+    <string name="always_expand_description">Always expand description</string>
 </resources>

--- a/app/src/main/res/xml/appearance_settings.xml
+++ b/app/src/main/res/xml/appearance_settings.xml
@@ -35,4 +35,9 @@
         android:title="@string/caption_setting_title"
         android:summary="@string/caption_setting_description"/>
 
+    <SwitchPreference
+        app:iconSpaceReserved="false"
+        android:defaultValue="false"
+        android:key="@string/always_expand_description_key"
+        android:title="@string/always_expand_description"/>
 </PreferenceScreen>


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

Closes #1113
I added a switch in appearance settings for that, and the default value is false (stays as it's now).