### PR TITLE
Add YouTube Music to supported links

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -145,6 +145,7 @@
                 <data android:host="youtube.com"/>
                 <data android:host="m.youtube.com"/>
                 <data android:host="www.youtube.com"/>
+                <data android:host="music.youtube.com"/>
                 <!-- video prefix -->
                 <data android:pathPrefix="/v/"/>
                 <data android:pathPrefix="/embed/"/>


### PR DESCRIPTION
This works when sharing songs from the YouTube Music app. From the web browser interface for YouTube Music, opening the link in NewPipe app causes a playlist to open that contains the song. This isn't ideal and will require some extractor changes that I will do later, if I can figure it out.

I chose to put the URL into the intent I chose because the one with youtu.be causes a worse result from the web interface. It caused an error instead of just opening as a playlist.

I understand if this is chosen not to be merged until I get the extractor end working.

Debug APK: [ytmusic.zip](https://github.com/TeamNewPipe/NewPipe/files/4184022/ytmusic.zip)

- [X] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
