### PR TITLE
 Fix Kodi button showing up with unsupported services

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -632,9 +632,10 @@ public class VideoDetailFragment extends BaseStateFragment<StreamInfo>
     }
 
     private void updateMenuItemVisibility() {
-        // show kodi if set in settings
+        // show kodi button if it supports the current service and it is enabled in settings
         menu.findItem(R.id.action_play_with_kodi).setVisible(
-                PreferenceManager.getDefaultSharedPreferences(activity).getBoolean(
+                KoreUtil.isServiceSupportedByKore(serviceId)
+                && PreferenceManager.getDefaultSharedPreferences(activity).getBoolean(
                         activity.getString(R.string.show_play_with_kodi_key), false));
     }
 
@@ -665,8 +666,7 @@ public class VideoDetailFragment extends BaseStateFragment<StreamInfo>
                 return true;
             case R.id.action_play_with_kodi:
                 try {
-                    NavigationHelper.playWithKore(activity, Uri.parse(
-                            url.replace("https", "http")));
+                    NavigationHelper.playWithKore(activity, Uri.parse(currentInfo.getUrl()));
                 } catch (Exception e) {
                     if (DEBUG) {
                         Log.i(TAG, "Failed to start kore", e);

--- a/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
@@ -593,9 +593,6 @@ public final class MainVideoPlayer extends AppCompatActivity
 
             titleTextView.setSelected(true);
             channelTextView.setSelected(true);
-            boolean showKodiButton = PreferenceManager.getDefaultSharedPreferences(this.context)
-                    .getBoolean(this.context.getString(R.string.show_play_with_kodi_key), false);
-            kodiButton.setVisibility(showKodiButton ? View.VISIBLE : View.GONE);
 
             getRootView().setKeepScreenOn(true);
         }
@@ -712,6 +709,13 @@ public final class MainVideoPlayer extends AppCompatActivity
         protected void onMetadataChanged(@NonNull final MediaSourceTag tag) {
             super.onMetadataChanged(tag);
 
+            // show kodi button if it supports the current service and it is enabled in settings
+            final boolean showKodiButton =
+                    KoreUtil.isServiceSupportedByKore(tag.getMetadata().getServiceId())
+                    && PreferenceManager.getDefaultSharedPreferences(context)
+                        .getBoolean(context.getString(R.string.show_play_with_kodi_key), false);
+            kodiButton.setVisibility(showKodiButton ? View.VISIBLE : View.GONE);
+
             titleTextView.setText(tag.getMetadata().getName());
             channelTextView.setText(tag.getMetadata().getUploaderName());
         }
@@ -725,13 +729,12 @@ public final class MainVideoPlayer extends AppCompatActivity
         public void onKodiShare() {
             onPause();
             try {
-                NavigationHelper.playWithKore(this.context,
-                        Uri.parse(playerImpl.getVideoUrl().replace("https", "http")));
+                NavigationHelper.playWithKore(context, Uri.parse(playerImpl.getVideoUrl()));
             } catch (Exception e) {
                 if (DEBUG) {
                     Log.i(TAG, "Failed to start kore", e);
                 }
-                KoreUtil.showInstallKoreDialog(this.context);
+                KoreUtil.showInstallKoreDialog(context);
             }
         }
 

--- a/app/src/main/java/org/schabi/newpipe/util/KoreUtil.java
+++ b/app/src/main/java/org/schabi/newpipe/util/KoreUtil.java
@@ -7,9 +7,15 @@ import android.content.DialogInterface;
 import androidx.appcompat.app.AlertDialog;
 
 import org.schabi.newpipe.R;
+import org.schabi.newpipe.extractor.ServiceList;
 
 public final class KoreUtil {
     private KoreUtil() { }
+
+    public static boolean isServiceSupportedByKore(final int serviceId) {
+        return (serviceId == ServiceList.YouTube.getServiceId()
+                || serviceId == ServiceList.SoundCloud.getServiceId());
+    }
 
     public static void showInstallKoreDialog(final Context context) {
         final AlertDialog.Builder builder = new AlertDialog.Builder(context);

--- a/app/src/main/res/layout-large-land/activity_main_player.xml
+++ b/app/src/main/res/layout-large-land/activity_main_player.xml
@@ -325,8 +325,9 @@
                     android:src="@drawable/ic_cast_white_24dp"
                     android:background="?attr/selectableItemBackground"
                     android:contentDescription="@string/play_with_kodi_title"
+                    android:visibility="gone"
                     tools:ignore="RtlHardcoded"
-                    android:visibility="visible"/>
+                    tools:visibility="visible"/>
 
                 <ImageButton
                     android:id="@+id/share"

--- a/app/src/main/res/layout/activity_main_player.xml
+++ b/app/src/main/res/layout/activity_main_player.xml
@@ -317,8 +317,9 @@
                     android:src="@drawable/ic_cast_white_24dp"
                     android:background="?attr/selectableItemBackground"
                     android:contentDescription="@string/play_with_kodi_title"
+                    android:visibility="gone"
                     tools:ignore="RtlHardcoded"
-                    android:visibility="visible"/>
+                    tools:visibility="visible"/>
 
                 <ImageButton
                     android:id="@+id/share"


### PR DESCRIPTION
#### What is it?
- [x] Bug fix (user facing)
- [ ] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This PR disables the share to Kodi button when the current service is not supported (see the Kore  [AndroidManifest.xml](https://github.com/xbmc/Kore/blob/master/app/src/main/AndroidManifest.xml)). Supported services are Youtube and Soundcloud. From that manifest I could also deduce that replacing `https` with `http` is not needed anymore.

#### Fixes the following issue(s)
- fixes #1166
- closes #1930

#### Testing apk
I tested if the urls correctly matched Kore's manifest, by installing the app (even without connecting it to anything) and sharing urls. Before this fix sharing MediaCCC urls would have generated an error (thus leading to a "Missing Kore app, install it?" dialog), so this method of testing is good. 
[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/4588833/app-debug.zip)

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
