### PR TITLE
Fix mute button inflation problems on API<21

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
@@ -403,7 +403,8 @@ public final class MainVideoPlayer extends AppCompatActivity
     }
 
     protected void setMuteButton(final ImageButton muteButton, final boolean isMuted) {
-        muteButton.setImageDrawable(ContextCompat.getDrawable(getApplicationContext(), isMuted ? R.drawable.ic_volume_off_white_72dp : R.drawable.ic_volume_up_white_72dp));
+        muteButton.setImageDrawable(AppCompatResources.getDrawable(getApplicationContext(),
+                isMuted ? R.drawable.ic_volume_off_white_72dp : R.drawable.ic_volume_up_white_72dp));
     }
 
 


### PR DESCRIPTION
See https://stackoverflow.com/questions/35819290/invalid-drawable-tag-vector
There was no need to change other ImageButtons because the image was set programmatically only in the mute button