### PR TITLE
Fixed brightness resetting on first gesture

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
@@ -909,6 +909,9 @@ public final class MainVideoPlayer extends AppCompatActivity
                 final float currentVolumeNormalized = (float) getAudioReactor().getVolume() / getAudioReactor().getMaxVolume();
                 volumeProgressBar.setProgress((int) (volumeProgressBar.getMax() * currentVolumeNormalized));
             }
+            //Set initial value for brightness progress bar based on current screen brightness
+            WindowManager.LayoutParams layoutParams = getWindow().getAttributes();
+            brightnessProgressBar.setProgress((int)(layoutParams.screenBrightness * brightnessProgressBar.getMax()));
         }
 
         @Override


### PR DESCRIPTION
- [x]  I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

Fixes #3084 

Brightness gesture now works the same ways as volume gesture. The brightness progress bar value is set to previously saved gesture value and increases/decreases value based on relative moment from this value. Previously saved brightness gesture value is calculated by current screen brightness.

Tested different brightness values and verified if the value persists in the next play.
[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/4209395/app-debug.zip)

