### PR TITLE
Fix visibility of group sort button in the subscriptions fragment

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
@@ -31,6 +31,7 @@ import org.schabi.newpipe.local.subscription.SubscriptionViewModel.SubscriptionS
 import org.schabi.newpipe.local.subscription.dialog.FeedGroupDialog
 import org.schabi.newpipe.local.subscription.dialog.FeedGroupReorderDialog
 import org.schabi.newpipe.local.subscription.item.*
+import org.schabi.newpipe.local.subscription.item.HeaderWithMenuItem.Companion.PAYLOAD_UPDATE_VISIBILITY_MENU_ITEM
 import org.schabi.newpipe.local.subscription.services.SubscriptionsExportService
 import org.schabi.newpipe.local.subscription.services.SubscriptionsExportService.EXPORT_COMPLETE_ACTION
 import org.schabi.newpipe.local.subscription.services.SubscriptionsExportService.KEY_FILE_PATH
@@ -361,11 +362,8 @@ class SubscriptionFragment : BaseStateFragment<SubscriptionState>() {
             feedGroupsListState = null
         }
 
-        if (groups.size < 2) {
-            items_list.post { feedGroupsSortMenuItem.notifyChanged(HeaderWithMenuItem.PAYLOAD_HIDE_MENU_ITEM) }
-        } else {
-            items_list.post { feedGroupsSortMenuItem.notifyChanged(HeaderWithMenuItem.PAYLOAD_SHOW_MENU_ITEM) }
-        }
+        feedGroupsSortMenuItem.showMenuItem = groups.size > 1
+        items_list.post { feedGroupsSortMenuItem.notifyChanged(PAYLOAD_UPDATE_VISIBILITY_MENU_ITEM) }
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/item/HeaderWithMenuItem.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/item/HeaderWithMenuItem.kt
@@ -10,23 +10,19 @@ import org.schabi.newpipe.R
 class HeaderWithMenuItem(
         val title: String,
         @DrawableRes val itemIcon: Int = 0,
+        var showMenuItem: Boolean = true,
         private val onClickListener: (() -> Unit)? = null,
         private val menuItemOnClickListener: (() -> Unit)? = null
 ) : Item() {
     companion object {
-        const val PAYLOAD_SHOW_MENU_ITEM = 1
-        const val PAYLOAD_HIDE_MENU_ITEM = 2
+        const val PAYLOAD_UPDATE_VISIBILITY_MENU_ITEM = 1
     }
 
     override fun getLayout(): Int = R.layout.header_with_menu_item
 
-
     override fun bind(viewHolder: GroupieViewHolder, position: Int, payloads: MutableList<Any>) {
-        if (payloads.contains(PAYLOAD_SHOW_MENU_ITEM)) {
-            viewHolder.header_menu_item.visibility = VISIBLE
-            return
-        } else if (payloads.contains(PAYLOAD_HIDE_MENU_ITEM)) {
-            viewHolder.header_menu_item.visibility = GONE
+        if (payloads.contains(PAYLOAD_UPDATE_VISIBILITY_MENU_ITEM)) {
+            updateMenuItemVisibility(viewHolder)
             return
         }
 
@@ -44,5 +40,10 @@ class HeaderWithMenuItem(
         val menuItemListener: OnClickListener? =
                 menuItemOnClickListener?.let { OnClickListener { menuItemOnClickListener.invoke() } }
         viewHolder.header_menu_item.setOnClickListener(menuItemListener)
+        updateMenuItemVisibility(viewHolder)
+    }
+
+    private fun updateMenuItemVisibility(viewHolder: GroupieViewHolder) {
+        viewHolder.header_menu_item.visibility = if (showMenuItem) VISIBLE else GONE
     }
 }


### PR DESCRIPTION
#### What is it?
- [x] Bug fix
- [ ] Feature
- [ ] Code base improvement
- [ ] Meta improvement to the project

#### Description of the changes in your PR

The visibility of the group sort button in the subscriptions fragment was not the right one when a rebind happened (e.g. return from another fragment that destroyed its host's views).