### PR TITLE
Add settings migration, remove "Detail page" option from share dialog and minimize to background by default

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -1236,7 +1236,7 @@ public class VideoDetailFragment
     }
 
     private boolean isExternalPlayerEnabled() {
-        return PreferenceManager.getDefaultSharedPreferences(getContext())
+        return PreferenceManager.getDefaultSharedPreferences(requireContext())
                 .getBoolean(getString(R.string.use_external_video_player_key), false);
     }
 
@@ -1247,23 +1247,7 @@ public class VideoDetailFragment
                 && !isExternalPlayerEnabled()
                 && (player == null || player.videoPlayerSelected())
                 && bottomSheetState != BottomSheetBehavior.STATE_HIDDEN
-                && isAutoplayAllowedByUser();
-    }
-
-    private boolean isAutoplayAllowedByUser() {
-        if (activity == null) {
-            return false;
-        }
-
-        switch (PlayerHelper.getAutoplayType(activity)) {
-            case PlayerHelper.AutoplayType.AUTOPLAY_TYPE_NEVER:
-                return false;
-            case PlayerHelper.AutoplayType.AUTOPLAY_TYPE_WIFI:
-                return !ListHelper.isMeteredNetwork(activity);
-            case PlayerHelper.AutoplayType.AUTOPLAY_TYPE_ALWAYS:
-            default:
-                return true;
-        }
+                && PlayerHelper.isAutoplayAllowedByUser(requireContext());
     }
 
     private void addVideoPlayerView() {

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
@@ -28,6 +28,7 @@ import org.schabi.newpipe.extractor.stream.VideoStream;
 import org.schabi.newpipe.player.playqueue.PlayQueue;
 import org.schabi.newpipe.player.playqueue.PlayQueueItem;
 import org.schabi.newpipe.player.playqueue.SinglePlayQueue;
+import org.schabi.newpipe.util.ListHelper;
 
 import java.lang.annotation.Retention;
 import java.text.DecimalFormat;
@@ -245,6 +246,18 @@ public final class PlayerHelper {
             return AUTOPLAY_TYPE_NEVER;
         } else {
             return AUTOPLAY_TYPE_WIFI;
+        }
+    }
+
+    public static boolean isAutoplayAllowedByUser(@NonNull final Context context) {
+        switch (PlayerHelper.getAutoplayType(context)) {
+            case PlayerHelper.AutoplayType.AUTOPLAY_TYPE_NEVER:
+                return false;
+            case PlayerHelper.AutoplayType.AUTOPLAY_TYPE_WIFI:
+                return !ListHelper.isMeteredNetwork(context);
+            case PlayerHelper.AutoplayType.AUTOPLAY_TYPE_ALWAYS:
+            default:
+                return true;
         }
     }
 

--- a/app/src/main/java/org/schabi/newpipe/report/UserAction.java
+++ b/app/src/main/java/org/schabi/newpipe/report/UserAction.java
@@ -20,7 +20,8 @@ public enum UserAction {
     DELETE_FROM_HISTORY("delete from history"),
     PLAY_STREAM("Play stream"),
     DOWNLOAD_POSTPROCESSING("download post-processing"),
-    DOWNLOAD_FAILED("download failed");
+    DOWNLOAD_FAILED("download failed"),
+    PREFERENCES_MIGRATION("migration of preferences");
 
 
     private final String message;

--- a/app/src/main/java/org/schabi/newpipe/settings/NewPipeSettings.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/NewPipeSettings.java
@@ -10,6 +10,7 @@ import androidx.preference.PreferenceManager;
 import org.schabi.newpipe.R;
 
 import java.io.File;
+import java.util.Set;
 
 /*
  * Created by k3b on 07.01.2016.
@@ -38,6 +39,22 @@ public final class NewPipeSettings {
     private NewPipeSettings() { }
 
     public static void initSettings(final Context context) {
+        // check if there are entries in the prefs to determine whether this is the first app run
+        Boolean isFirstRun = null;
+        final Set<String> prefsKeys = PreferenceManager.getDefaultSharedPreferences(context)
+                .getAll().keySet();
+        for (final String key: prefsKeys) {
+            // ACRA stores some info in the prefs during app initialization
+            // which happens before this method is called. Therefore ignore ACRA-related keys.
+            if (!key.toLowerCase().startsWith("acra")) {
+                isFirstRun = false;
+                break;
+            }
+        }
+        if (isFirstRun == null) {
+            isFirstRun = true;
+        }
+
         PreferenceManager.setDefaultValues(context, R.xml.appearance_settings, true);
         PreferenceManager.setDefaultValues(context, R.xml.content_settings, true);
         PreferenceManager.setDefaultValues(context, R.xml.download_settings, true);
@@ -48,6 +65,8 @@ public final class NewPipeSettings {
 
         getVideoDownloadFolder(context);
         getAudioDownloadFolder(context);
+
+        SettingMigrations.initMigrations(context, isFirstRun);
     }
 
     private static void getVideoDownloadFolder(final Context context) {

--- a/app/src/main/java/org/schabi/newpipe/settings/SettingMigrations.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/SettingMigrations.java
@@ -18,8 +18,22 @@ public final class SettingMigrations {
     /**
      * Version number for preferences. Must be incremented every time a migration is necessary.
      */
-    public static final int VERSION = 0;
+    public static final int VERSION = 1;
     private static SharedPreferences sp;
+
+    public static final Migration MIGRATION_0_1 = new Migration(0, 1) {
+        @Override
+        public void migrate(final Context context) {
+            // We changed the content of the dialog which opens when sharing a link to NewPipe
+            // by removing the "open detail page" option.
+            // Therefore, show the dialog once again to ensure users need to choose again and are
+            // aware of the changed dialog.
+            final SharedPreferences.Editor editor = sp.edit();
+            editor.putString(context.getString(R.string.preferred_open_action_key),
+                    context.getString(R.string.always_ask_open_action_key));
+            editor.apply();
+        }
+    };
 
     /**
      * List of all implemented migrations.
@@ -28,7 +42,7 @@ public final class SettingMigrations {
      * If not sorted correctly, migrations which depend on each other, may fail.
      */
     private static final Migration[] SETTING_MIGRATIONS = {
-
+        MIGRATION_0_1
     };
 
 

--- a/app/src/main/java/org/schabi/newpipe/settings/SettingMigrations.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/SettingMigrations.java
@@ -18,7 +18,7 @@ public final class SettingMigrations {
     /**
      * Version number for preferences. Must be incremented every time a migration is necessary.
      */
-    public static final int VERSION = 1;
+    public static final int VERSION = 2;
     private static SharedPreferences sp;
 
     public static final Migration MIGRATION_0_1 = new Migration(0, 1) {
@@ -35,6 +35,25 @@ public final class SettingMigrations {
         }
     };
 
+    public static final Migration MIGRATION_1_2 = new Migration(1, 2) {
+        @Override
+        protected void migrate(final Context context) {
+            // The new application workflow introduced in #2907 allows minimizing videos
+            // while playing to do other stuff within the app.
+            // For an even better workflow, we minimize a stream when switching the app to play in
+            // background.
+            // Therefore, set default value to background, if it has not been changed yet.
+            final String minimizeOnExitKey = context.getString(R.string.minimize_on_exit_key);
+            if (sp.getString(minimizeOnExitKey, "")
+                    .equals(context.getString(R.string.minimize_on_exit_none_key))) {
+                final SharedPreferences.Editor editor = sp.edit();
+                editor.putString(minimizeOnExitKey,
+                        context.getString(R.string.minimize_on_exit_background_key));
+                editor.apply();
+            }
+        }
+    };
+
     /**
      * List of all implemented migrations.
      * <p>
@@ -42,7 +61,8 @@ public final class SettingMigrations {
      * If not sorted correctly, migrations which depend on each other, may fail.
      */
     private static final Migration[] SETTING_MIGRATIONS = {
-        MIGRATION_0_1
+            MIGRATION_0_1,
+            MIGRATION_1_2
     };
 
 

--- a/app/src/main/java/org/schabi/newpipe/settings/SettingMigrations.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/SettingMigrations.java
@@ -1,0 +1,106 @@
+package org.schabi.newpipe.settings;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.util.Log;
+
+import androidx.preference.PreferenceManager;
+
+import org.schabi.newpipe.R;
+import org.schabi.newpipe.report.ErrorActivity;
+import org.schabi.newpipe.report.ErrorActivity.ErrorInfo;
+import org.schabi.newpipe.report.UserAction;
+
+import static org.schabi.newpipe.MainActivity.DEBUG;
+
+public final class SettingMigrations {
+    private static final String TAG = SettingMigrations.class.toString();
+    /**
+     * Version number for preferences. Must be incremented every time a migration is necessary.
+     */
+    public static final int VERSION = 0;
+    private static SharedPreferences sp;
+
+    /**
+     * List of all implemented migrations.
+     * <p>
+     * <b>Append new migrations to the end of the list</b> to keep it sorted ascending.
+     * If not sorted correctly, migrations which depend on each other, may fail.
+     */
+    private static final Migration[] SETTING_MIGRATIONS = {
+
+    };
+
+
+    public static void initMigrations(final Context context, final boolean isFirstRun) {
+        // setup migrations and check if there is something to do
+        sp = PreferenceManager.getDefaultSharedPreferences(context);
+        final String lastPrefVersionKey = context.getString(R.string.last_used_preferences_version);
+        final int lastPrefVersion = sp.getInt(lastPrefVersionKey, 0);
+
+        // no migration to run, already up to date
+        if (isFirstRun) {
+            sp.edit().putInt(lastPrefVersionKey, VERSION).apply();
+            return;
+        } else if (lastPrefVersion == VERSION) {
+            return;
+        }
+
+        // run migrations
+        int currentVersion = lastPrefVersion;
+        for (final Migration currentMigration : SETTING_MIGRATIONS) {
+            try {
+                if (currentMigration.shouldMigrate(currentVersion)) {
+                    if (DEBUG) {
+                        Log.d(TAG, "Migrating preferences from version "
+                                + currentVersion + " to " + currentMigration.newVersion);
+                    }
+                    currentMigration.migrate(context);
+                    currentVersion = currentMigration.newVersion;
+                }
+            } catch (final Exception e) {
+                // save the version with the last successful migration and report the error
+                sp.edit().putInt(lastPrefVersionKey, currentVersion).apply();
+                final ErrorInfo errorInfo = ErrorInfo.make(
+                        UserAction.PREFERENCES_MIGRATION,
+                        "none",
+                        "Migrating preferences from version " + lastPrefVersion + " to "
+                                + VERSION + ". "
+                                + "Error at " + currentVersion  + " => " + ++currentVersion,
+                        0
+                );
+                ErrorActivity.reportError(context, e, SettingMigrations.class, null, errorInfo);
+                return;
+            }
+        }
+
+        // store the current preferences version
+        sp.edit().putInt(lastPrefVersionKey, currentVersion).apply();
+    }
+
+    private SettingMigrations() { }
+
+    abstract static class Migration {
+        public final int oldVersion;
+        public final int newVersion;
+
+        protected Migration(final int oldVersion, final int newVersion) {
+            this.oldVersion = oldVersion;
+            this.newVersion = newVersion;
+        }
+
+        /**
+         * @param currentVersion current settings version
+         * @return Returns whether this migration should be run.
+         * A migration is necessary if the old version of this migration is lower than or equal to
+         * the current settings version.
+         */
+        private boolean shouldMigrate(final int currentVersion) {
+            return oldVersion >= currentVersion;
+        }
+
+        protected abstract void migrate(Context context);
+
+    }
+
+}

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -56,7 +56,7 @@
     </string-array>
 
     <string name="minimize_on_exit_key" translatable="false">minimize_on_exit_key</string>
-    <string name="minimize_on_exit_value" translatable="false">@string/minimize_on_exit_none_key</string>
+    <string name="minimize_on_exit_value" translatable="false">@string/minimize_on_exit_background_key</string>
     <string name="minimize_on_exit_none_key" translatable="false">minimize_on_exit_none_key</string>
     <string name="minimize_on_exit_background_key" translatable="false">minimize_on_exit_background_key</string>
     <string name="minimize_on_exit_popup_key" translatable="false">minimize_on_exit_popup_key</string>

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources translatable="false">
+    <!-- App versioning -->
+    <string name="last_used_version" translatable="false">last_used_version</string>
+    <string name="last_used_preferences_version" translatable="false">last_used_preferences_version</string>
+
     <!-- Service -->
     <string-array name="service_list" translatable="false">
         <item>@string/youtube</item>


### PR DESCRIPTION
#### What is it?
- [x] Bug fix (user facing)
- [x] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
The difference between "detail page" and the video player is only the phone's orientation. Therefore, we decided to remove the open "Detail Page" option from the share menu. To handle entries from older versions, I added a migration system for the settings / shared preferences which is quite similar to the one used in for the DB.
With the new app workflow introduced by the unified player PR, it is possible to minimize the video player to the bottom while doing other stuff in the app. However, this does only apply to the main fragment. When a user opens the settings or the about screen, the player stops. That's bad UX. For this reason, I set the "Minimize on app switch" setting to "background" instead of "None" to allow seamless transitions within the app as well as when closing NewPipe.

#### Fixes the following issue(s)
<!-- Also add reddit or other links which are relevant to your change. -->
Closes #4070

#### Testing apk

###### note: I did not have much time for testing. 
Please install the current dev version from the zip first and change the "Minimize on app switch" setting or keep it as it is to see if the migration works when updating with the other APK.

[apps.zip](https://github.com/TeamNewPipe/NewPipe/files/5214440/apps.zip)


#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
