### PR TITLE
Allow choosing which types of search suggestions to show

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/list/search/SearchFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/search/SearchFragment.java
@@ -55,8 +55,8 @@ import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeSearchQu
 import org.schabi.newpipe.fragments.BackPressable;
 import org.schabi.newpipe.fragments.list.BaseListFragment;
 import org.schabi.newpipe.ktx.AnimationType;
-import org.schabi.newpipe.ktx.ExceptionUtils;
 import org.schabi.newpipe.local.history.HistoryRecordManager;
+import org.schabi.newpipe.settings.NewPipeSettings;
 import org.schabi.newpipe.util.Constants;
 import org.schabi.newpipe.util.DeviceUtils;
 import org.schabi.newpipe.util.ExtractorHelper;
@@ -65,16 +65,19 @@ import org.schabi.newpipe.util.ServiceHelper;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import icepick.State;
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
-import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.disposables.CompositeDisposable;
 import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.schedulers.Schedulers;
@@ -143,7 +146,8 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
     @Nullable private Map<Integer, String> menuItemToFilterName = null;
     private StreamingService service;
     private Page nextPage;
-    private boolean isSuggestionsEnabled = true;
+    private boolean showLocalSuggestions = true;
+    private boolean showRemoteSuggestions = true;
 
     private Disposable searchDisposable;
     private Disposable suggestionDisposable;
@@ -194,24 +198,12 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
     public void onAttach(@NonNull final Context context) {
         super.onAttach(context);
 
+        final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(activity);
+        showLocalSuggestions = NewPipeSettings.showLocalSearchSuggestions(activity, prefs);
+        showRemoteSuggestions = NewPipeSettings.showRemoteSearchSuggestions(activity, prefs);
+
         suggestionListAdapter = new SuggestionListAdapter(activity);
-        final SharedPreferences preferences
-                = PreferenceManager.getDefaultSharedPreferences(activity);
-        final boolean isSearchHistoryEnabled = preferences
-                .getBoolean(getString(R.string.enable_search_history_key), true);
-        suggestionListAdapter.setShowSuggestionHistory(isSearchHistoryEnabled);
-
         historyRecordManager = new HistoryRecordManager(context);
-    }
-
-    @Override
-    public void onCreate(final Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-
-        final SharedPreferences preferences
-                = PreferenceManager.getDefaultSharedPreferences(activity);
-        isSuggestionsEnabled = preferences
-                .getBoolean(getString(R.string.show_search_suggestions_key), true);
     }
 
     @Override
@@ -554,7 +546,7 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
             if (DEBUG) {
                 Log.d(TAG, "onClick() called with: v = [" + v + "]");
             }
-            if (isSuggestionsEnabled && !isErrorPanelVisible()) {
+            if ((showLocalSuggestions || showRemoteSuggestions) && !isErrorPanelVisible()) {
                 showSuggestionsPanel();
             }
             if (DeviceUtils.isTv(getContext())) {
@@ -567,7 +559,8 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
                 Log.d(TAG, "onFocusChange() called with: "
                         + "v = [" + v + "], hasFocus = [" + hasFocus + "]");
             }
-            if (isSuggestionsEnabled && hasFocus && !isErrorPanelVisible()) {
+            if ((showLocalSuggestions || showRemoteSuggestions)
+                    && hasFocus && !isErrorPanelVisible()) {
                 showSuggestionsPanel();
             }
         });
@@ -743,6 +736,34 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
         return false;
     }
 
+
+    private Observable<List<SuggestionItem>> getLocalSuggestionsObservable(
+            final String query, final int similarQueryLimit) {
+        return historyRecordManager
+                .getRelatedSearches(query, similarQueryLimit, 25)
+                .toObservable()
+                .map(searchHistoryEntries -> {
+                    final Set<SuggestionItem> result = new HashSet<>(); // remove duplicates
+                    for (final SearchHistoryEntry entry : searchHistoryEntries) {
+                        result.add(new SuggestionItem(true, entry.getSearch()));
+                    }
+                    return new ArrayList<>(result);
+                });
+    }
+
+    private Observable<List<SuggestionItem>> getRemoteSuggestionsObservable(final String query) {
+        return ExtractorHelper
+                .suggestionsFor(serviceId, query)
+                .toObservable()
+                .map(strings -> {
+                    final List<SuggestionItem> result = new ArrayList<>();
+                    for (final String entry : strings) {
+                        result.add(new SuggestionItem(false, entry));
+                    }
+                    return result;
+                });
+    }
+
     private void initSuggestionObserver() {
         if (DEBUG) {
             Log.d(TAG, "initSuggestionObserver() called");
@@ -753,68 +774,42 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
 
         suggestionDisposable = suggestionPublisher
                 .debounce(SUGGESTIONS_DEBOUNCE, TimeUnit.MILLISECONDS)
-                .startWithItem(searchString != null
-                        ? searchString
-                        : "")
-                .filter(ss -> isSuggestionsEnabled)
+                .startWithItem(searchString == null ? "" : searchString)
                 .switchMap(query -> {
-                    final Flowable<List<SearchHistoryEntry>> flowable = historyRecordManager
-                            .getRelatedSearches(query, 3, 25);
-                    final Observable<List<SuggestionItem>> local = flowable.toObservable()
-                            .map(searchHistoryEntries -> {
-                                final List<SuggestionItem> result = new ArrayList<>();
-                                for (final SearchHistoryEntry entry : searchHistoryEntries) {
-                                    result.add(new SuggestionItem(true, entry.getSearch()));
-                                }
-                                return result;
-                            });
+                    // Only show remote suggestions if they are enabled in settings and
+                    // the query length is at least THRESHOLD_NETWORK_SUGGESTION
+                    final boolean shallShowRemoteSuggestionsNow = showRemoteSuggestions
+                            && query.length() >= THRESHOLD_NETWORK_SUGGESTION;
 
-                    if (query.length() < THRESHOLD_NETWORK_SUGGESTION) {
-                        // Only pass through if the query length
-                        // is equal or greater than THRESHOLD_NETWORK_SUGGESTION
-                        return local.materialize();
+                    if (showLocalSuggestions && shallShowRemoteSuggestionsNow) {
+                        return Observable.zip(getLocalSuggestionsObservable(query, 3),
+                                getRemoteSuggestionsObservable(query),
+                                (local, remote) -> {
+                                    remote.removeIf(remoteItem -> local.stream().anyMatch(
+                                            localItem -> localItem.equals(remoteItem)));
+                                    local.addAll(remote);
+                                    return local;
+                                })
+                                .materialize();
+                    } else if (showLocalSuggestions) {
+                        return getLocalSuggestionsObservable(query, 25)
+                                .materialize();
+                    } else if (shallShowRemoteSuggestionsNow) {
+                        return getRemoteSuggestionsObservable(query)
+                                .materialize();
+                    } else {
+                        return Single.fromCallable(Collections::<SuggestionItem>emptyList)
+                                .toObservable()
+                                .materialize();
                     }
-
-                    final Observable<List<SuggestionItem>> network = ExtractorHelper
-                            .suggestionsFor(serviceId, query)
-                            .onErrorReturn(throwable -> {
-                                if (!ExceptionUtils.isNetworkRelated(throwable)) {
-                                    showSnackBarError(new ErrorInfo(throwable,
-                                            UserAction.GET_SUGGESTIONS, searchString, serviceId));
-                                }
-                                return new ArrayList<>();
-                            })
-                            .toObservable()
-                            .map(strings -> {
-                                final List<SuggestionItem> result = new ArrayList<>();
-                                for (final String entry : strings) {
-                                    result.add(new SuggestionItem(false, entry));
-                                }
-                                return result;
-                            });
-
-                    return Observable.zip(local, network, (localResult, networkResult) -> {
-                        final List<SuggestionItem> result = new ArrayList<>();
-                        if (localResult.size() > 0) {
-                            result.addAll(localResult);
-                        }
-
-                        // Remove duplicates
-                        networkResult.removeIf(networkItem ->
-                                localResult.stream().anyMatch(localItem ->
-                                        localItem.query.equals(networkItem.query)));
-
-                        if (networkResult.size() > 0) {
-                            result.addAll(networkResult);
-                        }
-                        return result;
-                    }).materialize();
                 })
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(listNotification -> {
                     if (listNotification.isOnNext()) {
-                        handleSuggestions(listNotification.getValue());
+                        if (listNotification.getValue() != null) {
+                            handleSuggestions(listNotification.getValue());
+                        }
                     } else if (listNotification.isOnError()) {
                         showError(new ErrorInfo(listNotification.getError(),
                                 UserAction.GET_SUGGESTIONS, searchString, serviceId));

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/search/SearchFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/search/SearchFragment.java
@@ -55,6 +55,7 @@ import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeSearchQu
 import org.schabi.newpipe.fragments.BackPressable;
 import org.schabi.newpipe.fragments.list.BaseListFragment;
 import org.schabi.newpipe.ktx.AnimationType;
+import org.schabi.newpipe.ktx.ExceptionUtils;
 import org.schabi.newpipe.local.history.HistoryRecordManager;
 import org.schabi.newpipe.settings.NewPipeSettings;
 import org.schabi.newpipe.util.Constants;
@@ -782,7 +783,8 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
                             && query.length() >= THRESHOLD_NETWORK_SUGGESTION;
 
                     if (showLocalSuggestions && shallShowRemoteSuggestionsNow) {
-                        return Observable.zip(getLocalSuggestionsObservable(query, 3),
+                        return Observable.zip(
+                                getLocalSuggestionsObservable(query, 3),
                                 getRemoteSuggestionsObservable(query),
                                 (local, remote) -> {
                                     remote.removeIf(remoteItem -> local.stream().anyMatch(
@@ -810,8 +812,10 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
                         if (listNotification.getValue() != null) {
                             handleSuggestions(listNotification.getValue());
                         }
-                    } else if (listNotification.isOnError()) {
-                        showError(new ErrorInfo(listNotification.getError(),
+                    } else if (listNotification.isOnError()
+                            && listNotification.getError() != null
+                            && !ExceptionUtils.isInterruptedCaused(listNotification.getError())) {
+                        showSnackBarError(new ErrorInfo(listNotification.getError(),
                                 UserAction.GET_SUGGESTIONS, searchString, serviceId));
                     }
                 });

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/search/SuggestionItem.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/search/SuggestionItem.java
@@ -1,5 +1,7 @@
 package org.schabi.newpipe.fragments.list.search;
 
+import androidx.annotation.NonNull;
+
 public class SuggestionItem {
     final boolean fromHistory;
     public final String query;
@@ -9,6 +11,20 @@ public class SuggestionItem {
         this.query = query;
     }
 
+    @Override
+    public boolean equals(final Object o) {
+        if (o instanceof SuggestionItem) {
+            return query.equals(((SuggestionItem) o).query);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return query.hashCode();
+    }
+
+    @NonNull
     @Override
     public String toString() {
         return "[" + fromHistory + "→" + query + "]";

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/search/SuggestionListAdapter.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/search/SuggestionListAdapter.java
@@ -19,7 +19,6 @@ public class SuggestionListAdapter
     private final ArrayList<SuggestionItem> items = new ArrayList<>();
     private final Context context;
     private OnSuggestionItemSelected listener;
-    private boolean showSuggestionHistory = true;
 
     public SuggestionListAdapter(final Context context) {
         this.context = context;
@@ -27,25 +26,12 @@ public class SuggestionListAdapter
 
     public void setItems(final List<SuggestionItem> items) {
         this.items.clear();
-        if (showSuggestionHistory) {
-            this.items.addAll(items);
-        } else {
-            // remove history items if history is disabled
-            for (final SuggestionItem item : items) {
-                if (!item.fromHistory) {
-                    this.items.add(item);
-                }
-            }
-        }
+        this.items.addAll(items);
         notifyDataSetChanged();
     }
 
     public void setListener(final OnSuggestionItemSelected listener) {
         this.listener = listener;
-    }
-
-    public void setShowSuggestionHistory(final boolean v) {
-        showSuggestionHistory = v;
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
@@ -92,8 +92,7 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
                 .getPreferredLocalization(requireContext());
         initialSelectedContentCountry = org.schabi.newpipe.util.Localization
                 .getPreferredContentCountry(requireContext());
-        initialLanguage = PreferenceManager
-                .getDefaultSharedPreferences(requireContext()).getString("app_language_key", "en");
+        initialLanguage = defaultPreferences.getString(getString(R.string.app_language_key), "en");
 
         final Preference clearCookiePref = requirePreference(R.string.clear_cookie_key);
         clearCookiePref.setOnPreferenceClickListener(preference -> {
@@ -147,8 +146,8 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
                 .getPreferredLocalization(requireContext());
         final ContentCountry selectedContentCountry = org.schabi.newpipe.util.Localization
                 .getPreferredContentCountry(requireContext());
-        final String selectedLanguage = PreferenceManager
-                .getDefaultSharedPreferences(requireContext()).getString("app_language_key", "en");
+        final String selectedLanguage =
+                defaultPreferences.getString(getString(R.string.app_language_key), "en");
 
         if (!selectedLocalization.equals(initialSelectedLocalization)
                 || !selectedContentCountry.equals(initialSelectedContentCountry)

--- a/app/src/main/java/org/schabi/newpipe/settings/NewPipeSettings.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/NewPipeSettings.java
@@ -60,6 +60,10 @@ public final class NewPipeSettings {
             isFirstRun = true;
         }
 
+        // first run migrations, then setDefaultValues, since the latter requires the correct types
+        SettingMigrations.initMigrations(context, isFirstRun);
+
+        // readAgain is true so that if new settings are added their default value is set
         PreferenceManager.setDefaultValues(context, R.xml.main_settings, true);
         PreferenceManager.setDefaultValues(context, R.xml.video_audio_settings, true);
         PreferenceManager.setDefaultValues(context, R.xml.download_settings, true);
@@ -72,8 +76,6 @@ public final class NewPipeSettings {
 
         saveDefaultVideoDownloadDirectory(context);
         saveDefaultAudioDownloadDirectory(context);
-
-        SettingMigrations.initMigrations(context, isFirstRun);
     }
 
     static void saveDefaultVideoDownloadDirectory(final Context context) {

--- a/app/src/main/java/org/schabi/newpipe/settings/NewPipeSettings.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/NewPipeSettings.java
@@ -6,6 +6,7 @@ import android.os.Build;
 import android.os.Environment;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
 import androidx.preference.PreferenceManager;
 
 import org.schabi.newpipe.R;
@@ -123,5 +124,30 @@ public final class NewPipeSettings {
         final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
 
         return prefs.getBoolean(key, true);
+    }
+
+    private static boolean showSearchSuggestions(final Context context,
+                                                 final SharedPreferences sharedPreferences,
+                                                 @StringRes final int key) {
+        final Set<String> enabledSearchSuggestions = sharedPreferences.getStringSet(
+                context.getString(R.string.show_search_suggestions_key), null);
+
+        if (enabledSearchSuggestions == null) {
+            return true; // defaults to true
+        } else {
+            return enabledSearchSuggestions.contains(context.getString(key));
+        }
+    }
+
+    public static boolean showLocalSearchSuggestions(final Context context,
+                                                     final SharedPreferences sharedPreferences) {
+        return showSearchSuggestions(context, sharedPreferences,
+                R.string.show_local_search_suggestions_key);
+    }
+
+    public static boolean showRemoteSearchSuggestions(final Context context,
+                                                      final SharedPreferences sharedPreferences) {
+        return showSearchSuggestions(context, sharedPreferences,
+                R.string.show_remote_search_suggestions_key);
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/settings/SettingMigrations.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/SettingMigrations.java
@@ -19,12 +19,16 @@ import java.util.Set;
 
 import static org.schabi.newpipe.MainActivity.DEBUG;
 
+/**
+ * In order to add a migration, follow these steps, given P is the previous version:<br>
+ * - in the class body add a new {@code MIGRATION_P_P+1 = new Migration(P, P+1) { ... }} and put in
+ *   the {@code migrate()} method the code that need to be run when migrating from P to P+1<br>
+ * - add {@code MIGRATION_P_P+1} at the end of {@link SettingMigrations#SETTING_MIGRATIONS}<br>
+ * - increment {@link SettingMigrations#VERSION}'s value by 1 (so it should become P+1)
+ */
 public final class SettingMigrations {
+
     private static final String TAG = SettingMigrations.class.toString();
-    /**
-     * Version number for preferences. Must be incremented every time a migration is necessary.
-     */
-    public static final int VERSION = 3;
     private static SharedPreferences sp;
 
     public static final Migration MIGRATION_0_1 = new Migration(0, 1) {
@@ -84,8 +88,17 @@ public final class SettingMigrations {
 
             final String showSearchSuggestionsKey =
                     context.getString(R.string.show_search_suggestions_key);
+
+            boolean addAllSearchSuggestionTypes;
+            try {
+                addAllSearchSuggestionTypes = sp.getBoolean(showSearchSuggestionsKey, true);
+            } catch (final ClassCastException e) {
+                // just in case it was not a boolean for some reason, let's consider it a "true"
+                addAllSearchSuggestionTypes = true;
+            }
+
             final Set<String> showSearchSuggestionsValueList = new HashSet<>();
-            if (sp.getBoolean(showSearchSuggestionsKey, true)) {
+            if (addAllSearchSuggestionTypes) {
                 // if the preference was true, all suggestions will be shown, otherwise none
                 Collections.addAll(showSearchSuggestionsValueList, context.getResources()
                         .getStringArray(R.array.show_search_suggestions_value_list));
@@ -108,6 +121,11 @@ public final class SettingMigrations {
             MIGRATION_2_3,
             MIGRATION_3_4,
     };
+
+    /**
+     * Version number for preferences. Must be incremented every time a migration is necessary.
+     */
+    public static final int VERSION = 4;
 
 
     public static void initMigrations(final Context context, final boolean isFirstRun) {

--- a/app/src/main/java/org/schabi/newpipe/settings/SettingMigrations.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/SettingMigrations.java
@@ -13,6 +13,10 @@ import org.schabi.newpipe.error.ErrorInfo;
 import org.schabi.newpipe.error.UserAction;
 import org.schabi.newpipe.util.DeviceUtils;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
 import static org.schabi.newpipe.MainActivity.DEBUG;
 
 public final class SettingMigrations {
@@ -72,6 +76,26 @@ public final class SettingMigrations {
         }
     };
 
+    public static final Migration MIGRATION_3_4 = new Migration(3, 4) {
+        @Override
+        protected void migrate(final Context context) {
+            // Pull request #3546 added support for choosing the type of search suggestions to
+            // show, replacing the on-off switch used before, so migrate the previous user choice
+
+            final String showSearchSuggestionsKey =
+                    context.getString(R.string.show_search_suggestions_key);
+            final Set<String> showSearchSuggestionsValueList = new HashSet<>();
+            if (sp.getBoolean(showSearchSuggestionsKey, true)) {
+                // if the preference was true, all suggestions will be shown, otherwise none
+                Collections.addAll(showSearchSuggestionsValueList, context.getResources()
+                        .getStringArray(R.array.show_search_suggestions_value_list));
+            }
+
+            sp.edit().putStringSet(
+                    showSearchSuggestionsKey, showSearchSuggestionsValueList).apply();
+        }
+    };
+
     /**
      * List of all implemented migrations.
      * <p>
@@ -81,7 +105,8 @@ public final class SettingMigrations {
     private static final Migration[] SETTING_MIGRATIONS = {
             MIGRATION_0_1,
             MIGRATION_1_2,
-            MIGRATION_2_3
+            MIGRATION_2_3,
+            MIGRATION_3_4,
     };
 
 

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -227,6 +227,16 @@
 
     <!-- Content & History -->
     <string name="show_search_suggestions_key" translatable="false">show_search_suggestions</string>
+    <string name="show_local_search_suggestions_key" translatable="false">show_local_search_suggestions</string>
+    <string name="show_remote_search_suggestions_key" translatable="false">show_remote_search_suggestions</string>
+    <string-array name="show_search_suggestions_value_list" translatable="false">
+        <item>@string/show_local_search_suggestions_key</item>
+        <item>@string/show_remote_search_suggestions_key</item>
+    </string-array>
+    <string-array name="show_search_suggestions_description_list" translatable="false">
+        <item>@string/local_search_suggestions</item>
+        <item>@string/remote_search_suggestions</item>
+    </string-array>
     <string name="show_play_with_kodi_key" translatable="false">show_play_with_kodi</string>
     <string name="show_comments_key" translatable="false">show_comments</string>
     <string name="show_next_video_key" translatable="false">show_next_video</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -116,7 +116,9 @@
     <string name="player_gesture_controls_title">Player gesture controls</string>
     <string name="player_gesture_controls_summary">Use gestures to control player brightness and volume</string>
     <string name="show_search_suggestions_title">Search suggestions</string>
-    <string name="show_search_suggestions_summary">Show suggestions when searching</string>
+    <string name="show_search_suggestions_summary">Choose the suggestions to show when searching</string>
+    <string name="local_search_suggestions">Local search suggestions</string>
+    <string name="remote_search_suggestions">Remote search suggestions</string>
     <string name="enable_search_history_title">Search history</string>
     <string name="enable_search_history_summary">Store search queries locally</string>
     <string name="enable_watch_history_title">Watch history</string>

--- a/app/src/main/res/xml/content_settings.xml
+++ b/app/src/main/res/xml/content_settings.xml
@@ -65,11 +65,13 @@
         app:singleLineTitle="false"
         app:iconSpaceReserved="false" />
 
-    <SwitchPreferenceCompat
-        android:defaultValue="true"
+    <MultiSelectListPreference
         android:key="@string/show_search_suggestions_key"
         android:summary="@string/show_search_suggestions_summary"
         android:title="@string/show_search_suggestions_title"
+        android:entries="@array/show_search_suggestions_description_list"
+        android:entryValues="@array/show_search_suggestions_value_list"
+        android:defaultValue="@array/show_search_suggestions_value_list"
         app:singleLineTitle="false"
         app:iconSpaceReserved="false" />
 


### PR DESCRIPTION
#### What is it?
- [ ] Bug fix (user facing)
- [x] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<table>
<tr>
<td><img width="1500px" src="https://user-images.githubusercontent.com/36421898/85949795-142ddf80-b959-11ea-841e-4f8193ca5bab.png"/></td>
<td>This PR replaces the switch preference to enable/disable all search suggestions with a multiselect one, so that the user can choose which types of search suggestions he likes: local, remote, both, none.
Since the previous preference stored a <code>boolean</code> while the new one stores a <code>Set&lt;String&gt;</code>, I had to create a migration function and call it in <code>NewPipeSettings.init()</code>. If the previous value was <code>true</code>, both local and remote suggestions are activated, otherwise they are both deactivated. I testes this and it works both when updating the app and when importing a database with the old setting.</td>
</tr>
</table>

#### Fixes the following issue(s)
- fixes #3540 

#### Testing apk
@anpic could you test if this option suits you?
[app-debug_1.zip](https://github.com/TeamNewPipe/NewPipe/files/4842389/app-debug_1.zip)

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
