### PR TITLE
Improve age restriction and yt restricted content strings

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -1551,7 +1551,8 @@ public class VideoDetailFragment
     }
 
     private void hideAgeRestrictedContent() {
-        showError(getString(R.string.restricted_video), false);
+        showError(getString(R.string.restricted_video,
+                getString(R.string.show_age_restricted_content_title)), false);
 
         if (relatedStreamsLayout != null) { // tablet
             relatedStreamsLayout.setVisibility(View.INVISIBLE);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -154,10 +154,11 @@
     <string name="popup_playing_append">Queued on popup player</string>
     <string name="c3s_url" translatable="false">https://www.c3s.cc/</string>
     <string name="content">Content</string>
-    <string name="show_age_restricted_content_title">Age restricted content</string>
-    <string name="video_is_age_restricted">Show age restricted video. Future changes are possible from the settings.</string>
-    <string name="youtube_restricted_mode_enabled_title">YouTube restricted mode</string>
-    <string name="restricted_video">This video is age restricted.\n\nTurn on \"Age restricted content\" in the settings if you want to see it.</string>
+    <string name="show_age_restricted_content_title">Show age restricted content</string>
+    <string name="show_age_restricted_content_summary">Show content possibly unsuitable for children because it has an age limit (like 18+).</string>
+    <string name="youtube_restricted_mode_enabled_title">Turn on YouTube\'s \"Restricted Mode\"</string>
+    <string name="youtube_restricted_mode_enabled_summary">YouTube provides a \"Restricted Mode\" which hides potentially mature content.</string>
+    <string name="restricted_video">This video is age restricted.\n\nTurn on \"%1$s\" in the settings if you want to see it.</string>
     <string name="duration_live">Live</string>
     <string name="downloads">Downloads</string>
     <string name="downloads_title">Downloads</string>

--- a/app/src/main/res/xml/content_settings.xml
+++ b/app/src/main/res/xml/content_settings.xml
@@ -49,13 +49,15 @@
         app:iconSpaceReserved="false"
         android:defaultValue="false"
         android:key="@string/show_age_restricted_content"
-        android:title="@string/show_age_restricted_content_title"/>
+        android:title="@string/show_age_restricted_content_title"
+        android:summary="@string/show_age_restricted_content_summary"/>
 
     <SwitchPreferenceCompat
         app:iconSpaceReserved="false"
         android:defaultValue="false"
         android:key="@string/youtube_restricted_mode_enabled"
-        android:title="@string/youtube_restricted_mode_enabled_title"/>
+        android:title="@string/youtube_restricted_mode_enabled_title"
+        android:summary="@string/youtube_restricted_mode_enabled_summary"/>
 
     <SwitchPreferenceCompat
         app:iconSpaceReserved="false"


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe. Please take a moment to fill out the following suggestion on how to structure this PR description. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bug fix (user facing)
- [x] Feature (user facing)
- [x] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This PR changes the titles for "Show age restricted content" and "Enable YouTube's Restricted Mode" and adds a summary to them, since they have been confused by many users lately. In order to reduce redundancy in translations, I also changed the restricted-video-error string to include a `%1$s` instead of the duplicate "Show age restricted content" string. If the latter change causes prolems with translation syncing I can revert it. @wb9688 @opusforlife2 @comradekingu what do you think of these strings?

#### Testing apk
I also tested whether the latter change cause problems with languages different than English, where `%1$s` is not there yet, but it isn't creating problems.
[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/5301355/app-debug.zip)

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
