### PR TITLE
Call doInitialLoadLogic() in onStart()

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/BaseStateFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/BaseStateFragment.java
@@ -54,6 +54,11 @@ public abstract class BaseStateFragment<I> extends BaseFragment implements ViewC
     @Override
     public void onViewCreated(final View rootView, final Bundle savedInstanceState) {
         super.onViewCreated(rootView, savedInstanceState);
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
         doInitialLoadLogic();
     }
 


### PR DESCRIPTION
#### What is it?
- [x] Bug fix (user facing)
- [ ] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This PR will make it call `doInitialLoadLogic()` in `onStart()` instead of `onViewCreated()`, so that it only requests it once the fragment is visible or next-to-visible. I still need to test further to see whether it introduces any new bugs.

#### Fixes the following issue(s)
Partially fixes #2678 once it works

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
