### PR TITLE
Don't allow brightness percentage below 1% when using gesture control

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/event/PlayerGestureListener.java
+++ b/app/src/main/java/org/schabi/newpipe/player/event/PlayerGestureListener.java
@@ -271,7 +271,10 @@ public class PlayerGestureListener
             bar.setProgress((int) (bar.getMax() * Math.max(0, Math.min(1, oldBrightness))));
             bar.incrementProgressBy((int) distanceY);
 
-            final float currentProgressPercent = (float) bar.getProgress() / bar.getMax();
+            float currentProgressPercent = (float) bar.getProgress() / bar.getMax();
+            if (currentProgressPercent <= 0.01) {
+                currentProgressPercent = 0.01f;
+            }
             layoutParams.screenBrightness = currentProgressPercent;
             window.setAttributes(layoutParams);
 


### PR DESCRIPTION

<!-- Hey there. Thank you so much for improving NewPipe. Please take a moment to fill out the following suggestion on how to structure this PR description. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bug fix (user facing)
- [ ] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
When the gesture control for brightness results in a value below 0.01f (1%), then increase it to 0.01f
Even though the [doc](https://developer.android.com/reference/android/view/WindowManager.LayoutParams#screenBrightness) suggests otherwise, this avoids a sudden spike in brightness when scrolling down to the minimum. 



#### Fixes the following issue(s)
- #1778
- #4169 

#### Testing apk
after rebase: [app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/5360763/app-debug.zip)

@delightfulagony @lingislong
Could you check out if it works?

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
