### PR TITLE
 Improve search suggestion experience when remote ones can't be fetched

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/list/search/SearchFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/search/SearchFragment.java
@@ -79,7 +79,7 @@ import static androidx.recyclerview.widget.ItemTouchHelper.Callback.makeMovement
 import static java.util.Arrays.asList;
 import static org.schabi.newpipe.util.AnimationUtils.animateView;
 
-public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.InfoItemsPage>
+public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.InfoItemsPage<?>>
         implements BackPressable {
     /*//////////////////////////////////////////////////////////////////////////
     // Search
@@ -134,7 +134,6 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
     private Map<Integer, String> menuItemToFilterName;
     private StreamingService service;
     private Page nextPage;
-    private String contentCountry;
     private boolean isSuggestionsEnabled = true;
 
     private Disposable searchDisposable;
@@ -206,8 +205,6 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
                 = PreferenceManager.getDefaultSharedPreferences(activity);
         isSuggestionsEnabled = preferences
                 .getBoolean(getString(R.string.show_search_suggestions_key), true);
-        contentCountry = preferences.getString(getString(R.string.content_country_key),
-                getString(R.string.default_localization_key));
     }
 
     @Override
@@ -235,9 +232,7 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
         if (suggestionDisposable != null) {
             suggestionDisposable.dispose();
         }
-        if (disposables != null) {
-            disposables.clear();
-        }
+        disposables.clear();
         hideKeyboardSearch();
     }
 
@@ -251,8 +246,8 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
         try {
             service = NewPipe.getService(serviceId);
         } catch (final Exception e) {
-            ErrorActivity.reportError(getActivity(), e, getActivity().getClass(),
-                    getActivity().findViewById(android.R.id.content),
+            ErrorActivity.reportError(getActivity(), e, requireActivity().getClass(),
+                    requireActivity().findViewById(android.R.id.content),
                     ErrorActivity.ErrorInfo.make(UserAction.UI_ERROR,
                             "",
                             "", R.string.general_error));
@@ -305,26 +300,20 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
         if (suggestionDisposable != null) {
             suggestionDisposable.dispose();
         }
-        if (disposables != null) {
-            disposables.clear();
-        }
+        disposables.clear();
     }
 
     @Override
     public void onActivityResult(final int requestCode, final int resultCode, final Intent data) {
-        switch (requestCode) {
-            case ReCaptchaActivity.RECAPTCHA_REQUEST:
-                if (resultCode == Activity.RESULT_OK
-                        && !TextUtils.isEmpty(searchString)) {
-                    search(searchString, contentFilter, sortFilter);
-                } else {
-                    Log.e(TAG, "ReCaptcha failed");
-                }
-                break;
-
-            default:
-                Log.e(TAG, "Request code from activity not supported [" + requestCode + "]");
-                break;
+        if (requestCode == ReCaptchaActivity.RECAPTCHA_REQUEST) {
+            if (resultCode == Activity.RESULT_OK
+                    && !TextUtils.isEmpty(searchString)) {
+                search(searchString, contentFilter, sortFilter);
+            } else {
+                Log.e(TAG, "ReCaptcha failed");
+            }
+        } else {
+            Log.e(TAG, "Request code from activity not supported [" + requestCode + "]");
         }
     }
 
@@ -342,7 +331,7 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
             @Override
             public int getMovementFlags(@NonNull final RecyclerView recyclerView,
                                         @NonNull final RecyclerView.ViewHolder viewHolder) {
-                return getSuggestionMovementFlags(recyclerView, viewHolder);
+                return getSuggestionMovementFlags(viewHolder);
             }
 
             @Override
@@ -354,7 +343,7 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
 
             @Override
             public void onSwiped(@NonNull final RecyclerView.ViewHolder viewHolder, final int i) {
-                onSuggestionItemSwiped(viewHolder, i);
+                onSuggestionItemSwiped(viewHolder);
             }
         }).attachToRecyclerView(suggestionsRecyclerView);
 
@@ -673,8 +662,7 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
     }
 
     private void showDeleteSuggestionDialog(final SuggestionItem item) {
-        if (activity == null || historyRecordManager == null || suggestionPublisher == null
-                || searchEditText == null || disposables == null) {
+        if (activity == null || historyRecordManager == null || searchEditText == null) {
             return;
         }
         final String query = item.query;
@@ -802,21 +790,23 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
         // no-op
     }
 
-    private void search(final String ss, final String[] cf, final String sf) {
+    private void search(final String theSearchString,
+                        final String[] theContentFilter,
+                        final String theSortFilter) {
         if (DEBUG) {
-            Log.d(TAG, "search() called with: query = [" + ss + "]");
+            Log.d(TAG, "search() called with: query = [" + theSearchString + "]");
         }
-        if (ss.isEmpty()) {
+        if (theSearchString.isEmpty()) {
             return;
         }
 
         try {
-            final StreamingService streamingService = NewPipe.getServiceByUrl(ss);
+            final StreamingService streamingService = NewPipe.getServiceByUrl(theSearchString);
             if (streamingService != null) {
                 showLoading();
                 disposables.add(Observable
-                        .fromCallable(() ->
-                                NavigationHelper.getIntentByLink(activity, streamingService, ss))
+                        .fromCallable(() -> NavigationHelper.getIntentByLink(activity,
+                                streamingService, theSearchString))
                         .subscribeOn(Schedulers.io())
                         .observeOn(AndroidSchedulers.mainThread())
                         .subscribe(intent -> {
@@ -831,29 +821,27 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
         }
 
         lastSearchedString = this.searchString;
-        this.searchString = ss;
+        this.searchString = theSearchString;
         infoListAdapter.clearStreamItemList();
         hideSuggestionsPanel();
         hideKeyboardSearch();
 
-        historyRecordManager.onSearched(serviceId, ss)
+        disposables.add(historyRecordManager.onSearched(serviceId, theSearchString)
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                         ignored -> {
                         },
                         error -> showSnackBarError(error, UserAction.SEARCHED,
-                                NewPipe.getNameOfService(serviceId), ss, 0)
-                );
-        suggestionPublisher.onNext(ss);
+                                NewPipe.getNameOfService(serviceId), theSearchString, 0)
+                ));
+        suggestionPublisher.onNext(theSearchString);
         startLoading(false);
     }
 
     @Override
     public void startLoading(final boolean forceLoad) {
         super.startLoading(forceLoad);
-        if (disposables != null) {
-            disposables.clear();
-        }
+        disposables.clear();
         if (searchDisposable != null) {
             searchDisposable.dispose();
         }
@@ -892,8 +880,7 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
 
     @Override
     protected boolean hasMoreItems() {
-        // TODO: No way to tell if search has more items in the moment
-        return true;
+        return Page.isValid(nextPage);
     }
 
     @Override
@@ -906,22 +893,25 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
     // Utils
     //////////////////////////////////////////////////////////////////////////*/
 
-    private void changeContentFilter(final MenuItem item, final List<String> cf) {
-        this.filterItemCheckedId = item.getItemId();
+    private void changeContentFilter(final MenuItem item, final List<String> theContentFilter) {
+        filterItemCheckedId = item.getItemId();
         item.setChecked(true);
 
-        this.contentFilter = new String[]{cf.get(0)};
+        contentFilter = new String[]{theContentFilter.get(0)};
 
         if (!TextUtils.isEmpty(searchString)) {
-            search(searchString, this.contentFilter, sortFilter);
+            search(searchString, contentFilter, sortFilter);
         }
     }
 
-    private void setQuery(final int sid, final String ss, final String[] cf, final String sf) {
-        this.serviceId = sid;
-        this.searchString = searchString;
-        this.contentFilter = cf;
-        this.sortFilter = sf;
+    private void setQuery(final int theServiceId,
+                          final String theSearchString,
+                          final String[] theContentFilter,
+                          final String theSortFilter) {
+        serviceId = theServiceId;
+        searchString = theSearchString;
+        contentFilter = theContentFilter;
+        sortFilter = theSortFilter;
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -1038,7 +1028,7 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
     }
 
     @Override
-    public void handleNextItems(final ListExtractor.InfoItemsPage result) {
+    public void handleNextItems(final ListExtractor.InfoItemsPage<?> result) {
         showListFooter(false);
         infoListAdapter.addInfoItemList(result.getItems());
         nextPage = result.getNextPage();
@@ -1077,8 +1067,7 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
     // Suggestion item touch helper
     //////////////////////////////////////////////////////////////////////////*/
 
-    public int getSuggestionMovementFlags(@NonNull final RecyclerView recyclerView,
-                                          @NonNull final RecyclerView.ViewHolder viewHolder) {
+    public int getSuggestionMovementFlags(@NonNull final RecyclerView.ViewHolder viewHolder) {
         final int position = viewHolder.getAdapterPosition();
         if (position == RecyclerView.NO_POSITION) {
             return 0;
@@ -1089,8 +1078,7 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
                 ItemTouchHelper.LEFT | ItemTouchHelper.RIGHT) : 0;
     }
 
-    public void onSuggestionItemSwiped(@NonNull final RecyclerView.ViewHolder viewHolder,
-                                       final int i) {
+    public void onSuggestionItemSwiped(@NonNull final RecyclerView.ViewHolder viewHolder) {
         final int position = viewHolder.getAdapterPosition();
         final String query = suggestionListAdapter.getItem(position).query;
         final Disposable onDelete = historyRecordManager.deleteSearchHistory(query)


### PR DESCRIPTION
#### What is it?
- [x] Bug fix (user facing)
- [ ] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
- Do not show anything in case of network error (it can simply be ignored, see #3923 for more info). I had to add a `suggestionsPanelVisible` variable to check if the suggestions panel is visible, because checking visibility on `suggestionsPanel` itself was unreliable due to animations.
- Show a snackbar if the search suggestions generated an (e.g.) extractor error, which still allows writing things into the search box.
- Fix deprecations, warnings and useless null checks in SearchFragment (as reported by Android Studio)

#### Fixes the following issue(s)
- fixes #3923

#### Testing apk
I tested the snackbar by manually throwing an exception on every network search suggestion request, and the snackbar is shown correctly.
@opusforlife2 does this behaviour suit you?
[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/5006308/app-debug.zip)

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
