### PR TITLE
Hold player controls to keep them shown and other player annoyances

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
@@ -701,6 +701,12 @@ public final class MainVideoPlayer extends AppCompatActivity
             updatePlaybackButtons();
         }
 
+        @Override
+        public void onPlay() {
+            super.onPlay();
+            showControlsThenHide();
+        }
+
         /*//////////////////////////////////////////////////////////////////////////
         // Playback Listener
         //////////////////////////////////////////////////////////////////////////*/

--- a/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
@@ -95,6 +95,7 @@ import java.util.List;
 import java.util.Queue;
 import java.util.UUID;
 
+import static org.schabi.newpipe.player.BasePlayer.STATE_BUFFERING;
 import static org.schabi.newpipe.player.BasePlayer.STATE_PLAYING;
 import static org.schabi.newpipe.player.VideoPlayer.DEFAULT_CONTROLS_DURATION;
 import static org.schabi.newpipe.player.VideoPlayer.DEFAULT_CONTROLS_HIDE_TIME;
@@ -1292,6 +1293,7 @@ public final class MainVideoPlayer extends AppCompatActivity
                 playerImpl.getPlayPauseButton().performClick();
             }
 
+            onUpSetControlsCooldown = playerImpl.isControlsVisible();
             return true;
         }
 
@@ -1502,13 +1504,16 @@ public final class MainVideoPlayer extends AppCompatActivity
 
                 if (onUpSetControlsCooldown) {
                     onUpSetControlsCooldown = false;
+                    final boolean playingOrBuffering = playerImpl.getCurrentState() == STATE_PLAYING
+                            || playerImpl.getCurrentState() == STATE_BUFFERING;
+
                     if (playerImpl.isControlsVisible()) {
-                        if (playerImpl.getCurrentState() == STATE_PLAYING) {
+                        if (playingOrBuffering) {
                             playerImpl.hideControls(DEFAULT_CONTROLS_DURATION,
                                     DEFAULT_CONTROLS_HIDE_TIME);
                         }
                     } else {
-                        if (playerImpl.getCurrentState() == STATE_PLAYING) {
+                        if (playingOrBuffering) {
                             playerImpl.showControlsThenHide();
                         } else {
                             playerImpl.showControls(DEFAULT_CONTROLS_DURATION);

--- a/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/MainVideoPlayer.java
@@ -1273,7 +1273,6 @@ public final class MainVideoPlayer extends AppCompatActivity
         private final int maxVolume = playerImpl.getAudioReactor().getMaxVolume();
 
         private boolean isMoving = false;
-        private boolean wereControlsShownBeforeMoving = false;
         private boolean onUpSetControlsCooldown = false;
 
         @Override
@@ -1345,7 +1344,9 @@ public final class MainVideoPlayer extends AppCompatActivity
         @Override
         public boolean onScroll(final MotionEvent initialEvent, final MotionEvent movingEvent,
                                 final float distanceX, final float distanceY) {
-            onUpSetControlsCooldown = true;
+            if (!isMoving) {
+                onUpSetControlsCooldown = true;
+            }
             if (!isVolumeGestureEnabled && !isBrightnessGestureEnabled) {
                 return false;
             }
@@ -1373,7 +1374,17 @@ public final class MainVideoPlayer extends AppCompatActivity
                 return false;
             }
 
-            isMoving = true;
+            if (!isMoving) {
+                isMoving = true;
+                if (playerImpl.isControlsVisible()) {
+                    // hide controls during gesture but show them again afterward since
+                    // onUpSetControlsCooldown is true
+                    playerImpl.hideControls(DEFAULT_CONTROLS_DURATION, 0);
+                } else {
+                    // prevent controls from being shown after gesture
+                    onUpSetControlsCooldown = false;
+                }
+            }
 
             boolean acceptAnyArea = isVolumeGestureEnabled != isBrightnessGestureEnabled;
             boolean acceptVolumeArea = acceptAnyArea
@@ -1405,7 +1416,8 @@ public final class MainVideoPlayer extends AppCompatActivity
                 );
 
                 if (playerImpl.getVolumeRelativeLayout().getVisibility() != View.VISIBLE) {
-                    animateView(playerImpl.getVolumeRelativeLayout(), SCALE_AND_ALPHA, true, 200);
+                    animateView(playerImpl.getVolumeRelativeLayout(), SCALE_AND_ALPHA, true,
+                            DEFAULT_CONTROLS_DURATION);
                 }
                 if (playerImpl.getBrightnessRelativeLayout().getVisibility() == View.VISIBLE) {
                     playerImpl.getBrightnessRelativeLayout().setVisibility(View.GONE);
@@ -1436,7 +1448,7 @@ public final class MainVideoPlayer extends AppCompatActivity
 
                 if (playerImpl.getBrightnessRelativeLayout().getVisibility() != View.VISIBLE) {
                     animateView(playerImpl.getBrightnessRelativeLayout(), SCALE_AND_ALPHA, true,
-                            200);
+                            DEFAULT_CONTROLS_DURATION);
                 }
                 if (playerImpl.getVolumeRelativeLayout().getVisibility() == View.VISIBLE) {
                     playerImpl.getVolumeRelativeLayout().setVisibility(View.GONE);
@@ -1468,11 +1480,11 @@ public final class MainVideoPlayer extends AppCompatActivity
 
             if (playerImpl.getVolumeRelativeLayout().getVisibility() == View.VISIBLE) {
                 animateView(playerImpl.getVolumeRelativeLayout(), SCALE_AND_ALPHA, false,
-                        200, 200);
+                        DEFAULT_CONTROLS_DURATION, 0);
             }
             if (playerImpl.getBrightnessRelativeLayout().getVisibility() == View.VISIBLE) {
                 animateView(playerImpl.getBrightnessRelativeLayout(), SCALE_AND_ALPHA, false,
-                        200, 200);
+                        DEFAULT_CONTROLS_DURATION, 0);
             }
         }
 

--- a/app/src/main/java/org/schabi/newpipe/player/VideoPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/VideoPlayer.java
@@ -973,8 +973,8 @@ public abstract class VideoPlayer extends BasePlayer
                 ? DEFAULT_CONTROLS_HIDE_TIME
                 : DPAD_CONTROLS_HIDE_TIME;
 
-        animateView(controlsRoot, true, DEFAULT_CONTROLS_DURATION, 0,
-                () -> hideControls(DEFAULT_CONTROLS_DURATION, hideTime));
+        animateView(controlsRoot, true, DEFAULT_CONTROLS_DURATION);
+        hideControls(DEFAULT_CONTROLS_DURATION, hideTime + DEFAULT_CONTROLS_DURATION);
     }
 
     public void showControls(final long duration) {


### PR DESCRIPTION
#### What is it?
- [x] Bug fix (user facing)
- [x] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
With this PR the player controls are never hidden while the user is touching the screen (e.g. while holding a finger on the touch screen or while making gestures). This enables long titles to be read even if the marquee would be too slow to read in the small amount of time granted by `showControlsThenHide()`. This PR also fixes controls hiding after hiding and reshowing them on a paused video: the problem was the single tap function did not respect "if paused never hide automatically".
This PR also fixes:
- controls not hiding after replaying
- icons layered on top of each other while  changing brightness or volume

If this will be merged after Unified UI, I'd be ok with rebasing or reimplementing.

#### Fixes the following issue(s)
<!-- Also add reddit or other links which are relevant to your change. -->
- closes #3842

#### Testing apk
@hunkjazz @MD77MD could you test this thoroughly to confirm I didn't introduce nasty issues?
[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/4875473/app-debug.zip)

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
