### PR TITLE
Small fixes of issues with brightness, background playback, gestures

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
@@ -1339,6 +1339,11 @@ public abstract class BasePlayer implements
             return;
         }
         final StreamInfo currentInfo = currentMetadata.getMetadata();
+        if (playQueue != null) {
+            // Save current position. It will help to restore this position once a user
+            // wants to play prev or next stream from the queue
+            playQueue.setRecovery(playQueue.getIndex(), simpleExoPlayer.getContentPosition());
+        }
         savePlaybackState(currentInfo, simpleExoPlayer.getCurrentPosition());
     }
 

--- a/app/src/main/java/org/schabi/newpipe/player/MainPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/MainPlayer.java
@@ -184,6 +184,9 @@ public final class MainPlayer extends Service {
     @Override
     public void onTaskRemoved(final Intent rootIntent) {
         super.onTaskRemoved(rootIntent);
+        if (!playerImpl.videoPlayerSelected()) {
+            return;
+        }
         onDestroy();
         // Unload from memory completely
         Runtime.getRuntime().halt(0);

--- a/app/src/main/java/org/schabi/newpipe/player/event/PlayerGestureListener.java
+++ b/app/src/main/java/org/schabi/newpipe/player/event/PlayerGestureListener.java
@@ -202,7 +202,8 @@ public class PlayerGestureListener
 
     private boolean onScrollInMain(final MotionEvent initialEvent, final MotionEvent movingEvent,
                                    final float distanceX, final float distanceY) {
-        if (!isVolumeGestureEnabled && !isBrightnessGestureEnabled) {
+        if ((!isVolumeGestureEnabled && !isBrightnessGestureEnabled)
+                || !playerImpl.isFullscreen()) {
             return false;
         }
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe. Please take a moment to fill out the following suggestion on how to structure this PR description. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bug fix (user facing)

#### Description of the changes in your PR
Just fixes for issues linked below + one thing that allows to play previous video from queue using previously viewed position (start playing queue, play next stream, tap back button, position will be restored). 

Regarding this thing: https://github.com/TeamNewPipe/NewPipe/compare/dev...avently:small-fixes?expand=1#diff-5f76198512a7674ea2f085d5c554be97R187  it means that the app will be shut down only when video player is playing. Popup and background players will continue to play in background even if a user swiped the app away from recents. So the only way to kill the app is to use notification `close` button or popup player's close button from the bottom of the screen.

#### Fixes the following issue(s)
- closes https://github.com/TeamNewPipe/NewPipe/issues/4043
- closes https://github.com/TeamNewPipe/NewPipe/issues/4159
- closes https://github.com/TeamNewPipe/NewPipe/issues/4142

#### Testing apk
[app-release.zip](https://github.com/TeamNewPipe/NewPipe/files/5170655/app-release.zip)


#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
