### PR TITLE
Check for description == null

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -1018,7 +1018,7 @@ public class VideoDetailFragment extends BaseStateFragment<StreamInfo>
     }
 
     private void prepareDescription(final Description description) {
-        if (TextUtils.isEmpty(description.getContent())
+        if (description == null || TextUtils.isEmpty(description.getContent())
                 || description == Description.emptyDescription) {
             return;
         }


### PR DESCRIPTION
#### What is it?
- [x] Bug fix (user facing)
- [ ] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
I just found this issue while trying to debug the the age restricted videos issue. This shouldn't be able to happen with any service currently though.

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
