### PR TITLE
Fix repeated exceptions in Bookmarked Playlists

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/bookmark/BookmarkFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/bookmark/BookmarkFragment.java
@@ -62,8 +62,19 @@ public final class BookmarkFragment extends BaseLocalListFragment<List<PlaylistL
         items.addAll(localPlaylists);
         items.addAll(remotePlaylists);
 
-        Collections.sort(items, (left, right) ->
-                left.getOrderingName().compareToIgnoreCase(right.getOrderingName()));
+        Collections.sort(items, (left, right) -> {
+            String on1 = left.getOrderingName();
+            String on2 = right.getOrderingName();
+            if (on1 == null && on2 == null) {
+                return 0;
+            } else if (on1 != null && on2 == null) {
+                return -1;
+            } else if (on1 == null && on2 != null) {
+                return 1;
+            } else {
+                return on1.compareToIgnoreCase(on2);
+            }
+        });
 
         return items;
     }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe. Please take a moment to fill out the following suggestion on how to structure this PR description. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bug fix
- [ ] Feature

#### Long description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write a text instead if you can't fit it in a list -->
This is a fix for #3261 (App loops in null pointer with bookmarks exception).
A fix for a bug that prevented the Bookmarked Playlists screen from being displayed because the playlist name had changed to null for some reason.
When Bookmarked Playlists is displayed, sorting is done against the playlist names. This PR prevents crashes by allowing you to sort playlist names that contain a null.

The fundamental solution is to prevent null in playlist names, but I think this fix is necessary to open a database that is already in an unopenable state.

#### Fixes the following issue(s)
<!-- Also add reddit or other links which are relevant to your change. -->
- Fixes #3261

#### Testing apk
<!-- Ensure that you have your changes on a new branch which has a meaningful name. This name will be used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe. Do NOT name your branches like "patch-0" and "feature-1". For example, if your PR implements a bug fix for comments, an appropriate branch name would be "commentfix". -->
apk: [errorwithbookmarks.zip](https://github.com/TeamNewPipe/NewPipe/files/4428531/errorwithbookmarks.zip)
database: [NewPipeData-Test.zip](https://github.com/TeamNewPipe/NewPipe/files/4428532/NewPipeData-Test.zip)

Steps to reproduce the behavior:

1. Import this database.
2. Open the Bookmarked Playlists screen.

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
