### PR TITLE
Change share title to differentiate multiple builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,24 +3,6 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
-
-static String getGitWorkingBranch() {
-    try {
-        def gitProcess = "git rev-parse --abbrev-ref HEAD".execute()
-        gitProcess.waitFor()
-        if (gitProcess.exitValue() == 0) {
-            return gitProcess.text.trim()
-        } else {
-            // not a git repository
-            return ""
-        }
-    } catch (IOException ignored) {
-        // git was not found
-        return ""
-    }
-}
-
-
 android {
     compileSdkVersion 28
     buildToolsVersion '28.0.3'
@@ -142,4 +124,20 @@ dependencies {
 
     implementation "io.noties.markwon:core:${markwonVersion}"
     implementation "io.noties.markwon:linkify:${markwonVersion}"
+}
+
+static String getGitWorkingBranch() {
+    try {
+        def gitProcess = "git rev-parse --abbrev-ref HEAD".execute()
+        gitProcess.waitFor()
+        if (gitProcess.exitValue() == 0) {
+            return gitProcess.text.trim()
+        } else {
+            // not a git repository
+            return ""
+        }
+    } catch (IOException ignored) {
+        // git was not found
+        return ""
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -432,7 +432,7 @@
     <string name="soundcloud" translatable="false">SoundCloud</string>
     <string name="drawer_header_action_paceholder_text">Something will appear here soon ;D</string>
     <!-- Preferred player -->
-    <string name="preferred_open_action_share_menu_title" translatable="false">NewPipe</string>
+    <string name="preferred_open_action_share_menu_title" translatable="false">@string/app_name</string>
     <string name="preferred_open_action_settings_title">Preferred \'open\' action</string>
     <string name="preferred_open_action_settings_summary">Default action when opening content — %s</string>
     <string name="video_player">Video player</string>


### PR DESCRIPTION
The share title is currently hard coded and it was missed by #3133.

I was also inclined to create another variant for this, but a simple `true` in that if statement seems to be enough to force the default behavior when needed, not worth it.

- Change share title as well to differentiate multiple builds
- Move code with lower priority to the bottom of the file