### PR TITLE
Do not remove items generating errors form queue

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
@@ -64,7 +64,6 @@ import org.schabi.newpipe.player.helper.LoadController;
 import org.schabi.newpipe.player.helper.MediaSessionManager;
 import org.schabi.newpipe.player.helper.PlayerDataSource;
 import org.schabi.newpipe.player.helper.PlayerHelper;
-import org.schabi.newpipe.player.mediasource.FailedMediaSource;
 import org.schabi.newpipe.player.playback.BasePlayerMediaSession;
 import org.schabi.newpipe.player.playback.CustomTrackSelector;
 import org.schabi.newpipe.player.playback.MediaSourceManager;
@@ -77,7 +76,6 @@ import org.schabi.newpipe.util.ImageDisplayConstants;
 import org.schabi.newpipe.util.SerializedCache;
 
 import java.io.IOException;
-import java.net.UnknownHostException;
 
 import io.reactivex.Observable;
 import io.reactivex.disposables.CompositeDisposable;
@@ -835,16 +833,8 @@ public abstract class BasePlayer implements
         final Throwable cause = error.getCause();
         if (error instanceof BehindLiveWindowException) {
             reload();
-        } else if (cause instanceof UnknownHostException) {
-            playQueue.error(/*isNetworkProblem=*/true);
-        } else if (isCurrentWindowValid()) {
-            playQueue.error(/*isTransitioningToBadStream=*/true);
-        } else if (cause instanceof FailedMediaSource.MediaSourceResolutionException) {
-            playQueue.error(/*recoverableWithNoAvailableStream=*/false);
-        } else if (cause instanceof FailedMediaSource.StreamInfoLoadException) {
-            playQueue.error(/*recoverableIfLoadFailsWhenNetworkIsFine=*/false);
         } else {
-            playQueue.error(/*noIdeaWhatHappenedAndLetUserChooseWhatToDo=*/true);
+            playQueue.error();
         }
     }
 

--- a/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueue.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueue.java
@@ -305,25 +305,16 @@ public abstract class PlayQueue implements Serializable {
     }
 
     /**
-     * Report an exception for the item at the current index in order and the course of action:
-     * if the error can be skipped or the current item should be removed.
+     * Report an exception for the item at the current index in order and skip to the next one
      * <p>
      * This is done as a separate event as the underlying manager may have
      * different implementation regarding exceptions.
      * </p>
-     *
-     * @param skippable whether the error could be skipped
      */
-    public synchronized void error(final boolean skippable) {
-        final int index = getIndex();
-
-        if (skippable) {
-            queueIndex.incrementAndGet();
-        } else {
-            removeInternal(index);
-        }
-
-        broadcast(new ErrorEvent(index, getIndex(), skippable));
+    public synchronized void error() {
+        final int oldIndex = getIndex();
+        queueIndex.incrementAndGet();
+        broadcast(new ErrorEvent(oldIndex, getIndex()));
     }
 
     private synchronized void removeInternal(final int removeIndex) {

--- a/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueueAdapter.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueueAdapter.java
@@ -115,9 +115,6 @@ public class PlayQueueAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
                 break;
             case ERROR:
                 final ErrorEvent errorEvent = (ErrorEvent) message;
-                if (!errorEvent.isSkippable()) {
-                    notifyItemRemoved(errorEvent.getErrorIndex());
-                }
                 notifyItemChanged(errorEvent.getErrorIndex());
                 notifyItemChanged(errorEvent.getQueueIndex());
                 break;

--- a/app/src/main/java/org/schabi/newpipe/player/playqueue/events/ErrorEvent.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playqueue/events/ErrorEvent.java
@@ -3,12 +3,10 @@ package org.schabi.newpipe.player.playqueue.events;
 public class ErrorEvent implements PlayQueueEvent {
     private final int errorIndex;
     private final int queueIndex;
-    private final boolean skippable;
 
-    public ErrorEvent(final int errorIndex, final int queueIndex, final boolean skippable) {
+    public ErrorEvent(final int errorIndex, final int queueIndex) {
         this.errorIndex = errorIndex;
         this.queueIndex = queueIndex;
-        this.skippable = skippable;
     }
 
     @Override
@@ -22,9 +20,5 @@ public class ErrorEvent implements PlayQueueEvent {
 
     public int getQueueIndex() {
         return queueIndex;
-    }
-
-    public boolean isSkippable() {
-        return skippable;
     }
 }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe. Please take a moment to fill out the following suggestion on how to structure this PR description. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bug fix (user facing)
- [ ] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<table>
<tr>
<td><img width="3000px" src="https://user-images.githubusercontent.com/36421898/83352146-e8afd900-a349-11ea-9892-17c381aa98a7.gif" /></td>
<td>When an item in the play queue failed to load, only some kind of errors were previously considered as "skippable" (i.e. go to the next stream without removing the current one). But other errors were not (e.g. network errors), so it was annoying in case of a temporary internet instability, because many streams would be removed from a possibly carefully handcrafted queue. This PR keeps the old behaviour when a stream cannot be played, except that every item is considered as "skippable". So if an erroring stream is encountered, the queue index is incremented without removing the old item. If the end of the queue is reached, the index never resets to 0 (even in repeating mode), to prevent "Could not play this stream" loops in case every stream fails.</td>
</tr>
</table>



#### Fixes the following issue(s)
<!-- Also add reddit or other links which are relevant to your change. -->
- fixes #2268
- fixes #3097
- fixes #3725

#### Testing apk
@barudaret @gillhash @daufinsyd
[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/4707625/app-debug.zip)

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
