### PR TITLE
Fix mute button causing crashes on API 19

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/ServicePlayerActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ServicePlayerActivity.java
@@ -3,17 +3,9 @@ package org.schabi.newpipe.player;
 import android.content.ComponentName;
 import android.content.Intent;
 import android.content.ServiceConnection;
-import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.os.IBinder;
 import android.provider.Settings;
-
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
-import androidx.appcompat.widget.Toolbar;
-import androidx.recyclerview.widget.ItemTouchHelper;
-
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -25,6 +17,12 @@ import android.widget.PopupMenu;
 import android.widget.ProgressBar;
 import android.widget.SeekBar;
 import android.widget.TextView;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.recyclerview.widget.ItemTouchHelper;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 
 import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Player;
@@ -698,13 +696,10 @@ public abstract class ServicePlayerActivity extends AppCompatActivity
             item.setTitle(player.isMuted() ? R.string.unmute : R.string.mute);
 
             //2) Icon change accordingly to current App Theme
-            item.setIcon(player.isMuted() ? getThemedDrawable(R.attr.volume_off) : getThemedDrawable(R.attr.volume_on));
+            // using rootView.getContext() because getApplicationContext() didn't work
+            item.setIcon(player.isMuted()
+                    ? ThemeHelper.resolveResourceIdFromAttr(rootView.getContext(), R.attr.volume_off)
+                    : ThemeHelper.resolveResourceIdFromAttr(rootView.getContext(), R.attr.volume_on));
         }
-    }
-
-    private Drawable getThemedDrawable(int attribute) {
-        return getResources().getDrawable(
-                getTheme().obtainStyledAttributes(R.style.Theme_AppCompat, new int[]{attribute})
-                        .getResourceId(0, 0));
     }
 }


### PR DESCRIPTION
#### What is it?
- [x] Bug fix :fire:
- [ ] Feature

#### Long description of the changes in your PR
Fixes crashes when instantiating the background and popup queues, due to a problem in obtaining and setting the drawable to the menu icon on API 19.
Note: using rootView.getContext() because getApplicationContext() didn't work (it was probably missing information about theme)

#### Fixes the following issue(s)
- Fixes #3320

#### Testing apk
I tested this fix on Android 4.4 (API 19, emulator) and Android 7.1 (phone). @AnotherLife could you test this apk?
[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/4414294/app-debug.zip)

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
