### PR TITLE
Fix rotation when auto-rotate is disabled

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -1421,13 +1421,6 @@ public class VideoDetailFragment
         if (player != null && player.isFullscreen()) {
             player.toggleFullscreen();
         }
-        // This will show systemUI and pause the player.
-        // User can tap on Play button and video will be in fullscreen mode again
-        // Note for tablet: trying to avoid orientation changes since it's not easy
-        // to physically rotate the tablet every time
-        if (!DeviceUtils.isTablet(activity)) {
-            activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
-        }
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -1934,6 +1927,11 @@ public class VideoDetailFragment
         // Just turn on fullscreen mode in landscape orientation
         if (isLandscape() && DeviceUtils.isTablet(activity)) {
             player.toggleFullscreen();
+            return;
+        }
+
+        if (isLandscape() && PlayerHelper.globalScreenOrientationLocked(activity)) {
+            activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
             return;
         }
 

--- a/app/src/main/java/org/schabi/newpipe/player/VideoPlayerImpl.java
+++ b/app/src/main/java/org/schabi/newpipe/player/VideoPlayerImpl.java
@@ -743,6 +743,15 @@ public class VideoPlayerImpl extends VideoPlayer
                 return;
             }
 
+            // This makes the button function correctly if you disable auto-rotate
+            // while watching a vertical video and your phones in landscape
+            final boolean orientationLocked = PlayerHelper.globalScreenOrientationLocked(service);
+            final boolean isTablet = DeviceUtils.isTablet(service);
+            if (orientationLocked && isFullscreen && service.isLandscape() && !isTablet) {
+                fragmentListener.onScreenRotationButtonClicked();
+                return;
+            }
+
             isFullscreen = !isFullscreen;
             setControlsSize();
             fragmentListener.onFullscreenStateChanged(isFullscreen());


### PR DESCRIPTION
#### What is it?
- [x] Bug fix (user facing)
- [ ] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR

1. Enable auto-rotate and watch a video in landscape
2. Disable auto-rotate while watching the video in landscape

Previously NewPipe would return you to your default orientation, but now you'll remain stuck in landscape and NewPipe's fullscreen button won't do anything no matter how many times you press on it.

With this change NewPipe will remain in landscape mode, but when you press on the fullscreen button it'll correctly change the orientation to portrait.

#### Testing apk
[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/5196379/app-debug.zip)

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
