### PR TITLE
Show error when video has age limit and setting is disabled

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -816,7 +816,7 @@ public class VideoDetailFragment extends BaseStateFragment<StreamInfo>
                     isLoading.set(false);
                     if (result.getAgeLimit() != NO_AGE_LIMIT && !prefs.getBoolean(
                             getString(R.string.show_age_restricted_content), false)) {
-                        showError(getString(R.string.restricted_video), false);
+                        hideAgeRestrictedContent();
                     } else {
                         currentInfo = result;
                         handleResult(result);
@@ -1239,6 +1239,16 @@ public class VideoDetailFragment extends BaseStateFragment<StreamInfo>
         }
     }
 
+    private void hideAgeRestrictedContent() {
+        showError(getString(R.string.restricted_video), false);
+
+        if (relatedStreamsLayout != null) { // tablet
+            relatedStreamsLayout.setVisibility(View.INVISIBLE);
+        }
+
+        viewPager.setVisibility(View.GONE);
+        tabLayout.setVisibility(View.GONE);
+    }
 
     public void openDownloadDialog() {
         try {

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -103,6 +103,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.schedulers.Schedulers;
 
 import static org.schabi.newpipe.extractor.StreamingService.ServiceInfo.MediaCapability.COMMENTS;
+import static org.schabi.newpipe.extractor.stream.StreamExtractor.NO_AGE_LIMIT;
 import static org.schabi.newpipe.util.AnimationUtils.animateView;
 
 public class VideoDetailFragment extends BaseStateFragment<StreamInfo>
@@ -806,19 +807,25 @@ public class VideoDetailFragment extends BaseStateFragment<StreamInfo>
             currentWorker.dispose();
         }
 
+        final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(activity);
+
         currentWorker = ExtractorHelper.getStreamInfo(serviceId, url, forceLoad)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe((@NonNull StreamInfo result) -> {
+                .subscribe((@NonNull final StreamInfo result) -> {
                     isLoading.set(false);
-                    currentInfo = result;
-                    handleResult(result);
-                    showContent();
-                }, (@NonNull Throwable throwable) -> {
+                    if (result.getAgeLimit() != NO_AGE_LIMIT && !prefs.getBoolean(
+                            getString(R.string.show_age_restricted_content), false)) {
+                        showError(getString(R.string.restricted_video), false);
+                    } else {
+                        currentInfo = result;
+                        handleResult(result);
+                        showContent();
+                    }
+                }, (@NonNull final Throwable throwable) -> {
                     isLoading.set(false);
                     onError(throwable);
                 });
-
     }
 
     private void initTabs() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -136,8 +136,9 @@
     <string name="play_btn_text">Play</string>
     <string name="content">Content</string>
     <string name="show_age_restricted_content_title">Age restricted content</string>
-    <string name="duration_live">Live</string>
     <string name="video_is_age_restricted">Show age restricted video. Future changes are possible from the settings.</string>
+    <string name="restricted_video">This video is age restricted.\n\nIf you want to view it, enable \"Age restricted content\" in the settings.</string>
+    <string name="duration_live">Live</string>
     <string name="downloads">Downloads</string>
     <string name="downloads_title">Downloads</string>
     <string name="error_report_title">Error report</string>


### PR DESCRIPTION
#### What is it?
- [x] Bug fix (user facing)
- [ ] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Now it will show an error for videos with an age limit when the option to view age restricted videos is disabled in the settings:

![Screenshot of video detail fragment with error](https://user-images.githubusercontent.com/46277131/78990761-96b3b980-7b37-11ea-8595-790fd04573cb.jpg)

Apparently there already was a bug in NewPipe that it will still show the tabs when an error occured, and this PR doesn't fix that yet, though it makes it much more noticable.

#### Fixes the following issue(s)
This PR will fix #776.

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
