### PR TITLE
Add support for GitHub Actions

### DIFF
--- a/.github/workflows/build-pull-requests.yml
+++ b/.github/workflows/build-pull-requests.yml
@@ -1,0 +1,34 @@
+name: Build Pull Requests
+
+on:
+  pull_request:
+    branches: # we might want to add all branches here
+      - 'master'
+      - 'dev'
+
+jobs:
+  build:
+    name: Build project & generate APK
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: set up JDK 1.8
+        uses: actions/setup-java@v1.4.0
+        with:
+          java-version: 1.8
+
+      - name: Build debug APK
+        run: bash ./gradlew assembleDebug --stacktrace
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v2
+        with:
+          name: app
+          path: app/build/outputs/apk/debug/*.apk
+
+      - name: Create comment linking to the artifact
+        uses: thollander/actions-comment-pull-request@1f25fabed60c3f141743c3a522529950a8fb2191
+        with:
+          message: 'The APK was build successfuly. You can find it here: https://github.com/TobiGr/NewPipe/actions/runs/${{github.run_id}}'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe. Please take a moment to fill out the following suggestion on how to structure this PR description. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bug fix (user facing)
- [ ] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [x] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This enables GitHub Actions to work with PRs.
Build PRs pointing to dev or master branch and create a comment linking to the APK download page on success. Otherwise, the creator is notified (if enabled by them).
Example PR: https://github.com/TobiGr/NewPipe/pull/7

#### ToDo
- [ ] Check out the Git branch and do not use HEAD. Currently, all APKs have the id `org.schabi.newpipe.HEAD` and app name is "NewPipe HEAD"
- [ ] Disable & Remove Travis integration
- [ ] Require successful GitHub Action checks for merging a PR

#### Ideas
- Do not comment a link to the workflow page when `<!-- NO_APK_NOTIFICATION -->` is in (preferably at the end of) the PR description.
- Post a warning when a PR is approved, but the extractor repo is not set to `TeamNewPipe/NewPipeExtractor`
#### Fixes the following issue(s)
<!-- Also add reddit or other links which are relevant to your change. -->
- Addresses #3940 

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
