### PR TITLE
Make the drawer layout adapt to any status bar size

### DIFF
--- a/app/src/main/res/layout/drawer_header.xml
+++ b/app/src/main/res/layout/drawer_header.xml
@@ -1,24 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="wrap_content"
-    android:layout_height="@dimen/drawer_header_height"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
     android:background="?colorPrimary"
     android:nextFocusDown="@+id/drawer_header_action_button">
 
     <ImageView
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="0dp"
         android:scaleType="centerCrop"
         android:src="@drawable/background_header"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
         tools:ignore="ContentDescription" />
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/drawer_header_padding_top"
+        android:fitsSystemWindows="true"
+        android:gravity="bottom"
+        android:minHeight="@dimen/drawer_header_content_min_height"
         android:orientation="vertical"
-        android:paddingTop="@dimen/drawer_header_padding_top">
+        app:layout_constraintTop_toTopOf="parent">
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -53,7 +59,8 @@
                 android:textStyle="bold"
                 app:autoSizeMaxTextSize="@dimen/drawer_header_newpipe_title_max_text_size"
                 app:autoSizeMinTextSize="@dimen/drawer_header_newpipe_title_min_text_size"
-                app:autoSizeTextType="uniform" />
+                app:autoSizeTextType="uniform"
+                tools:ignore="UnusedAttribute" />
         </LinearLayout>
 
         <LinearLayout
@@ -68,7 +75,7 @@
 
             <LinearLayout
                 android:layout_width="0dp"
-                android:layout_height="wrap_content"
+                android:layout_height="32dp"
                 android:layout_weight="1"
                 android:gravity="center"
                 android:orientation="horizontal">
@@ -108,7 +115,8 @@
     <Button
         android:id="@+id/drawer_header_action_button"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="0dp"
         android:background="?selectableItemBackground"
-        android:focusable="true" />
-</FrameLayout>
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-v21/dimens.xml
+++ b/app/src/main/res/values-v21/dimens.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <!-- Menu Drawer Dimensions -->
-    <dimen name="drawer_header_height">150dp</dimen>
-    <dimen name="drawer_header_padding_top">36dp</dimen>
-</resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Menu Drawer Dimensions -->
-    <dimen name="drawer_header_height">130dp</dimen>
+    <dimen name="drawer_header_content_min_height">120dp</dimen>
     <dimen name="drawer_header_padding_top">16dp</dimen>
     <dimen name="drawer_header_newpipe_icon_size">48dp</dimen>
     <dimen name="drawer_header_newpipe_icon_title_space">12dp</dimen>


### PR DESCRIPTION
#### What is it?
- [x] Bug fix
- [ ] Feature

#### Long description of the changes in your PR

The padding and height for the drawer layout were being hardcoded, and when the drawer was shown in phones with non-standard status bar sizes, it would not be positioned correctly.

This improves the drawer specifically for phones that have a notch.

#### Testing apk

###### Long press the drawer header to switch between app names.
[improve-drawer-height-handling.apk.zip](https://github.com/TeamNewPipe/NewPipe/files/4421610/improve-drawer-height-handling.apk.zip)
