### PR TITLE
handle ContentNotSupportedException

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -136,7 +136,7 @@ dependencies {
         exclude module: 'support-annotations'
     })
 
-    implementation 'com.github.B0pol:NewPipeExtractor:cf24e2935cbb46117ab7bd2705d5e86f68f649e1'
+    implementation 'com.github.B0pol:NewPipeExtractor:9a7c6b7ab00c0f5b8337232fc66d3d9b538c229f'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.23.0'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -136,7 +136,7 @@ dependencies {
         exclude module: 'support-annotations'
     })
 
-    implementation 'com.github.B0pol:NewPipeExtractor:9a7c6b7ab00c0f5b8337232fc66d3d9b538c229f'
+    implementation 'com.github.TeamNewPipe:NewPipeExtractor:a5155fb'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.23.0'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -136,7 +136,7 @@ dependencies {
         exclude module: 'support-annotations'
     })
 
-    implementation 'com.github.TeamNewPipe:NewPipeExtractor:69e0624e3'
+    implementation 'com.github.B0pol:NewPipeExtractor:cf24e2935cbb46117ab7bd2705d5e86f68f649e1'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.23.0'
 

--- a/app/src/main/java/org/schabi/newpipe/fragments/BaseStateFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/BaseStateFragment.java
@@ -20,6 +20,7 @@ import org.schabi.newpipe.MainActivity;
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.ReCaptchaActivity;
 import org.schabi.newpipe.extractor.exceptions.ContentNotAvailableException;
+import org.schabi.newpipe.extractor.exceptions.ContentNotSupportedException;
 import org.schabi.newpipe.extractor.exceptions.ReCaptchaException;
 import org.schabi.newpipe.report.ErrorActivity;
 import org.schabi.newpipe.report.UserAction;
@@ -215,6 +216,9 @@ public abstract class BaseStateFragment<I> extends BaseFragment implements ViewC
             return true;
         } else if (exception instanceof IOException) {
             showError(getString(R.string.network_error), true);
+            return true;
+        } else if (exception instanceof ContentNotSupportedException) {
+            showError(getString(R.string.content_not_supported), false);
             return true;
         }
 

--- a/app/src/main/java/org/schabi/newpipe/util/ExtractorHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ExtractorHelper.java
@@ -37,6 +37,7 @@ import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.channel.ChannelInfo;
 import org.schabi.newpipe.extractor.comments.CommentsInfo;
 import org.schabi.newpipe.extractor.exceptions.ContentNotAvailableException;
+import org.schabi.newpipe.extractor.exceptions.ContentNotSupportedException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.exceptions.ReCaptchaException;
 import org.schabi.newpipe.extractor.feed.FeedExtractor;
@@ -293,6 +294,8 @@ public final class ExtractorHelper {
                 Toast.makeText(context, R.string.network_error, Toast.LENGTH_LONG).show();
             } else if (exception instanceof ContentNotAvailableException) {
                 Toast.makeText(context, R.string.content_not_available, Toast.LENGTH_LONG).show();
+            } else if (exception instanceof ContentNotSupportedException) {
+                Toast.makeText(context, R.string.content_not_supported, Toast.LENGTH_LONG).show();
             } else {
                 int errorId = exception instanceof YoutubeStreamExtractor.DecryptException
                         ? R.string.youtube_signature_decryption_error

--- a/app/src/main/res/layout/fragment_channel.xml
+++ b/app/src/main/res/layout/fragment_channel.xml
@@ -32,6 +32,7 @@
         tools:visibility="visible">
 
         <TextView
+            android:id="@+id/channel_kaomoji"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
@@ -42,11 +43,21 @@
             tools:ignore="HardcodedText,UnusedAttribute"/>
 
         <TextView
+            android:id="@+id/channel_no_videos"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:text="@string/empty_view_no_videos"
             android:textSize="24sp"/>
+
+        <TextView
+            android:layout_marginTop="20dp"
+            android:id="@+id/error_content_not_supported"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/content_not_supported"
+            android:textSize="15sp"
+            android:visibility="gone" />
 
     </LinearLayout>
 

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -586,4 +586,5 @@
     <string name="mute">Mutigi</string>
     <string name="unmute">Malmutigi</string>
     <string name="help">Helpo</string>
+    <string name="content_not_supported">Tio enhavo ne estas ankoraŭ subtenata per NewPipe.\n\nĜi espereble estos en sekvanta versio.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -598,4 +598,5 @@
 \n
 \n Donc le choix vous revient : Préferez-vous la vitesse ou des informations précises \?</string>
     <string name="help">Aide</string>
+    <string name="content_not_supported">Ce contenu n\'est pas encore supporté par NewPipe.\n\nIl le sera peut-être dans une version future.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -637,4 +637,5 @@
     <string name="feed_use_dedicated_fetch_method_enable_button">Enable fast mode</string>
     <string name="feed_use_dedicated_fetch_method_disable_button">Disable fast mode</string>
     <string name="feed_use_dedicated_fetch_method_help_text">Do you think feed loading is too slow? If so, try enabling fast loading (you can change it in settings or by pressing the button below).\n\nNewPipe offers two feed loading strategies:\n• Fetching the whole subscription channel, which is slow but complete.\n• Using a dedicated service endpoint, which is fast but usually not complete.\n\nThe difference between the two is that the fast one usually lacks some information, like the item\'s duration or type (can\'t distinguish between live videos and normal ones) and it may return less items.\n\nYouTube is an example of a service that offers this fast method with its RSS feed.\n\nSo the choice boils down to what you prefer: speed or precise information.</string>
+    <string name="content_not_supported">This content is not yet supported by NewPipe.\n\nIt will hopefully be supported in a future version.</string>
 </resources>


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe. Please take a moment to fill out the following suggestion on how to structure this PR description. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bug fix
- [ ] Feature
- [x] improvement

#### Long description of the changes in your PR
See https://github.com/TeamNewPipe/NewPipeExtractor/pull/300 and https://github.com/TeamNewPipe/NewPipeExtractor/pull/250
Copy paste from https://github.com/TeamNewPipe/NewPipeExtractor/pull/300
> Follows the discussion we had in https://github.com/TeamNewPipe/NewPipeExtractor/pull/250
It will greatly improve SoundCloud usability, because instead of randomly crashing, it will show the error with an appropriated UI, not a crash report, then the average user will understand why, and he can go back to play another track.
Before, the user was confused, and it went back to main kiosk each time, so it was really annoying.

How to Test: use debug apk below, search for "Dua Lipa" in SoundCloud, go to her channel page, and play the newest track, or go to youtube music.

Screenshots:
<img src="https://user-images.githubusercontent.com/58657617/78676267-b9df2e80-78d5-11ea-938d-8b07a6d8a76e.png" width="200"> <img src="https://user-images.githubusercontent.com/58657617/78676277-bc418880-78d5-11ea-97c3-ad283bfb9a1e.png" width="200">

#### Relies on the following changes
<!-- Delete this if it doesn't apply to you. -->
https://github.com/TeamNewPipe/NewPipeExtractor/pull/300

#### Testing apk
[NewPipe_contentnotsupported-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/4444808/NewPipe_contentnotsupported-debug.zip)


#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
