### PR TITLE
Fix ReCaptcha Activity for another type of recaptcha page

### DIFF
--- a/app/src/debug/java/org/schabi/newpipe/DebugApp.java
+++ b/app/src/debug/java/org/schabi/newpipe/DebugApp.java
@@ -40,8 +40,10 @@ public class DebugApp extends App {
 
     @Override
     protected Downloader getDownloader() {
-        return DownloaderImpl.init(new OkHttpClient.Builder()
+        DownloaderImpl downloader = DownloaderImpl.init(new OkHttpClient.Builder()
                 .addNetworkInterceptor(new StethoInterceptor()));
+        setCookiesToDownloader(downloader);
+        return downloader;
     }
 
     private void initStetho() {

--- a/app/src/main/java/org/schabi/newpipe/App.java
+++ b/app/src/main/java/org/schabi/newpipe/App.java
@@ -5,10 +5,12 @@ import android.app.Application;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.os.Build;
 import android.util.Log;
 
 import androidx.annotation.Nullable;
+import androidx.preference.PreferenceManager;
 
 import com.nostra13.universalimageloader.cache.memory.impl.LRULimitedMemoryCache;
 import com.nostra13.universalimageloader.core.ImageLoader;
@@ -125,7 +127,16 @@ public class App extends Application {
     }
 
     protected Downloader getDownloader() {
-        return DownloaderImpl.init(null);
+        DownloaderImpl downloader = DownloaderImpl.init(null);
+        setCookiesToDownloader(downloader);
+        return downloader;
+    }
+
+    protected void setCookiesToDownloader(final DownloaderImpl downloader) {
+        final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(
+                getApplicationContext());
+        final String key = getApplicationContext().getString(R.string.recaptcha_cookies_key);
+        downloader.setCookies(prefs.getString(key, ""));
     }
 
     private void configureRxJavaErrorHandler() {

--- a/app/src/main/java/org/schabi/newpipe/ReCaptchaActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/ReCaptchaActivity.java
@@ -206,7 +206,7 @@ public class ReCaptchaActivity extends AppCompatActivity {
             Log.d(TAG, "handleCookies: cookies=" + (cookies == null ? "null" : cookies));
         }
 
-        if (cookies == null || foundCookies.contains(cookies)) {
+        if (cookies == null) {
             return;
         }
 

--- a/app/src/main/java/org/schabi/newpipe/ReCaptchaActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/ReCaptchaActivity.java
@@ -1,6 +1,7 @@
 package org.schabi.newpipe;
 
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
@@ -19,6 +20,7 @@ import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.app.NavUtils;
+import androidx.preference.PreferenceManager;
 
 import org.schabi.newpipe.util.ThemeHelper;
 
@@ -159,6 +161,12 @@ public class ReCaptchaActivity extends AppCompatActivity {
         }
 
         if (!foundCookies.isEmpty()) {
+            // save cookies to preferences
+            final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(
+                    getApplicationContext());
+            final String key = getApplicationContext().getString(R.string.recaptcha_cookies_key);
+            prefs.edit().putString(key, foundCookies).apply();
+
             // give cookies to Downloader class
             DownloaderImpl.getInstance().setCookies(foundCookies);
             setResult(RESULT_OK);
@@ -170,7 +178,7 @@ public class ReCaptchaActivity extends AppCompatActivity {
     }
 
 
-    private void handleCookiesFromUrl(final @Nullable String url) {
+    private void handleCookiesFromUrl(@Nullable final String url) {
         if (MainActivity.DEBUG) {
             Log.d(TAG, "handleCookiesFromUrl: url=" + (url == null ? "null" : url));
         }
@@ -201,7 +209,7 @@ public class ReCaptchaActivity extends AppCompatActivity {
         }
     }
 
-    private void handleCookies(final @Nullable String cookies) {
+    private void handleCookies(@Nullable final String cookies) {
         if (MainActivity.DEBUG) {
             Log.d(TAG, "handleCookies: cookies=" + (cookies == null ? "null" : cookies));
         }
@@ -214,7 +222,7 @@ public class ReCaptchaActivity extends AppCompatActivity {
         // add here methods to extract cookies for other services
     }
 
-    private void addYoutubeCookies(final @NonNull String cookies) {
+    private void addYoutubeCookies(@NonNull final String cookies) {
         if (cookies.contains("s_gl=") || cookies.contains("goojf=")
                 || cookies.contains("VISITOR_INFO1_LIVE=")
                 || cookies.contains("GOOGLE_ABUSE_EXEMPTION=")) {

--- a/app/src/main/java/org/schabi/newpipe/ReCaptchaActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/ReCaptchaActivity.java
@@ -7,17 +7,23 @@ import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.webkit.CookieManager;
+import android.webkit.WebResourceRequest;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.app.NavUtils;
 
 import org.schabi.newpipe.util.ThemeHelper;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 
 /*
  * Created by beneth <bmauduit@beneth.fr> on 06.12.16.
@@ -71,10 +77,33 @@ public class ReCaptchaActivity extends AppCompatActivity {
         webSettings.setJavaScriptEnabled(true);
 
         webView.setWebViewClient(new WebViewClient() {
+            @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+            @Override
+            public boolean shouldOverrideUrlLoading(final WebView view,
+                                                    final WebResourceRequest request) {
+                String url = request.getUrl().toString();
+                if (MainActivity.DEBUG) {
+                    Log.d(TAG, "shouldOverrideUrlLoading: request.url=" + url);
+                }
+
+                handleCookiesFromUrl(url);
+                return false;
+            }
+
+            @Override
+            public boolean shouldOverrideUrlLoading(final WebView view, final String url) {
+                if (MainActivity.DEBUG) {
+                    Log.d(TAG, "shouldOverrideUrlLoading: url=" + url);
+                }
+
+                handleCookiesFromUrl(url);
+                return false;
+            }
+
             @Override
             public void onPageFinished(final WebView view, final String url) {
                 super.onPageFinished(view, url);
-                handleCookies(url);
+                handleCookiesFromUrl(url);
             }
         });
 
@@ -124,7 +153,11 @@ public class ReCaptchaActivity extends AppCompatActivity {
     }
 
     private void saveCookiesAndFinish() {
-        handleCookies(webView.getUrl()); // try to get cookies of unclosed page
+        handleCookiesFromUrl(webView.getUrl()); // try to get cookies of unclosed page
+        if (MainActivity.DEBUG) {
+            Log.d(TAG, "saveCookiesAndFinish: foundCookies=" + foundCookies);
+        }
+
         if (!foundCookies.isEmpty()) {
             // give cookies to Downloader class
             DownloaderImpl.getInstance().setCookies(foundCookies);
@@ -137,23 +170,54 @@ public class ReCaptchaActivity extends AppCompatActivity {
     }
 
 
-    private void handleCookies(final String url) {
-        String cookies = CookieManager.getInstance().getCookie(url);
+    private void handleCookiesFromUrl(final @Nullable String url) {
         if (MainActivity.DEBUG) {
-            Log.d(TAG, "handleCookies: "
-                    + "url=" + url + "; cookies=" + (cookies == null ? "null" : cookies));
+            Log.d(TAG, "handleCookiesFromUrl: url=" + (url == null ? "null" : url));
         }
-        if (cookies == null) {
+
+        if (url == null) {
+            return;
+        }
+
+        String cookies = CookieManager.getInstance().getCookie(url);
+        handleCookies(cookies);
+
+        // sometimes cookies are inside the url
+        int abuseStart = url.indexOf("google_abuse=");
+        if (abuseStart != -1) {
+            int abuseEnd = url.indexOf("+path");
+
+            try {
+                String abuseCookie = url.substring(abuseStart + 13, abuseEnd);
+                abuseCookie = URLDecoder.decode(abuseCookie, "UTF-8");
+                handleCookies(abuseCookie);
+            } catch (UnsupportedEncodingException | StringIndexOutOfBoundsException e) {
+                if (MainActivity.DEBUG) {
+                    e.printStackTrace();
+                    Log.d(TAG, "handleCookiesFromUrl: invalid google abuse starting at "
+                            + abuseStart + " and ending at " + abuseEnd + " for url " + url);
+                }
+            }
+        }
+    }
+
+    private void handleCookies(final @Nullable String cookies) {
+        if (MainActivity.DEBUG) {
+            Log.d(TAG, "handleCookies: cookies=" + (cookies == null ? "null" : cookies));
+        }
+
+        if (cookies == null || foundCookies.contains(cookies)) {
             return;
         }
 
         addYoutubeCookies(cookies);
-        // add other methods to extract cookies here
+        // add here methods to extract cookies for other services
     }
 
-    private void addYoutubeCookies(@NonNull final String cookies) {
+    private void addYoutubeCookies(final @NonNull String cookies) {
         if (cookies.contains("s_gl=") || cookies.contains("goojf=")
-                || cookies.contains("VISITOR_INFO1_LIVE=")) {
+                || cookies.contains("VISITOR_INFO1_LIVE=")
+                || cookies.contains("GOOGLE_ABUSE_EXEMPTION=")) {
             // youtube seems to also need the other cookies:
             addCookie(cookies);
         }

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -1129,4 +1129,5 @@
         <item>@string/grid</item>
     </string-array>
 
+    <string name="recaptcha_cookies_key" translatable="false">recaptcha_cookies_key</string>
 </resources>


### PR DESCRIPTION
#### What is it?
- [x] Bug fix (user facing)
- [ ] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
- Try to get cookies from pages even when they start loading, because non-html pages like ones with `pbj=1` never stop loading.
- Try to extract the cookie directly from the redirection url, by looking at the field `google_abuse=`.
- Add `GOOGLE_ABUSE_EXEMPTION=` to the youtube recaptcha cookies.
- Store cookies into shared preferences so that the user does not have to solve a recaptcha every time he opens the app

#### Fixes the following issue(s)
Fixes #3134 fixes #3272 fixes #3418 fixes #3310

#### Testing apk
@mehedihasanziku @baraa272 @LargePrime @tusch001 could you test this, if recaptchas still pop up for you? Also, @Ristovski, even though I didn't change anything about webviews, could you test, too?
[NewPipe_recaptcha-debug_1.zip](https://github.com/TeamNewPipe/NewPipe/files/4464377/NewPipe_recaptcha-debug_1.zip)

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
