### PR TITLE
added apk upload and comment on pr in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,11 @@ android:
 
 before_install: 
   - yes | sdkmanager "platforms;android-28"
+  - echo -e "machine github.com\n  login newpipe-machine-user\n  password $CI_USER_PASSWORD" > ~/.netrc
+  - echo -e "machine api.github.com\n  login newpipe-machine-user\n  password $CI_USER_PASSWORD" >> ~/.netrc
+  - chmod 600 ~/.netrc
+  - chmod +x ./dev-scripts/uploadApkAndCommentOnPR.sh
 script: ./gradlew -Dorg.gradle.jvmargs=-Xmx1536m assembleDebug lintDebug testDebugUnitTest
 
-licenses:
-  - '.+'
+after_success:
+  - ./dev-scripts/uploadApkAndCommentOnPR.sh

--- a/dev-scripts/uploadApkAndCommentOnPR.sh
+++ b/dev-scripts/uploadApkAndCommentOnPR.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+    exit 0
+else
+    COMMIT_HASH=$(git rev-parse --short HEAD)
+    APK_NAME="pr${TRAVIS_PULL_REQUEST}-${COMMIT_HASH}.apk"
+    FILES_DIR="/tmp/newpipe-files"
+    DATE="$(date +"%Y/%m/%d")"
+    APK_DIR="${FILES_DIR}/${DATE}"
+    git clone https://github.com/newpipe-machine-user/newpipe-files.git "${FILES_DIR}"
+    mkdir -p "${APK_DIR}"
+    cp ./app/build/outputs/apk/debug/app-debug.apk "${APK_DIR}/${APK_NAME}"
+    cd "${FILES_DIR}" && git add -A && git commit -m "${APK_NAME}" && git push origin master
+    APK_LINK="https://github.com/newpipe-machine-user/newpipe-files/blob/master/${DATE}/${APK_NAME}"
+    COMMENT="Find the test apk [${APK_NAME}](${APK_LINK})\n <sub>TeamNewPipe takes no responsibility for this apk. Install at your own risk</sub>"
+    curl -nso /dev/null -X POST -d "{\"body\": \"${COMMENT}\"}" "https://api.github.com/repos/${TRAVIS_REPO_SLUG}/issues/${TRAVIS_PULL_REQUEST}/comments"
+fi


### PR DESCRIPTION
Implemented the feature requested in https://github.com/TeamNewPipe/NewPipe/pull/3196#issuecomment-596200424
Travis will put a comment like [this](https://github.com/yausername/NewPipe/pull/1#issuecomment-597382609) on every build of a PR.
`CI_USER_PASSWORD` environment variable has to be added in travis settings. (I can share this with someone who has access to travis settings.)


- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
