### PR TITLE
Revert manifest removal from debug build variant

### DIFF
--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="org.schabi.newpipe">
+
+    <application
+        android:name=".DebugApp"
+        tools:replace="android:name" />
+</manifest>


### PR DESCRIPTION
One more thing that was missed.

The file was responsible for making the app use the Debug application class, which various debug tools depended on.