### PR TITLE
Prevent jumping of the player and wrong padding on devices with cutout

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -1982,6 +1982,11 @@ public class VideoDetailFragment
             return;
         }
 
+        // Prevent jumping of the player on devices with cutout
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            activity.getWindow().getAttributes().layoutInDisplayCutoutMode =
+                    WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_DEFAULT;
+        }
         activity.getWindow().getDecorView().setSystemUiVisibility(0);
         activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS);
     }
@@ -1995,6 +2000,11 @@ public class VideoDetailFragment
             return;
         }
 
+        // Prevent jumping of the player on devices with cutout
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            activity.getWindow().getAttributes().layoutInDisplayCutoutMode =
+                    WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_NEVER;
+        }
         final int visibility = View.SYSTEM_UI_FLAG_LAYOUT_STABLE
                 | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
                 | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION

--- a/app/src/main/java/org/schabi/newpipe/player/VideoPlayerImpl.java
+++ b/app/src/main/java/org/schabi/newpipe/player/VideoPlayerImpl.java
@@ -1538,8 +1538,9 @@ public class VideoPlayerImpl extends VideoPlayer
                 && navBarAtTheBottom ? size.y : ViewGroup.LayoutParams.MATCH_PARENT;
         controlsRoot.requestLayout();
 
+        final DisplayMetrics metrics = getRootView().getResources().getDisplayMetrics();
         int topPadding = isFullscreen && !isInMultiWindow() ? getStatusBarHeight() : 0;
-        topPadding = !isLandscape && hasCutout(topPadding) ? 0 : topPadding;
+        topPadding = !isLandscape && DeviceUtils.hasCutout(topPadding, metrics) ? 0 : topPadding;
         getRootView().findViewById(R.id.playbackWindowRoot).setTranslationY(topPadding);
         getBottomControlsRoot().setTranslationY(-topPadding);
     }
@@ -1567,20 +1568,6 @@ public class VideoPlayerImpl extends VideoPlayer
                     TypedValue.COMPLEX_UNIT_DIP, 24, metrics);
         }
         return statusBarHeight;
-    }
-
-    /*
-    * Compares current status bar height with default status bar height in Android and decides,
-    * does the device has cutout or not
-    * */
-    private boolean hasCutout(final float statusBarHeight) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            final DisplayMetrics metrics = getRootView().getResources().getDisplayMetrics();
-            final float defaultStatusBarHeight = TypedValue.applyDimension(
-                    TypedValue.COMPLEX_UNIT_DIP, 25, metrics);
-            return statusBarHeight > defaultStatusBarHeight;
-        }
-        return false;
     }
 
     protected void setMuteButton(final ImageButton button, final boolean isMuted) {

--- a/app/src/main/java/org/schabi/newpipe/player/VideoPlayerImpl.java
+++ b/app/src/main/java/org/schabi/newpipe/player/VideoPlayerImpl.java
@@ -915,8 +915,8 @@ public class VideoPlayerImpl extends VideoPlayer
         // show kodi button if it supports the current service and it is enabled in settings
         final boolean showKodiButton = playQueue != null && playQueue.getItem() != null
                 && KoreUtil.isServiceSupportedByKore(playQueue.getItem().getServiceId())
-                        && PreferenceManager.getDefaultSharedPreferences(context)
-                        .getBoolean(context.getString(R.string.show_play_with_kodi_key), false);
+                && PreferenceManager.getDefaultSharedPreferences(context)
+                .getBoolean(context.getString(R.string.show_play_with_kodi_key), false);
         playWithKodi.setVisibility(videoPlayerSelected() && kodiEnabled && showKodiButton
                 ? View.VISIBLE : View.GONE);
     }
@@ -1499,9 +1499,10 @@ public class VideoPlayerImpl extends VideoPlayer
         // It doesn't include NavigationBar, notches, etc.
         display.getSize(size);
 
+        final boolean isLandscape = service.isLandscape();
         final int width = isFullscreen
-                ? (service.isLandscape()
-                ? size.x : size.y) : ViewGroup.LayoutParams.MATCH_PARENT;
+                ? (isLandscape ? size.x : size.y)
+                : ViewGroup.LayoutParams.MATCH_PARENT;
         final int gravity = isFullscreen
                 ? (display.getRotation() == Surface.ROTATION_90
                 ? Gravity.START : Gravity.END)
@@ -1532,14 +1533,15 @@ public class VideoPlayerImpl extends VideoPlayer
         // And the situations when we need to set custom height is
         // in fullscreen mode in tablet in non-multiWindow mode or with vertical video.
         // Other than that MATCH_PARENT is good
-        final boolean navBarAtTheBottom = DeviceUtils.isTablet(service) || !service.isLandscape();
+        final boolean navBarAtTheBottom = DeviceUtils.isTablet(service) || !isLandscape;
         controlsRoot.getLayoutParams().height = isFullscreen && !isInMultiWindow()
                 && navBarAtTheBottom ? size.y : ViewGroup.LayoutParams.MATCH_PARENT;
         controlsRoot.requestLayout();
 
-        final int topPadding = isFullscreen && !isInMultiWindow() ? getStatusBarHeight() : 0;
-        getRootView().findViewById(R.id.playbackWindowRoot).setPadding(0, topPadding, 0, 0);
-        getRootView().findViewById(R.id.playbackWindowRoot).requestLayout();
+        int topPadding = isFullscreen && !isInMultiWindow() ? getStatusBarHeight() : 0;
+        topPadding = !isLandscape && hasCutout(topPadding) ? 0 : topPadding;
+        getRootView().findViewById(R.id.playbackWindowRoot).setTranslationY(topPadding);
+        getBottomControlsRoot().setTranslationY(-topPadding);
     }
 
     /**
@@ -1548,8 +1550,12 @@ public class VideoPlayerImpl extends VideoPlayer
      */
     private int getStatusBarHeight() {
         int statusBarHeight = 0;
-        final int resourceId = service.getResources().getIdentifier(
-                "status_bar_height_landscape", "dimen", "android");
+        final int resourceId = service.isLandscape()
+                ? service.getResources().getIdentifier(
+                "status_bar_height_landscape", "dimen", "android")
+                : service.getResources().getIdentifier(
+                "status_bar_height", "dimen", "android");
+
         if (resourceId > 0) {
             statusBarHeight = service.getResources().getDimensionPixelSize(resourceId);
         }
@@ -1561,6 +1567,20 @@ public class VideoPlayerImpl extends VideoPlayer
                     TypedValue.COMPLEX_UNIT_DIP, 24, metrics);
         }
         return statusBarHeight;
+    }
+
+    /*
+    * Compares current status bar height with default status bar height in Android and decides,
+    * does the device has cutout or not
+    * */
+    private boolean hasCutout(final float statusBarHeight) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            final DisplayMetrics metrics = getRootView().getResources().getDisplayMetrics();
+            final float defaultStatusBarHeight = TypedValue.applyDimension(
+                    TypedValue.COMPLEX_UNIT_DIP, 25, metrics);
+            return statusBarHeight > defaultStatusBarHeight;
+        }
+        return false;
     }
 
     protected void setMuteButton(final ImageButton button, final boolean isMuted) {
@@ -2081,7 +2101,7 @@ public class VideoPlayerImpl extends VideoPlayer
      * This will be called when a user goes to another app/activity, turns off a screen.
      * We don't want to interrupt playback and don't want to see notification so
      * next lines of code will enable audio-only playback only if needed
-     * */
+     */
     private void onFragmentStopped() {
         if (videoPlayerSelected() && (isPlaying() || isLoading())) {
             if (backgroundPlaybackEnabled()) {

--- a/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
@@ -6,6 +6,8 @@ import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.os.BatteryManager;
 import android.os.Build;
+import android.util.DisplayMetrics;
+import android.util.TypedValue;
 import android.view.KeyEvent;
 
 import androidx.annotation.NonNull;
@@ -71,5 +73,18 @@ public final class DeviceUtils {
             default:
                 return false;
         }
+    }
+
+    /*
+     * Compares current status bar height with default status bar height in Android and decides,
+     * does the device has cutout or not
+     * */
+    public static boolean hasCutout(final float statusBarHeight, final DisplayMetrics metrics) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            final float defaultStatusBarHeight = TypedValue.applyDimension(
+                    TypedValue.COMPLEX_UNIT_DIP, 25, metrics);
+            return statusBarHeight > defaultStatusBarHeight;
+        }
+        return false;
     }
 }


### PR DESCRIPTION
#### What is it?
- [x] Bug fix (user facing)

#### Description of the changes in your PR
On devices with cutout there is a "jump" when you are in multiWindow mode or when you're watching vertical video in fullscreen. This PR fixes that jump (the first commit).

On the same devices there is a problem related to top padding on vertical videos in portrait in fullscreen. This is more interesting because a couple hours ago I thought I will not be able to fix it. This problem makes situation when the center of the player is not in the center of the screen. After hours trying I installed the app on my phone and the issue is fixed actually (same Android version but different result). So I have no idea will my method (from the second commit) work on user's devices or not. I think the issue is still here but on devices with non-standard screen ratio. But I don't know how to fix it. You can merge the PR as is or merge only first commit, or drop it.

In short:
- in multiwindow mode all videos work great
- there is no jump that happened before when a user shows/hides controls in the player
- there is a correct padding on top of the player (but I'm sure it isn't on devices with non-standart ratio).

Everyone who has a device with a hole, cutout, whatever check this build in vertical videos in landscape, in portrait, in multi window mode, check non-vertical videos too.
 
#### Fixes the following issue(s)
partially fixes #4040

#### Testing apk
[app-release-final.zip](https://github.com/TeamNewPipe/NewPipe/files/5085735/app-release-final.zip)


#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
