### PR TITLE
Fix F-Droid build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,12 +27,6 @@ android {
     }
 
     buildTypes {
-        release {
-            minifyEnabled true
-            shrinkResources true
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-        }
-
         debug {
             multiDexEnabled true
             debuggable true
@@ -49,6 +43,16 @@ android {
                 resValue "string", "app_name", "NewPipe " + workingBranch
                 archivesBaseName = 'NewPipe_' + normalizedWorkingBranch
             }
+        }
+
+        // Keep the release build type at the end of the list to override 'archivesBaseName' of
+        // debug build. This seems to be a Gradle bug, therefore
+        // TODO: update Gradle version
+        release {
+            minifyEnabled true
+            shrinkResources true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            archivesBaseName = 'app'
         }
     }
 


### PR DESCRIPTION
Fixes the behaviour described in https://github.com/TeamNewPipe/NewPipe/pull/3265#issuecomment-612102349

<!-- Hey there. Thank you so much for improving NewPipe. Please take a moment to fill out the following suggestion on how to structure this PR description. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bug fix (build facing)
- [ ] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write a text instead if you can't fit it in a list -->

@Bubu told us:
> when doing a release build the apk is now called:
`NewPipe_head-release-unsigned.apk`. Also a file in the `META-INF` dir now ends up being called `NewPipe_head_release.kotlin_module` instead of `app_release.kotlin_module`.

For some reason the `archivesBaseName` Gradle property from debug builds was used in release builds. Forcing it to be `app` and changing the order of build flavors fixed the problem for me

#### Fixes the following issue(s)
<!-- Also add reddit or other links which are relevant to your change. -->
- https://github.com/TeamNewPipe/NewPipe/pull/3265#issuecomment-612102349


#### Testing apk
<!-- Ensure that you have your changes on a new branch which has a meaningful name. This name will be used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe. Do NOT name your branches like "patch-0" and "feature-1". For example, if your PR implements a bug fix for comments, an appropriate branch name would be "commentfix". -->
@Bubu With the changes I could not reproduce the behaviour you mentioned. Can you verify this by running a build on your machine, please?
[app-release-unsigned.apk.zip](https://github.com/TeamNewPipe/NewPipe/files/4463031/app-release-unsigned.apk.zip)

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
