### PR TITLE
Handle content not available exception more comprehensively

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/BaseStateFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/BaseStateFragment.java
@@ -17,6 +17,7 @@ import org.schabi.newpipe.BaseFragment;
 import org.schabi.newpipe.MainActivity;
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.ReCaptchaActivity;
+import org.schabi.newpipe.extractor.exceptions.ContentNotAvailableException;
 import org.schabi.newpipe.extractor.exceptions.ReCaptchaException;
 import org.schabi.newpipe.report.ErrorActivity;
 import org.schabi.newpipe.report.UserAction;
@@ -180,6 +181,9 @@ public abstract class BaseStateFragment<I> extends BaseFragment implements ViewC
 
         if (exception instanceof ReCaptchaException) {
             onReCaptchaException((ReCaptchaException) exception);
+            return true;
+        } else if (exception instanceof ContentNotAvailableException) {
+            showError(getString(R.string.content_not_available), false);
             return true;
         } else if (exception instanceof IOException) {
             showError(getString(R.string.network_error), true);

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -51,7 +51,6 @@ import org.schabi.newpipe.download.DownloadDialog;
 import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.ServiceList;
-import org.schabi.newpipe.extractor.exceptions.ContentNotAvailableException;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.services.youtube.extractors.YoutubeStreamExtractor;
@@ -1220,20 +1219,12 @@ public class VideoDetailFragment
     protected boolean onError(Throwable exception) {
         if (super.onError(exception)) return true;
 
-        else if (exception instanceof ContentNotAvailableException) {
-            showError(getString(R.string.content_not_available), false);
-        } else {
-            int errorId = exception instanceof YoutubeStreamExtractor.DecryptException
-                    ? R.string.youtube_signature_decryption_error
-                    : exception instanceof ParsingException
-                    ? R.string.parsing_error
-                    : R.string.general_error;
-            onUnrecoverableError(exception,
-                    UserAction.REQUESTED_STREAM,
-                    NewPipe.getNameOfService(serviceId),
-                    url,
-                    errorId);
-        }
+        int errorId = exception instanceof YoutubeStreamExtractor.DecryptException ? R.string.youtube_signature_decryption_error
+                : exception instanceof ExtractionException ? R.string.parsing_error
+                : R.string.general_error;
+
+        onUnrecoverableError(exception, UserAction.REQUESTED_STREAM,
+                NewPipe.getNameOfService(serviceId), url, errorId);
 
         return true;
     }

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
@@ -440,16 +440,12 @@ public class ChannelFragment extends BaseListInfoFragment<ChannelInfo> {
     protected boolean onError(Throwable exception) {
         if (super.onError(exception)) return true;
 
-        if (exception instanceof ContentNotAvailableException) {
-            showError(getString(R.string.content_not_available), false);
-        } else {
-            int errorId = exception instanceof ExtractionException ? R.string.parsing_error : R.string.general_error;
-            onUnrecoverableError(exception,
-                    UserAction.REQUESTED_CHANNEL,
-                    NewPipe.getNameOfService(serviceId),
-                    url,
-                    errorId);
-        }
+        int errorId = exception instanceof ExtractionException
+                ? R.string.parsing_error : R.string.general_error;
+
+        onUnrecoverableError(exception, UserAction.REQUESTED_CHANNEL,
+                NewPipe.getNameOfService(serviceId), url, errorId);
+
         return true;
     }
 


### PR DESCRIPTION
#### What is it?
- [x] Bug fix
- [ ] Feature

#### Long description of the changes in your PR

Some fragments were not handling these types of exceptions.

We should improve the display of `ContentNotAvailableException` exceptions in the future by showing more specific details, like not found.

For now, a "Content unavailable" is better than a crash.

#### Relates to the following issue(s)
- #3277