### PR TITLE
ask for display over other apps permission in settings

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/settings/VideoAudioSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/VideoAudioSettingsFragment.java
@@ -24,11 +24,18 @@ public class VideoAudioSettingsFragment extends BasePreferenceFragment {
         listener = new SharedPreferences.OnSharedPreferenceChangeListener() {
             @Override
             public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String s) {
+
+                //on M and above, if user chooses to minimise to popup player on exit and the app doesn't have
+                //display over other apps permission, show a snackbar to let the user give permission
                 if(s.equals(getString(R.string.minimize_on_exit_key))){
+
                     String newSetting = sharedPreferences.getString(s,null);
                     if(newSetting != null){
+
                         if(newSetting.equals(getString(R.string.minimize_on_exit_popup_key))){
+
                             if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !Settings.canDrawOverlays(getContext())){
+
                                 Snackbar.make(getListView(),R.string.permission_display_over_apps,Snackbar.LENGTH_INDEFINITE)
                                         .setAction(R.string.settings, new View.OnClickListener() {
                                             @Override

--- a/app/src/main/java/org/schabi/newpipe/settings/VideoAudioSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/VideoAudioSettingsFragment.java
@@ -21,36 +21,27 @@ public class VideoAudioSettingsFragment extends BasePreferenceFragment {
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        listener = new SharedPreferences.OnSharedPreferenceChangeListener() {
-            @Override
-            public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String s) {
+        listener = (sharedPreferences, s) -> {
 
-                //on M and above, if user chooses to minimise to popup player on exit and the app doesn't have
-                //display over other apps permission, show a snackbar to let the user give permission
-                if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
-                        s.equals(getString(R.string.minimize_on_exit_key))){
+            // on M and above, if user chooses to minimise to popup player on exit and the app doesn't have
+            // display over other apps permission, show a snackbar to let the user give permission
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
+                    s.equals(getString(R.string.minimize_on_exit_key))) {
 
-                    String newSetting = sharedPreferences.getString(s,null);
-                    if(newSetting != null
-                            && newSetting.equals(getString(R.string.minimize_on_exit_popup_key))
-                            && !Settings.canDrawOverlays(getContext())){
+                String newSetting = sharedPreferences.getString(s, null);
+                if (newSetting != null
+                        && newSetting.equals(getString(R.string.minimize_on_exit_popup_key))
+                        && !Settings.canDrawOverlays(getContext())) {
 
-                            Snackbar.make(getListView(),R.string.permission_display_over_apps,Snackbar.LENGTH_INDEFINITE)
-                                    .setAction(R.string.settings, new View.OnClickListener() {
-                                        @Override
-                                        public void onClick(View view) {
-                                            PermissionHelper.checkSystemAlertWindowPermission(getContext());
-                                        }
-                                    })
-                                    .show();
+                    Snackbar.make(getListView(), R.string.permission_display_over_apps, Snackbar.LENGTH_INDEFINITE)
+                            .setAction(R.string.settings,
+                                    view -> PermissionHelper.checkSystemAlertWindowPermission(getContext()))
+                            .show();
 
-                    }
                 }
             }
-
         };
     }
-
 
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/settings/VideoAudioSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/VideoAudioSettingsFragment.java
@@ -1,12 +1,68 @@
 package org.schabi.newpipe.settings;
 
+import android.content.SharedPreferences;
+import android.os.Build;
 import android.os.Bundle;
+import android.provider.Settings;
+import android.view.View;
+
+import androidx.annotation.Nullable;
+
+import com.google.android.material.snackbar.Snackbar;
 
 import org.schabi.newpipe.R;
+import org.schabi.newpipe.util.PermissionHelper;
 
 public class VideoAudioSettingsFragment extends BasePreferenceFragment {
+
+    private SharedPreferences.OnSharedPreferenceChangeListener listener;
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        listener = new SharedPreferences.OnSharedPreferenceChangeListener() {
+            @Override
+            public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String s) {
+                if(s.equals(getString(R.string.minimize_on_exit_key))){
+                    String newSetting = sharedPreferences.getString(s,null);
+                    if(newSetting != null){
+                        if(newSetting.equals(getString(R.string.minimize_on_exit_popup_key))){
+                            if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !Settings.canDrawOverlays(getContext())){
+                                Snackbar.make(getListView(),R.string.permission_display_over_apps,Snackbar.LENGTH_INDEFINITE)
+                                        .setAction(R.string.settings, new View.OnClickListener() {
+                                            @Override
+                                            public void onClick(View view) {
+                                                PermissionHelper.checkSystemAlertWindowPermission(getContext());
+                                            }
+                                        })
+                                        .show();
+
+                            }
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+
+
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
         addPreferencesFromResource(R.xml.video_audio_settings);
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        getPreferenceManager().getSharedPreferences().registerOnSharedPreferenceChangeListener(listener);
+
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        getPreferenceManager().getSharedPreferences().unregisterOnSharedPreferenceChangeListener(listener);
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/settings/VideoAudioSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/VideoAudioSettingsFragment.java
@@ -27,29 +27,27 @@ public class VideoAudioSettingsFragment extends BasePreferenceFragment {
 
                 //on M and above, if user chooses to minimise to popup player on exit and the app doesn't have
                 //display over other apps permission, show a snackbar to let the user give permission
-                if(s.equals(getString(R.string.minimize_on_exit_key))){
+                if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
+                        s.equals(getString(R.string.minimize_on_exit_key))){
 
                     String newSetting = sharedPreferences.getString(s,null);
-                    if(newSetting != null){
+                    if(newSetting != null
+                            && newSetting.equals(getString(R.string.minimize_on_exit_popup_key))
+                            && !Settings.canDrawOverlays(getContext())){
 
-                        if(newSetting.equals(getString(R.string.minimize_on_exit_popup_key))){
+                            Snackbar.make(getListView(),R.string.permission_display_over_apps,Snackbar.LENGTH_INDEFINITE)
+                                    .setAction(R.string.settings, new View.OnClickListener() {
+                                        @Override
+                                        public void onClick(View view) {
+                                            PermissionHelper.checkSystemAlertWindowPermission(getContext());
+                                        }
+                                    })
+                                    .show();
 
-                            if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !Settings.canDrawOverlays(getContext())){
-
-                                Snackbar.make(getListView(),R.string.permission_display_over_apps,Snackbar.LENGTH_INDEFINITE)
-                                        .setAction(R.string.settings, new View.OnClickListener() {
-                                            @Override
-                                            public void onClick(View view) {
-                                                PermissionHelper.checkSystemAlertWindowPermission(getContext());
-                                            }
-                                        })
-                                        .show();
-
-                            }
-                        }
                     }
                 }
             }
+
         };
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -227,6 +227,7 @@
     <string name="saved_tabs_invalid_json">Using default tabs, error while reading saved tabs</string>
     <string name="restore_defaults">Restore defaults</string>
     <string name="restore_defaults_confirmation">Do you want to restore the defaults?</string>
+    <string name="permission_display_over_apps">Give permission to display over other apps</string>
     <!-- error activity -->
     <string name="sorry_string">Sorry, that should not have happened.</string>
     <string name="guru_meditation" translatable="false">Guru Meditation.</string>


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

#2922 - This issue seems to happen on any device on Android 6 and above. Specifically on Android 10, it seems like it doesn't open the Settings window for the permission when the home button is pressed. But even in cases where it does show the window, it won't open the popup window when you give it the permission. 

So i added a snackbar that lets the user go to the settings when they set the "minimise on home" option to "minimise to popup player". 
