### PR TITLE
Change APK base name depending on the branch name for debug builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,6 +46,7 @@ android {
             } else {
                 applicationIdSuffix ".debug." + normalizedWorkingBranch
                 resValue "string", "app_name", "NewPipe " + workingBranch
+                archivesBaseName = 'NewPipe_' + normalizedWorkingBranch
             }
         }
     }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe. Please take a moment to fill out the following suggestion on how to structure this PR description. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bug fix
- [ ] Feature
- [x] Development improvement

#### Long description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write a text instead if you can't fit it in a list -->
Debug APKs are now named after their branch name as suggested by @opusforlife2  e.g. the debug APK for this branch is named `NewPipe_apk_base_name-debug.apk`
Release builds are not touched, as well as debug builds on dev and master branch.

#### Testing apk
<!-- Ensure that you have your changes on a new branch which has a meaningful name. This name will be used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe. Do NOT name your branches like "patch-0" and "feature-1". For example, if your PR implements a bug fix for comments, an appropriate branch name would be "commentfix". -->
not needed

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
