### PR TITLE
Show radio icon as uploader avatar in Youtube mixes 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -175,7 +175,7 @@ dependencies {
 
     // NewPipe dependencies
     // You can use a local version by uncommenting a few lines in settings.gradle
-    implementation 'com.github.TeamNewPipe:NewPipeExtractor:b3835bd616ab28b861c83dcefd56e1754c6d20be'
+    implementation 'com.github.TeamNewPipe:NewPipeExtractor:85fa006214b003f21eacb76c445a167732f19981'
     implementation "com.github.TeamNewPipe:nanojson:1d9e1aea9049fc9f85e68b43ba39fe7be1c1f751"
 
     implementation "org.jsoup:jsoup:1.13.1"

--- a/app/src/test/java/org/schabi/newpipe/ktx/OffsetDateTimeToCalendarTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/ktx/OffsetDateTimeToCalendarTest.kt
@@ -4,7 +4,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.time.LocalDate
 import java.time.OffsetDateTime
-import java.time.ZoneId
 import java.time.ZoneOffset
 import java.util.Calendar
 import java.util.TimeZone
@@ -13,7 +12,7 @@ class OffsetDateTimeToCalendarTest {
     @Test
     fun testRelativeTimeWithCurrentOffsetDateTime() {
         val calendar = LocalDate.of(2020, 1, 1).atStartOfDay().atOffset(ZoneOffset.UTC)
-                .toCalendar()
+            .toCalendar()
 
         assertEquals(2020, calendar[Calendar.YEAR])
         assertEquals(0, calendar[Calendar.MONTH])


### PR DESCRIPTION
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

~~Shows "100+ videos" when the stream count of a playlist is `ListExtractor.ITEM_COUNT_MORE_THAN_100` and shows "∞ videos" when the stream count of a playlist is `ListExtractor.ITEM_COUNT_INFINITE`.
Uses the global `utils.Localization.localizeStreamCount()` function everywhere, i.e. in `PlaylistFragment`, `PlaylistInfoItem` and `ChannelMiniInfoItem` to correctly localize the item count (before it was not used in Playlist-related classes).~~
Now only does as described in the title. As discussed below using YouTube's logo is too risky, so we are using a radio icon instead.

Depends on TeamNewPipe/NewPipeExtractor#280 @XiangRongLin 
