### PR TITLE
Fix visual glitch when exiting the app

### DIFF
--- a/app/src/main/res/values-v21/styles_services.xml
+++ b/app/src/main/res/values-v21/styles_services.xml
@@ -1,69 +1,69 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- YouTube -->
-    <style name="LightTheme.YouTube" parent="LightTheme.Switchable">
+    <style name="LightTheme.YouTube" parent="LightTheme">
         <item name="colorPrimaryDark">@color/light_youtube_statusbar_color</item>
     </style>
 
-    <style name="DarkTheme.YouTube" parent="DarkTheme.Switchable">
+    <style name="DarkTheme.YouTube" parent="DarkTheme">
         <item name="colorPrimaryDark">@color/dark_youtube_statusbar_color</item>
     </style>
 
-    <style name="BlackTheme.YouTube" parent="BlackTheme.Switchable">
+    <style name="BlackTheme.YouTube" parent="BlackTheme">
         <item name="colorPrimaryDark">@color/dark_youtube_statusbar_color</item>
     </style>
     <!-- SoundCloud -->
-    <style name="LightTheme.SoundCloud" parent="LightTheme.Switchable">
+    <style name="LightTheme.SoundCloud" parent="LightTheme">
         <item name="colorPrimary">@color/light_soundcloud_primary_color</item>
         <item name="colorPrimaryDark">@color/light_soundcloud_statusbar_color</item>
         <item name="colorAccent">@color/light_soundcloud_accent_color</item>
     </style>
 
-    <style name="DarkTheme.SoundCloud" parent="DarkTheme.Switchable">
+    <style name="DarkTheme.SoundCloud" parent="DarkTheme">
         <item name="colorPrimary">@color/dark_soundcloud_primary_color</item>
         <item name="colorPrimaryDark">@color/dark_soundcloud_statusbar_color</item>
         <item name="colorAccent">@color/dark_soundcloud_accent_color</item>
     </style>
 
-    <style name="BlackTheme.SoundCloud" parent="BlackTheme.Switchable">
+    <style name="BlackTheme.SoundCloud" parent="BlackTheme">
         <item name="colorPrimary">@color/dark_soundcloud_primary_color</item>
         <item name="colorPrimaryDark">@color/dark_soundcloud_statusbar_color</item>
         <item name="colorAccent">@color/dark_soundcloud_accent_color</item>
     </style>
 
     <!-- PeerTube -->
-    <style name="LightTheme.PeerTube" parent="LightTheme.Switchable">
+    <style name="LightTheme.PeerTube" parent="LightTheme">
         <item name="colorPrimary">@color/light_peertube_primary_color</item>
         <item name="colorPrimaryDark">@color/light_peertube_dark_color</item>
         <item name="colorAccent">@color/light_peertube_accent_color</item>
     </style>
 
-    <style name="DarkTheme.PeerTube" parent="DarkTheme.Switchable">
+    <style name="DarkTheme.PeerTube" parent="DarkTheme">
         <item name="colorPrimary">@color/dark_peertube_primary_color</item>
         <item name="colorPrimaryDark">@color/dark_peertube_dark_color</item>
         <item name="colorAccent">@color/dark_peertube_accent_color</item>
     </style>
 
-    <style name="BlackTheme.PeerTube" parent="BlackTheme.Switchable">
+    <style name="BlackTheme.PeerTube" parent="BlackTheme">
         <item name="colorPrimary">@color/dark_peertube_primary_color</item>
         <item name="colorPrimaryDark">@color/dark_peertube_dark_color</item>
         <item name="colorAccent">@color/dark_peertube_accent_color</item>
     </style>
 
     <!-- Media.ccc -->
-    <style name="LightTheme.MediaCCC" parent="LightTheme.Switchable">
+    <style name="LightTheme.MediaCCC" parent="LightTheme">
         <item name="colorPrimary">@color/light_media_ccc_primary_color</item>
         <item name="colorPrimaryDark">@color/light_media_ccc_statusbar_color</item>
         <item name="colorAccent">@color/light_media_ccc_accent_color</item>
     </style>
 
-    <style name="DarkTheme.MediaCCC" parent="DarkTheme.Switchable">
+    <style name="DarkTheme.MediaCCC" parent="DarkTheme">
         <item name="colorPrimary">@color/dark_media_ccc_primary_color</item>
         <item name="colorPrimaryDark">@color/dark_media_ccc_statusbar_color</item>
         <item name="colorAccent">@color/dark_media_ccc_accent_color</item>
     </style>
 
-    <style name="BlackTheme.MediaCCC" parent="BlackTheme.Switchable">
+    <style name="BlackTheme.MediaCCC" parent="BlackTheme">
         <item name="colorPrimary">@color/dark_media_ccc_primary_color</item>
         <item name="colorPrimaryDark">@color/dark_media_ccc_statusbar_color</item>
         <item name="colorAccent">@color/dark_media_ccc_accent_color</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -74,10 +74,6 @@
         <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
     </style>
 
-    <style name="LightTheme.Switchable">
-        <item name="android:windowAnimationStyle">@style/SwitchAnimation</item>
-    </style>
-
     <style name="Base.V7.DarkTheme" parent="Theme.AppCompat.NoActionBar" />
     <style name="Base.DarkTheme" parent="Base.V7.DarkTheme" />
     <style name="DarkTheme" parent="Base.DarkTheme">
@@ -144,10 +140,6 @@
         <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
     </style>
 
-    <style name="DarkTheme.Switchable">
-        <item name="android:windowAnimationStyle">@style/SwitchAnimation</item>
-    </style>
-
     <style name="Base.V7.BlackTheme" parent="DarkTheme"/>
     <style name="Base.BlackTheme" parent="Base.V7.BlackTheme"/>
     <style name="BlackTheme" parent="Base.BlackTheme">
@@ -156,10 +148,6 @@
 
         <item name="separator_color">@color/black_separator_color</item>
         <item name="contrast_background_color">@color/black_contrast_background_color</item>
-    </style>
-
-    <style name="BlackTheme.Switchable">
-        <item name="android:windowAnimationStyle">@style/SwitchAnimation</item>
     </style>
 
     <!-- Dialogs -->
@@ -190,11 +178,6 @@
 
     <style name="BlackSettingsTheme" parent="BlackTheme">
         <item name="colorAccent">@color/black_settings_accent_color</item>
-    </style>
-
-    <style name="SwitchAnimation" parent="@android:style/Animation.Activity">
-        <item name="android:windowEnterAnimation">@anim/switch_service_in</item>
-        <item name="android:windowExitAnimation">@anim/switch_service_out</item>
     </style>
 
     <style name="Toolbar.Title" parent="TextAppearance.Widget.AppCompat.Toolbar.Title">

--- a/app/src/main/res/values/styles_services.xml
+++ b/app/src/main/res/values/styles_services.xml
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- YouTube -->
-    <style name="LightTheme.YouTube" parent="LightTheme.Switchable">
+    <style name="LightTheme.YouTube" parent="LightTheme">
     </style>
 
-    <style name="DarkTheme.YouTube" parent="DarkTheme.Switchable">
+    <style name="DarkTheme.YouTube" parent="DarkTheme">
     </style>
 
-    <style name="BlackTheme.YouTube" parent="BlackTheme.Switchable">
+    <style name="BlackTheme.YouTube" parent="BlackTheme">
     </style>
 
     <!-- SoundCloud -->
-    <style name="LightTheme.SoundCloud" parent="LightTheme.Switchable">
+    <style name="LightTheme.SoundCloud" parent="LightTheme">
         <item name="colorPrimary">@color/light_soundcloud_primary_color</item>
         <item name="colorPrimaryDark">@color/light_soundcloud_dark_color</item>
         <item name="colorAccent">@color/light_soundcloud_accent_color</item>
         <item name="progress_horizontal_drawable">@drawable/progress_soundcloud_horizontal_light</item>
     </style>
 
-    <style name="DarkTheme.SoundCloud" parent="DarkTheme.Switchable">
+    <style name="DarkTheme.SoundCloud" parent="DarkTheme">
         <item name="colorPrimary">@color/dark_soundcloud_primary_color</item>
         <item name="colorPrimaryDark">@color/dark_soundcloud_dark_color</item>
         <item name="colorAccent">@color/dark_soundcloud_accent_color</item>
         <item name="progress_horizontal_drawable">@drawable/progress_soundcloud_horizontal_dark</item>
     </style>
 
-    <style name="BlackTheme.SoundCloud" parent="BlackTheme.Switchable">
+    <style name="BlackTheme.SoundCloud" parent="BlackTheme">
         <item name="colorPrimary">@color/dark_soundcloud_primary_color</item>
         <item name="colorPrimaryDark">@color/dark_soundcloud_dark_color</item>
         <item name="colorAccent">@color/dark_soundcloud_accent_color</item>
@@ -33,38 +33,38 @@
     </style>
 
     <!-- PeerTube -->
-    <style name="LightTheme.PeerTube" parent="LightTheme.Switchable">
+    <style name="LightTheme.PeerTube" parent="LightTheme">
         <item name="colorPrimary">@color/light_peertube_primary_color</item>
         <item name="colorPrimaryDark">@color/light_peertube_dark_color</item>
         <item name="colorAccent">@color/light_peertube_accent_color</item>
     </style>
 
-    <style name="DarkTheme.PeerTube" parent="DarkTheme.Switchable">
+    <style name="DarkTheme.PeerTube" parent="DarkTheme">
         <item name="colorPrimary">@color/dark_peertube_primary_color</item>
         <item name="colorPrimaryDark">@color/dark_peertube_dark_color</item>
         <item name="colorAccent">@color/dark_peertube_accent_color</item>
     </style>
 
-    <style name="BlackTheme.PeerTube" parent="BlackTheme.Switchable">
+    <style name="BlackTheme.PeerTube" parent="BlackTheme">
         <item name="colorPrimary">@color/dark_peertube_primary_color</item>
         <item name="colorPrimaryDark">@color/dark_peertube_dark_color</item>
         <item name="colorAccent">@color/dark_peertube_accent_color</item>
     </style>
 
     <!-- Media.ccc -->
-    <style name="LightTheme.MediaCCC" parent="LightTheme.Switchable">
+    <style name="LightTheme.MediaCCC" parent="LightTheme">
         <item name="colorPrimary">@color/light_media_ccc_primary_color</item>
         <item name="colorPrimaryDark">@color/light_media_ccc_statusbar_color</item>
         <item name="colorAccent">@color/light_media_ccc_accent_color</item>
     </style>
 
-    <style name="DarkTheme.MediaCCC" parent="DarkTheme.Switchable">
+    <style name="DarkTheme.MediaCCC" parent="DarkTheme">
         <item name="colorPrimary">@color/dark_media_ccc_primary_color</item>
         <item name="colorPrimaryDark">@color/dark_media_ccc_statusbar_color</item>
         <item name="colorAccent">@color/dark_media_ccc_accent_color</item>
     </style>
 
-    <style name="BlackTheme.MediaCCC" parent="BlackTheme.Switchable">
+    <style name="BlackTheme.MediaCCC" parent="BlackTheme">
         <item name="colorPrimary">@color/dark_media_ccc_primary_color</item>
         <item name="colorPrimaryDark">@color/dark_media_ccc_statusbar_color</item>
         <item name="colorAccent">@color/dark_media_ccc_accent_color</item>


### PR DESCRIPTION
This is a pretty old issue, I'm surprised nobody was annoyed enough to fix it.

It was even added by me, 2 years ago. The reason was to provide smooth transitions when changing the theme, and it worked, but in recent versions of Android it doesn't seem to make a difference other than trigger this annoying glitch.

---

Closes #1173.
