### PR TITLE
Avoid unnecessary changes to the upload date of saved streams

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/database/stream/dao/StreamDAO.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/stream/dao/StreamDAO.kt
@@ -80,7 +80,12 @@ abstract class StreamDAO : BasicDAO<StreamEntity> {
 
         val isNewerStreamLive = newerStream.streamType == AUDIO_LIVE_STREAM || newerStream.streamType == LIVE_STREAM
         if (!isNewerStreamLive) {
-            if (existentMinimalStream.uploadDate != null && existentMinimalStream.isUploadDateApproximation != true) {
+
+            // Use the existent upload date if the newer stream does not have a better precision
+            // (i.e. is an approximation). This is done to prevent unnecessary changes.
+            val hasBetterPrecision =
+                    newerStream.uploadDate != null && newerStream.isUploadDateApproximation != true
+            if (existentMinimalStream.uploadDate != null && !hasBetterPrecision) {
                 newerStream.uploadDate = existentMinimalStream.uploadDate
                 newerStream.textualUploadDate = existentMinimalStream.textualUploadDate
                 newerStream.isUploadDateApproximation = existentMinimalStream.isUploadDateApproximation


### PR DESCRIPTION
#### What is it?
- [ ] Bug fix
- [ ] Feature
- [x] Improvement
- [ ] Meta improvement to the project

#### Description of the changes in your PR

The upload date was being updated regardless if the new one had more precision or not, this caused items on the feed to jump around when the user opened one of them.

This changes it to only update when the existent upload date is null or the new one has a higher precision (i.e. is not an approximation).