### PR TITLE
Fix ACRA bug reports not containing stack trace

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -89,6 +89,7 @@ ext {
     androidxRoomVersion = '2.2.5'
     groupieVersion = '2.8.0'
     markwonVersion = '4.3.1'
+    googleAutoServiceVersion = '1.0-rc7'
 }
 
 configurations {
@@ -174,6 +175,9 @@ dependencies {
     implementation "com.google.android.exoplayer:extension-mediasession:${exoPlayerVersion}"
 
     implementation "com.google.android.material:material:1.1.0"
+
+    compileOnly "com.google.auto.service:auto-service-annotations:${googleAutoServiceVersion}"
+    kapt "com.google.auto.service:auto-service:${googleAutoServiceVersion}"
 
     implementation "androidx.appcompat:appcompat:1.1.0"
     implementation "androidx.preference:preference:1.1.1"

--- a/app/src/debug/java/org/schabi/newpipe/DebugApp.kt
+++ b/app/src/debug/java/org/schabi/newpipe/DebugApp.kt
@@ -1,6 +1,5 @@
 package org.schabi.newpipe
 
-import android.content.Context
 import androidx.multidex.MultiDex
 import androidx.preference.PreferenceManager
 import com.facebook.stetho.Stetho
@@ -11,11 +10,6 @@ import okhttp3.OkHttpClient
 import org.schabi.newpipe.extractor.downloader.Downloader
 
 class DebugApp : App() {
-    override fun attachBaseContext(base: Context) {
-        super.attachBaseContext(base)
-        MultiDex.install(this)
-    }
-
     override fun onCreate() {
         super.onCreate()
         initStetho()
@@ -32,6 +26,12 @@ class DebugApp : App() {
                 .addNetworkInterceptor(StethoInterceptor()))
         setCookiesToDownloader(downloader)
         return downloader
+    }
+
+    override fun initACRA() {
+        // install MultiDex before initializing ACRA
+        MultiDex.install(this)
+        super.initACRA()
     }
 
     private fun initStetho() {

--- a/app/src/main/java/org/schabi/newpipe/App.java
+++ b/app/src/main/java/org/schabi/newpipe/App.java
@@ -204,6 +204,10 @@ public class App extends Application {
      * Should be overridden if MultiDex is enabled, since it has to be initialized before ACRA.
      */
     protected void initACRA() {
+        if (ACRA.isACRASenderServiceProcess()) {
+            return;
+        }
+
         try {
             final CoreConfiguration acraConfig = new CoreConfigurationBuilder(this)
                     .setReportSenderFactoryClasses(REPORT_SENDER_FACTORY_CLASSES)

--- a/app/src/main/java/org/schabi/newpipe/App.java
+++ b/app/src/main/java/org/schabi/newpipe/App.java
@@ -77,7 +77,6 @@ public class App extends Application {
     @Override
     protected void attachBaseContext(final Context base) {
         super.attachBaseContext(base);
-
         initACRA();
     }
 
@@ -200,7 +199,11 @@ public class App extends Application {
                 .build();
     }
 
-    private void initACRA() {
+    /**
+     * Called in {@link #attachBaseContext(Context)} after calling the {@code super} method.
+     * Should be overridden if MultiDex is enabled, since it has to be initialized before ACRA.
+     */
+    protected void initACRA() {
         try {
             final CoreConfiguration acraConfig = new CoreConfigurationBuilder(this)
                     .setReportSenderFactoryClasses(REPORT_SENDER_FACTORY_CLASSES)

--- a/app/src/main/java/org/schabi/newpipe/App.java
+++ b/app/src/main/java/org/schabi/newpipe/App.java
@@ -20,10 +20,8 @@ import org.acra.ACRA;
 import org.acra.config.ACRAConfigurationException;
 import org.acra.config.CoreConfiguration;
 import org.acra.config.CoreConfigurationBuilder;
-import org.acra.sender.ReportSenderFactory;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.downloader.Downloader;
-import org.schabi.newpipe.report.AcraReportSenderFactory;
 import org.schabi.newpipe.report.ErrorActivity;
 import org.schabi.newpipe.report.UserAction;
 import org.schabi.newpipe.settings.SettingsActivity;
@@ -65,9 +63,6 @@ import io.reactivex.plugins.RxJavaPlugins;
 
 public class App extends Application {
     protected static final String TAG = App.class.toString();
-    @SuppressWarnings("unchecked")
-    private static final Class<? extends ReportSenderFactory>[]
-            REPORT_SENDER_FACTORY_CLASSES = new Class[]{AcraReportSenderFactory.class};
     private static App app;
 
     public static App getApp() {
@@ -210,7 +205,6 @@ public class App extends Application {
 
         try {
             final CoreConfiguration acraConfig = new CoreConfigurationBuilder(this)
-                    .setReportSenderFactoryClasses(REPORT_SENDER_FACTORY_CLASSES)
                     .setBuildConfigClass(BuildConfig.class)
                     .build();
             ACRA.init(this, acraConfig);

--- a/app/src/main/java/org/schabi/newpipe/report/AcraReportSenderFactory.java
+++ b/app/src/main/java/org/schabi/newpipe/report/AcraReportSenderFactory.java
@@ -4,9 +4,12 @@ import android.content.Context;
 
 import androidx.annotation.NonNull;
 
+import com.google.auto.service.AutoService;
+
 import org.acra.config.CoreConfiguration;
 import org.acra.sender.ReportSender;
 import org.acra.sender.ReportSenderFactory;
+import org.schabi.newpipe.App;
 
 /*
  * Created by Christian Schabesberger on 13.09.16.
@@ -28,6 +31,10 @@ import org.acra.sender.ReportSenderFactory;
  * along with NewPipe.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+/**
+ * Used by ACRA in {@link App}.initAcra() as the factory for report senders.
+ */
+@AutoService(ReportSenderFactory.class)
 public class AcraReportSenderFactory implements ReportSenderFactory {
     @NonNull
     public ReportSender create(@NonNull final Context context,


### PR DESCRIPTION
#### What is it?
- [x] Bug fix (user facing)
- [ ] Feature (user facing)
- [x] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This PR fixes blank reports not containing the stack trace (as seen in #3930). This was caused by `MultiDex.install` not being called before ACRA initialization, so ACRA could not load some of its classes and failed to initialize the stack trace collector (among others). See ACRA/acra#619 and [ACRA wiki](https://github.com/ACRA/acra/wiki/Troubleshooting-Guide#legacy-multidex).

This PR also contains two other improvements to ACRA's initialization code:
- Skip ACRA initialization if the current process ends with `:acra` (i.e. is created by ACRA): https://github.com/ACRA/acra/wiki/Troubleshooting-Guide#applicationoncreate
- Remove deprecated calls to set the `ReportSender` class in the configuration: `setReportSenderFactoryClasses()` is deprecated, now extensions (`ReportSenderFactory` is an extension) should be registered using `@AutoService`. This commit adds two compile-time dependencies and only fixes a deprecation, so it can be skipped if needed. See https://github.com/ACRA/acra/wiki/Custom-Extensions#by-annotation

I think this should be merged as soon as possible, as otherwise it is not possible debug APKs by giving them to people, as there would be no stack trace in case of errors.

<sup>It took me ages to find the root cause of this 😩</sup>

#### Testing apk
This apk crashes every time a video is opened, use that to check if ACRA correctly catches the unhandled exception.
[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/4987144/app-debug.zip)

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
