### PR TITLE
Prevent tapping behind queue in main player

### DIFF
--- a/app/src/main/res/layout-large-land/player.xml
+++ b/app/src/main/res/layout-large-land/player.xml
@@ -466,6 +466,8 @@
         <RelativeLayout
             android:layout_width="match_parent"
             android:layout_height="60dp"
+            android:clickable="true"
+            android:focusable="true"
             android:id="@+id/playQueueControl">
 
             <androidx.appcompat.widget.AppCompatImageButton

--- a/app/src/main/res/layout/player.xml
+++ b/app/src/main/res/layout/player.xml
@@ -462,6 +462,8 @@
         <RelativeLayout
             android:layout_width="match_parent"
             android:layout_height="60dp"
+            android:clickable="true"
+            android:focusable="true"
             android:id="@+id/playQueueControl">
 
             <androidx.appcompat.widget.AppCompatImageButton


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe. Please take a moment to fill out the following suggestion on how to structure this PR description. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bug fix (user facing)
- [ ] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write a text instead if you can't fit it in a list -->
- Now the user cannot interact with the controls behind the video queue in the main player

#### Fixes the following issue(s)
<!-- Also add reddit or other links which are relevant to your change. -->
- https://github.com/TeamNewPipe/NewPipe/issues/4332#issuecomment-699863945 - "open a playlist in full-screen mode. while playing, tab the top-right button to show the queue. the bug: although the queue window is on top, you can still accidentally press the player ui buttons such as the video quality menu . I think the queue window should block player buttons until dismissed."

#### Test APK

[tap-behind-queue.zip](https://github.com/TeamNewPipe/NewPipe/files/5302041/tap-behind-queue.zip)

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.