### PR TITLE
Export and import remember last path directory

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
@@ -7,6 +7,7 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.os.Environment;
 import android.preference.PreferenceManager;
 import android.util.Log;
 import android.widget.Toast;
@@ -26,6 +27,7 @@ import org.schabi.newpipe.extractor.localization.ContentCountry;
 import org.schabi.newpipe.extractor.localization.Localization;
 import org.schabi.newpipe.report.ErrorActivity;
 import org.schabi.newpipe.report.UserAction;
+import org.schabi.newpipe.util.Constants;
 import org.schabi.newpipe.util.FilePickerActivityHelper;
 import org.schabi.newpipe.util.ZipHelper;
 
@@ -119,7 +121,10 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
 
         Preference importDataPreference = findPreference(getString(R.string.import_data));
         importDataPreference.setOnPreferenceClickListener((Preference p) -> {
+            String startPath = defaultPreferences.getString(Constants.IMPORT_PATH_DIRECTORY,
+                    Environment.getExternalStorageDirectory().getPath());
             Intent i = new Intent(getActivity(), FilePickerActivityHelper.class)
+                    .putExtra(FilePickerActivityHelper.EXTRA_START_PATH, startPath)
                     .putExtra(FilePickerActivityHelper.EXTRA_ALLOW_MULTIPLE, false)
                     .putExtra(FilePickerActivityHelper.EXTRA_ALLOW_CREATE_DIR, false)
                     .putExtra(FilePickerActivityHelper.EXTRA_MODE,
@@ -129,8 +134,12 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
         });
 
         Preference exportDataPreference = findPreference(getString(R.string.export_data));
+
         exportDataPreference.setOnPreferenceClickListener((Preference p) -> {
+            String startPath = defaultPreferences.getString(Constants.EXPORT_PATH_DIRECTORY,
+                    Environment.getExternalStorageDirectory().getPath());
             Intent i = new Intent(getActivity(), FilePickerActivityHelper.class)
+                    .putExtra(FilePickerActivityHelper.EXTRA_START_PATH, startPath)
                     .putExtra(FilePickerActivityHelper.EXTRA_ALLOW_MULTIPLE, false)
                     .putExtra(FilePickerActivityHelper.EXTRA_ALLOW_CREATE_DIR, true)
                     .putExtra(FilePickerActivityHelper.EXTRA_MODE,
@@ -177,9 +186,14 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
                 && resultCode == Activity.RESULT_OK && data.getData() != null) {
             String path = Utils.getFileForUri(data.getData()).getAbsolutePath();
             if (requestCode == REQUEST_EXPORT_PATH) {
+                defaultPreferences.edit().putString(Constants.EXPORT_PATH_DIRECTORY,
+                        path.toString()).apply();
                 SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US);
                 exportDatabase(path + "/NewPipeData-" + sdf.format(new Date()) + ".zip");
             } else {
+                String importDir = new File(path).getParent();
+                defaultPreferences.edit().putString(Constants.IMPORT_PATH_DIRECTORY,
+                        importDir).apply();
                 AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
                 builder.setMessage(R.string.override_current_data)
                         .setPositiveButton(getString(R.string.finish),

--- a/app/src/main/java/org/schabi/newpipe/util/Constants.java
+++ b/app/src/main/java/org/schabi/newpipe/util/Constants.java
@@ -11,6 +11,9 @@ public final class Constants {
     public static final String KEY_THEME_CHANGE = "key_theme_change";
     public static final String KEY_MAIN_PAGE_CHANGE = "key_main_page_change";
 
+    public static final String EXPORT_PATH_DIRECTORY = "export_path_directory";
+    public static final String IMPORT_PATH_DIRECTORY = "import_path_directory";
+
     public static final int NO_SERVICE_ID = -1;
 
     private Constants() { }


### PR DESCRIPTION

#### What is it?
- [ ] Bug fix (user facing)
- [x] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR

This allow NewPipe to remember the directories for export and import, so its easier and faster to restore and save to the desired directory. When the directory is deleted this fallback to the standard external storage directory.

#### Testing apk


[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/4706376/app-debug.zip)


#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
