### PR TITLE
Fix audio/video desync caused by floating point cumulative errors

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
@@ -331,13 +331,12 @@ public abstract class BasePlayer implements
         final SharedPreferences preferences =
                 PreferenceManager.getDefaultSharedPreferences(context);
 
-        final float speed = preferences
-            .getFloat(context.getString(R.string.playback_speed_key), getPlaybackSpeed());
-        final float pitch = preferences.getFloat(context.getString(R.string.playback_pitch_key),
-            getPlaybackPitch());
-        final boolean skipSilence = preferences
-            .getBoolean(context.getString(R.string.playback_skip_silence_key),
-                getPlaybackSkipSilence());
+        final float speed = preferences.getFloat(
+                context.getString(R.string.playback_speed_key), getPlaybackSpeed());
+        final float pitch = preferences.getFloat(
+                context.getString(R.string.playback_pitch_key), getPlaybackPitch());
+        final boolean skipSilence = preferences.getBoolean(
+                context.getString(R.string.playback_skip_silence_key), getPlaybackSkipSilence());
         return new PlaybackParameters(speed, pitch, skipSilence);
     }
 
@@ -1471,10 +1470,21 @@ public abstract class BasePlayer implements
         return parameters == null ? PlaybackParameters.DEFAULT : parameters;
     }
 
+    /**
+     * Sets the playback parameters of the player, and also saves them to shared preferences.
+     * Speed and pitch are rounded up to 2 decimal places before being used or saved.
+     * @param speed the playback speed, will be rounded to up to 2 decimal places
+     * @param pitch the playback pitch, will be rounded to up to 2 decimal places
+     * @param skipSilence skip silence during playback
+     */
     public void setPlaybackParameters(final float speed, final float pitch,
                                       final boolean skipSilence) {
-        savePlaybackParametersToPreferences(speed, pitch, skipSilence);
-        simpleExoPlayer.setPlaybackParameters(new PlaybackParameters(speed, pitch, skipSilence));
+        final float roundedSpeed = Math.round(speed * 100.0f) / 100.0f;
+        final float roundedPitch = Math.round(pitch * 100.0f) / 100.0f;
+
+        savePlaybackParametersToPreferences(roundedSpeed, roundedPitch, skipSilence);
+        simpleExoPlayer.setPlaybackParameters(
+                new PlaybackParameters(roundedSpeed, roundedPitch, skipSilence));
     }
 
     private void savePlaybackParametersToPreferences(final float speed, final float pitch,


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe. Please take a moment to fill out the following suggestion on how to structure this PR description. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bug fix (user facing)
- [ ] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
After doing a `git bisect` I found out which commit caused the desync to appear: 3855e488cb78959dbf6327ff187fda8867e42b43
The problem was that the value of playback speed, even though displayed as `1.0x`, was instead `1.00267911`. This was probably caused by cumulative floating point errors after saving and restoring the value many times from shared preferences. This PR rounds speed and pitch to 2 decimal places before saving them or feeding them to the player, so that any floating point error is eliminated and the issue is not there anymore.



#### Fixes the following issue(s)
<!-- Also add reddit or other links which are relevant to your change. -->
- fixes #3550

#### Testing apk
*The reason as to why having a playback speed very near 1.0 caused desync is still unknown to me*, but I tested this PR with the settings provided at https://github.com/TeamNewPipe/NewPipe/issues/3550#issuecomment-626040706 and the issue is not there anymore (I am sure it was there before with the same setup).
@LukasThyWalls @juantxorena @ajtpak @mgolden356 @Godecki @macearl @vadiof @loque036 @B0pol @coolsan06 @theScrabi could you test this apk and confirm it fixes the issue?
[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/4854310/app-debug.zip)


#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
