### PR TITLE
Add settings for default download media type.

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
@@ -519,6 +519,11 @@ public class DownloadDialog extends DialogFragment
         String defaultMedia = prefs.getString(getString(R.string.default_download_type),
                 getString(R.string.default_download_type_default));
 
+        if (defaultMedia.equals(getString(R.string.select_last_used_download_type))) {
+            defaultMedia = prefs.getString(getString(R.string.last_used_download_type),
+                    getString(R.string.default_download_type_default));
+        }
+
         assert defaultMedia != null;
         if (isVideoStreamsAvailable && (defaultMedia.equals(getString(R.string.video)))) {
             videoButton.setChecked(true);
@@ -609,6 +614,7 @@ public class DownloadDialog extends DialogFragment
         StoredDirectoryHelper mainStorage;
         MediaFormat format;
         String mime;
+        String selectedMediaType;
 
         // first, build the filename and get the output folder (if possible)
         // later, run a very very very large file checking logic
@@ -617,6 +623,7 @@ public class DownloadDialog extends DialogFragment
 
         switch (radioStreamsGroup.getCheckedRadioButtonId()) {
             case R.id.audio_button:
+                selectedMediaType = getString(R.string.audio);
                 mainStorage = mainStorageAudio;
                 format = audioStreamsAdapter.getItem(selectedAudioIndex).getFormat();
                 switch (format) {
@@ -631,12 +638,14 @@ public class DownloadDialog extends DialogFragment
                 }
                 break;
             case R.id.video_button:
+                selectedMediaType = getString(R.string.video);
                 mainStorage = mainStorageVideo;
                 format = videoStreamsAdapter.getItem(selectedVideoIndex).getFormat();
                 mime = format.mimeType;
                 filename += format.suffix;
                 break;
             case R.id.subtitle_button:
+                selectedMediaType = getString(R.string.caption_setting_title);
                 mainStorage = mainStorageVideo; // subtitle & video files go together
                 format = subtitleStreamsAdapter.getItem(selectedSubtitleIndex).getFormat();
                 mime = format.mimeType;
@@ -678,6 +687,11 @@ public class DownloadDialog extends DialogFragment
 
         // check for existing file with the same name
         checkSelectedDownload(mainStorage, mainStorage.findFile(filename), filename, mime);
+
+        // remember the last media type downloaded by the user
+        SharedPreferences.Editor editor = prefs.edit();
+        editor.putString(getString(R.string.last_used_download_type), selectedMediaType);
+        editor.apply();
     }
 
     private void checkSelectedDownload(final StoredDirectoryHelper mainStorage,

--- a/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
@@ -515,7 +515,22 @@ public class DownloadDialog extends DialogFragment
         videoButton.setVisibility(isVideoStreamsAvailable ? View.VISIBLE : View.GONE);
         subtitleButton.setVisibility(isSubtitleStreamsAvailable ? View.VISIBLE : View.GONE);
 
-        if (isVideoStreamsAvailable) {
+        prefs = PreferenceManager.getDefaultSharedPreferences(getContext());
+        String defaultMedia = prefs.getString(getString(R.string.default_download_type),
+                getString(R.string.default_download_type_default));
+
+        assert defaultMedia != null;
+        if (isVideoStreamsAvailable && (defaultMedia.equals(getString(R.string.video)))) {
+            videoButton.setChecked(true);
+            setupVideoSpinner();
+        } else if (isAudioStreamsAvailable && (defaultMedia.equals(getString(R.string.audio)))) {
+            audioButton.setChecked(true);
+            setupAudioSpinner();
+        } else if (isSubtitleStreamsAvailable
+                && (defaultMedia.equals(getString(R.string.caption_setting_title)))) {
+            subtitleButton.setChecked(true);
+            setupSubtitleSpinner();
+        } else if (isVideoStreamsAvailable) {
             videoButton.setChecked(true);
             setupVideoSpinner();
         } else if (isAudioStreamsAvailable) {

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -614,4 +614,6 @@
     <string name="show_original_time_ago_title">Afficher la date originelle sur les items</string>
     <string name="youtube_restricted_mode_enabled_title">Mode restreint de YouTube</string>
     <string name="feed_group_show_only_ungrouped_subscriptions">Afficher les abonnements sans groupes uniquement</string>
+    <string name="default_download_type_msg">Média par défaut</string>
+    <string name="default_download_type_desc">Type de média à télécharger par défaut</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -616,4 +616,5 @@
     <string name="feed_group_show_only_ungrouped_subscriptions">Afficher les abonnements sans groupes uniquement</string>
     <string name="default_download_type_msg">Média par défaut</string>
     <string name="default_download_type_desc">Type de média à télécharger par défaut</string>
+    <string name="select_last_used_download_type">Se souvenir du choix précédent</string>
 </resources>

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -220,6 +220,14 @@
     <string name="clear_playback_states_key" translatable="false">clear_playback_states</string>
     <string name="clear_search_history_key" translatable="false">clear_search_history</string>
 
+    <string name="default_download_type" translatable="false">default_download</string>
+    <string name="default_download_type_default" translatable="false">@string/video</string>
+    <string-array name="default_download_type_list" translatable="false">
+        <item>@string/video</item>
+        <item>@string/audio</item>
+        <item>@string/caption_setting_title</item>
+    </string-array>
+
     <string name="downloads_storage_ask" translatable="false">downloads_storage_ask</string>
     <string name="storage_use_saf" translatable="false">storage_use_saf</string>
 

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -226,7 +226,9 @@
         <item>@string/video</item>
         <item>@string/audio</item>
         <item>@string/caption_setting_title</item>
+        <item>@string/select_last_used_download_type</item>
     </string-array>
+    <string name="last_used_download_type" translatable="false">@string/video</string>
 
     <string name="downloads_storage_ask" translatable="false">downloads_storage_ask</string>
     <string name="storage_use_saf" translatable="false">storage_use_saf</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -587,6 +587,8 @@
     <string name="delete_downloaded_files">Delete downloaded files</string>
     <string name="deleted_downloads">Deleted %1$d downloads</string>
     <string name="stop">Stop</string>
+    <string name="default_download_type_msg">Default download</string>
+    <string name="default_download_type_desc">Media type to download by default</string>
     <string name="max_retry_msg">Maximum retries</string>
     <string name="max_retry_desc">Maximum number of attempts before canceling the download</string>
     <string name="pause_downloads_on_mobile">Interrupt on metered networks</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -589,6 +589,7 @@
     <string name="stop">Stop</string>
     <string name="default_download_type_msg">Default download</string>
     <string name="default_download_type_desc">Media type to download by default</string>
+    <string name="select_last_used_download_type">Remember last used</string>
     <string name="max_retry_msg">Maximum retries</string>
     <string name="max_retry_desc">Maximum number of attempts before canceling the download</string>
     <string name="pause_downloads_on_mobile">Interrupt on metered networks</string>

--- a/app/src/main/res/xml/download_settings.xml
+++ b/app/src/main/res/xml/download_settings.xml
@@ -4,6 +4,14 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:title="@string/settings_category_downloads_title">
 
+    <ListPreference
+        app:iconSpaceReserved="false"
+        android:defaultValue="@string/default_download_type_default"
+        android:entries="@array/default_download_type_list"
+        android:entryValues="@array/default_download_type_list"
+        android:key="@string/default_download_type"
+        android:summary="@string/default_download_type_desc"
+        android:title="@string/default_download_type_msg" />
 
     <CheckBoxPreference
         app:iconSpaceReserved="false"


### PR DESCRIPTION
#### What is it?
- [x] Feature (user facing)

#### Description of the changes in your PR
- Users can now select a default media type for their downloads.

#### Fixes the following issue(s)
- Closes feature request #3490. This implementation follows the suggestion (1): a default value in preferences.

#### Relies on the following changes
- Added a new setting in the download preferences.

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them. Please note that I do not plan to maintain this feature.
