### PR TITLE
Always hide controls if video is playing [Android TV]

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
@@ -1098,7 +1098,7 @@ public final class MainVideoPlayer extends AppCompatActivity
             }
 
             View controlsRoot = getControlsRoot();
-            if (controlsRoot.isInTouchMode()) {
+            if (controlsRoot.isInTouchMode() || isPlaying()) {
                 getControlsVisibilityHandler().removeCallbacksAndMessages(null);
                 getControlsVisibilityHandler().postDelayed(() ->
                         animateView(controlsRoot, false, duration, 0,

--- a/app/src/main/java/org/schabi/newpipe/player/VideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/VideoPlayer.java
@@ -98,8 +98,8 @@ public abstract class VideoPlayer extends BasePlayer
     //////////////////////////////////////////////////////////////////////////*/
 
     public static final int DEFAULT_CONTROLS_DURATION = 300; // 300 millis
-    public static final int DEFAULT_CONTROLS_HIDE_TIME = 2000;  // 2 Seconds
-    public static final int DPAD_CONTROLS_HIDE_TIME = 7000;  // 7 Seconds
+    public static final int DEFAULT_CONTROLS_HIDE_TIME = 2000; // 2 seconds
+    public static final int DPAD_CONTROLS_HIDE_TIME = 5000; // 5 seconds
 
     protected static final int RENDERER_UNAVAILABLE = -1;
 


### PR DESCRIPTION
#### What is it?
- [x] Bug fix (user facing)
- [ ] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
In #2806 a new `safeHideControls` function was added, that would hide controls only if they were opened using a touch gesture. This is obviously never the case when using a tv, so after  `safeHideControls` was used (i.e. after every click on the interface), nothing would happen, preventing controls from ever being hidden. I assume this was added because on a tv it takes some time to press the correct buttons, thus having the ui close while selecting things would have been annoying, so now I made it so that `safeHideControls` hides controls while the video is playing, too, and otherwise the old behaviour is preserved. Also see https://github.com/TeamNewPipe/NewPipe/pull/2806#discussion_r420373214

#### Fixes the following issue(s)
- fixes #3403

#### Testing apk
@Poomex @B0pol @Generator could you test if the usability on TV devices is preserved, even if the ui is hidden when the video is playing?
[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/4588183/app-debug.zip)

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
