### PR TITLE
Fixes enqueue resuming paused videos

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/PopupVideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/PopupVideoPlayer.java
@@ -166,9 +166,6 @@ public final class PopupVideoPlayer extends Service {
             initPopup();
             initPopupCloseOverlay();
         }
-        if (!playerImpl.isPlaying()) {
-            playerImpl.getPlayer().setPlayWhenReady(true);
-        }
 
         playerImpl.handleIntent(intent);
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe. Please take a moment to fill out the following suggestion on how to structure this PR description. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bug fix (user facing)
- [ ] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write a text instead if you can't fit it in a list -->
- Fixes an issue where having a paused video in the popup player then enqueuing another video would cause the paused video to start playing again.
- Does not break expected behavior, clicking the popup button will still immediately play the video that it was clicked on.

#### Fixes the following issue(s)
<!-- Also add reddit or other links which are relevant to your change. -->
- fixes #3760 

#### Testing apk
<!-- Ensure that you have your changes on a new branch which has a meaningful name. This name will be used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe. Do NOT name your branches like "patch-0" and "feature-1". For example, if your PR implements a bug fix for comments, an appropriate branch name would be "commentfix". -->
[debug.zip](https://github.com/TeamNewPipe/NewPipe/files/4796122/app-debug.apk.zip)

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
