### PR TITLE
Fix queue channel name color for some devices

### DIFF
--- a/app/src/main/res/layout/activity_player_queue_control.xml
+++ b/app/src/main/res/layout/activity_player_queue_control.xml
@@ -55,7 +55,6 @@
 
             <TextView
                 android:id="@+id/song_name"
-                style="@android:style/TextAppearance.StatusBar.EventContent.Title"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:ellipsize="marquee"
@@ -63,14 +62,13 @@
                 android:marqueeRepeatLimit="marquee_forever"
                 android:scrollHorizontally="true"
                 android:singleLine="true"
+                android:textAppearance="?android:attr/textAppearanceLarge"
                 android:textSize="14sp"
-                android:textColor="?attr/colorAccent"
                 tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis nec aliquam augue, eget cursus est. Ut id tristique enim, ut scelerisque tellus. Sed ultricies ipsum non mauris ultricies, commodo malesuada velit porta."
                 />
 
             <TextView
                 android:id="@+id/artist_name"
-                style="@android:style/TextAppearance.StatusBar.EventContent"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:ellipsize="marquee"
@@ -78,6 +76,7 @@
                 android:marqueeRepeatLimit="marquee_forever"
                 android:scrollHorizontally="true"
                 android:singleLine="true"
+                android:textAppearance="?android:attr/textAppearanceMedium"
                 android:textSize="12sp"
                 tools:text="Duis posuere arcu condimentum lobortis mattis."/>
         </LinearLayout>


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe. Please take a moment to fill out the following suggestion on how to structure this PR description. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bug fix (user facing)
- [ ] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write a text instead if you can't fit it in a list -->
For some reason a strange `style` attribute was used for title and channel in background/popup queues. This caused some problems on some devices. So I removed the `style` attributes from the `TextView`s and added `textAppearance`, with the same values used in `fragment_video_detail` for, respectively, title and description.

#### Fixes the following issue(s)
<!-- Also add reddit or other links which are relevant to your change. -->
- fixes #2586

#### Testing apk
@xxkfqz @primarto please test if this fixes the issue, thank you in advance ;-)
[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/4840662/app-debug.zip)

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
