### PR TITLE
Open in browser button now really opens in browser

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/util/ShareUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ShareUtils.java
@@ -16,36 +16,33 @@ public final class ShareUtils {
      * Open the url with the system default browser.
      * <p>
      * If no browser is set as default, fallbacks to
-     * {@link ShareUtils#openUrlBrowserChooser(Context, String)}
+     * {@link ShareUtils#openInDefaultApp(Context, String)}
      *
      * @param context the context to use
      * @param url     the url to browse
      */
     public static void openUrlInBrowser(final Context context, final String url) {
-        final Intent intent = new Intent(Intent.ACTION_VIEW);
-        intent.setData(Uri.parse(url));
-
         final String defaultBrowserPackageName = getDefaultBrowserPackageName(context);
 
         if (defaultBrowserPackageName.equals("android")) {
             // no browser set as default
-            openUrlBrowserChooser(context, url);
+            openInDefaultApp(context, url);
         } else {
+            final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
             intent.setPackage(defaultBrowserPackageName);
             context.startActivity(intent);
         }
     }
 
     /**
-     * Open the url with application chooser, including browser and apps able to open url.
+     * Open the url in the default app set to open this type of link
      * <p>
-     * If any app (except browser, typically NewPipe) is set as default,
-     * it will nor open in browser, neither open the chooser, but just the default app.
+     * If no app is set as default, it will open a chooser
      *
      * @param context the context to use
      * @param url     the url to browse
      */
-    private static void openUrlBrowserChooser(final Context context, final String url) {
+    private static void openInDefaultApp(final Context context, final String url) {
         final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
         context.startActivity(Intent.createChooser(
                 intent, context.getString(R.string.share_dialog_title)));

--- a/app/src/main/java/org/schabi/newpipe/util/ShareUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ShareUtils.java
@@ -2,19 +2,77 @@ package org.schabi.newpipe.util;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.net.Uri;
 
 import org.schabi.newpipe.R;
 
 public final class ShareUtils {
-    private ShareUtils() { }
+    private ShareUtils() {
+    }
 
+    /**
+     * Open the url with the system default browser.
+     * <p>
+     * If no browser is set as default, fallbacks to
+     * {@link ShareUtils#openUrlBrowserChooser(Context, String)}
+     *
+     * @param context the context to use
+     * @param url     the url to browse
+     */
     public static void openUrlInBrowser(final Context context, final String url) {
-        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+        final Intent intent = new Intent(Intent.ACTION_VIEW);
+        intent.setData(Uri.parse(url));
+
+        final String defaultBrowserPackageName = getDefaultBrowserPackageName(context);
+
+        if (defaultBrowserPackageName.equals("android")) {
+            // no browser set as default
+            openUrlBrowserChooser(context, url);
+        } else {
+            intent.setPackage(defaultBrowserPackageName);
+            context.startActivity(intent);
+        }
+    }
+
+    /**
+     * Open the url with application chooser, including browser and apps able to open url.
+     * <p>
+     * If any app (except browser, typically NewPipe) is set as default,
+     * it will nor open in browser, neither open the chooser, but just the default app.
+     *
+     * @param context the context to use
+     * @param url     the url to browse
+     */
+    private static void openUrlBrowserChooser(final Context context, final String url) {
+        final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
         context.startActivity(Intent.createChooser(
                 intent, context.getString(R.string.share_dialog_title)));
     }
 
+    /**
+     * Get the default browser package name.
+     * <p>
+     * If no browser is set as default, it will return "android"
+     *
+     * @param context the context to use
+     * @return the package name of the default browser, or "android" if there's no default
+     */
+    private static String getDefaultBrowserPackageName(final Context context) {
+        final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("http://"));
+        final ResolveInfo resolveInfo = context.getPackageManager().resolveActivity(
+                intent, PackageManager.MATCH_DEFAULT_ONLY);
+        return resolveInfo.activityInfo.packageName;
+    }
+
+    /**
+     * Open the android share menu to share the current url.
+     *
+     * @param context the context to use
+     * @param subject the url subject, typically the title
+     * @param url     the url to share
+     */
     public static void shareUrl(final Context context, final String subject, final String url) {
         Intent intent = new Intent(Intent.ACTION_SEND);
         intent.setType("text/plain");

--- a/app/src/main/java/org/schabi/newpipe/util/ShareUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ShareUtils.java
@@ -35,7 +35,7 @@ public final class ShareUtils {
     }
 
     /**
-     * Open the url in the default app set to open this type of link
+     * Open the url in the default app set to open this type of link.
      * <p>
      * If no app is set as default, it will open a chooser
      *


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe. Please take a moment to fill out the following suggestion on how to structure this PR description. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bug fix (user facing)
- [ ] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write a text instead if you can't fit it in a list -->
- Open in browser buttons open in default browser for android 6+ (otherwise no change).

#### Fixes the following issue(s)
- Open in browser button not opening in browser, but either showing a chooser, or worse: opening in NewPipe if NewPipe is set as default for youtube links. I just wanna open in browser

It will only work for android 6+ since it uses default apps, available from settings -> apps -> more -> default apps -> browser app, [a new feature in android 6](https://www.tomsguide.com/us/change-default-apps-in-android,review-3309.html), otherwise it will not change. It will also not change if you have no browser set as default. It's a rare case, because if you have only one browser that does not happen, if you have two, as soon as you choose one browser as default for opening a link, it will be set default in that selector.
Therefore there are only two such cases: fresh new browser install, or not any link set as default.

I've tested with Firefox, Firefox preview and a chromium based browser and had no troubles with this code (I first had a problem with Firefox browsers but changed the way to send the intent, following [playWithKore()](https://github.com/TeamNewPipe/NewPipe/blob/dev/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java#L602) and now it works).

#### Testing apk
[NewPipe_openInBrowser.zip](https://github.com/TeamNewPipe/NewPipe/files/4551024/NewPipe_openInBrowser.zip)

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
