### PR TITLE
Reintroduce "Settings" button in app bar

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -453,15 +453,9 @@ public class MainActivity extends AppCompatActivity {
             NavigationHelper.openMainActivity(this);
         }
 
-        if (sharedPreferences.getBoolean(Constants.KEY_ENABLE_WATCH_HISTORY, true)) {
-            if (DEBUG) Log.d(TAG, "do not show History-menu as its disabled in settings");
-            drawerItems.getMenu().findItem(ITEM_ID_HISTORY).setVisible(true);
-        }
-
-        if (!sharedPreferences.getBoolean(Constants.KEY_ENABLE_WATCH_HISTORY, true)) {
-            if (DEBUG) Log.d(TAG, "show History-menu as its enabled in settings");
-            drawerItems.getMenu().findItem(ITEM_ID_HISTORY).setVisible(false);
-        }
+        final boolean isHistoryEnabled = sharedPreferences.getBoolean(
+                getString(R.string.enable_watch_history_key), true);
+        drawerItems.getMenu().findItem(ITEM_ID_HISTORY).setVisible(isHistoryEnabled);
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/about/AboutActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/about/AboutActivity.java
@@ -89,13 +89,6 @@ public class AboutActivity extends AppCompatActivity {
 
 
     @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
-        // Inflate the menu; this adds items to the action bar if it is present.
-        getMenuInflater().inflate(R.menu.menu_about, menu);
-        return true;
-    }
-
-    @Override
     public boolean onOptionsItemSelected(MenuItem item) {
 
         int id = item.getItemId();

--- a/app/src/main/java/org/schabi/newpipe/download/DownloadActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadActivity.java
@@ -80,9 +80,6 @@ public class DownloadActivity extends AppCompatActivity {
             case android.R.id.home:
                 onBackPressed();
                 return true;
-            case R.id.action_settings:
-                NavigationHelper.openSettings(this);
-                return true;
             default:
                 return super.onOptionsItemSelected(item);
         }

--- a/app/src/main/java/org/schabi/newpipe/download/DownloadActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadActivity.java
@@ -12,6 +12,7 @@ import android.view.MenuItem;
 import android.view.ViewTreeObserver;
 
 import org.schabi.newpipe.R;
+import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.ThemeHelper;
 
 import us.shandian.giga.service.DownloadManagerService;
@@ -76,11 +77,12 @@ public class DownloadActivity extends AppCompatActivity {
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
-            case android.R.id.home: {
+            case android.R.id.home:
                 onBackPressed();
                 return true;
-            }
-
+            case R.id.action_settings:
+                NavigationHelper.openSettings(this);
+                return true;
             default:
                 return super.onOptionsItemSelected(item);
         }

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -600,22 +600,27 @@ public class VideoDetailFragment
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        if (isLoading.get()) {
-            // if is still loading block menu
+        int id = item.getItemId();
+        if (id == R.id.action_settings) {
+            NavigationHelper.openSettings(requireContext());
             return true;
         }
 
-        int id = item.getItemId();
+        if (isLoading.get()) {
+            // if still loading, block menu buttons related to video info
+            return true;
+        }
+
         switch (id) {
             case R.id.menu_item_share: {
                 if (currentInfo != null) {
-                    ShareUtils.shareUrl(this.getContext(), currentInfo.getName(), currentInfo.getOriginalUrl());
+                    ShareUtils.shareUrl(requireContext(), currentInfo.getName(), currentInfo.getOriginalUrl());
                 }
                 return true;
             }
             case R.id.menu_item_openInBrowser: {
                 if (currentInfo != null) {
-                    ShareUtils.openUrlInBrowser(this.getContext(), currentInfo.getOriginalUrl());
+                    ShareUtils.openUrlInBrowser(requireContext(), currentInfo.getOriginalUrl());
                 }
                 return true;
             }

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
@@ -175,17 +175,20 @@ public class ChannelFragment extends BaseListInfoFragment<ChannelInfo> {
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
+            case R.id.action_settings:
+                NavigationHelper.openSettings(requireContext());
+                break;
             case R.id.menu_item_rss:
                 openRssFeed();
                 break;
             case R.id.menu_item_openInBrowser:
                 if (currentInfo != null) {
-                    ShareUtils.openUrlInBrowser(this.getContext(), currentInfo.getOriginalUrl());
+                    ShareUtils.openUrlInBrowser(requireContext(), currentInfo.getOriginalUrl());
                 }
                 break;
             case R.id.menu_item_share:
                 if (currentInfo != null) {
-                    ShareUtils.shareUrl(this.getContext(), name, currentInfo.getOriginalUrl());
+                    ShareUtils.shareUrl(requireContext(), name, currentInfo.getOriginalUrl());
                 }
                 break;
             default:

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
@@ -222,11 +222,14 @@ public class PlaylistFragment extends BaseListInfoFragment<PlaylistInfo> {
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
+            case R.id.action_settings:
+                NavigationHelper.openSettings(requireContext());
+                break;
             case R.id.menu_item_openInBrowser:
-                ShareUtils.openUrlInBrowser(this.getContext(), url);
+                ShareUtils.openUrlInBrowser(requireContext(), url);
                 break;
             case R.id.menu_item_share:
-                ShareUtils.shareUrl(this.getContext(), name, url);
+                ShareUtils.shareUrl(requireContext(), name, url);
                 break;
             case R.id.menu_item_bookmark:
                 onBookmarkClicked();

--- a/app/src/main/java/org/schabi/newpipe/player/ServicePlayerActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ServicePlayerActivity.java
@@ -156,6 +156,9 @@ public abstract class ServicePlayerActivity extends AppCompatActivity
             case android.R.id.home:
                 finish();
                 return true;
+            case R.id.action_settings:
+                NavigationHelper.openSettings(this);
+                return true;
             case R.id.action_append_playlist:
                 appendAllToPlaylist();
                 return true;

--- a/app/src/main/java/org/schabi/newpipe/util/Constants.java
+++ b/app/src/main/java/org/schabi/newpipe/util/Constants.java
@@ -11,7 +11,5 @@ public class Constants {
     public static final String KEY_THEME_CHANGE = "key_theme_change";
     public static final String KEY_MAIN_PAGE_CHANGE = "key_main_page_change";
 
-    public static final String KEY_ENABLE_WATCH_HISTORY = "enable_watch_history";
-
     public static final int NO_SERVICE_ID = -1;
 }

--- a/app/src/main/res/menu/download_menu.xml
+++ b/app/src/main/res/menu/download_menu.xml
@@ -27,4 +27,7 @@
         android:title="@string/clear_download_history"
         app:showAsAction="ifRoom" />
 
+    <item android:id="@+id/action_settings"
+        android:title="@string/settings"
+        app:showAsAction="never" />
 </menu>

--- a/app/src/main/res/menu/download_menu.xml
+++ b/app/src/main/res/menu/download_menu.xml
@@ -26,8 +26,4 @@
         android:icon="?attr/ic_delete"
         android:title="@string/clear_download_history"
         app:showAsAction="ifRoom" />
-
-    <item android:id="@+id/action_settings"
-        android:title="@string/settings"
-        app:showAsAction="never" />
 </menu>

--- a/app/src/main/res/menu/menu_about.xml
+++ b/app/src/main/res/menu/menu_about.xml
@@ -1,6 +1,0 @@
-<menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:context="org.schabi.newpipe.about.AboutActivity">
-
-</menu>

--- a/app/src/main/res/menu/menu_channel.xml
+++ b/app/src/main/res/menu/menu_channel.xml
@@ -5,11 +5,6 @@
     tools:context=".fragments.list.impl.ChannelFragment">
 
     <item
-        android:id="@+id/menu_item_openInBrowser"
-        android:title="@string/open_in_browser"
-        app:showAsAction="never"/>
-
-    <item
         android:id="@+id/menu_item_rss"
         android:icon="?attr/rss"
         android:title="@string/rss_button_title"
@@ -22,4 +17,16 @@
         android:icon="?attr/share"
         android:title="@string/share"
         app:showAsAction="ifRoom"/>
+
+    <item
+        android:id="@+id/action_settings"
+        android:orderInCategory="1"
+        android:title="@string/settings"
+        app:showAsAction="never"/>
+
+    <item
+        android:id="@+id/menu_item_openInBrowser"
+        android:orderInCategory="2"
+        android:title="@string/open_in_browser"
+        app:showAsAction="never"/>
 </menu>

--- a/app/src/main/res/menu/menu_play_queue.xml
+++ b/app/src/main/res/menu/menu_play_queue.xml
@@ -10,13 +10,18 @@
         android:visible="true"
         app:showAsAction="ifRoom"/>
 
+    <item android:id="@+id/action_settings"
+        android:orderInCategory="1"
+        android:title="@string/settings"
+        app:showAsAction="never"/>
+
     <item android:id="@+id/action_system_audio"
-        android:orderInCategory="996"
+        android:orderInCategory="2"
         android:title="@string/play_queue_audio_settings"
         app:showAsAction="never"/>
 
     <item android:id="@+id/action_switch_main"
-        android:orderInCategory="999"
+        android:orderInCategory="3"
         android:title="@string/switch_to_main"
         app:showAsAction="never"/>
 </menu>

--- a/app/src/main/res/menu/menu_playlist.xml
+++ b/app/src/main/res/menu/menu_playlist.xml
@@ -4,11 +4,6 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <item
-        android:id="@+id/menu_item_openInBrowser"
-        android:title="@string/open_in_browser"
-        app:showAsAction="never"/>
-
-    <item
         android:id="@+id/menu_item_share"
         android:icon="?attr/share"
         android:title="@string/share"
@@ -21,4 +16,16 @@
         android:visible="true"
         app:showAsAction="ifRoom"
         tools:visible="true"/>
+
+    <item
+        android:id="@+id/action_settings"
+        android:orderInCategory="1"
+        android:title="@string/settings"
+        app:showAsAction="never"/>
+
+    <item
+        android:id="@+id/menu_item_openInBrowser"
+        android:orderInCategory="2"
+        android:title="@string/open_in_browser"
+        app:showAsAction="never"/>
 </menu>

--- a/app/src/main/res/menu/video_detail_menu.xml
+++ b/app/src/main/res/menu/video_detail_menu.xml
@@ -15,7 +15,14 @@
         app:showAsAction="ifRoom"/>
 
     <item
+        android:id="@+id/action_settings"
+        android:orderInCategory="1"
+        android:title="@string/settings"
+        app:showAsAction="never"/>
+
+    <item
         android:id="@+id/menu_item_openInBrowser"
+        android:orderInCategory="2"
         android:title="@string/open_in_browser"
         app:showAsAction="never"/>
 </menu>


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

As noted by @opusforlife2 in https://github.com/TeamNewPipe/NewPipe/issues/3114#issuecomment-589933537 it is sometimes useful to access settings from activities other than the main one. So this PR readds *some* "Settings" buttons removed in #2960.

In particular, the activities where the button is restored are:
- Queue (background and popup queue activities)
- VideoDetail (see @opusforlife2 usecase)
- Playlist (same as VideoDetail)
- Channel (same as VideoDetail)
- Download (I'm not really sure about this one, because the Download activity is only accessible via the drawer and the user could just press "back", so it would categorize as one of the activities below that do not require the button, but I feel like it would be useful anyway sometimes... **could you give some feedback?**)

Other activities that I think don't need the button, because accessing settings from there is unusual or pressing "back" once is enough:
- MainActivity (just open the drawer)
- Kiosk (press back and the drawer is already open because it was used to open the KioskActivity itself)
- Bookmarks (same as Kiosk)
- What's New (same as Kiosk)
- Subscriptions (same as Kiosk)
- History (same as Kiosk)