### PR TITLE
Allow playback speed to be changed up to 8x

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlaybackParameterDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlaybackParameterDialog.java
@@ -24,7 +24,8 @@ import static org.schabi.newpipe.util.Localization.assureCorrectAppLanguage;
 public class PlaybackParameterDialog extends DialogFragment {
     // Minimum allowable range in ExoPlayer
     private static final double MINIMUM_PLAYBACK_VALUE = 0.10f;
-    private static final double MAXIMUM_PLAYBACK_VALUE = 3.00f;
+    // Maximum allowable range in ExoPlayer
+    private static final double MAXIMUM_PLAYBACK_VALUE = 8.00f;
 
     private static final char STEP_UP_SIGN = '+';
     private static final char STEP_DOWN_SIGN = '-';


### PR DESCRIPTION
#### What is it?
- [ ] Bug fix (user facing)
- [X] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR

ExoPlayer supports up to 8x. I see no disadvantages for users to experiment with playback speeds if their device and internet connection are capable enough.
Source for ExoPlayer limitation of 8x:
https://github.com/google/ExoPlayer/blob/release-v2/library/core/src/main/java/com/google/android/exoplayer2/audio/SonicAudioProcessor.java

#### Fixes the following issue(s)
closes #3876 

#### Agreement
- [X] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
