### PR TITLE
Hide 5, 15, 25 second seek options if inexact seek is enabled

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/settings/VideoAudioSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/VideoAudioSettingsFragment.java
@@ -7,6 +7,7 @@ import android.os.Bundle;
 import android.provider.Settings;
 
 import android.text.format.DateUtils;
+import android.widget.Toast;
 import androidx.annotation.Nullable;
 import androidx.preference.ListPreference;
 
@@ -86,8 +87,16 @@ public class VideoAudioSettingsFragment extends BasePreferenceFragment {
         durations.setEntries(displayedDescriptionValues.toArray(new CharSequence[0]));
         final int selectedDuration = Integer.parseInt(durations.getValue());
         if (selectedDuration / (int) DateUtils.SECOND_IN_MILLIS % 10 == 5) {
-            durations.setValue(
-                Integer.toString(selectedDuration + 5 * (int) DateUtils.SECOND_IN_MILLIS));
+            final int newDuration = selectedDuration / (int) DateUtils.SECOND_IN_MILLIS + 5;
+            durations.setValue(Integer.toString(newDuration * (int) DateUtils.SECOND_IN_MILLIS));
+
+            Toast toast = Toast.makeText(getContext(),
+                getString(R.string.new_seek_duration_toast) + " " + String.format(
+                    res.getQuantityString(R.plurals.dynamic_seek_duration_description,
+                        newDuration),
+                    newDuration),
+                Toast.LENGTH_LONG);
+            toast.show();
         }
     }
 

--- a/app/src/main/java/org/schabi/newpipe/settings/VideoAudioSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/VideoAudioSettingsFragment.java
@@ -6,6 +6,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.provider.Settings;
 
+import android.text.format.DateUtils;
 import androidx.annotation.Nullable;
 import androidx.preference.ListPreference;
 
@@ -65,7 +66,8 @@ public class VideoAudioSettingsFragment extends BasePreferenceFragment {
             .getBoolean(res.getString(R.string.use_inexact_seek_key), false);
 
         for (String durationsValue : durationsValues) {
-            currentDurationValue = Integer.parseInt(durationsValue) / 1000;
+            currentDurationValue =
+                Integer.parseInt(durationsValue) / (int) DateUtils.SECOND_IN_MILLIS;
             if (inexactSeek && currentDurationValue % 10 == 5) {
                 continue;
             }
@@ -83,8 +85,9 @@ public class VideoAudioSettingsFragment extends BasePreferenceFragment {
         durations.setEntryValues(displayedDurationValues.toArray(new CharSequence[0]));
         durations.setEntries(displayedDescriptionValues.toArray(new CharSequence[0]));
         final int selectedDuration = Integer.parseInt(durations.getValue());
-        if (selectedDuration / 1000 % 10 == 5) {
-            durations.setValue(Integer.toString(selectedDuration + 5 * 1000));
+        if (selectedDuration / (int) DateUtils.SECOND_IN_MILLIS % 10 == 5) {
+            durations.setValue(
+                Integer.toString(selectedDuration + 5 * (int) DateUtils.SECOND_IN_MILLIS));
         }
     }
 

--- a/app/src/main/java/org/schabi/newpipe/settings/VideoAudioSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/VideoAudioSettingsFragment.java
@@ -24,32 +24,7 @@ public class VideoAudioSettingsFragment extends BasePreferenceFragment {
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        //initializing R.array.seek_duration_description to display the translation of seconds
-        Resources res = getResources();
-        String[] durationsValues = res.getStringArray(R.array.seek_duration_value);
-        String[] durationsDescriptions = res.getStringArray(R.array.seek_duration_description);
-        List<String> durationsValResult = new LinkedList<>();
-        List<String> durationsDesResult = new LinkedList<>();
-        int currentDurationValue;
-        final boolean inexactSeek = getPreferenceManager().getSharedPreferences()
-            .getBoolean(res.getString(R.string.use_inexact_seek_key), false);
-
-        for (int i = 0; i < durationsDescriptions.length; i++) {
-            currentDurationValue = Integer.parseInt(durationsValues[i]) / 1000;
-            if (inexactSeek && currentDurationValue % 10 != 5) {
-                try {
-                    durationsValResult.add(durationsValues[i]);
-                    durationsDesResult.add(String.format(
-                        res.getQuantityString(R.plurals.dynamic_seek_duration_description, currentDurationValue),
-                        currentDurationValue));
-                } catch (Resources.NotFoundException ignored) {
-                    //if this happens, the translation is missing, and the english string will be displayed instead
-                }
-            }
-        }
-        ListPreference durations = (ListPreference) findPreference(getString(R.string.seek_duration_key));
-        durations.setEntryValues(durationsValResult.toArray(new CharSequence[0]));
-        durations.setEntries(durationsDesResult.toArray(new CharSequence[0]));
+        updateSeekOptions();
 
         listener = (sharedPreferences, s) -> {
 
@@ -69,8 +44,47 @@ public class VideoAudioSettingsFragment extends BasePreferenceFragment {
                             .show();
 
                 }
+            } else if (s.equals(getString(R.string.use_inexact_seek_key))) {
+                updateSeekOptions();
             }
         };
+    }
+
+    /**
+     * Update fast-forward/-rewind seek duration options according to language and inexact seek setting.
+     * Exoplayer can't seek 5 seconds in audio when using inexact seek.
+     */
+    private void updateSeekOptions() {
+        //initializing R.array.seek_duration_description to display the translation of seconds
+        final Resources res = getResources();
+        final String[] durationsValues = res.getStringArray(R.array.seek_duration_value);
+        final List<String> displayedDurationValues = new LinkedList<>();
+        final List<String> displayedDescriptionValues = new LinkedList<>();
+        int currentDurationValue;
+        final boolean inexactSeek = getPreferenceManager().getSharedPreferences()
+            .getBoolean(res.getString(R.string.use_inexact_seek_key), false);
+
+        for (String durationsValue : durationsValues) {
+            currentDurationValue = Integer.parseInt(durationsValue) / 1000;
+            if (inexactSeek && currentDurationValue % 10 == 5) {
+                continue;
+            }
+            try {
+                displayedDurationValues.add(durationsValue);
+                displayedDescriptionValues.add(String.format(
+                    res.getQuantityString(R.plurals.dynamic_seek_duration_description,
+                        currentDurationValue),
+                    currentDurationValue));
+            } catch (Resources.NotFoundException ignored) {
+                //if this happens, the translation is missing, and the english string will be displayed instead
+            }
+        }
+        final ListPreference durations = (ListPreference) findPreference(getString(R.string.seek_duration_key));
+        durations.setEntryValues(displayedDurationValues.toArray(new CharSequence[0]));
+        durations.setEntries(displayedDescriptionValues.toArray(new CharSequence[0]));
+        if (Integer.parseInt(durations.getValue()) / 1000 % 10 == 5) {
+            durations.setValueIndex(0);
+        }
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/settings/VideoAudioSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/VideoAudioSettingsFragment.java
@@ -82,6 +82,7 @@ public class VideoAudioSettingsFragment extends BasePreferenceFragment {
                 //if this happens, the translation is missing, and the english string will be displayed instead
             }
         }
+
         final ListPreference durations = (ListPreference) findPreference(getString(R.string.seek_duration_key));
         durations.setEntryValues(displayedDurationValues.toArray(new CharSequence[0]));
         durations.setEntries(displayedDescriptionValues.toArray(new CharSequence[0]));
@@ -90,12 +91,10 @@ public class VideoAudioSettingsFragment extends BasePreferenceFragment {
             final int newDuration = selectedDuration / (int) DateUtils.SECOND_IN_MILLIS + 5;
             durations.setValue(Integer.toString(newDuration * (int) DateUtils.SECOND_IN_MILLIS));
 
-            Toast toast = Toast.makeText(getContext(),
-                getString(R.string.new_seek_duration_toast) + " " + String.format(
-                    res.getQuantityString(R.plurals.dynamic_seek_duration_description,
-                        newDuration),
-                    newDuration),
-                Toast.LENGTH_LONG);
+            Toast toast = Toast
+                .makeText(getContext(),
+                    getString(R.string.new_seek_duration_toast, newDuration),
+                    Toast.LENGTH_LONG);
             toast.show();
         }
     }

--- a/app/src/main/java/org/schabi/newpipe/settings/VideoAudioSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/VideoAudioSettingsFragment.java
@@ -82,8 +82,9 @@ public class VideoAudioSettingsFragment extends BasePreferenceFragment {
         final ListPreference durations = (ListPreference) findPreference(getString(R.string.seek_duration_key));
         durations.setEntryValues(displayedDurationValues.toArray(new CharSequence[0]));
         durations.setEntries(displayedDescriptionValues.toArray(new CharSequence[0]));
-        if (Integer.parseInt(durations.getValue()) / 1000 % 10 == 5) {
-            durations.setValueIndex(0);
+        final int selectedDuration = Integer.parseInt(durations.getValue());
+        if (selectedDuration / 1000 % 10 == 5) {
+            durations.setValue(Integer.toString(selectedDuration + 5 * 1000));
         }
     }
 

--- a/app/src/main/java/org/schabi/newpipe/settings/VideoAudioSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/VideoAudioSettingsFragment.java
@@ -11,6 +11,8 @@ import androidx.preference.ListPreference;
 
 import com.google.android.material.snackbar.Snackbar;
 
+import java.util.LinkedList;
+import java.util.List;
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.util.PermissionHelper;
 
@@ -26,19 +28,28 @@ public class VideoAudioSettingsFragment extends BasePreferenceFragment {
         Resources res = getResources();
         String[] durationsValues = res.getStringArray(R.array.seek_duration_value);
         String[] durationsDescriptions = res.getStringArray(R.array.seek_duration_description);
+        List<String> durationsValResult = new LinkedList<>();
+        List<String> durationsDesResult = new LinkedList<>();
         int currentDurationValue;
+        final boolean inexactSeek = getPreferenceManager().getSharedPreferences()
+            .getBoolean(res.getString(R.string.use_inexact_seek_key), false);
+
         for (int i = 0; i < durationsDescriptions.length; i++) {
             currentDurationValue = Integer.parseInt(durationsValues[i]) / 1000;
-            try {
-                durationsDescriptions[i] = String.format(
+            if (inexactSeek && currentDurationValue % 10 != 5) {
+                try {
+                    durationsValResult.add(durationsValues[i]);
+                    durationsDesResult.add(String.format(
                         res.getQuantityString(R.plurals.dynamic_seek_duration_description, currentDurationValue),
-                        currentDurationValue);
-            } catch (Resources.NotFoundException ignored) {
-                //if this happens, the translation is missing, and the english string will be displayed instead
+                        currentDurationValue));
+                } catch (Resources.NotFoundException ignored) {
+                    //if this happens, the translation is missing, and the english string will be displayed instead
+                }
             }
         }
         ListPreference durations = (ListPreference) findPreference(getString(R.string.seek_duration_key));
-        durations.setEntries(durationsDescriptions);
+        durations.setEntryValues(durationsValResult.toArray(new CharSequence[0]));
+        durations.setEntries(durationsDesResult.toArray(new CharSequence[0]));
 
         listener = (sharedPreferences, s) -> {
 
@@ -61,7 +72,6 @@ public class VideoAudioSettingsFragment extends BasePreferenceFragment {
             }
         };
     }
-
 
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {

--- a/app/src/main/java/org/schabi/newpipe/settings/VideoAudioSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/VideoAudioSettingsFragment.java
@@ -72,8 +72,9 @@ public class VideoAudioSettingsFragment extends BasePreferenceFragment {
             if (inexactSeek && currentDurationValue % 10 == 5) {
                 continue;
             }
+
+            displayedDurationValues.add(durationsValue);
             try {
-                displayedDurationValues.add(durationsValue);
                 displayedDescriptionValues.add(String.format(
                     res.getQuantityString(R.plurals.dynamic_seek_duration_description,
                         currentDurationValue),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,7 +71,7 @@
     <string name="popup_remember_size_pos_title">Remember popup size and position</string>
     <string name="popup_remember_size_pos_summary">Remember last size and position of popup</string>
     <string name="use_inexact_seek_title">Use fast inexact seek</string>
-    <string name="use_inexact_seek_summary">Inexact seek allows the player to seek to positions faster with reduced precision</string>
+    <string name="use_inexact_seek_summary">Inexact seek allows the player to seek to positions faster with reduced precision. Seeking for 5, 15 or 25 seconds doesn\'t work with this.</string>
     <string name="seek_duration_title">Fast-forward/-rewind seek duration</string>
     <string name="download_thumbnail_title">Load thumbnails</string>
     <string name="show_comments_title">Show comments</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -593,7 +593,7 @@
     <string name="app_language_title">App language</string>
     <string name="systems_language">System default</string>
     <string name="dynamic_seek_duration_description">%s seconds</string>
-    <string name="new_seek_duration_toast">Due to ExoPlayer contraints the seek duration was set to %d seconds</string>
+    <string name="new_seek_duration_toast">Due to ExoPlayer constraints the seek duration was set to %d seconds</string>
     <plurals name="dynamic_seek_duration_description">
         <item quantity="other">%s seconds</item>
     </plurals>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -593,6 +593,7 @@
     <string name="app_language_title">App language</string>
     <string name="systems_language">System default</string>
     <string name="dynamic_seek_duration_description">%s seconds</string>
+    <string name="new_seek_duration_toast">Due to ExoPlayer contraints the seek duration was set to</string>
     <plurals name="dynamic_seek_duration_description">
         <item quantity="other">%s seconds</item>
     </plurals>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -593,7 +593,7 @@
     <string name="app_language_title">App language</string>
     <string name="systems_language">System default</string>
     <string name="dynamic_seek_duration_description">%s seconds</string>
-    <string name="new_seek_duration_toast">Due to ExoPlayer contraints the seek duration was set to</string>
+    <string name="new_seek_duration_toast">Due to ExoPlayer contraints the seek duration was set to %d seconds</string>
     <plurals name="dynamic_seek_duration_description">
         <item quantity="other">%s seconds</item>
     </plurals>


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

closes #3127 

Hides 5, 15, 25 second seek options if inexact seek is enabled. If one of those values was selected while activating inexact seek, it automatically gets set to 10 seconds.

Will the edited string resource make any problems concerning translation with weblate, since it was not a rewrite but adding additional info.

I tested it on my Android 10 and 7.1 devices.
Updated apk: [app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/4283025/app-debug.zip)

