### PR TITLE
Migrate annotation to androidx on ReCaptchaActivity

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/ReCaptchaActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/ReCaptchaActivity.java
@@ -18,7 +18,7 @@ import android.webkit.WebViewClient;
 
 import org.schabi.newpipe.util.ThemeHelper;
 
-import javax.annotation.Nonnull;
+import androidx.annotation.NonNull;
 
 /*
  * Created by beneth <bmauduit@beneth.fr> on 06.12.16.
@@ -147,7 +147,7 @@ public class ReCaptchaActivity extends AppCompatActivity {
         // add other methods to extract cookies here
     }
 
-    private void addYoutubeCookies(@Nonnull String cookies) {
+    private void addYoutubeCookies(@NonNull String cookies) {
         if (cookies.contains("s_gl=") || cookies.contains("goojf=") || cookies.contains("VISITOR_INFO1_LIVE=")) {
             // youtube seems to also need the other cookies:
             addCookie(cookies);


### PR DESCRIPTION
Release build is failing without this on android studio

Cheers

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
