### PR TITLE
Fix seek duration not showing

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -569,10 +569,10 @@
     <string name="videos_string">الفيديوهات</string>
     <plurals name="dynamic_seek_duration_description">
         <item quantity="zero">%s ثوانٍ</item>
-        <item quantity="one"/>
-        <item quantity="two"/>
-        <item quantity="few"/>
-        <item quantity="many"/>
-        <item quantity="other"/>
+        <item quantity="one">%s ثوانٍ</item>
+        <item quantity="two">%s ثوانٍ</item>
+        <item quantity="few">%s ثوانٍ</item>
+        <item quantity="many">%s ثوانٍ</item>
+        <item quantity="other">%s ثوانٍ</item>
     </plurals>
 </resources>

--- a/app/src/main/res/values-b+ast/strings.xml
+++ b/app/src/main/res/values-b+ast/strings.xml
@@ -278,7 +278,7 @@
     <string name="videos_string">Vídeos</string>
     <plurals name="dynamic_seek_duration_description">
         <item quantity="one">%s segundos</item>
-        <item quantity="other"/>
+        <item quantity="other">%s segundos</item>
     </plurals>
     <string name="playback_tempo">Tempu</string>
     <string name="playback_pitch">Tonu</string>

--- a/app/src/main/res/values-b+zh+HANS+CN/strings.xml
+++ b/app/src/main/res/values-b+zh+HANS+CN/strings.xml
@@ -38,8 +38,7 @@
     <string name="later">稍后</string>
     <string name="network_error">网络错误</string>
     <plurals name="videos">
-        <item quantity="one">视频</item>
-        <item quantity="other"/>
+        <item quantity="other">%s 视频</item>
     </plurals>
     <string name="disabled">禁用</string>
     <string name="controls_background_title">后台播放</string>
@@ -90,8 +89,7 @@
     <string name="retry">重试</string>
     <string name="storage_permission_denied">存储访问权限已被拒绝</string>
     <plurals name="views">
-        <item quantity="one">%s 次观看</item>
-        <item quantity="other"/>
+        <item quantity="other">%s 次观看</item>
     </plurals>
     <string name="short_thousand">千</string>
     <string name="short_million">百万</string>
@@ -130,8 +128,7 @@
     <string name="search_no_results">没有结果</string>
     <string name="no_subscribers">没有订阅者</string>
     <plurals name="subscribers">
-        <item quantity="one">%s 位订阅者</item>
-        <item quantity="other"/>
+        <item quantity="other">%s 位订阅者</item>
     </plurals>
     <string name="no_videos">没有视频</string>
     <string name="detail_drag_description">拖动以重新排序</string>
@@ -468,8 +465,7 @@
     <string name="show_comments_title">显示评论</string>
     <string name="show_comments_summary">禁用，以停止显示评论</string>
     <plurals name="comments">
-        <item quantity="one">%s 条评论</item>
-        <item quantity="other"/>
+        <item quantity="other">%s 条评论</item>
     </plurals>
     <string name="error_unable_to_load_comments">无法加载评论</string>
     <string name="close">关闭</string>
@@ -506,13 +502,11 @@
     <string name="default_kiosk_page_summary">『时下流行』页-默认</string>
     <string name="no_one_watching">没有人在观看</string>
     <plurals name="watching">
-        <item quantity="one">%s 人在观看</item>
-        <item quantity="other"/>
+        <item quantity="other">%s 人在观看</item>
     </plurals>
     <string name="no_one_listening">没有人在听</string>
     <plurals name="listening">
-        <item quantity="one">％s 人在听</item>
-        <item quantity="other"/>
+        <item quantity="other">％s 人在听</item>
     </plurals>
     <string name="localization_changes_requires_app_restart">重新启动应用后，语言将更改。</string>
     <string name="peertube_instance_url_title">PeerTube 服务器</string>
@@ -543,8 +537,7 @@
     <string name="recaptcha_done_button">完成</string>
     <string name="videos_string">视频</string>
     <plurals name="dynamic_seek_duration_description">
-        <item quantity="one">%s秒</item>
-        <item quantity="other"/>
+        <item quantity="other">%s秒</item>
     </plurals>
     <string name="new_seek_duration_toast">由于ExoPlayer的限制，搜寻间隔设置为％d秒</string>
     <string name="mute">静音</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -555,8 +555,8 @@ otevření ve vyskakovacím okně</string>
     <string name="videos_string">Videa</string>
     <plurals name="dynamic_seek_duration_description">
         <item quantity="one">%s sekund</item>
-        <item quantity="few"/>
-        <item quantity="other"/>
+        <item quantity="few">%s sekund</item>
+        <item quantity="other">%s sekund</item>
     </plurals>
     <string name="new_seek_duration_toast">Kvůli omezením ExoPlayer bylo prohledávání nastaveno na %d vteřin</string>
     <string name="mute">Umlčet</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -544,11 +544,10 @@
     <string name="systems_language">Systemstandard</string>
     <string name="subtitle_activity_recaptcha">\"Fertig\" drücken, wenn es gelöst wurde</string>
     <string name="recaptcha_done_button">Fertig</string>
-    <string name="duration_live_button" translatable="false">Live</string>
     <string name="videos_string">Videos</string>
     <plurals name="dynamic_seek_duration_description">
-        <item quantity="one">%s Sekunden</item>
-        <item quantity="other"/>
+        <item quantity="one">%s Sekunde</item>
+        <item quantity="other">%s Sekunden</item>
     </plurals>
     <string name="new_seek_duration_toast">Aufgrund von ExoPlayer-Einschränkungen wurde die Suchdauer auf %d Sekunden gesetzt</string>
     <string name="mute">Stumm</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -544,6 +544,7 @@
     <string name="subtitle_activity_recaptcha">Premu « Finita » kiam solvita</string>
     <string name="recaptcha_done_button">Finita</string>
     <plurals name="dynamic_seek_duration_description">
+        <item quantity="one">%s sekundo</item>
         <item quantity="other">%s sekundoj</item>
     </plurals>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -545,8 +545,8 @@
     <string name="recaptcha_done_button">Hecho</string>
     <string name="videos_string">Vídeos</string>
     <plurals name="dynamic_seek_duration_description">
-        <item quantity="one">%s segundos</item>
-        <item quantity="other"/>
+        <item quantity="one">%s segundo</item>
+        <item quantity="other">%s segundos</item>
     </plurals>
     <string name="new_seek_duration_toast">Debido a limitaciones de ExoPlayer la duración de la búsqueda fue fijada en %d segundos</string>
     <string name="mute">Silenciar</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -546,7 +546,7 @@
     <string name="videos_string">Bideoak</string>
     <plurals name="dynamic_seek_duration_description">
         <item quantity="one">%s segundu</item>
-        <item quantity="other"/>
+        <item quantity="other">%s segundu</item>
     </plurals>
     <string name="new_seek_duration_toast">ExoPlayer-en mugak direla eta bilaketaren iraupena %d segundotan ezarri da</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -543,7 +543,6 @@
     <string name="systems_language">Langue du système</string>
     <string name="subtitle_activity_recaptcha">Appuyez sur « Terminé » une fois résolu</string>
     <string name="recaptcha_done_button">Terminé</string>
-    <string name="duration_live_button" translatable="false">En direct</string>
     <string name="videos_string">Vidéos</string>
     <plurals name="dynamic_seek_duration_description">
         <item quantity="one">%s seconde</item>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -558,9 +558,9 @@
     <string name="videos_string">סרטונים</string>
     <plurals name="dynamic_seek_duration_description">
         <item quantity="one">%s שניות</item>
-        <item quantity="two"/>
-        <item quantity="many"/>
-        <item quantity="other"/>
+        <item quantity="two">%s שניות</item>
+        <item quantity="many">%s שניות</item>
+        <item quantity="other">%s שניות</item>
     </plurals>
     <string name="new_seek_duration_toast">עקב מגבלות של ExoPlayer מגבלות טווחי החיפוש הוגדרו לכדי %d שניות</string>
     <string name="mute">השתקה</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -546,7 +546,7 @@
     <string name="videos_string">Video</string>
     <plurals name="dynamic_seek_duration_description">
         <item quantity="one">%s secondi</item>
-        <item quantity="other"/>
+        <item quantity="other">%s secondi</item>
     </plurals>
     <string name="new_seek_duration_toast">A causa dei vincoli di ExoPlayer la durata dello spostamento rapido è stata impostata a %d secondi</string>
     <string name="mute">Silenzia</string>

--- a/app/src/main/res/values-ku/strings.xml
+++ b/app/src/main/res/values-ku/strings.xml
@@ -548,6 +548,6 @@
     <string name="videos_string">ڤیدیۆکان</string>
     <plurals name="dynamic_seek_duration_description">
         <item quantity="one">%s چرکە</item>
-        <item quantity="other"></item>
+        <item quantity="other">%s چرکە</item>
     </plurals>
 </resources>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -545,6 +545,6 @@
     <string name="videos_string">Videoer</string>
     <plurals name="dynamic_seek_duration_description">
         <item quantity="one">%s sekunder</item>
-        <item quantity="other"></item>
+        <item quantity="other">%s sekunder</item>
     </plurals>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -552,8 +552,8 @@
     <string name="videos_string">Filmy</string>
     <plurals name="dynamic_seek_duration_description">
         <item quantity="one">%s sekund</item>
-        <item quantity="few"/>
-        <item quantity="many"/>
+        <item quantity="few">%s sekund</item>
+        <item quantity="many">%s sekund</item>
     </plurals>
     <string name="new_seek_duration_toast">Ze względu na ograniczenia ExoPlayer, czas trwania wyszukiwania został ustawiony na %d sekund</string>
     <string name="mute">Wycisz</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -553,8 +553,8 @@ abrir em modo popup</string>
     <string name="recaptcha_done_button">Feito</string>
     <string name="videos_string">Vídeos</string>
     <plurals name="dynamic_seek_duration_description">
-        <item quantity="one">%s segundos</item>
-        <item quantity="other"/>
+        <item quantity="one">%s segundo</item>
+        <item quantity="other">%s segundos</item>
     </plurals>
     <string name="new_seek_duration_toast">Devido as configurações do ExoPlayer, a duração de busca foi alterada para %d segundos</string>
     <string name="mute">Desativar som</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -548,7 +548,6 @@
     <string name="systems_language">Как в системе</string>
     <string name="subtitle_activity_recaptcha">По завершении нажмите Готово</string>
     <string name="recaptcha_done_button">Готово</string>
-    <string name="duration_live_button" translatable="false">Трансляция</string>
     <string name="videos_string">Видео</string>
     <plurals name="dynamic_seek_duration_description">
         <item quantity="one">%s секунда</item>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -462,8 +462,7 @@
     <string name="show_comments_summary">關閉以隱藏留言</string>
     <string name="autoplay_title">自動播放</string>
     <plurals name="comments">
-        <item quantity="one">%s 條留言</item>
-        <item quantity="other"/>
+        <item quantity="other">%s 條留言</item>
     </plurals>
     <string name="no_comments">沒有留言</string>
     <string name="error_unable_to_load_comments">無法載入留言</string>
@@ -499,19 +498,16 @@
     <string name="download_choose_new_path">變更下載資料夾以使其生效</string>
     <string name="drawer_header_description">切換服務，目前已選取：</string>
     <plurals name="videos">
-        <item quantity="one">%s 影片</item>
-        <item quantity="other"/>
+        <item quantity="other">%s 影片</item>
     </plurals>
     <string name="default_kiosk_page_summary">預設 Kiosk</string>
     <string name="no_one_watching">沒有人在看</string>
     <plurals name="watching">
-        <item quantity="one">%s 個觀眾</item>
-        <item quantity="other"/>
+        <item quantity="other">%s 個觀眾</item>
     </plurals>
     <string name="no_one_listening">沒有人正在聽</string>
     <plurals name="listening">
-        <item quantity="one">%s 個聽眾</item>
-        <item quantity="other"/>
+        <item quantity="other">%s 個聽眾</item>
     </plurals>
     <string name="localization_changes_requires_app_restart">語言將會在重新啟動應用程式後變更。</string>
     <string name="seek_duration_title">快轉／快退搜尋持續時間</string>
@@ -542,8 +538,7 @@
     <string name="recaptcha_done_button">完成</string>
     <string name="videos_string">影片</string>
     <plurals name="dynamic_seek_duration_description">
-        <item quantity="one">%s秒</item>
-        <item quantity="other"/>
+        <item quantity="other">%s秒</item>
     </plurals>
     <string name="new_seek_duration_toast">因為 ExoPlayer 的限制，搜尋持續時間設定為 %d 秒</string>
     <string name="mute">靜音</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -593,9 +593,9 @@
     <string name="choose_instance_prompt">Choose an instance</string>
     <string name="app_language_title">App language</string>
     <string name="systems_language">System default</string>
-    <string name="dynamic_seek_duration_description">%s seconds</string>
     <string name="new_seek_duration_toast">Due to ExoPlayer constraints the seek duration was set to %d seconds</string>
     <plurals name="dynamic_seek_duration_description">
+        <item quantity="one">%s second</item>
         <item quantity="other">%s seconds</item>
     </plurals>
 </resources>


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

Fixes #3169.

I put the already translated string into all cases where the plural is needed. Therefore, the translation may be innacurate, but I'll explain:

+ People translated for "%s seconds", in general, so it's already plural, even if it can be innacurate, it's better than blank.
+ If we don't put everywhere, sometimes it's blank. Same, innacurate is better than blank.
+ Translators will be notified that the strings has changed, and either they will confirm it's ok, or correct the string.

I also corrected the «one» plural translation for some languages I know how plural works (eg french, german, spanish…)

For Chinese, for all plurals, from IDEA: one or zero is never called, it's always other.
So with the same reasoning, I put the already translated word.

BTW, it may happen in the future to other languages that didn't made the translation for 0.18.6, but did it before we release the next version (0.19.0 hopefully).
So if someone is releasing a new version @TobiGr @Stypox  — and after Weblate sync — please check if the problem happens too, and do the same fix, or ping me and I'll quickly fix it. (It should not happen if you sync weblate twice, one after this is merged, and one right before release as usual).