### PR TITLE
persist shuffle mode using sharedPreferences

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -456,7 +456,7 @@ public class MainActivity extends AppCompatActivity {
         }
 
         SharedPreferences sharedPreferences =
-                context.getSharedPreferences("play_mode_state", MODE_PRIVATE);
+                this.getSharedPreferences("play_mode_state", MODE_PRIVATE);
         SharedPreferences.Editor editor = sharedPreferences.edit();
         editor.putBoolean("shuffle_mode", false);
         editor.apply();

--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -454,6 +454,12 @@ public class MainActivity extends AppCompatActivity {
         if (!isChangingConfigurations()) {
             StateSaver.clearStateFiles();
         }
+
+        SharedPrefrences sharedPrefrences =
+                context.getSharedPrefrences("play_mode_state", MODE_PRIVATE);
+        SharedPrefrences.Editor editor = sharedPrefrences.edit();
+        editor.putBoolean("shuffle_mode",false);
+        editor.apply();
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -455,9 +455,9 @@ public class MainActivity extends AppCompatActivity {
             StateSaver.clearStateFiles();
         }
 
-        SharedPrefrences sharedPrefrences =
-                context.getSharedPrefrences("play_mode_state", MODE_PRIVATE);
-        SharedPrefrences.Editor editor = sharedPrefrences.edit();
+        SharedPreferences sharedPreferences =
+                context.getSharedPreferences("play_mode_state", MODE_PRIVATE);
+        SharedPreferences.Editor editor = sharedPreferences.edit();
         editor.putBoolean("shuffle_mode", false);
         editor.apply();
     }

--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -458,7 +458,7 @@ public class MainActivity extends AppCompatActivity {
         SharedPrefrences sharedPrefrences =
                 context.getSharedPrefrences("play_mode_state", MODE_PRIVATE);
         SharedPrefrences.Editor editor = sharedPrefrences.edit();
-        editor.putBoolean("shuffle_mode",false);
+        editor.putBoolean("shuffle_mode", false);
         editor.apply();
     }
 

--- a/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
@@ -398,6 +398,11 @@ public abstract class BasePlayer implements
                                 final boolean isMuted) {
         destroyPlayer();
         initPlayer(playOnReady);
+        SharedPrefrences sharedPrefrences =
+                context.getSharedPrefrences("play_mode_state", MODE_PRIVATE);
+        boolean shuffleMode = SharedPrefrences.getBoolean("shuffle_mode",false);
+        simpleExoPlayer.setShuffleModeEnabled(shuffleMode);
+
         setRepeatMode(repeatMode);
         setPlaybackParameters(playbackSpeed, playbackPitch, playbackSkipSilence);
 
@@ -664,6 +669,11 @@ public abstract class BasePlayer implements
         if (simpleExoPlayer == null) {
             return;
         }
+        SharedPrefrences sharedPrefrences =
+                context.getSharedPrefrences("play_mode_state", MODE_PRIVATE);
+        SharedPrefrences.Editor editor = sharedPrefrences.edit();
+        editor.putBoolean("shuffle_mode",!simpleExoPlayer.getShuffleModeEnabled());
+        editor.apply();
         simpleExoPlayer.setShuffleModeEnabled(!simpleExoPlayer.getShuffleModeEnabled());
     }
     /*//////////////////////////////////////////////////////////////////////////

--- a/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
@@ -400,7 +400,7 @@ public abstract class BasePlayer implements
         initPlayer(playOnReady);
         SharedPrefrences sharedPrefrences =
                 context.getSharedPrefrences("play_mode_state", MODE_PRIVATE);
-        boolean shuffleMode = SharedPrefrences.getBoolean("shuffle_mode",false);
+        boolean shuffleMode = SharedPrefrences.getBoolean("shuffle_mode", false);
         simpleExoPlayer.setShuffleModeEnabled(shuffleMode);
 
         setRepeatMode(repeatMode);
@@ -672,7 +672,7 @@ public abstract class BasePlayer implements
         SharedPrefrences sharedPrefrences =
                 context.getSharedPrefrences("play_mode_state", MODE_PRIVATE);
         SharedPrefrences.Editor editor = sharedPrefrences.edit();
-        editor.putBoolean("shuffle_mode",!simpleExoPlayer.getShuffleModeEnabled());
+        editor.putBoolean("shuffle_mode", !simpleExoPlayer.getShuffleModeEnabled());
         editor.apply();
         simpleExoPlayer.setShuffleModeEnabled(!simpleExoPlayer.getShuffleModeEnabled());
     }

--- a/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
@@ -398,9 +398,9 @@ public abstract class BasePlayer implements
                                 final boolean isMuted) {
         destroyPlayer();
         initPlayer(playOnReady);
-        SharedPrefrences sharedPrefrences =
-                context.getSharedPrefrences("play_mode_state", MODE_PRIVATE);
-        boolean shuffleMode = SharedPrefrences.getBoolean("shuffle_mode", false);
+        SharedPreferences sharedPreferences =
+                context.getSharedPreferences("play_mode_state", MODE_PRIVATE);
+        boolean shuffleMode = SharedPreferences.getBoolean("shuffle_mode", false);
         simpleExoPlayer.setShuffleModeEnabled(shuffleMode);
 
         setRepeatMode(repeatMode);
@@ -669,9 +669,9 @@ public abstract class BasePlayer implements
         if (simpleExoPlayer == null) {
             return;
         }
-        SharedPrefrences sharedPrefrences =
-                context.getSharedPrefrences("play_mode_state", MODE_PRIVATE);
-        SharedPrefrences.Editor editor = sharedPrefrences.edit();
+        SharedPreferences sharedPreferences =
+                context.getSharedPreferences("play_mode_state", MODE_PRIVATE);
+        SharedPreferences.Editor editor = sharedPreferences.edit();
         editor.putBoolean("shuffle_mode", !simpleExoPlayer.getShuffleModeEnabled());
         editor.apply();
         simpleExoPlayer.setShuffleModeEnabled(!simpleExoPlayer.getShuffleModeEnabled());

--- a/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
@@ -19,6 +19,7 @@
 
 package org.schabi.newpipe.player;
 
+import android.app.Activity;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -399,8 +400,8 @@ public abstract class BasePlayer implements
         destroyPlayer();
         initPlayer(playOnReady);
         SharedPreferences sharedPreferences =
-                context.getSharedPreferences("play_mode_state", MODE_PRIVATE);
-        boolean shuffleMode = SharedPreferences.getBoolean("shuffle_mode", false);
+                context.getSharedPreferences("play_mode_state", Activity.MODE_PRIVATE);
+        boolean shuffleMode = sharedPreferences.getBoolean("shuffle_mode", false);
         simpleExoPlayer.setShuffleModeEnabled(shuffleMode);
 
         setRepeatMode(repeatMode);
@@ -670,7 +671,7 @@ public abstract class BasePlayer implements
             return;
         }
         SharedPreferences sharedPreferences =
-                context.getSharedPreferences("play_mode_state", MODE_PRIVATE);
+                context.getSharedPreferences("play_mode_state", Activity.MODE_PRIVATE);
         SharedPreferences.Editor editor = sharedPreferences.edit();
         editor.putBoolean("shuffle_mode", !simpleExoPlayer.getShuffleModeEnabled());
         editor.apply();


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe. Please take a moment to fill out the following suggestion on how to structure this PR description. Having roughly the same layout helps everyone considerably :)-->

#### What is  it?
- [ ] Bug fix (user facing)
- [X] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
saves the shuffle mode in shared preferences and retrieves it after initiating player.
the shared preferences resets in main activities `onDestroy` method

#### Fixes the following issue(s)
- fixes #1795

#### Testing apk
<!-- Ensure that you have your changes on a new branch which has a meaningful name. This name will be used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe. Do NOT name your branches like "patch-0" and "feature-1". For example, if your PR implements a bug fix for comments, an appropriate branch name would be "commentfix". -->
debug.zip

#### Agreement
- [X] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
