### PR TITLE
Disabled preloading when switching streams

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -958,6 +958,9 @@ public class VideoDetailFragment
             return;
         }
         setInitialData(sid, videoUrl, title, queue);
+        if (player != null) {
+            player.disablePreloadingOfCurrentTrack();
+        }
         startLoading(false, true);
     }
 

--- a/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/BasePlayer.java
@@ -1411,6 +1411,11 @@ public abstract class BasePlayer implements
     }
 
     @NonNull
+    public LoadController getLoadController() {
+        return (LoadController) loadControl;
+    }
+
+    @NonNull
     public String getVideoUrl() {
         return currentMetadata == null
                 ? context.getString(R.string.unknown_content)

--- a/app/src/main/java/org/schabi/newpipe/player/VideoPlayerImpl.java
+++ b/app/src/main/java/org/schabi/newpipe/player/VideoPlayerImpl.java
@@ -1484,6 +1484,10 @@ public class VideoPlayerImpl extends VideoPlayer
         }
     }
 
+    public void disablePreloadingOfCurrentTrack() {
+        getLoadController().disablePreloadingOfCurrentTrack();
+    }
+
     /**
      * Measures width and height of controls visible on screen.
      * It ensures that controls will be side-by-side with NavigationBar and notches

--- a/app/src/main/java/org/schabi/newpipe/player/helper/LoadController.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/LoadController.java
@@ -13,6 +13,7 @@ public class LoadController implements LoadControl {
 
     private final long initialPlaybackBufferUs;
     private final LoadControl internalLoadControl;
+    private boolean preloadingEnabled = true;
 
     /*//////////////////////////////////////////////////////////////////////////
     // Default Load Control
@@ -41,6 +42,7 @@ public class LoadController implements LoadControl {
 
     @Override
     public void onPrepared() {
+        preloadingEnabled = true;
         internalLoadControl.onPrepared();
     }
 
@@ -52,11 +54,13 @@ public class LoadController implements LoadControl {
 
     @Override
     public void onStopped() {
+        preloadingEnabled = true;
         internalLoadControl.onStopped();
     }
 
     @Override
     public void onReleased() {
+        preloadingEnabled = true;
         internalLoadControl.onReleased();
     }
 
@@ -78,6 +82,9 @@ public class LoadController implements LoadControl {
     @Override
     public boolean shouldContinueLoading(final long bufferedDurationUs,
                                          final float playbackSpeed) {
+        if (!preloadingEnabled) {
+            return false;
+        }
         return internalLoadControl.shouldContinueLoading(bufferedDurationUs, playbackSpeed);
     }
 
@@ -89,5 +96,9 @@ public class LoadController implements LoadControl {
         final boolean isInternalStartingPlayback = internalLoadControl
                 .shouldStartPlayback(bufferedDurationUs, playbackSpeed, rebuffering);
         return isInitialPlaybackBufferFilled || isInternalStartingPlayback;
+    }
+
+    public void disablePreloadingOfCurrentTrack() {
+        preloadingEnabled = false;
     }
 }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe. Please take a moment to fill out the following suggestion on how to structure this PR description. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Feature (user facing)

#### Description of the changes in your PR
When you play one video and then select another the player will stop loading the first stream. Which theoretically saves some megabytes while next video is loading.  So the first video will NOT stop playing but will stop loading more parts that will never be viewed because the second video shows up.

#### Fixes the following issue(s)
closes #4232 

#### Testing apk
[disabled-preloading.zip](https://github.com/TeamNewPipe/NewPipe/files/5184067/disabled-preloading.zip)


#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
