### PR TITLE
Improve size handling of the drawer header title

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -33,6 +33,7 @@ import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.Window;
 import android.view.WindowManager;
 import android.widget.AdapterView;
@@ -301,6 +302,20 @@ public class MainActivity extends AppCompatActivity {
         headerServiceView = hView.findViewById(R.id.drawer_header_service_view);
         toggleServiceButton = hView.findViewById(R.id.drawer_header_action_button);
         toggleServiceButton.setOnClickListener(view -> toggleServices());
+
+        // If the current app name is bigger than the default "NewPipe" (7 chars),
+        // let the text view grow a little more as well.
+        if (getString(R.string.app_name).length() > "NewPipe".length()) {
+            final TextView headerTitle = hView.findViewById(R.id.drawer_header_newpipe_title);
+            final ViewGroup.LayoutParams layoutParams = headerTitle.getLayoutParams();
+            layoutParams.width = ViewGroup.LayoutParams.WRAP_CONTENT;
+            headerTitle.setLayoutParams(layoutParams);
+            headerTitle.setMaxLines(2);
+            headerTitle.setMinWidth(getResources()
+                    .getDimensionPixelSize(R.dimen.drawer_header_newpipe_title_default_width));
+            headerTitle.setMaxWidth(getResources()
+                    .getDimensionPixelSize(R.dimen.drawer_header_newpipe_title_max_width));
+        }
     }
 
     private void toggleServices() {

--- a/app/src/main/res/layout/drawer_header.xml
+++ b/app/src/main/res/layout/drawer_header.xml
@@ -45,22 +45,21 @@
 
             <TextView
                 android:id="@+id/drawer_header_newpipe_title"
-                android:layout_width="wrap_content"
+                android:layout_width="@dimen/drawer_header_newpipe_title_default_width"
                 android:layout_height="match_parent"
                 android:layout_marginEnd="@dimen/drawer_header_newpipe_icon_title_space"
                 android:ellipsize="end"
                 android:gravity="start|center_vertical"
                 android:hyphenationFrequency="full"
-                android:maxWidth="@dimen/drawer_header_newpipe_title_max_width"
-                android:maxLines="2"
-                android:minWidth="@dimen/drawer_header_newpipe_title_min_width"
+                android:maxLines="1"
                 android:text="@string/app_name"
                 android:textColor="@color/drawer_header_font_color"
                 android:textStyle="bold"
                 app:autoSizeMaxTextSize="@dimen/drawer_header_newpipe_title_max_text_size"
                 app:autoSizeMinTextSize="@dimen/drawer_header_newpipe_title_min_text_size"
                 app:autoSizeTextType="uniform"
-                tools:ignore="UnusedAttribute" />
+                tools:ignore="UnusedAttribute"
+                tools:text="NewPipe" />
         </LinearLayout>
 
         <LinearLayout

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -5,8 +5,8 @@
     <dimen name="drawer_header_padding_top">16dp</dimen>
     <dimen name="drawer_header_newpipe_icon_size">48dp</dimen>
     <dimen name="drawer_header_newpipe_icon_title_space">12dp</dimen>
-    <dimen name="drawer_header_newpipe_title_min_width">120dp</dimen>
-    <dimen name="drawer_header_newpipe_title_max_width">220dp</dimen>
+    <dimen name="drawer_header_newpipe_title_default_width">130dp</dimen>
+    <dimen name="drawer_header_newpipe_title_max_width">200dp</dimen>
     <dimen name="drawer_header_newpipe_title_min_text_size">18sp</dimen>
     <dimen name="drawer_header_newpipe_title_max_text_size">32sp</dimen>
     <dimen name="drawer_header_service_icon_size">16dp</dimen>


### PR DESCRIPTION
#### What is it?
- [x] Bug fix
- [ ] Feature
- [ ] Code base improvement
- [ ] Meta improvement to the project

#### Description of the changes in your PR

Some devices, specially with custom fonts that changed the font width, weren't being correctly adjusted before.

#### Fixes the following issue(s)
- Fix #3381


#### Testing apk

###### Long press the drawer header to switch between app names.
[improve-drawer-title-size-handling.apk.zip](https://github.com/TeamNewPipe/NewPipe/files/4461735/improve-drawer-title-size-handling.apk.zip)
