### PR TITLE
Internal updater

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES"/>
 
     <application
         android:name=".App"

--- a/app/src/main/java/org/schabi/newpipe/App.java
+++ b/app/src/main/java/org/schabi/newpipe/App.java
@@ -112,7 +112,7 @@ public class App extends Application {
         configureRxJavaErrorHandler();
 
         // Check for new version
-        new CheckForNewAppVersionTask().execute();
+        new CheckForNewAppVersionTask(false).execute();
     }
 
     protected Downloader getDownloader() {

--- a/app/src/main/java/org/schabi/newpipe/CheckForNewAppVersionTask.java
+++ b/app/src/main/java/org/schabi/newpipe/CheckForNewAppVersionTask.java
@@ -9,7 +9,6 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.Signature;
 import android.net.ConnectivityManager;
-import android.net.Uri;
 import android.os.AsyncTask;
 import android.preference.PreferenceManager;
 import androidx.core.app.NotificationCompat;
@@ -20,6 +19,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.schabi.newpipe.report.ErrorActivity;
 import org.schabi.newpipe.report.UserAction;
+import org.schabi.newpipe.settings.SettingsActivity;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -147,7 +147,9 @@ public class CheckForNewAppVersionTask extends AsyncTask<Void, Void, String> {
         if (BuildConfig.VERSION_CODE < Integer.valueOf(versionCode)) {
 
             // A pending intent to open the apk location url in the browser.
-            Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(apkLocationUrl));
+            Intent intent = new Intent(App.getApp(), SettingsActivity.class);
+            intent.putExtra("update", true);
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             PendingIntent pendingIntent
                     = PendingIntent.getActivity(app, 0, intent, 0);
 

--- a/app/src/main/java/org/schabi/newpipe/settings/CheckForUpdatesFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/CheckForUpdatesFragment.java
@@ -1,6 +1,8 @@
 package org.schabi.newpipe.settings;
 
+import android.Manifest;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
@@ -15,6 +17,7 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
 import androidx.core.content.FileProvider;
 
 import org.schabi.newpipe.BaseFragment;
@@ -43,6 +46,7 @@ public class CheckForUpdatesFragment extends BaseFragment implements CheckForNew
     private ProgressBar mProgressBar;
 
     private boolean checked = false;
+    private String apkUrl;
 
     private File downloads = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
 
@@ -147,6 +151,37 @@ public class CheckForUpdatesFragment extends BaseFragment implements CheckForNew
      * This downloads a new apk version to the cache and installs it
      */
     private void downloadNewVersion(String apkUrl) {
+
+        this.apkUrl = apkUrl;
+
+        // can't use ActivityCompat.checkWriteStoragePermissions() because it does not work within fragments
+        if (ContextCompat.checkSelfPermission(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                != PackageManager.PERMISSION_GRANTED) {
+            requestPermissions(new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, 1337);
+        } else {
+            startDownload(this.apkUrl);
+        }
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        for (int i: grantResults){
+            if (i == PackageManager.PERMISSION_DENIED){
+                return;
+            }
+        }
+        startDownload(this.apkUrl);
+    }
+
+    /**
+     * This starts the download
+     */
+    private void startDownload(String apkUrl) {
+
+        if (apkUrl == null)
+            return;
+
+        Log.i("CheckForUpdatesFragment", "Downloading " + apkUrl);
 
         mActionButton.setVisibility(View.GONE);
         mProgressBar.setVisibility(View.VISIBLE);

--- a/app/src/main/java/org/schabi/newpipe/settings/CheckForUpdatesFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/CheckForUpdatesFragment.java
@@ -5,6 +5,7 @@ import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Environment;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -250,7 +251,7 @@ public class CheckForUpdatesFragment extends BaseFragment implements CheckForNew
                 }
 
             } catch (IOException e) {
-                e.printStackTrace();
+                Log.e("CheckForUpdatesFragment", "Update download failed: ", e);
                 return FAILED;
             }
 
@@ -258,10 +259,10 @@ public class CheckForUpdatesFragment extends BaseFragment implements CheckForNew
         }
 
         @Override
-        protected void onPostExecute(Integer aVoid) {
-            super.onPostExecute(aVoid);
-            System.out.println(aVoid);
-            if (aVoid == FAILED) {
+        protected void onPostExecute(Integer res) {
+            super.onPostExecute(res);
+            Log.i("CheckForUpdatesFragment", "Task returned " + res);
+            if (res == FAILED) {
                 listener.fail();
                 return;
             }

--- a/app/src/main/java/org/schabi/newpipe/settings/CheckForUpdatesFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/CheckForUpdatesFragment.java
@@ -1,0 +1,285 @@
+package org.schabi.newpipe.settings;
+
+import android.content.Intent;
+import android.net.Uri;
+import android.os.AsyncTask;
+import android.os.Bundle;
+import android.os.Environment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.content.FileProvider;
+
+import org.schabi.newpipe.BaseFragment;
+import org.schabi.newpipe.BuildConfig;
+import org.schabi.newpipe.CheckForNewAppVersionTask;
+import org.schabi.newpipe.R;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Locale;
+
+/**
+ * This is a fragment that checks for updates, downloads them, and offers them for install
+ */
+public class CheckForUpdatesFragment extends BaseFragment implements CheckForNewAppVersionTask.UpdateCallback {
+
+    public static final String APK_NAME = "/newpipe.apk";
+
+    private TextView mTitle;
+    private TextView mSubtitle;
+    private Button mActionButton;
+    private ProgressBar mProgressBar;
+
+    private boolean checked = false;
+
+    private File downloads = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        View root = inflater.inflate(R.layout.fragment_update_check, container, false);
+        mTitle = root.findViewById(R.id.check_for_updates_title);
+        mSubtitle = root.findViewById(R.id.check_for_updates_subtitle);
+        mActionButton = root.findViewById(R.id.check_for_updates_download);
+        mProgressBar = root.findViewById(R.id.check_for_updates_progress);
+        return root;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        checkForUpdates();
+    }
+
+    /**
+     * This performs a check for updates
+     */
+    private void checkForUpdates() {
+
+        if (checked)
+            return;
+
+        mProgressBar.setVisibility(View.GONE);
+        mActionButton.setVisibility(View.GONE);
+
+        mTitle.setText(R.string.updates_checking_for_updates);
+        mSubtitle.setText("");
+
+        CheckForNewAppVersionTask task = new CheckForNewAppVersionTask(true);
+        task.setUpdateCallback(this);
+        task.execute();
+
+    }
+
+    /**
+     * This is the callback from the version check
+     */
+    @Override
+    public void updateAvailable(String versionName, String versionCode, String apkUrl) {
+        if (versionCode == null)
+            failedToCheck();
+        else if (BuildConfig.VERSION_CODE < Integer.valueOf(versionCode))
+            updatesAreAvailable(versionName, apkUrl);
+        else if (BuildConfig.VERSION_CODE == Integer.valueOf(versionCode))
+            applicationUpToDate(versionName);
+        checked = true;
+    }
+
+    /**
+     * This callback happens when the app is up to date
+     */
+    private void applicationUpToDate(String versionName) {
+
+        mTitle.setText(R.string.updates_app_up_to_date);
+        mSubtitle.setText(versionName);
+
+        mActionButton.setVisibility(View.VISIBLE);
+        mActionButton.setText(R.string.updates_check_for_updates);
+        mActionButton.setOnClickListener((v) -> {
+            checked = false;
+            checkForUpdates();
+        });
+    }
+
+    /**
+     * The update check has failed... show that
+     */
+    private void failedToCheck() {
+        mTitle.setText(R.string.updates_failed_to_check);
+        mSubtitle.setText("");
+        mProgressBar.setVisibility(View.GONE);
+
+        mActionButton.setVisibility(View.VISIBLE);
+        mActionButton.setText(R.string.updates_check_for_updates);
+        mActionButton.setOnClickListener((v) -> {
+            checked = false;
+            checkForUpdates();
+        });
+    }
+
+    /**
+     * There are updates available!
+     */
+    private void updatesAreAvailable(String versionName, String apkUrl) {
+        mTitle.setText(String.format(getText(R.string.updates_new_version_available).toString(), versionName));
+        mSubtitle.setText(R.string.updates_click_to_download);
+
+        mActionButton.setVisibility(View.VISIBLE);
+        mActionButton.setText(R.string.download);
+        mActionButton.setOnClickListener((v) -> {
+            downloadNewVersion(apkUrl);
+        });
+    }
+
+    /**
+     * This downloads a new apk version to the cache and installs it
+     */
+    private void downloadNewVersion(String apkUrl) {
+
+        mActionButton.setVisibility(View.GONE);
+        mProgressBar.setVisibility(View.VISIBLE);
+
+        mTitle.setText(R.string.updates_downloading);
+        mSubtitle.setText(R.string.updates_connecting);
+
+        ApkDownloadTask task = new ApkDownloadTask(new ApkDownloadTask.DownloadListener() {
+
+            @Override
+            public void update(int progress, boolean done) {
+                mProgressBar.setProgress(progress);
+                mSubtitle.setText(String.format(Locale.ENGLISH,"%d %%", progress));
+                if (done)
+                    installApk();
+            }
+
+            @Override
+            public void fail() {
+                failedToCheck();
+            }
+        });
+
+        task.execute(apkUrl, new File(downloads, APK_NAME)
+                .getAbsolutePath());
+
+    }
+
+    /**
+     * This installs the APK
+     */
+    private void installApk() {
+
+        mProgressBar.setVisibility(View.GONE);
+        mTitle.setText(R.string.updates_ready);
+        mSubtitle.setText(R.string.updates_press_to_install);
+
+        mActionButton.setVisibility(View.VISIBLE);
+        mActionButton.setText(R.string.install);
+        mActionButton.setOnClickListener((v) -> {
+
+            File file = new File(downloads, APK_NAME);
+            Uri fileUri = FileProvider.getUriForFile(getContext(),
+                    BuildConfig.APPLICATION_ID + ".provider",
+                    file);
+
+            Intent intent = new Intent(Intent.ACTION_VIEW);
+            intent.setDataAndType(fileUri,"application/vnd.android.package-archive");
+            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+            intent.putExtra(Intent.EXTRA_NOT_UNKNOWN_SOURCE, true);
+            startActivity(intent);
+
+        });
+
+    }
+
+    /**
+     * This is a task that downloads the APK to the disk
+     */
+    private static class ApkDownloadTask extends AsyncTask<String, Integer, Integer> {
+
+        private static final int OK = 0;
+        private static final int FAILED = 1;
+        private DownloadListener listener;
+
+        public ApkDownloadTask(DownloadListener listener) {
+            this.listener = listener;
+        }
+
+        @Override
+        protected Integer doInBackground(String... strings) {
+
+            try {
+                URL url = new URL(strings[0]);
+                HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+                int code = connection.getResponseCode();
+                if (code == HttpURLConnection.HTTP_OK) {
+                    InputStream in = connection.getInputStream();
+                    FileOutputStream fos = new FileOutputStream(strings[1]);
+                    int length = connection.getContentLength();
+                    float totalRead = 0;
+                    int previous = 0;
+                    int current;
+                    int b;
+                    byte[] buf = new byte[8192];
+                    while ((b = in.read(buf)) != -1) {
+                        totalRead += b;
+                        current = Math.round(totalRead / length * 100.0f);
+                        /*
+                         * with this we limit sub-perc micro-updating of the UI
+                         */
+                        if (current != previous) {
+                            previous = current;
+                            publishProgress(current);
+                        }
+                        fos.write(buf, 0, b);
+                    }
+                    in.close();
+                    fos.close();
+                    return OK;
+                }
+
+            } catch (IOException e) {
+                e.printStackTrace();
+                return FAILED;
+            }
+
+            return OK;
+        }
+
+        @Override
+        protected void onPostExecute(Integer aVoid) {
+            super.onPostExecute(aVoid);
+            System.out.println(aVoid);
+            if (aVoid == FAILED) {
+                listener.fail();
+                return;
+            }
+            listener.update(100, true);
+        }
+
+        @Override
+        protected void onProgressUpdate(Integer... values) {
+            super.onProgressUpdate(values);
+            listener.update(values[0], false);
+
+        }
+
+        public interface DownloadListener {
+            void update(int progress, boolean done);
+            void fail();
+        }
+    }
+
+
+}

--- a/app/src/main/java/org/schabi/newpipe/settings/MainSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/MainSettingsFragment.java
@@ -14,7 +14,7 @@ public class MainSettingsFragment extends BasePreferenceFragment {
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
         addPreferencesFromResource(R.xml.main_settings);
 
-        if (!CheckForNewAppVersionTask.isGithubApk()) {
+        if (!CheckForNewAppVersionTask.isGithubApk() && !DEBUG) {
             final Preference update = findPreference(getString(R.string.update_pref_screen_key));
             getPreferenceScreen().removePreference(update);
 

--- a/app/src/main/java/org/schabi/newpipe/settings/SettingsActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/SettingsActivity.java
@@ -1,6 +1,7 @@
 package org.schabi.newpipe.settings;
 
 import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
 import androidx.fragment.app.Fragment;
 import androidx.appcompat.app.ActionBar;
@@ -52,9 +53,12 @@ public class SettingsActivity extends AppCompatActivity implements BasePreferenc
         Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
 
+        Intent intent = getIntent();
+        boolean update = intent.getBooleanExtra("update", false);
+
         if (savedInstanceBundle == null) {
             getSupportFragmentManager().beginTransaction()
-                    .replace(R.id.fragment_holder, new MainSettingsFragment())
+                    .replace(R.id.fragment_holder, update ? new CheckForUpdatesFragment() : new MainSettingsFragment())
                     .commit();
         }
     }

--- a/app/src/main/res/layout/fragment_update_check.xml
+++ b/app/src/main/res/layout/fragment_update_check.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <ImageView
+        android:id="@+id/check_for_updates_icon"
+        android:layout_marginTop="100dp"
+        android:layout_centerHorizontal="true"
+        android:src="@mipmap/ic_launcher"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
+
+    </ImageView>
+
+    <TextView
+        android:textColor="@color/white"
+        android:textSize="@dimen/header_footer_text_size"
+        android:layout_marginTop="@dimen/activity_vertical_margin"
+        android:layout_centerHorizontal="true"
+        android:layout_below="@id/check_for_updates_icon"
+        tools:text="Checking for updates..."
+        android:id="@+id/check_for_updates_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
+    </TextView>
+
+    <TextView
+        android:id="@+id/check_for_updates_subtitle"
+        tools:text="18.4.0"
+        android:layout_marginTop="@dimen/activity_vertical_margin"
+        android:layout_below="@id/check_for_updates_title"
+        android:layout_centerHorizontal="true"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
+
+    </TextView>
+
+    <Button
+        android:visibility="gone"
+        android:id="@+id/check_for_updates_download"
+        android:layout_centerHorizontal="true"
+        android:layout_marginBottom="@dimen/activity_vertical_margin"
+        android:layout_alignParentBottom="true"
+        android:text="@string/download"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
+    </Button>
+
+    <ProgressBar
+        style="?android:attr/progressBarStyleHorizontal"
+        android:visibility="gone"
+        android:id="@+id/check_for_updates_progress"
+        android:layout_margin="@dimen/activity_vertical_margin"
+        android:layout_alignParentBottom="true"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+    </ProgressBar>
+
+</RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -593,6 +593,18 @@
     <string name="app_language_title">App language</string>
     <string name="systems_language">System default</string>
     <string name="dynamic_seek_duration_description">%s seconds</string>
+    <string name="updates_check_for_updates">Check for updates</string>
+    <string name="updates_check_for_updates_summary">Click here to check for a new version</string>
+    <string name="update_show_notification">Show a notification</string>
+    <string name="updates_checking_for_updates">Checking for updates...</string>
+    <string name="updates_app_up_to_date">NewPipe is up to date</string>
+    <string name="updates_failed_to_check">Update check failed</string>
+    <string name="updates_new_version_available">New version is available (%s)</string>
+    <string name="updates_click_to_download">Click the download button to update</string>
+    <string name="updates_ready">Update is ready</string>
+    <string name="updates_press_to_install">Click install to install the update</string>
+    <string name="updates_downloading">Downloading update...</string>
+    <string name="updates_connecting">Connecting to update server...</string>
     <plurals name="dynamic_seek_duration_description">
         <item quantity="other">%s seconds</item>
     </plurals>

--- a/app/src/main/res/xml/update_settings.xml
+++ b/app/src/main/res/xml/update_settings.xml
@@ -9,7 +9,13 @@
         app:iconSpaceReserved="false"
         android:defaultValue="true"
         android:key="@string/update_app_key"
-        android:title="@string/updates_setting_title"
+        android:title="@string/update_show_notification"
         android:summary="@string/updates_setting_description"/>
+
+    <PreferenceScreen
+        app:iconSpaceReserved="false"
+        android:title="@string/updates_check_for_updates"
+        android:summary="@string/updates_check_for_updates_summary"
+        android:fragment="org.schabi.newpipe.settings.CheckForUpdatesFragment"/>
 
 </PreferenceScreen>


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

This adds an internal updater, that is used instead of the external download action. It also adds a "check for updates" action to the update settings

The updater:

1) Checks for updates using the existing `CheckForNewAppVersionTask`
2) Downloads the latest apk file according to `CheckForNewAppVersionTask` to Downloads/newpipe.apk
3) Runs the package installer

The edits to existing code are minimal

![](https://i.imgur.com/bFGMWux.jpg)
![](https://i.imgur.com/ciKB51R.jpg)
![](https://i.imgur.com/jxosKKc.jpg)
![](https://i.imgur.com/fH7gQZi.jpg)