### PR TITLE
Enqueue on long click on background/popup in channel

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
@@ -465,6 +465,16 @@ public class ChannelFragment extends BaseListInfoFragment<ChannelInfo> {
                 .playOnPopupPlayer(activity, getPlayQueue(), false));
         headerBackgroundButton.setOnClickListener(view -> NavigationHelper
                 .playOnBackgroundPlayer(activity, getPlayQueue(), false));
+
+        headerPopupButton.setOnLongClickListener(view -> {
+            NavigationHelper.enqueueOnPopupPlayer(activity, getPlayQueue(), true);
+            return true;
+        });
+
+        headerBackgroundButton.setOnLongClickListener(view -> {
+            NavigationHelper.enqueueOnBackgroundPlayer(activity, getPlayQueue(), true);
+            return true;
+        });
     }
 
     private void showContentNotSupported() {


### PR DESCRIPTION
#### What is it?
- [ ] Bug fix (user facing)
- [x] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Make background and popup buttons in the channel header long clickable, and trigger an enqueue action in that case, just like in local and remote playlist activities. This is a very small change copied directly from [PlaylistFragment.java](https://github.com/TeamNewPipe/NewPipe/blob/dev/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java#L327-L335).

#### Fixes the following issue(s)
Fixes #3450 

#### Testing apk
@minsk21 test this :-D
[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/4498645/app-debug.zip)

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
