### PR TITLE
Replace PrettyTime with DateUtils.getRelativeTimeSpanString()

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -197,7 +197,6 @@ dependencies {
     implementation 'io.reactivex.rxjava2:rxjava:2.2.2'
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.0'
     implementation 'com.jakewharton.rxbinding2:rxbinding:2.1.1'
-    implementation 'org.ocpsoft.prettytime:prettytime:4.0.3.Final'
 
     implementation "androidx.room:room-runtime:${roomDbLibVersion}"
     implementation "androidx.room:room-rxjava2:${roomDbLibVersion}"

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -18,7 +18,6 @@
 
 -dontobfuscate
 -keep class org.schabi.newpipe.extractor.timeago.patterns.** { *; }
--keep class org.ocpsoft.prettytime.i18n.** { *; }
 
 -keep class org.mozilla.javascript.** { *; }
 

--- a/app/src/main/java/org/schabi/newpipe/about/AboutActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/about/AboutActivity.java
@@ -57,8 +57,6 @@ public class AboutActivity extends AppCompatActivity {
                     "https://github.com/ReactiveX/RxJava", StandardLicenses.APACHE2),
             new SoftwareComponent("RxBinding", "2015 - 2018", "Jake Wharton",
                     "https://github.com/JakeWharton/RxBinding", StandardLicenses.APACHE2),
-            new SoftwareComponent("PrettyTime", "2012 - 2020", "Lincoln Baxter, III",
-                    "https://github.com/ocpsoft/prettytime", StandardLicenses.APACHE2),
             new SoftwareComponent("Markwon", "2017 - 2020", "Noties",
                     "https://github.com/noties/Markwon", StandardLicenses.APACHE2),
             new SoftwareComponent("Groupie", "2016", "Lisa Wray",

--- a/app/src/main/java/org/schabi/newpipe/util/Localization.java
+++ b/app/src/main/java/org/schabi/newpipe/util/Localization.java
@@ -7,14 +7,13 @@ import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.preference.PreferenceManager;
 import android.text.TextUtils;
+import android.text.format.DateUtils;
 import android.util.DisplayMetrics;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.PluralsRes;
 import androidx.annotation.StringRes;
 
-import org.ocpsoft.prettytime.PrettyTime;
-import org.ocpsoft.prettytime.units.Decade;
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.extractor.ListExtractor;
 import org.schabi.newpipe.extractor.localization.ContentCountry;
@@ -53,12 +52,11 @@ import java.util.Locale;
 public final class Localization {
 
     private static final String DOT_SEPARATOR = " • ";
-    private static PrettyTime prettyTime;
 
     private Localization() { }
 
     public static void init(final Context context) {
-        initPrettyTime(context);
+
     }
 
     @NonNull
@@ -290,24 +288,10 @@ public final class Localization {
         }
     }
 
-    /*//////////////////////////////////////////////////////////////////////////
-    // Pretty Time
-    //////////////////////////////////////////////////////////////////////////*/
-
-    private static void initPrettyTime(final Context context) {
-        prettyTime = new PrettyTime(getAppLocale(context));
-        // Do not use decades as YouTube doesn't either.
-        prettyTime.removeUnit(Decade.class);
-    }
-
-    private static PrettyTime getPrettyTime() {
-        return prettyTime;
-    }
-
     public static String relativeTime(final Calendar calendarTime) {
-        String time = getPrettyTime().formatUnrounded(calendarTime);
-        return time.startsWith("-") ? time.substring(1) : time;
-        //workaround fix for russian showing -1 day ago, -19hrs ago…
+        return DateUtils.getRelativeTimeSpanString(
+                calendarTime.getTimeInMillis(), System.currentTimeMillis(),
+                DateUtils.MINUTE_IN_MILLIS).toString();
     }
 
     private static void changeAppLanguage(final Locale loc, final Resources res) {


### PR DESCRIPTION
#### What is it?
- [X] Bug fix (user facing)
- [ ] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR

Remove dependency on PrettyTime by replacing it with a call to `DateUtils.getRelativeTimeSpanString`, which formats relative time in a similar way (although slightly differently):
https://developer.android.com/reference/android/text/format/DateUtils#getRelativeTimeSpanString(long)

One downside is that DateUtils abbreviates time unit names despite that the corresponding flag is not set (FORMAT_ABBREVIATE_RELATIVE). I didn't find a way to disable that...

#### Fixes the following issue(s)

PrettyTime has a bug with formatting relative time in Russian  - https://github.com/ocpsoft/prettytime/issues/182
For example, instead of "2 дня назад" (2 days ago) PrettyTime produces "2 дней назад", which is incorrect plural of "day" in Russian (same with other time units).

#### Testing apk
[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/4605511/app-debug.zip)

#### Agreement
- [ X I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.

