### PR TITLE
Allow numbers and uppercase letters in app package id

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,7 +33,7 @@ android {
 
             // suffix the app id and the app name with git branch name
             def workingBranch = getGitWorkingBranch()
-            def normalizedWorkingBranch = workingBranch.replaceAll("[^A-Za-z]+", "").toLowerCase()
+            def normalizedWorkingBranch = workingBranch.replaceFirst("^[^A-Za-z]+", "").replaceAll("[^0-9A-Za-z]+", "")
             if (normalizedWorkingBranch.isEmpty() || workingBranch == "master" || workingBranch == "dev") {
                 // default values when branch name could not be determined or is master or dev
                 applicationIdSuffix ".debug"


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe. Please take a moment to fill out the following suggestion on how to structure this PR description. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bug fix (user facing)
- [ ] Feature (user facing)
- [x] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
When I work on PRs from other people I am used to calling the local branches `prNUMBER`, i.e. `pr3178`. But all such names resulted the same app package id, since numbers were stripped completely, leading to conflicting APKs (e.g. https://github.com/TeamNewPipe/NewPipe/pull/4259#issuecomment-699543016 ). This PR fixes the issue by only stripping the numbers at the beginning of the git branch, [as required by Android](https://stackoverflow.com/questions/12041857/what-is-the-rule-of-the-name-of-the-packages-that-start-with-number#12042111), but not all of the others. While I was at it I also removed `toLowercase()` since package ids needn't be only lowercase, according to [the same SO](https://stackoverflow.com/questions/12041857/what-is-the-rule-of-the-name-of-the-packages-that-start-with-number#12042111).

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
