### PR TITLE
Reduced CPU usage when playing a video by 7-10%

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -1769,10 +1769,11 @@ public class VideoDetailFragment
     private void showPlaybackProgress(final long progress, final long duration) {
         final int progressSeconds = (int) TimeUnit.MILLISECONDS.toSeconds(progress);
         final int durationSeconds = (int) TimeUnit.MILLISECONDS.toSeconds(duration);
+        // If the old and the new progress values have a big difference then use
+        // animation. Otherwise don't because it affects CPU
+        final boolean shouldAnimate = Math.abs(positionView.getProgress() - progressSeconds) > 2;
         positionView.setMax(durationSeconds);
-        // If there is no player inside fragment use animation, otherwise don't because
-        // it affects CPU
-        if (playerPlaceholder.getChildCount() == 0) {
+        if (shouldAnimate) {
             positionView.setProgressAnimated(progressSeconds);
         } else {
             positionView.setProgress(progressSeconds);


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe. Please take a moment to fill out the following suggestion on how to structure this PR description. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bug fix (user facing)
- [ ] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write a text instead if you can't fit it in a list -->
After reading this comment https://github.com/TeamNewPipe/NewPipe/pull/3948#issuecomment-668241710  
> this new unified player ... drains the bettery twice as much

I checked how much CPU the player uses. And found out that @MD77MD said incorrect information but even if it's not true (about double difference) the new player definitely uses more CPU than 0.19.8. Difference is about 15%. So I started seaching for the cause and found that this line https://github.com/TeamNewPipe/NewPipe/blob/dev/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java#L1774
adds 7-10% of CPU load. Actually there is no need to animate the progress bar when it's hidden under the video but it should be updated anyway (without animation) to reflect playing position changes. 

Next. After this change the difference is still here but small: around 5%. Please, note, that I tested it on 5-year old phone while it had 1% of battery and worked on a charger with screen recorder impact so absolute values in your case would be less as well as difference.

I couldn't find a cause until I realized that MainVideoPlayer (old video player in 0.19.8) doesn't use notification. So it doesn't need to update it twice every second. This was it! After commenting out everything after this line: https://github.com/TeamNewPipe/NewPipe/blob/dev/app/src/main/java/org/schabi/newpipe/player/VideoPlayerImpl.java#L640   the CPU usage was the same compared to 0.19.8 (0-1% difference).

Here is a screenrecord of comparison (with commented code related to notification) of new and old apps:
https://www.dropbox.com/s/l2sdo5rsjfmjusc/2020-08-05-12-01-09.mp4?dl=0

Of course this shouldn't be commented out in the current codebase but it gives us information about why this little difference exists: it's needed to update notification. 

#### Testing apk
[test-apk.zip](https://github.com/TeamNewPipe/NewPipe/files/5027736/test-apk.zip)


#### Agreement
- [X] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
