### PR TITLE
Removed java.util.Objects calls

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -112,7 +112,6 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import icepick.State;
@@ -1177,7 +1176,7 @@ public class VideoDetailFragment
 
         // Video view can have elements visible from popup,
         // We hide it here but once it ready the view will be shown in handleIntent()
-        Objects.requireNonNull(playerService.getView()).setVisibility(View.GONE);
+        playerService.getView().setVisibility(View.GONE);
         addVideoPlayerView();
 
         final Intent playerIntent = NavigationHelper
@@ -1351,7 +1350,7 @@ public class VideoDetailFragment
         final int height;
         if (player != null && player.isFullscreen()) {
             height = isInMultiWindow()
-                    ? Objects.requireNonNull(getView()).getHeight()
+                    ? requireView().getHeight()
                     : activity.getWindow().getDecorView().getHeight();
         } else {
             height = isPortrait


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe. Please take a moment to fill out the following suggestion on how to structure this PR description. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bug fix (user facing)
- [ ] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write a text instead if you can't fit it in a list -->
For some reason supported calls in API 19 (https://developer.android.com/reference/java/util/Objects#requireNonNull(T)) actually unsupported in API 19 (see #4060) even when the same code works on other devices with API 19 :). So I just deleted these calls.

#### Fixes the following issues
fixes #4060

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
