### PR TITLE
Depend on formatKtlint instead of runKtlint for preDebugBuild

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -134,7 +134,7 @@ task formatKtlint(type: JavaExec) {
 }
 
 afterEvaluate {
-    preDebugBuild.dependsOn runCheckstyle, runKtlint
+    preDebugBuild.dependsOn runCheckstyle, formatKtlint
 }
 
 dependencies {


### PR DESCRIPTION
#### What is it?
- [ ] Bug fix (user facing)
- [ ] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [x] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Run `formatKtlint` instead of `runKtlint` before `preDebugBuild`, because IntelliJ IDEA doesn't put `java`, `javax`, and `kotlin` packages in alphabetical order like Ktlint expects. This is pretty annoying when working in Kotlin, however it has already be fixed by JetBrains upstream. This PR works around that, by running `formatKtlint`, which will try to change the Kotlin code to follow the code style and only if it's not possible (AFAIK only wildcard imports), fail instead of failing when the Kotlin code doesn't follow the code style.

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
