### PR TITLE
Save and restore playback parameters into/from preferences

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
@@ -120,9 +120,6 @@ public final class NavigationHelper {
                                          final boolean isMuted) {
         return getPlayerIntent(context, targetClazz, playQueue, playbackQuality, resumePlayback)
                 .putExtra(BasePlayer.REPEAT_MODE, repeatMode)
-                .putExtra(BasePlayer.PLAYBACK_SPEED, playbackSpeed)
-                .putExtra(BasePlayer.PLAYBACK_PITCH, playbackPitch)
-                .putExtra(BasePlayer.PLAYBACK_SKIP_SILENCE, playbackSkipSilence)
                 .putExtra(BasePlayer.START_PAUSED, startPaused)
                 .putExtra(BasePlayer.IS_MUTED, isMuted);
     }

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -177,6 +177,9 @@
     <string name="enable_playback_resume_key" translatable="false">enable_playback_resume</string>
     <string name="enable_playback_state_lists_key" translatable="false">enable_playback_state_lists</string>
     <string name="playback_unhook_key" translatable="false">playback_unhook_key</string>
+    <string name="playback_speed_key" translatable="false">playback_speed_key</string>
+    <string name="playback_pitch_key" translatable="false">playback_pitch_key</string>
+    <string name="playback_skip_silence_key" translatable="false">playback_skip_silence_key</string>
 
     <string name="app_language_key" translatable="false">app_language_key</string>
     <string name="enable_lock_screen_video_thumbnail_key" translatable="false">enable_lock_screen_video_thumbnail</string>


### PR DESCRIPTION
#### What is it?
- [x] Feature

#### Long description of the changes in your PR
- Playback parameters are speed, pitch and skip silence
- Save playback parameters into shared preferences whenever they are set
- Retrieve playback parameters from shared preferences when starting any player
- Remove playback parameters from being passed from one player to another through intents. Instead they can be retrieved from the shared preferences.

#### Fixes the following issue(s)
- solves #735

#### Testing apk
[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/4398458/app-debug.zip)

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

#### Note
I noticed that changing the playback parameters while the video is paused gets ignored. At first I thought i broke something, until I noticed that it was like this before too.

