### PR TITLE
Hide controls when resumed by media keys

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
@@ -222,6 +222,13 @@ public final class MainVideoPlayer extends AppCompatActivity
         switch (event.getKeyCode()) {
             default:
                 break;
+            case KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE:
+                if (playerImpl.isPlaying()) {
+                    break;
+                }
+            case KeyEvent.KEYCODE_MEDIA_PLAY:
+                playerImpl.hideControls(DEFAULT_CONTROLS_DURATION, DEFAULT_CONTROLS_HIDE_TIME);
+                break;
             case KeyEvent.KEYCODE_BACK:
                 if (AndroidTvUtils.isTv(getApplicationContext())
                         && playerImpl.isControlsVisible()) {


### PR DESCRIPTION

#### What is it?
- [x] Bug fix (user facing)
- [ ] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR

Hide controls after playback is paused by external media key.

#### Fixes the following issue(s)

Fixes #3403

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
