### PR TITLE
Change retry & subscribe buttons background color based on service color

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
@@ -47,6 +47,7 @@ import org.schabi.newpipe.util.ImageDisplayConstants;
 import org.schabi.newpipe.util.Localization;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.ShareUtils;
+import org.schabi.newpipe.util.ThemeHelper;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -374,8 +375,8 @@ public class ChannelFragment extends BaseListInfoFragment<ChannelInfo>
         int backgroundDuration = isButtonVisible ? 300 : 0;
         int textDuration = isButtonVisible ? 200 : 0;
 
-        int subscribeBackground = ContextCompat
-                .getColor(activity, R.color.subscribe_background_color);
+        int subscribeBackground = ThemeHelper
+                .resolveColorFromAttr(activity, R.attr.colorPrimary);
         int subscribeText = ContextCompat.getColor(activity, R.color.subscribe_text_color);
         int subscribedBackground = ContextCompat
                 .getColor(activity, R.color.subscribed_background_color);

--- a/app/src/main/res/layout-large-land/fragment_video_detail.xml
+++ b/app/src/main/res/layout-large-land/fragment_video_detail.xml
@@ -313,18 +313,6 @@
                                     tools:text="Uploader" />
                             </LinearLayout>
 
-                            <!--<Button
-                                android:id="@+id/detail_uploader_subscribe"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_gravity="center_vertical|right"
-                                android:layout_marginRight="12dp"
-                                android:text="@string/rss_button_title"
-                                android:textSize="12sp"
-                                android:theme="@style/RedButton"
-                                android:drawableLeft="@drawable/ic_rss_feed_white_24dp"
-                                tools:ignore="RtlHardcoded"
-                                android:visibility="gone"/>-->
                         </LinearLayout>
 
                         <!-- VIEW & THUMBS -->

--- a/app/src/main/res/layout/channel_header.xml
+++ b/app/src/main/res/layout/channel_header.xml
@@ -108,7 +108,7 @@
             android:layout_marginRight="2dp"
             android:text="@string/subscribe_button_title"
             android:textSize="@dimen/channel_rss_title_size"
-            android:theme="@style/RedButton"
+            android:theme="@style/ServiceColoredButton"
             android:visibility="gone"
             tools:ignore="RtlHardcoded"
             tools:visibility="visible" />

--- a/app/src/main/res/layout/error_retry.xml
+++ b/app/src/main/res/layout/error_retry.xml
@@ -28,6 +28,6 @@
         android:textAllCaps="true"
         android:textAppearance="@style/TextAppearance.AppCompat.Body1"
         android:textSize="16sp"
-        android:theme="@style/RedButton"/>
+        android:theme="@style/ServiceColoredButton"/>
 
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_video_detail.xml
+++ b/app/src/main/res/layout/fragment_video_detail.xml
@@ -308,18 +308,6 @@
 
                             </LinearLayout>
 
-                            <!--<Button
-                                android:id="@+id/detail_uploader_subscribe"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_gravity="center_vertical|right"
-                                android:layout_marginRight="12dp"
-                                android:text="@string/rss_button_title"
-                                android:textSize="12sp"
-                                android:theme="@style/RedButton"
-                                android:drawableLeft="@drawable/ic_rss_feed_white_24dp"
-                                tools:ignore="RtlHardcoded"
-                                android:visibility="gone"/>-->
                         </LinearLayout>
 
                         <!-- VIEW & THUMBS -->

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -56,7 +56,6 @@
     <color name="background_title_color">#ffffff</color>
     <color name="background_subtext_color">#999999</color>
 
-    <color name="subscribe_background_color">#e53935</color>
     <color name="subscribe_text_color">#fff</color>
     <color name="subscribed_background_color">#d6d6d6</color>
     <color name="subscribed_text_color">#717171</color>

--- a/app/src/main/res/values/styles_misc.xml
+++ b/app/src/main/res/values/styles_misc.xml
@@ -1,12 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="RedButton" parent="Widget.AppCompat.Button.Colored">
-        <item name="colorButtonNormal">@color/subscribe_background_color</item>
-        <item name="android:textColor">@color/subscribe_text_color</item>
-        <item name="colorControlHighlight">@color/dark_ripple_color</item>
-    </style>
-
+    <!-- Follows service's primary color -->
     <style name="ServiceColoredButton" parent="Widget.AppCompat.Button.Colored">
         <item name="colorButtonNormal">?attr/colorPrimary</item>
         <item name="android:textColor">@color/subscribe_text_color</item>

--- a/app/src/main/res/values/styles_misc.xml
+++ b/app/src/main/res/values/styles_misc.xml
@@ -7,6 +7,12 @@
         <item name="colorControlHighlight">@color/dark_ripple_color</item>
     </style>
 
+    <style name="ServiceColoredButton" parent="Widget.AppCompat.Button.Colored">
+        <item name="colorButtonNormal">?attr/colorPrimary</item>
+        <item name="android:textColor">@color/subscribe_text_color</item>
+        <item name="colorControlHighlight">@color/dark_ripple_color</item>
+    </style>
+
 
     <!--File picker styles-->
     <style name="FilePickerThemeLight" parent="NNF_BaseTheme.Light">


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe. Please take a moment to fill out the following suggestion on how to structure this PR description. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bug fix (user facing)
- [x] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write a text instead if you can't fit it in a list -->
- change retry (when there is a network error) button color, to follow service's color

#### Fixes the following issue(s)
<!-- Also add reddit or other links which are relevant to your change. -->
- fixes #1134

#### Testing apk
<!-- Ensure that you have your changes on a new branch which has a meaningful name. This name will be used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe. Do NOT name your branches like "patch-0" and "feature-1". For example, if your PR implements a bug fix for comments, an appropriate branch name would be "commentfix". -->
[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/4605400/app-debug.zip)

#### Screenshots
<img width="200" src="https://user-images.githubusercontent.com/58657617/81494994-7ee96580-929c-11ea-871b-793747aedf23.png"> <img width="200" src="https://user-images.githubusercontent.com/58657617/81495007-8f99db80-929c-11ea-9022-d0d57601f529.png"> <img width="200" src="https://user-images.githubusercontent.com/58657617/81494999-84df4680-929c-11ea-9272-2122e1c9a6ce.png"> <img width="200" src="https://user-images.githubusercontent.com/58657617/81495003-8ad52780-929c-11ea-8067-98f4e3c02181.png">

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.