### PR TITLE
Use androidx.annotation.NonNull instead of io.reactivex.annotations.NonNull

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/App.java
+++ b/app/src/main/java/org/schabi/newpipe/App.java
@@ -9,6 +9,7 @@ import android.content.SharedPreferences;
 import android.os.Build;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
 import androidx.preference.PreferenceManager;
 
 import com.nostra13.universalimageloader.cache.memory.impl.LRULimitedMemoryCache;
@@ -37,7 +38,6 @@ import java.net.SocketException;
 import java.util.Collections;
 import java.util.List;
 
-import io.reactivex.annotations.NonNull;
 import io.reactivex.exceptions.CompositeException;
 import io.reactivex.exceptions.MissingBackpressureException;
 import io.reactivex.exceptions.OnErrorNotImplementedException;

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -1025,7 +1025,7 @@ public class VideoDetailFragment extends BaseStateFragment<StreamInfo>
 
         if (description.getType() == Description.HTML) {
             disposables.add(Single.just(description.getContent())
-                    .map((@io.reactivex.annotations.NonNull String descriptionText) -> {
+                    .map((@NonNull String descriptionText) -> {
                         Spanned parsedDescription;
                         if (Build.VERSION.SDK_INT >= 24) {
                             parsedDescription = Html.fromHtml(descriptionText, 0);
@@ -1037,7 +1037,7 @@ public class VideoDetailFragment extends BaseStateFragment<StreamInfo>
                     })
                     .subscribeOn(Schedulers.computation())
                     .observeOn(AndroidSchedulers.mainThread())
-                    .subscribe((@io.reactivex.annotations.NonNull Spanned spanned) -> {
+                    .subscribe((@NonNull Spanned spanned) -> {
                         videoDescriptionView.setText(spanned);
                         videoDescriptionView.setVisibility(View.VISIBLE);
                     }));

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListInfoFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListInfoFragment.java
@@ -158,11 +158,10 @@ public abstract class BaseListInfoFragment<I extends ListInfo>
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .doFinally(this::allowDownwardFocusScroll)
-                .subscribe((@io.reactivex.annotations.NonNull
-                                    ListExtractor.InfoItemsPage InfoItemsPage) -> {
+                .subscribe((@NonNull ListExtractor.InfoItemsPage InfoItemsPage) -> {
                     isLoading.set(false);
                     handleNextItems(InfoItemsPage);
-                }, (@io.reactivex.annotations.NonNull Throwable throwable) -> {
+                }, (@NonNull Throwable throwable) -> {
                     isLoading.set(false);
                     onError(throwable);
                 });

--- a/app/src/main/java/org/schabi/newpipe/player/playqueue/AbstractInfoPlayQueue.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playqueue/AbstractInfoPlayQueue.java
@@ -2,6 +2,8 @@ package org.schabi.newpipe.player.playqueue;
 
 import android.util.Log;
 
+import androidx.annotation.NonNull;
+
 import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.ListExtractor;
 import org.schabi.newpipe.extractor.ListInfo;
@@ -13,7 +15,6 @@ import java.util.Collections;
 import java.util.List;
 
 import io.reactivex.SingleObserver;
-import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.Disposable;
 
 abstract class AbstractInfoPlayQueue<T extends ListInfo, U extends InfoItem> extends PlayQueue {

--- a/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueueAdapter.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueueAdapter.java
@@ -6,6 +6,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
 import org.schabi.newpipe.R;
@@ -20,7 +21,6 @@ import org.schabi.newpipe.util.FallbackViewHolder;
 import java.util.List;
 
 import io.reactivex.Observer;
-import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.Disposable;
 
 /**


### PR DESCRIPTION
#### What is it?
- [ ] Bug fix (user facing)
- [ ] Feature (user facing)
- [x] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Apparently we were using ReactiveX' `NonNull` annotations at certain places, while we're using AndroidX' `NonNull` annotations everywhere else.

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
