### PR TITLE
Do not include Checkstyle in any APK

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -91,6 +91,11 @@ ext {
     markwonVersion = '4.3.1'
 }
 
+configurations {
+    checkstyle
+    ktlint
+}
+
 checkstyle {
     configFile rootProject.file('checkstyle.xml')
     ignoreFailures false
@@ -106,8 +111,7 @@ task runCheckstyle(type: Checkstyle) {
     exclude '**/BuildConfig.java'
     exclude 'main/java/us/shandian/giga/**'
 
-    // empty classpath
-    classpath = files()
+    classpath = configurations.checkstyle
 
     showViolations true
 
@@ -115,10 +119,6 @@ task runCheckstyle(type: Checkstyle) {
         xml.enabled true
         html.enabled true
     }
-}
-
-configurations {
-    ktlint
 }
 
 task runKtlint(type: JavaExec) {
@@ -143,7 +143,7 @@ dependencies {
     implementation "frankiesardo:icepick:${icepickVersion}"
     kapt "frankiesardo:icepick-processor:${icepickVersion}"
 
-    debugImplementation "com.puppycrawl.tools:checkstyle:${checkstyleVersion}"
+    checkstyle "com.puppycrawl.tools:checkstyle:${checkstyleVersion}"
     ktlint "com.pinterest:ktlint:0.35.0"
 
     debugImplementation "com.facebook.stetho:stetho:${stethoVersion}"


### PR DESCRIPTION
#### What is it?
- [ ] Bug fix (user facing)
- [ ] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [x] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Currently unnecessary Checkstyle stuff is included in debug APKs. I changed `build.gradle` to not include that stuff in the debug APKs, while it still runs Checkstyle. This causes debug APKs to be like 8 MB smaller.

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
