### PR TITLE
Player overlays now centered

### DIFF
--- a/app/src/main/java/com/google/android/material/appbar/FlingBehavior.java
+++ b/app/src/main/java/com/google/android/material/appbar/FlingBehavior.java
@@ -5,7 +5,6 @@ import android.graphics.Rect;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.view.View;
-import android.view.ViewGroup;
 import android.widget.OverScroller;
 
 import androidx.annotation.NonNull;
@@ -14,6 +13,8 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import org.schabi.newpipe.R;
 
 import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
 
 // See https://stackoverflow.com/questions/56849221#57997489
 public final class FlingBehavior extends AppBarLayout.Behavior {
@@ -25,6 +26,9 @@ public final class FlingBehavior extends AppBarLayout.Behavior {
 
     private boolean allowScroll = true;
     private final Rect globalRect = new Rect();
+    private final List<Integer> skipInterceptionOfElements = Arrays.asList(
+            R.id.playQueuePanel, R.id.playbackSeekBar,
+            R.id.playPauseButton, R.id.playPreviousButton, R.id.playNextButton);
 
     @Override
     public boolean onRequestChildRectangleOnScreen(
@@ -60,20 +64,14 @@ public final class FlingBehavior extends AppBarLayout.Behavior {
 
     public boolean onInterceptTouchEvent(final CoordinatorLayout parent, final AppBarLayout child,
                                          final MotionEvent ev) {
-        final ViewGroup playQueue = child.findViewById(R.id.playQueuePanel);
-        if (playQueue != null) {
-            final boolean visible = playQueue.getGlobalVisibleRect(globalRect);
-            if (visible && globalRect.contains((int) ev.getRawX(), (int) ev.getRawY())) {
-                allowScroll = false;
-                return false;
-            }
-        }
-        final View seekBar = child.findViewById(R.id.playbackSeekBar);
-        if (seekBar != null) {
-            final boolean visible = seekBar.getGlobalVisibleRect(globalRect);
-            if (visible && globalRect.contains((int) ev.getRawX(), (int) ev.getRawY())) {
-                allowScroll = false;
-                return false;
+        for (final Integer element : skipInterceptionOfElements) {
+            final View view = child.findViewById(element);
+            if (view != null) {
+                final boolean visible = view.getGlobalVisibleRect(globalRect);
+                if (visible && globalRect.contains((int) ev.getRawX(), (int) ev.getRawY())) {
+                    allowScroll = false;
+                    return false;
+                }
             }
         }
         allowScroll = true;

--- a/app/src/main/java/org/schabi/newpipe/player/VideoPlayerImpl.java
+++ b/app/src/main/java/org/schabi/newpipe/player/VideoPlayerImpl.java
@@ -172,6 +172,8 @@ public class VideoPlayerImpl extends VideoPlayer
     private RecyclerView itemsList;
     private ItemTouchHelper itemTouchHelper;
 
+    private RelativeLayout playerOverlays;
+
     private boolean queueVisible;
     private MainPlayer.PlayerType playerType = MainPlayer.PlayerType.VIDEO;
 
@@ -304,6 +306,8 @@ public class VideoPlayerImpl extends VideoPlayer
         this.queueLayout = view.findViewById(R.id.playQueuePanel);
         this.itemsListCloseButton = view.findViewById(R.id.playQueueClose);
         this.itemsList = view.findViewById(R.id.playQueue);
+
+        this.playerOverlays = view.findViewById(R.id.player_overlays);
 
         closingOverlayView = view.findViewById(R.id.closingOverlay);
 
@@ -481,6 +485,16 @@ public class VideoPlayerImpl extends VideoPlayer
                 return windowInsets;
             });
         }
+
+        // PlaybackControlRoot already consumed window insets but we should pass them to
+        // player_overlays too. Without it they will be off-centered
+        getControlsRoot().addOnLayoutChangeListener((v, left, top, right, bottom,
+                                                     oldLeft, oldTop, oldRight, oldBottom) ->
+                playerOverlays.setPadding(
+                        v.getPaddingLeft(),
+                        v.getPaddingTop(),
+                        v.getPaddingRight(),
+                        v.getPaddingBottom()));
     }
 
     public boolean onKeyDown(final int keyCode) {

--- a/app/src/main/java/org/schabi/newpipe/player/event/CustomBottomSheetBehavior.java
+++ b/app/src/main/java/org/schabi/newpipe/player/event/CustomBottomSheetBehavior.java
@@ -5,7 +5,6 @@ import android.graphics.Rect;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.view.View;
-import android.view.ViewGroup;
 import android.widget.FrameLayout;
 import androidx.annotation.NonNull;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
@@ -21,12 +20,12 @@ public class CustomBottomSheetBehavior extends BottomSheetBehavior<FrameLayout> 
         super(context, attrs);
     }
 
-    boolean visible;
     Rect globalRect = new Rect();
     private boolean skippingInterception = false;
     private final List<Integer> skipInterceptionOfElements = Arrays.asList(
             R.id.detail_content_root_layout, R.id.relatedStreamsLayout,
-            R.id.playQueuePanel, R.id.viewpager, R.id.bottomControls);
+            R.id.playQueuePanel, R.id.viewpager, R.id.bottomControls,
+            R.id.playPauseButton, R.id.playPreviousButton, R.id.playNextButton);
 
     @Override
     public boolean onInterceptTouchEvent(@NonNull final CoordinatorLayout parent,
@@ -48,9 +47,9 @@ public class CustomBottomSheetBehavior extends BottomSheetBehavior<FrameLayout> 
                 && event.getAction() == MotionEvent.ACTION_DOWN) {
             // Without overriding scrolling will not work when user touches these elements
             for (final Integer element : skipInterceptionOfElements) {
-                final ViewGroup viewGroup = child.findViewById(element);
-                if (viewGroup != null) {
-                    visible = viewGroup.getGlobalVisibleRect(globalRect);
+                final View view = child.findViewById(element);
+                if (view != null) {
+                    final boolean visible = view.getGlobalVisibleRect(globalRect);
                     if (visible
                             && globalRect.contains((int) event.getRawX(), (int) event.getRawY())) {
                         // Makes bottom part of the player draggable in portrait when

--- a/app/src/main/res/layout-large-land/player.xml
+++ b/app/src/main/res/layout-large-land/player.xml
@@ -530,117 +530,123 @@
 
     </RelativeLayout>
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:gravity="center"
-        android:orientation="vertical">
-
-        <ImageView
-            android:id="@+id/controlAnimationView"
-            android:layout_width="100dp"
-            android:layout_height="100dp"
-            android:background="@drawable/background_oval_black_transparent"
-            android:padding="15dp"
-            android:visibility="gone"
-            tools:ignore="ContentDescription"
-            tools:src="@drawable/ic_fast_rewind_white_24dp"
-            tools:visibility="visible" />
-    </LinearLayout>
-
-
     <RelativeLayout
-        android:id="@+id/loading_panel"
+        android:id="@+id/player_overlays"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="@android:color/black"
-        tools:visibility="gone">
+        android:layout_height="match_parent">
 
-        <ProgressBar
-            android:id="@+id/progressBarLoadingPanel"
-            style="?android:attr/progressBarStyleLargeInverse"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerInParent="true"
-            android:indeterminate="true"/>
-    </RelativeLayout>
-
-    <RelativeLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_gravity="center"
-        tools:ignore="RtlHardcoded">
-
-        <RelativeLayout
-            android:id="@+id/volumeRelativeLayout"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerInParent="true"
-            android:background="@drawable/background_oval_black_transparent"
-            android:visibility="gone"
-            tools:visibility="visible">
-
-            <ProgressBar
-                android:id="@+id/volumeProgressBar"
-                style="?android:progressBarStyleHorizontal"
-                android:layout_width="128dp"
-                android:layout_height="128dp"
-                android:indeterminate="false"
-                android:progressDrawable="@drawable/progress_circular_white" />
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:gravity="center"
+            android:orientation="vertical">
 
             <ImageView
-                android:id="@+id/volumeImageView"
-                android:layout_width="70dp"
-                android:layout_height="70dp"
-                android:layout_centerInParent="true"
+                android:id="@+id/controlAnimationView"
+                android:layout_width="100dp"
+                android:layout_height="100dp"
+                android:background="@drawable/background_oval_black_transparent"
+                android:padding="15dp"
+                android:visibility="gone"
                 tools:ignore="ContentDescription"
-                tools:src="@drawable/ic_volume_up_white_24dp" />
+                tools:src="@drawable/ic_fast_rewind_white_24dp"
+                tools:visibility="visible" />
+        </LinearLayout>
+
+        <RelativeLayout
+            android:id="@+id/loading_panel"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@android:color/black"
+            tools:visibility="gone">
+
+            <ProgressBar
+                android:id="@+id/progressBarLoadingPanel"
+                style="?android:attr/progressBarStyleLargeInverse"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerInParent="true"
+                android:indeterminate="true" />
         </RelativeLayout>
 
         <RelativeLayout
-            android:id="@+id/brightnessRelativeLayout"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerInParent="true"
-            android:background="@drawable/background_oval_black_transparent"
-            android:visibility="gone"
-            tools:visibility="visible">
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_gravity="center"
+            tools:ignore="RtlHardcoded">
 
-            <ProgressBar
-                android:id="@+id/brightnessProgressBar"
-                style="?android:progressBarStyleHorizontal"
-                android:layout_width="128dp"
-                android:layout_height="128dp"
-                android:indeterminate="false"
-                android:progressDrawable="@drawable/progress_circular_white" />
-
-            <ImageView
-                android:id="@+id/brightnessImageView"
-                android:layout_width="70dp"
-                android:layout_height="70dp"
+            <RelativeLayout
+                android:id="@+id/volumeRelativeLayout"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
                 android:layout_centerInParent="true"
-                tools:ignore="ContentDescription"
-                tools:src="@drawable/ic_brightness_high_white_24dp" />
+                android:background="@drawable/background_oval_black_transparent"
+                android:visibility="gone"
+                tools:visibility="visible">
+
+                <ProgressBar
+                    android:id="@+id/volumeProgressBar"
+                    style="?android:progressBarStyleHorizontal"
+                    android:layout_width="128dp"
+                    android:layout_height="128dp"
+                    android:indeterminate="false"
+                    android:progressDrawable="@drawable/progress_circular_white" />
+
+                <ImageView
+                    android:id="@+id/volumeImageView"
+                    android:layout_width="70dp"
+                    android:layout_height="70dp"
+                    android:layout_centerInParent="true"
+                    tools:ignore="ContentDescription"
+                    tools:src="@drawable/ic_volume_up_white_24dp" />
+            </RelativeLayout>
+
+            <RelativeLayout
+                android:id="@+id/brightnessRelativeLayout"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerInParent="true"
+                android:background="@drawable/background_oval_black_transparent"
+                android:visibility="gone"
+                tools:visibility="visible">
+
+                <ProgressBar
+                    android:id="@+id/brightnessProgressBar"
+                    style="?android:progressBarStyleHorizontal"
+                    android:layout_width="128dp"
+                    android:layout_height="128dp"
+                    android:indeterminate="false"
+                    android:progressDrawable="@drawable/progress_circular_white" />
+
+                <ImageView
+                    android:id="@+id/brightnessImageView"
+                    android:layout_width="70dp"
+                    android:layout_height="70dp"
+                    android:layout_centerInParent="true"
+                    tools:ignore="ContentDescription"
+                    tools:src="@drawable/ic_brightness_high_white_24dp" />
+            </RelativeLayout>
+
+            <TextView
+                android:id="@+id/currentDisplaySeek"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerInParent="true"
+                android:layout_marginBottom="58dp"
+                android:background="#64000000"
+                android:paddingBottom="10dp"
+                android:paddingLeft="30dp"
+                android:paddingRight="30dp"
+                android:paddingTop="10dp"
+                android:textColor="@android:color/white"
+                android:textSize="26sp"
+                android:textStyle="bold"
+                android:visibility="gone"
+                tools:ignore="RtlHardcoded"
+                tools:text="1:06:29"
+                tools:visibility="visible" />
         </RelativeLayout>
 
-        <TextView
-            android:id="@+id/currentDisplaySeek"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerInParent="true"
-            android:layout_marginBottom="58dp"
-            android:background="#64000000"
-            android:paddingBottom="10dp"
-            android:paddingLeft="30dp"
-            android:paddingRight="30dp"
-            android:paddingTop="10dp"
-            android:textColor="@android:color/white"
-            android:textSize="26sp"
-            android:textStyle="bold"
-            android:visibility="gone"
-            tools:ignore="RtlHardcoded"
-            tools:text="1:06:29"
-            tools:visibility="visible" />
     </RelativeLayout>
 
     <TextView

--- a/app/src/main/res/layout/play_queue_item.xml
+++ b/app/src/main/res/layout/play_queue_item.xml
@@ -12,7 +12,7 @@
     android:paddingTop="6dp"
     android:paddingBottom="6dp">
 
-    <ImageView
+    <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/itemSelected"
         android:layout_width="10dp"
         android:layout_height="10dp"
@@ -38,7 +38,7 @@
         android:src="@drawable/dummy_thumbnail"
         tools:ignore="RtlHardcoded"/>
 
-    <ImageView
+    <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/itemHandle"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"

--- a/app/src/main/res/layout/player.xml
+++ b/app/src/main/res/layout/player.xml
@@ -526,117 +526,123 @@
 
     </RelativeLayout>
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:gravity="center"
-        android:orientation="vertical">
-
-        <ImageView
-            android:id="@+id/controlAnimationView"
-            android:layout_width="100dp"
-            android:layout_height="100dp"
-            android:padding="15dp"
-            android:background="@drawable/background_oval_black_transparent"
-            android:visibility="gone"
-            tools:ignore="ContentDescription"
-            tools:src="@drawable/ic_fast_rewind_white_24dp"
-            tools:visibility="visible" />
-    </LinearLayout>
-
-
     <RelativeLayout
-        android:id="@+id/loading_panel"
+        android:id="@+id/player_overlays"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="@android:color/black"
-        tools:visibility="gone">
+        android:layout_height="match_parent">
 
-        <ProgressBar
-            android:id="@+id/progressBarLoadingPanel"
-            style="?android:attr/progressBarStyleLargeInverse"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerInParent="true"
-            android:indeterminate="true"/>
-    </RelativeLayout>
-
-    <RelativeLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_gravity="center"
-        tools:ignore="RtlHardcoded">
-
-        <RelativeLayout
-            android:id="@+id/volumeRelativeLayout"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerInParent="true"
-            android:background="@drawable/background_oval_black_transparent"
-            android:visibility="gone"
-            tools:visibility="visible">
-
-            <ProgressBar
-                android:id="@+id/volumeProgressBar"
-                style="?android:progressBarStyleHorizontal"
-                android:layout_width="128dp"
-                android:layout_height="128dp"
-                android:indeterminate="false"
-                android:progressDrawable="@drawable/progress_circular_white" />
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:gravity="center"
+            android:orientation="vertical">
 
             <ImageView
-                android:id="@+id/volumeImageView"
-                android:layout_width="70dp"
-                android:layout_height="70dp"
-                android:layout_centerInParent="true"
+                android:id="@+id/controlAnimationView"
+                android:layout_width="100dp"
+                android:layout_height="100dp"
+                android:padding="15dp"
+                android:background="@drawable/background_oval_black_transparent"
+                android:visibility="gone"
                 tools:ignore="ContentDescription"
-                tools:src="@drawable/ic_volume_up_white_24dp" />
+                tools:src="@drawable/ic_fast_rewind_white_24dp"
+                tools:visibility="visible" />
+        </LinearLayout>
+
+        <RelativeLayout
+            android:id="@+id/loading_panel"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@android:color/black"
+            tools:visibility="gone">
+
+            <ProgressBar
+                android:id="@+id/progressBarLoadingPanel"
+                style="?android:attr/progressBarStyleLargeInverse"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerInParent="true"
+                android:indeterminate="true" />
         </RelativeLayout>
 
         <RelativeLayout
-            android:id="@+id/brightnessRelativeLayout"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerInParent="true"
-            android:background="@drawable/background_oval_black_transparent"
-            android:visibility="gone"
-            tools:visibility="visible">
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_gravity="center"
+            tools:ignore="RtlHardcoded">
 
-            <ProgressBar
-                android:id="@+id/brightnessProgressBar"
-                style="?android:progressBarStyleHorizontal"
-                android:layout_width="128dp"
-                android:layout_height="128dp"
-                android:indeterminate="false"
-                android:progressDrawable="@drawable/progress_circular_white" />
-
-            <ImageView
-                android:id="@+id/brightnessImageView"
-                android:layout_width="70dp"
-                android:layout_height="70dp"
+            <RelativeLayout
+                android:id="@+id/volumeRelativeLayout"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
                 android:layout_centerInParent="true"
-                tools:ignore="ContentDescription"
-                tools:src="@drawable/ic_brightness_high_white_24dp" />
+                android:background="@drawable/background_oval_black_transparent"
+                android:visibility="gone"
+                tools:visibility="visible">
+
+                <ProgressBar
+                    android:id="@+id/volumeProgressBar"
+                    style="?android:progressBarStyleHorizontal"
+                    android:layout_width="128dp"
+                    android:layout_height="128dp"
+                    android:indeterminate="false"
+                    android:progressDrawable="@drawable/progress_circular_white" />
+
+                <ImageView
+                    android:id="@+id/volumeImageView"
+                    android:layout_width="70dp"
+                    android:layout_height="70dp"
+                    android:layout_centerInParent="true"
+                    tools:ignore="ContentDescription"
+                    tools:src="@drawable/ic_volume_up_white_24dp" />
+            </RelativeLayout>
+
+            <RelativeLayout
+                android:id="@+id/brightnessRelativeLayout"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerInParent="true"
+                android:background="@drawable/background_oval_black_transparent"
+                android:visibility="gone"
+                tools:visibility="visible">
+
+                <ProgressBar
+                    android:id="@+id/brightnessProgressBar"
+                    style="?android:progressBarStyleHorizontal"
+                    android:layout_width="128dp"
+                    android:layout_height="128dp"
+                    android:indeterminate="false"
+                    android:progressDrawable="@drawable/progress_circular_white" />
+
+                <ImageView
+                    android:id="@+id/brightnessImageView"
+                    android:layout_width="70dp"
+                    android:layout_height="70dp"
+                    android:layout_centerInParent="true"
+                    tools:ignore="ContentDescription"
+                    tools:src="@drawable/ic_brightness_high_white_24dp" />
+            </RelativeLayout>
+
+            <TextView
+                android:id="@+id/currentDisplaySeek"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerInParent="true"
+                android:layout_marginBottom="58dp"
+                android:background="#64000000"
+                android:paddingBottom="10dp"
+                android:paddingLeft="30dp"
+                android:paddingRight="30dp"
+                android:paddingTop="10dp"
+                android:textColor="@android:color/white"
+                android:textSize="26sp"
+                android:textStyle="bold"
+                android:visibility="gone"
+                tools:ignore="RtlHardcoded"
+                tools:text="1:06:29"
+                tools:visibility="visible" />
         </RelativeLayout>
 
-        <TextView
-            android:id="@+id/currentDisplaySeek"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerInParent="true"
-            android:layout_marginBottom="58dp"
-            android:background="#64000000"
-            android:paddingBottom="10dp"
-            android:paddingLeft="30dp"
-            android:paddingRight="30dp"
-            android:paddingTop="10dp"
-            android:textColor="@android:color/white"
-            android:textSize="26sp"
-            android:textStyle="bold"
-            android:visibility="gone"
-            tools:ignore="RtlHardcoded"
-            tools:text="1:06:29"
-            tools:visibility="visible" />
     </RelativeLayout>
 
     <TextView


### PR DESCRIPTION
#### What is it?
- [x] Bug fix (user facing)

#### Description of the changes in your PR
Overlays were off-centered before this PR. By overlays I mean volume slider, brightness slider, loading icon, etc. Now it's fixed.
Also excluded play/prev/next buttons from swipe interception so now it's not possible to drag them up/down with expectation to drag the whole player.
If you'll find any issue, please, fix it yourself or just drop the PR because waiting of the fix from my side will take months. Thank you for understanding.

P.s. so many changes in player.xml in diff view but actually it's just the overlays were included into top level relativelayout to be able to position them via one assigment of paddings. For review it's easier to open previous player.xml and new player.xml side-by-side.

#### Fixes the following issue(s)
https://github.com/TeamNewPipe/NewPipe/issues/4332#issuecomment-701459044
 

#### Testing apk
[overlays.zip](https://github.com/TeamNewPipe/NewPipe/files/5308821/overlays.zip)



#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.