### PR TITLE
Allow time ago debug setting translation

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -480,8 +480,8 @@
     <string name="enable_leak_canary_summary">Memory leak monitoring may cause the app to become unresponsive when heap dumping</string>
     <string name="enable_disposed_exceptions_title">Report out-of-lifecycle errors</string>
     <string name="enable_disposed_exceptions_summary">Force reporting of undeliverable Rx exceptions outside of fragment or activity lifecycle after disposal</string>
-    <string name="show_original_time_ago_title" translatable="false">Show original time ago on items</string>
-    <string name="show_original_time_ago_summary" translatable="false">Original texts from services will be visible in stream items</string>
+    <string name="show_original_time_ago_title">Show original time ago on items</string>
+    <string name="show_original_time_ago_summary">Original texts from services will be visible in stream items</string>
     <!-- Subscriptions import/export -->
     <string name="import_export_title">Import/export</string>
     <string name="import_title">Import</string>


### PR DESCRIPTION
Other debug settings are translatable as well, so why not allow translation for these? Thanks to @AnXh3L0 for pointing that out.