### PR TITLE
Improve long-press menu strings

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -430,10 +430,10 @@
     <string name="play_queue_audio_settings">Audio Settings</string>
     <string name="hold_to_append">Hold to enqueue</string>
     <string name="enqueue_on_background">Enqueue in the background</string>
-    <string name="enqueue_on_popup">Enqueue in a new popup</string>
+    <string name="enqueue_on_popup">Enqueue in a popup</string>
     <string name="start_here_on_main">Start playing here</string>
     <string name="start_here_on_background">Start playing in the background</string>
-    <string name="start_here_on_popup">Start playing in a new popup</string>
+    <string name="start_here_on_popup">Start playing in a popup</string>
     <!-- Drawer -->
     <string name="drawer_open">Open Drawer</string>
     <string name="drawer_close">Close Drawer</string>


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe. Please take a moment to fill out the following suggestion on how to structure this PR description. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bug fix (user facing)
- [ ] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
According to a user on IRC "the menu is confusingly worded, [...], it seems to correctly enqueue in the miniplayer and in the background, it just calls it "a new" miniplayer even if there is already a miniplayer, which obscures the fact that the action will enqueue a song". So I removed the `new` word from the long-press menu strings

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
