### PR TITLE
Fix search crash: adapter array index out of bounds

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/list/search/SearchFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/search/SearchFragment.java
@@ -1020,6 +1020,10 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
     public int getSuggestionMovementFlags(@NonNull final RecyclerView recyclerView,
                                           @NonNull final RecyclerView.ViewHolder viewHolder) {
         final int position = viewHolder.getAdapterPosition();
+        if (position == RecyclerView.NO_POSITION) {
+            return 0;
+        }
+
         final SuggestionItem item = suggestionListAdapter.getItem(position);
         return item.fromHistory ? makeMovementFlags(0,
                 ItemTouchHelper.LEFT | ItemTouchHelper.RIGHT) : 0;


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe. Please take a moment to fill out the following suggestion on how to structure this PR description. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bug fix (user facing)
- [ ] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
I don't know the cause of the IndexOutOfBounds exception, it could have something to do with the adapter not having finished to update itself after the last call to `notifyDataSetChanged()`. Anyway, a simple check should fix it.

#### Fixes the following issue(s)
Fixes #3575 

#### Testing apk
@ltomes @test2a could you test this apk and see if it fixes the issue?
[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/4742764/app-debug.zip)

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
