### PR TITLE
Fix bug in main screen tabs state management

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/MainFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/MainFragment.java
@@ -136,16 +136,17 @@ public class MainFragment extends BaseFragment implements TabLayout.OnTabSelecte
     // Tabs
     //////////////////////////////////////////////////////////////////////////*/
 
-    public void setupTabs() {
+    private void setupTabs() {
         tabsList.clear();
         tabsList.addAll(tabsManager.getTabs());
 
         if (pagerAdapter == null || !pagerAdapter.sameTabs(tabsList)) {
             pagerAdapter = new SelectedTabsPagerAdapter(requireContext(), getChildFragmentManager(), tabsList);
         }
-        // Clear previous tabs/fragments and set new adapter
-        viewPager.setAdapter(pagerAdapter);
+
+        viewPager.setAdapter(null);
         viewPager.setOffscreenPageLimit(tabsList.size());
+        viewPager.setAdapter(pagerAdapter);
 
         updateTabsIconAndDescription();
         updateTitleForTab(viewPager.getCurrentItem());
@@ -194,6 +195,7 @@ public class MainFragment extends BaseFragment implements TabLayout.OnTabSelecte
             this.internalTabsList = new ArrayList<>(tabsList);
         }
 
+        @NonNull
         @Override
         public Fragment getItem(int position) {
             final Tab tab = internalTabsList.get(position);


### PR DESCRIPTION
Tabs were not being destroyed/restored correctly due to a call to a method that populated the view pager before it even had a chance of restoring itself.

The solution was to null out the adapter before calling that method so the view pager will postpone the populating process.