### PR TITLE
Set bottom padding of the main fragment when the mini player is visible

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -2176,6 +2176,30 @@ public class VideoDetailFragment
         }
     }
 
+    /**
+     * When the mini player exists the view underneath it is not touchable.
+     * Bottom padding should be equal to the mini player's height in this case
+     *
+     * @param showMore whether main fragment should be expanded or not
+     * */
+    private void manageSpaceAtTheBottom(final boolean showMore) {
+        final int peekHeight = getResources().getDimensionPixelSize(R.dimen.mini_player_height);
+        final ViewGroup holder = requireActivity().findViewById(R.id.fragment_holder);
+        final int newBottomPadding;
+        if (showMore) {
+            newBottomPadding = 0;
+        } else {
+            newBottomPadding = peekHeight;
+        }
+        if (holder.getPaddingBottom() == newBottomPadding) {
+            return;
+        }
+        holder.setPadding(holder.getPaddingLeft(),
+                holder.getPaddingTop(),
+                holder.getPaddingRight(),
+                newBottomPadding);
+    }
+
     private void setupBottomPlayer() {
         final CoordinatorLayout.LayoutParams params =
                 (CoordinatorLayout.LayoutParams) appBarLayout.getLayoutParams();
@@ -2186,6 +2210,7 @@ public class VideoDetailFragment
         bottomSheetBehavior.setState(bottomSheetState);
         final int peekHeight = getResources().getDimensionPixelSize(R.dimen.mini_player_height);
         if (bottomSheetState != BottomSheetBehavior.STATE_HIDDEN) {
+            manageSpaceAtTheBottom(false);
             bottomSheetBehavior.setPeekHeight(peekHeight);
             if (bottomSheetState == BottomSheetBehavior.STATE_COLLAPSED) {
                 overlay.setAlpha(MAX_OVERLAY_ALPHA);
@@ -2203,12 +2228,14 @@ public class VideoDetailFragment
                 switch (newState) {
                     case BottomSheetBehavior.STATE_HIDDEN:
                         moveFocusToMainFragment(true);
+                        manageSpaceAtTheBottom(true);
 
                         bottomSheetBehavior.setPeekHeight(0);
                         cleanUp();
                         break;
                     case BottomSheetBehavior.STATE_EXPANDED:
                         moveFocusToMainFragment(false);
+                        manageSpaceAtTheBottom(false);
 
                         bottomSheetBehavior.setPeekHeight(peekHeight);
                         // Disable click because overlay buttons located on top of buttons


### PR DESCRIPTION
#### What is it?
- [x] Bug fix (user facing)

#### Description of the changes in your PR
Makes more space underneath the mini player when it's visible or expanded into main player. So the last items in recyclerView from main fragment will be visible in both cases: opened or closed player. Works in multiWindow mode too.

#### Fixes the following issue(s)
closes #4047

#### Testing apk
[app-release.zip](https://github.com/TeamNewPipe/NewPipe/files/5079228/app-release.zip)

@XiangRongLin check this one, should be ok.

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
