### PR TITLE
Relocate two settings from Appearance to Content

### DIFF
--- a/app/src/main/res/xml/appearance_settings.xml
+++ b/app/src/main/res/xml/appearance_settings.xml
@@ -16,12 +16,6 @@
     <SwitchPreference
         app:iconSpaceReserved="false"
         android:defaultValue="true"
-        android:key="@string/show_next_video_key"
-        android:title="@string/show_next_and_similar_title"/>
-
-    <SwitchPreference
-        app:iconSpaceReserved="false"
-        android:defaultValue="true"
         android:key="@string/show_hold_to_append_key"
         android:title="@string/show_hold_to_append_title"
         android:summary="@string/show_hold_to_append_summary"/>
@@ -40,12 +34,5 @@
         android:key="@string/caption_settings_key"
         android:title="@string/caption_setting_title"
         android:summary="@string/caption_setting_description"/>
-
-    <PreferenceScreen
-        app:iconSpaceReserved="false"
-        android:fragment="org.schabi.newpipe.settings.tabs.ChooseTabsFragment"
-        android:summary="@string/main_page_content_summary"
-        android:key="@string/main_page_content_key"
-        android:title="@string/main_page_content"/>
 
 </PreferenceScreen>

--- a/app/src/main/res/xml/content_settings.xml
+++ b/app/src/main/res/xml/content_settings.xml
@@ -33,6 +33,13 @@
 
     <PreferenceScreen
         app:iconSpaceReserved="false"
+        android:fragment="org.schabi.newpipe.settings.tabs.ChooseTabsFragment"
+        android:summary="@string/main_page_content_summary"
+        android:key="@string/main_page_content_key"
+        android:title="@string/main_page_content"/>
+
+    <PreferenceScreen
+        app:iconSpaceReserved="false"
         android:fragment="org.schabi.newpipe.settings.PeertubeInstanceListFragment"
         android:key="@string/peertube_instance_setup_key"
         android:title="@string/peertube_instance_url_title"
@@ -57,6 +64,12 @@
         android:key="@string/download_thumbnail_key"
         android:title="@string/download_thumbnail_title"
         android:summary="@string/download_thumbnail_summary"/>
+
+    <SwitchPreference
+        app:iconSpaceReserved="false"
+        android:defaultValue="true"
+        android:key="@string/show_next_video_key"
+        android:title="@string/show_next_and_similar_title"/>
 
     <SwitchPreference
         app:iconSpaceReserved="false"


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

"Show 'Next' and 'Similar' videos" and "Content of main page" have been relocated from Appearance to Content settings.

APK for testing: [app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/4296606/app-debug.zip)

Closes #3166. Closes #3176.