### PR TITLE
Removed remember popup properties setting

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/VideoPlayerImpl.java
+++ b/app/src/main/java/org/schabi/newpipe/player/VideoPlayerImpl.java
@@ -1656,13 +1656,10 @@ public class VideoPlayerImpl extends VideoPlayer
 
         updateScreenSize();
 
-        final boolean popupRememberSizeAndPos = PlayerHelper.isRememberingPopupDimensions(service);
         final float defaultSize = service.getResources().getDimension(R.dimen.popup_default_width);
         final SharedPreferences sharedPreferences =
                 PreferenceManager.getDefaultSharedPreferences(service);
-        popupWidth = popupRememberSizeAndPos
-                ? sharedPreferences.getFloat(POPUP_SAVED_WIDTH, defaultSize)
-                : defaultSize;
+        popupWidth = sharedPreferences.getFloat(POPUP_SAVED_WIDTH, defaultSize);
         popupHeight = getMinimumVideoHeight(popupWidth);
 
         popupLayoutParams = new WindowManager.LayoutParams(
@@ -1676,10 +1673,8 @@ public class VideoPlayerImpl extends VideoPlayer
 
         final int centerX = (int) (screenWidth / 2f - popupWidth / 2f);
         final int centerY = (int) (screenHeight / 2f - popupHeight / 2f);
-        popupLayoutParams.x = popupRememberSizeAndPos
-                ? sharedPreferences.getInt(POPUP_SAVED_X, centerX) : centerX;
-        popupLayoutParams.y = popupRememberSizeAndPos
-                ? sharedPreferences.getInt(POPUP_SAVED_Y, centerY) : centerY;
+        popupLayoutParams.x = sharedPreferences.getInt(POPUP_SAVED_X, centerX);
+        popupLayoutParams.y = sharedPreferences.getInt(POPUP_SAVED_Y, centerY);
 
         checkPopupPositionBounds();
 

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
@@ -209,10 +209,6 @@ public final class PlayerHelper {
         return isBrightnessGestureEnabled(context, true);
     }
 
-    public static boolean isRememberingPopupDimensions(@NonNull final Context context) {
-        return isRememberingPopupDimensions(context, true);
-    }
-
     public static boolean isAutoQueueEnabled(@NonNull final Context context) {
         return isAutoQueueEnabled(context, false);
     }
@@ -391,12 +387,6 @@ public final class PlayerHelper {
                                                       final boolean b) {
         return getPreferences(context)
                 .getBoolean(context.getString(R.string.brightness_gesture_control_key), b);
-    }
-
-    private static boolean isRememberingPopupDimensions(@NonNull final Context context,
-                                                        final boolean b) {
-        return getPreferences(context)
-                .getBoolean(context.getString(R.string.popup_remember_size_pos_key), b);
     }
 
     private static boolean isUsingInexactSeek(@NonNull final Context context) {

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -89,8 +89,6 @@
     <string name="show_higher_resolutions_title">عرض أعلى جودة</string>
     <string name="show_higher_resolutions_summary">بعض الأجهزة فقط تدعم تشغيل مقاطع الفيديو 2K/4K</string>
     <string name="default_video_format_title">تنسيق الفيديو الافتراضي</string>
-    <string name="popup_remember_size_pos_title">تذكر خصائص النوافذ المنبثقة</string>
-    <string name="popup_remember_size_pos_summary">تذكر آخر مكان و حجم للنافذة المنبثقة</string>
     <string name="player_gesture_controls_title">اعدادات إيماءة المشغل</string>
     <string name="player_gesture_controls_summary">استخدم الإيماءات للتحكم في سطوع وصوت المشغل</string>
     <string name="show_search_suggestions_title">اقتراحات البحث</string>

--- a/app/src/main/res/values-b+zh+HANS+CN/strings.xml
+++ b/app/src/main/res/values-b+zh+HANS+CN/strings.xml
@@ -209,8 +209,6 @@
     <string name="show_higher_resolutions_title">使用更高的分辨率</string>
     <string name="show_higher_resolutions_summary">仅某些设备支持播放2K / 4K视频</string>
     <string name="clear">清除</string>
-    <string name="popup_remember_size_pos_title">记住悬浮窗属性</string>
-    <string name="popup_remember_size_pos_summary">记住最后一次使用悬浮窗的大小和位置</string>
     <string name="settings_category_popup_title">悬浮窗</string>
     <string name="popup_resizing_indicator_title">调整大小</string>
     <string name="use_external_video_player_summary">隐藏部分没有音频的分辨率</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -58,8 +58,6 @@
     <string name="light_theme_title">Светлая</string>
     <string name="dark_theme_title">Цёмная</string>
     <string name="black_theme_title">Чорная</string>
-    <string name="popup_remember_size_pos_title">Аднавіць акно</string>
-    <string name="popup_remember_size_pos_summary">Запамінаць памер і становішча ўсплываючага акна</string>
     <string name="use_inexact_seek_title">Хуткі пошук пазіцыі</string>
     <string name="use_inexact_seek_summary">Недакладны пошук дазваляе плэеру шукаць пазіцыю хутчэй, але менш дакладна</string>
     <string name="download_thumbnail_title">Загружаць мініяцюры</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -52,8 +52,6 @@
     <string name="light_theme_title">Светла</string>
     <string name="dark_theme_title">Тъмна</string>
     <string name="black_theme_title">Черна</string>
-    <string name="popup_remember_size_pos_title">Помни размера и позицията на прозореца</string>
-    <string name="popup_remember_size_pos_summary">Използвай размера и позицията на прозореца от предишния път</string>
     <string name="player_gesture_controls_title">Контролиране на плейъра чрез жестове</string>
     <string name="player_gesture_controls_summary">Позволи използване на жестове за контрол на яркостта и силата на звука на плейъра</string>
     <string name="show_search_suggestions_title">Предложения за търсене</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -44,8 +44,6 @@
     <string name="light_theme_title">উজ্জ্বল</string>
     <string name="dark_theme_title">অন্ধকার</string>
     <string name="black_theme_title">কালো</string>
-    <string name="popup_remember_size_pos_title">পপআপ আকার এবং অবস্থান মনে রাখো</string>
-    <string name="popup_remember_size_pos_summary">শেষ আকার এবং পপআপ সেট অবস্থান মনে রাখো</string>
     <string name="download_dialog_title">ডাউনলোড</string>
     <string name="show_next_and_similar_title">পরবর্তী এবং অনুরূপ ভিডিওগুলি দেখাও</string>
     <string name="unsupported_url">URL সমর্থিত নয়</string>

--- a/app/src/main/res/values-bn-rIN/strings.xml
+++ b/app/src/main/res/values-bn-rIN/strings.xml
@@ -119,8 +119,6 @@
     <string name="seek_duration_title">দ্রুত-ফরওয়ার্ড/-পুনরায় সন্ধান সময়কাল</string>
     <string name="use_inexact_seek_summary">অনির্দিষ্ট সন্ধান প্লেয়ারকে আরো দ্রুত গতিতে সন্ধান করার সুবিধা দেয়, কিন্তু এটি সম্পূর্ণ নির্ভুল নাও হতে পারে ৷ ৫, ১৫ ও ২৫ সেকেন্ডের জন্য এটা কাজ করবে না ৷</string>
     <string name="use_inexact_seek_title">দ্রুত টানা ব্যাবহার করুন</string>
-    <string name="popup_remember_size_pos_summary">শেষ আকার এবং পপআপ সেট অবস্থান মনে রাখো</string>
-    <string name="popup_remember_size_pos_title">পপআপ আকার এবং অবস্থান মনে রাখো</string>
     <string name="black_theme_title">কালো</string>
     <string name="dark_theme_title">অন্ধকার</string>
     <string name="light_theme_title">উজ্জ্বল</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -287,8 +287,6 @@
     <string name="seek_duration_title">দ্রুত-ফরওয়ার্ড/-পুনরায় সন্ধান সময়কাল</string>
     <string name="use_inexact_seek_summary">অনির্দিষ্ট সন্ধান প্লেয়ারকে আরো দ্রুত গতিতে সন্ধান করার সুবিধা দেয়, কিন্তু এটি সম্পূর্ণ নির্ভুল নাও হতে পারে ৷ ৫, ১৫ ও ২৫ সেকেন্ডের জন্য এটা কাজ করবে না ৷</string>
     <string name="use_inexact_seek_title">দ্রুত টানা ব্যাবহার করুন</string>
-    <string name="popup_remember_size_pos_summary">শেষ আকার এবং পপআপ সেট অবস্থান মনে রাখো</string>
-    <string name="popup_remember_size_pos_title">পপআপ আকার এবং অবস্থান মনে রাখো</string>
     <string name="black_theme_title">কালো</string>
     <string name="dark_theme_title">অন্ধকার</string>
     <string name="light_theme_title">উজ্জ্বল</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -143,8 +143,6 @@
     <string name="kore_not_found">No s\'ha trobat l\'aplicació Kore. Voleu instal·lar-la\?</string>
     <string name="show_play_with_kodi_title">Mostra «Reprodueix amb el Kodi»</string>
     <string name="show_play_with_kodi_summary">Mostra una opció per reproduir un vídeo amb el centre multimèdia Kodi</string>
-    <string name="popup_remember_size_pos_title">Reproductor emergent intel·ligent</string>
-    <string name="popup_remember_size_pos_summary">Recorda la darrera mida i posició del reproductor emergent</string>
     <string name="use_inexact_seek_title">Cerca ràpida poc precisa</string>
     <string name="use_inexact_seek_summary">La cerca poc precisa permet que el reproductor cerqui una posició més ràpidament amb menys precisió. Cerques de 5, 15 o 25 segons no hi funcionaran.</string>
     <string name="download_thumbnail_title">Carrega les miniatures</string>

--- a/app/src/main/res/values-ckb/strings.xml
+++ b/app/src/main/res/values-ckb/strings.xml
@@ -91,7 +91,6 @@
     <string name="live_streams_not_supported">پەخشی ڕاستەوخۆ پشتگیری ناکرێ لەئێستادا</string>
     <string name="channel_unsubscribed">به‌شداریت نەما له‌ كه‌ناڵ</string>
     <string name="player_stream_failure">ناتوانرێ ئەم پەخشە کارپێبکرێ</string>
-    <string name="popup_remember_size_pos_title">بیرهاتنه‌وه‌ی شوێن و قه‌باره‌ی په‌نجه‌ره‌ی بچووک</string>
     <string name="player_recoverable_failure">گێڕانەوەی کارپێکەر بۆکاتی پێش کێشە</string>
     <string name="minimize_on_exit_none_description">هیچیان</string>
     <string name="pause_downloads_on_mobile_desc">بەسوودە بۆ کاتی گۆڕینی هێڵ بۆ داتای مۆبایل, لەگەڵ ئەوەشدا زۆربەی داگرتنەکان ڕاناگرێت</string>
@@ -342,7 +341,6 @@
     <string name="recaptcha_done_button">تەواو</string>
     <string name="detail_likes_img_view_description">بەدڵبوون</string>
     <string name="error_unable_to_load_license">ناتوانرێ مۆڵەت باربکرێ</string>
-    <string name="popup_remember_size_pos_summary">بیرهاتنه‌وه‌ی كۆتا قه‌باره‌ و شوێنی په‌نجه‌ره‌ی بچووك</string>
     <string name="create">دروستکردن</string>
     <string name="import_network_expensive_warning">ئەوە بزانە ئەم کردارە پێویستی بە هێڵێکی گران هەیە. 
 \n 

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -120,8 +120,6 @@
     <string name="show_higher_resolutions_title">Zobrazovat vyšší rozlišení</string>
     <string name="show_higher_resolutions_summary">Pouze některá zařízení dokáží přehrát 2K/4K videa</string>
     <string name="default_video_format_title">Výchozí formát videa</string>
-    <string name="popup_remember_size_pos_title">Pamatovat si vlastnosti vyskakovacího okna</string>
-    <string name="popup_remember_size_pos_summary">Pamatovat si poslední velikost a pozici vyskakovacího okna</string>
     <string name="popup_mode_share_menu_title">Režim vyskakovacího okna</string>
     <string name="subscribe_button_title">Odebírat</string>
     <string name="subscribed_button_title">Odebíráno</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -61,8 +61,6 @@
     <string name="light_theme_title">Lyst</string>
     <string name="dark_theme_title">Mørkt</string>
     <string name="black_theme_title">Sort</string>
-    <string name="popup_remember_size_pos_title">Husk størrelse og placering af pop op</string>
-    <string name="popup_remember_size_pos_summary">Husk sidste størrelse og placering af pop op-afspiller</string>
     <string name="use_inexact_seek_title">Brug hurtig og upræcis søgning</string>
     <string name="use_inexact_seek_summary">Upræcis søgning lader afspilleren finde placeringer hurtigere, men mindre præcist</string>
     <string name="download_thumbnail_title">Indlæs miniaturebilleder</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -128,9 +128,7 @@
     <string name="show_higher_resolutions_summary">Nur manche Geräte können Videos in 2K/4K abspielen</string>
     <string name="controls_background_title">Hintergrund</string>
     <string name="controls_popup_title">Pop-up</string>
-    <string name="popup_remember_size_pos_title">Pop-up Eigenschaften merken</string>
     <string name="use_external_video_player_summary">Entfernt Tonspur bei manchen Auflösungen</string>
-    <string name="popup_remember_size_pos_summary">Letzte Größe und Position des Pop-ups merken</string>
     <string name="player_gesture_controls_title">Gestensteuerung</string>
     <string name="player_gesture_controls_summary">Helligkeit und Lautstärke mittels Gesten einstellen</string>
     <string name="show_search_suggestions_title">Suchvorschläge</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -107,8 +107,6 @@
     <string name="default_popup_resolution_title">Προεπιλεγμένη ανάλυση αναδυόμενου παραθύρου</string>
     <string name="show_higher_resolutions_title">Εμφάνιση υψηλότερων αναλύσεων</string>
     <string name="default_video_format_title">Προεπιλεγμένη μορφή βίντεο</string>
-    <string name="popup_remember_size_pos_title">Ενθύμιση τις ιδιότητες του αναδυόμενου παραθύρου</string>
-    <string name="popup_remember_size_pos_summary">Ενθύμιση του τελευταίου μεγέθους και θέσης του παραθύρου</string>
     <string name="use_inexact_seek_title">Χρήση γρήγορης ανακριβούς αναζήτησης</string>
     <string name="use_inexact_seek_summary">Η μην ακριβής αναζήτηση επιτρέπει στην εφαρμογή να αναζητεί θέσεις στο βίντεο γρηγορότερα με μειωμένη ακρίβεια. Δε λειτουργεί για διαστήματα των 5, 15 ή 25 δευτερολέπτων.</string>
     <string name="download_thumbnail_title">Φόρτωση μικρογραφιών</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -90,8 +90,6 @@
     <string name="show_higher_resolutions_summary">Nur kelkaj aparatoj povas ludi 2K / 4K filmetojn</string>
     <string name="default_video_format_title">Defaŭlta fomato de filmeto</string>
     <string name="black_theme_title">Nigra</string>
-    <string name="popup_remember_size_pos_title">Memoru ŝprucfenestran grandecon kaj pozicion</string>
-    <string name="popup_remember_size_pos_summary">Memoru lastan grandecon kaj pozicion de ŝprucfenestro</string>
     <string name="use_inexact_seek_title">Uzi rapide, ne precizan serĉon</string>
     <string name="use_inexact_seek_summary">Ne preciza serĉo permesas al la ludanto serĉi poziciojn pli rapide kun malalta precizeco. Serĉi por 5, 15 kaj 25 sekundoj ne funckios kun tio opcio.</string>
     <string name="download_thumbnail_title">Ŝarĝi bildetojn</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -130,8 +130,6 @@
     <string name="filter">Filtro</string>
     <string name="refresh">Actualizar</string>
     <string name="clear">Limpiar</string>
-    <string name="popup_remember_size_pos_title">Recordar propiedades del reproductor emergente</string>
-    <string name="popup_remember_size_pos_summary">Recordar el último tamaño y posición del reproductor emergente</string>
     <string name="settings_category_popup_title">Emergente</string>
     <string name="popup_resizing_indicator_title">Redimensionando</string>
     <string name="use_external_video_player_summary">Elimina el audio en algunas resoluciones</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -57,8 +57,6 @@
     <string name="light_theme_title">Hele</string>
     <string name="dark_theme_title">Tume</string>
     <string name="black_theme_title">Must</string>
-    <string name="popup_remember_size_pos_title">Pea hüpikakna suurus ja asukoht meeles</string>
-    <string name="popup_remember_size_pos_summary">Pea hüpikakna viimane suurus ja asukoht meeles</string>
     <string name="use_inexact_seek_title">Kasuta ebatäpset kerimist</string>
     <string name="use_inexact_seek_summary">Ebatäpne kerimine lubab pleieril otsida asukohta kiiremini täpsuse arvel</string>
     <string name="download_thumbnail_title">Laadi pisipildid</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -59,8 +59,6 @@
     <string name="default_video_format_title">Hobetsitako bideo-formatua</string>
     <string name="theme_title">Gaia</string>
     <string name="black_theme_title">Beltza</string>
-    <string name="popup_remember_size_pos_title">Gogoratu laster-leihoaren tamaina eta posizioa</string>
-    <string name="popup_remember_size_pos_summary">Gogoratu laster-leihoaren azken tamaina eta posizioa</string>
     <string name="player_gesture_controls_title">Erreproduzigailuaren keinu bidezko kontrola</string>
     <string name="player_gesture_controls_summary">Erabili keinuak erreproduzigailuaren distira eta bolumena kontrolatzeko</string>
     <string name="show_search_suggestions_title">Bilaketa-iradokizunak</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -288,8 +288,6 @@
     <string name="popup_mode_share_menu_title">حالت تصویر در تصویر</string>
     <string name="default_popup_resolution_title">اندازه پیش فرض پنجره جداگانه</string>
     <string name="controls_popup_title">تصویر در تصویر</string>
-    <string name="popup_remember_size_pos_title">به یاد نگه داشتن خصوصیات</string>
-    <string name="popup_remember_size_pos_summary">به یاد داشتن آخرین اندازه و موقعیت قبلی پنجره جداگانه</string>
     <string name="use_inexact_seek_title">زمان فعلی پخش کننده را به صورت تقریبی و سریع جلو ببر</string>
     <string name="use_inexact_seek_summary">این گزینه باعث می شود هنگام جلو/عقب کردن زمان تصویر، به جای زمان دقیق انتخاب شده، به زمان غیر دقیق و نزدیک به مکان انتخاب شده برود که این کار سریع تر انجام می شود.</string>
     <string name="app_ui_crash">کاره یا رابط کاربری با خطا مواجه شد</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -53,8 +53,6 @@
     <string name="light_theme_title">Kirkas</string>
     <string name="dark_theme_title">Tumma</string>
     <string name="black_theme_title">Musta</string>
-    <string name="popup_remember_size_pos_title">Muista ponnahdusikkunan ominaisuudet</string>
-    <string name="popup_remember_size_pos_summary">Muista ponnahdusikkunan viimeisin koko ja sijainti</string>
     <string name="player_gesture_controls_title">Soittimen eleohjaus</string>
     <string name="player_gesture_controls_summary">Käytä eleitä ohjataksesi soittimen kirkkautta ja äänentasoa</string>
     <string name="show_search_suggestions_title">Hakuehdotukset</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -125,8 +125,6 @@
     <string name="show_higher_resolutions_title">Afficher des définitions plus élevées</string>
     <string name="show_higher_resolutions_summary">Seuls certains appareils peuvent lire les vidéos 2K et 4K</string>
     <string name="default_video_format_title">Format vidéo par défaut</string>
-    <string name="popup_remember_size_pos_title">Mémoriser les propriétés de la fenêtre flottante</string>
-    <string name="popup_remember_size_pos_summary">Mémorise les dernières taille et position de la fenêtre flottante</string>
     <string name="settings_category_popup_title">Flottant</string>
     <string name="filter">Filtre</string>
     <string name="refresh">Rafraîchir</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -58,8 +58,6 @@
     <string name="light_theme_title">Claro</string>
     <string name="dark_theme_title">Escuro</string>
     <string name="black_theme_title">Negro</string>
-    <string name="popup_remember_size_pos_title">Lembrar o tamaño e a posición do «popup»</string>
-    <string name="popup_remember_size_pos_summary">Lembrar o tamaño e a posición anteriores do «popup»</string>
     <string name="use_inexact_seek_title">Usar un salto inexacto mais inexacto</string>
     <string name="use_inexact_seek_summary">Busca incorrecta permite ao xogador buscar posicións máis rápidas con precisión reducida. A busca de 5, 15 ou 25 segundos non funciona con isto.</string>
     <string name="download_thumbnail_title">Carregar miniaturas</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -45,8 +45,6 @@
     <string name="light_theme_title">בהיר</string>
     <string name="dark_theme_title">כהה</string>
     <string name="black_theme_title">שחור</string>
-    <string name="popup_remember_size_pos_title">שמירת מאפייני החלון הצף</string>
-    <string name="popup_remember_size_pos_summary">שמירת המיקום והגודל האחרונים של החלון הצף</string>
     <string name="player_gesture_controls_title">מחוות מגע לשליטה בנגן</string>
     <string name="player_gesture_controls_summary">שימוש במחוות כדי לשלוט בבהירות ובעצמת השמע של הנגן</string>
     <string name="show_search_suggestions_title">הצעות חיפוש</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -81,8 +81,6 @@
     <string name="default_video_format_title">डिफ़ॉल्ट विडियो का फॉर्मेट</string>
     <string name="theme_title">एप्प का नया रूप</string>
     <string name="dark_theme_title">काला</string>
-    <string name="popup_remember_size_pos_title">विडियो पॉपअप की आकर और उसकी स्थति को याद रखे</string>
-    <string name="popup_remember_size_pos_summary">विडियो पॉपअप के पहले वाली आकर और उसकी स्थिति को याद रखे</string>
     <string name="player_gesture_controls_title">प्लेयर इशारा नियंत्रण</string>
     <string name="player_gesture_controls_summary">विडियो प्लेयर की ब्राइटनेस और ध्वनी को नियंत्रण के लिए फ़ोन में इशारो का प्रयोग करे</string>
     <string name="show_search_suggestions_title">खोज के सुझाव देखे</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -53,8 +53,6 @@
     <string name="light_theme_title">Svijetla</string>
     <string name="dark_theme_title">Tamna</string>
     <string name="black_theme_title">Crno</string>
-    <string name="popup_remember_size_pos_title">Zapamti veličinu i poziciju skočnog prozora</string>
-    <string name="popup_remember_size_pos_summary">Zapamti posljednju veličinu i poziciju skočnog prozora</string>
     <string name="player_gesture_controls_title">Kontroliranje reproduktora gestama</string>
     <string name="player_gesture_controls_summary">Koristi geste za kontrolu svjetline i glasnoće reproduktora</string>
     <string name="show_search_suggestions_title">Sugestije pri traženju</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -122,8 +122,6 @@
     <string name="show_higher_resolutions_summary">Csak néhány eszköz tud lejátszani 2K/4K videókat</string>
     <string name="default_video_format_title">Alapértelmezett videó formátum</string>
     <string name="black_theme_title">Fekete</string>
-    <string name="popup_remember_size_pos_title">Jegyezze meg a felugró ablak helyét és méretét</string>
-    <string name="popup_remember_size_pos_summary">Jegyezze meg a felugró ablak előző helyét és méretét</string>
     <string name="show_search_suggestions_title">Keresési javaslatok</string>
     <string name="show_search_suggestions_summary">Mutasson javaslatokat keresés közben</string>
     <string name="enable_search_history_title">Keresési előzmények</string>

--- a/app/src/main/res/values-ia/strings.xml
+++ b/app/src/main/res/values-ia/strings.xml
@@ -171,8 +171,6 @@
     <string name="main_page_content">Contento del pagina principal</string>
     <string name="select_a_channel">Selige un canal</string>
     <string name="recaptcha_done_button">Preste</string>
-    <string name="popup_remember_size_pos_summary">Rememorar ultime grandor e position del reproductor emergente</string>
-    <string name="popup_remember_size_pos_title">Rememorar grandor e position del fenestra emergente</string>
     <plurals name="videos">
         <item quantity="one">%s video</item>
         <item quantity="other">%s videos</item>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -129,8 +129,6 @@
     <string name="clear">Bersihkan</string>
     <string name="filter">Filter</string>
     <string name="use_external_video_player_summary">Menghapus audio pada beberapa resolusi</string>
-    <string name="popup_remember_size_pos_title">Ingat properti popup</string>
-    <string name="popup_remember_size_pos_summary">Ingat ukuran dan posisi terakhir popup</string>
     <string name="settings_category_popup_title">Popup</string>
     <string name="popup_resizing_indicator_title">Ubah ukuran</string>
     <string name="player_gesture_controls_title">Kontrol gestur pemutar</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -125,8 +125,6 @@
     <string name="show_higher_resolutions_title">Mostra Altre Risoluzioni</string>
     <string name="show_higher_resolutions_summary">Solo alcuni dispositivi possono riprodurre video 2K/4K</string>
     <string name="default_video_format_title">Formato Video Predefinito</string>
-    <string name="popup_remember_size_pos_title">Ricorda Poprietà Popup</string>
-    <string name="popup_remember_size_pos_summary">Ricorda dimensione e posizione della finestra Popup</string>
     <string name="player_gesture_controls_title">Controllo Gesti Lettore Multimediale</string>
     <string name="player_gesture_controls_summary">Usa i gesti per controllare luminosità e volume del lettore multimediale</string>
     <string name="show_search_suggestions_title">Suggerimenti Ricerca</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -129,8 +129,6 @@
     <string name="filter">フィルター</string>
     <string name="refresh">更新</string>
     <string name="clear">クリア</string>
-    <string name="popup_remember_size_pos_title">ポップアップの属性を記憶</string>
-    <string name="popup_remember_size_pos_summary">ポップアップしたサイズと位置を記憶します</string>
     <string name="settings_category_popup_title">ポップアップ</string>
     <string name="popup_resizing_indicator_title">サイズを変更</string>
     <string name="use_external_video_player_summary">一部の解像度では音声がありません</string>

--- a/app/src/main/res/values-jv/strings.xml
+++ b/app/src/main/res/values-jv/strings.xml
@@ -20,8 +20,6 @@
     <string name="show_comments_title">Duduhke komentar</string>
     <string name="download_thumbnail_title">Duduhke gambar cilik</string>
     <string name="seek_duration_title">Durasi cepet maju/mundure</string>
-    <string name="popup_remember_size_pos_summary">Eling-eling ukuran lan posisi ngambang terakhir</string>
-    <string name="popup_remember_size_pos_title">Eling-eling ukuran lan posisi ngambang</string>
     <string name="black_theme_title">Ireng</string>
     <string name="dark_theme_title">Peteng</string>
     <string name="light_theme_title">Padhang</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -104,8 +104,6 @@
     <string name="show_higher_resolutions_summary">일부 기기에서만 2K/4K 해상도 재생이 지원됩니다</string>
     <string name="default_video_format_title">기본 비디오 형식</string>
     <string name="black_theme_title">검은 테마</string>
-    <string name="popup_remember_size_pos_title">팝업 크기 및 위치 기억</string>
-    <string name="popup_remember_size_pos_summary">마지막으로 사용한 팝업 위치 및 크기를 기억합니다</string>
     <string name="player_gesture_controls_title">제스처 재생 조작</string>
     <string name="player_gesture_controls_summary">제스처를 사용해 화면 밝기와 음량을 조절합니다</string>
     <string name="show_search_suggestions_title">검색 제안</string>

--- a/app/src/main/res/values-ku/strings.xml
+++ b/app/src/main/res/values-ku/strings.xml
@@ -58,8 +58,6 @@
     <string name="light_theme_title">ڕۆشن</string>
     <string name="dark_theme_title">تاریک</string>
     <string name="black_theme_title">ڕه‌ش</string>
-    <string name="popup_remember_size_pos_title">بیرهاتنه‌وه‌ی شوێن و قه‌باره‌ی په‌نجه‌ره‌</string>
-    <string name="popup_remember_size_pos_summary">بیرهاتنه‌وه‌ی كۆتا قه‌باره‌ و شوێنی په‌نجه‌ره‌ی بچووك</string>
     <string name="download_thumbnail_title">باركردنی وێنۆچكه‌كان</string>
     <string name="download_thumbnail_summary">ناچالاكی بكه‌ بۆ ڕاگرتنی وێنۆچكه‌كان له‌ باركردن و پاشه‌كه‌وتبوون له‌سه‌ر بیرگه‌ی ئامێره‌كه‌ت.
 \nگۆڕینی ئه‌مه‌ ده‌بێته‌ هۆی سڕینه‌وه‌یان له‌سه‌ر بیرگه‌ی مۆبایله‌كه‌ت.</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -45,8 +45,6 @@
     <string name="light_theme_title">Šviesi</string>
     <string name="dark_theme_title">Tamsi</string>
     <string name="black_theme_title">Juoda</string>
-    <string name="popup_remember_size_pos_title">Prisiminti iššokančio lango dydį ir vietą</string>
-    <string name="popup_remember_size_pos_summary">Prisiminti paskutinį iššokančio lango dydį ir vietą</string>
     <string name="player_gesture_controls_title">Grotuvo valdymas gestais</string>
     <string name="player_gesture_controls_summary">Naudokite gestus valdyti grotuvo ryškumą ir garsumą</string>
     <string name="show_search_suggestions_title">Paieškos nuspėjimai</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -58,8 +58,6 @@
     <string name="light_theme_title">Светла</string>
     <string name="dark_theme_title">Темна</string>
     <string name="black_theme_title">Црна</string>
-    <string name="popup_remember_size_pos_title">Запамти го местото и големината на малиот прозорец</string>
-    <string name="popup_remember_size_pos_summary">Запамти ја последната големина и место на прозорчето</string>
     <string name="use_inexact_seek_title">Брзо, непрецизно премотување</string>
     <string name="use_inexact_seek_summary">Со непрецизното премотување се пребарува побрзо, но со намалена презицност.</string>
     <string name="download_thumbnail_title">Прочитај мали видео-сликички</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -398,8 +398,6 @@
     <string name="seek_duration_title">ഫാസ്റ്റ്-ഫോർവേർഡ്/റീവൈൻഡ് സമയദൈർഘ്യം</string>
     <string name="use_inexact_seek_title">Inexact seek ഉപയോഗിക്കുക</string>
     <string name="use_inexact_seek_summary">കുറഞ്ഞ കൃത്യതയോടെ സീക് ചെയ്യാൻ Inexact seek സഹായിക്കുന്നു. 5/15/25 സെക്കൻഡ് സീക്‌ ഈ മോഡിൽ പ്രവർത്തിക്കുകയില്ല.</string>
-    <string name="popup_remember_size_pos_summary">പോപ്പപ്പിന്റെ അവസാന വലുപ്പവും സ്ഥാനവും ഓർത്തിരിക്കുക</string>
-    <string name="popup_remember_size_pos_title">പോപ്പപ്പ് വലുപ്പവും സ്ഥാനവും ഓർത്തിരിക്കുക</string>
     <string name="black_theme_title">കട്ട ഇരുട്ട് തീം</string>
     <string name="dark_theme_title">ഡാർക്ക് തീം</string>
     <string name="light_theme_title">ലൈറ്റ് തീം</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -61,8 +61,6 @@
     <string name="light_theme_title">Cerah</string>
     <string name="dark_theme_title">Gelap</string>
     <string name="black_theme_title">Hitam</string>
-    <string name="popup_remember_size_pos_title">Mengingat saiz dan posisi popup</string>
-    <string name="popup_remember_size_pos_summary">Mengingat saiz dan posisi popup terakhir</string>
     <string name="use_inexact_seek_title">Gunakan tinjau laju tidak tepat</string>
     <string name="use_inexact_seek_summary">Membolehkan pemain untuk meninjau ke posisi lebih laju dengan kurang ketepatan</string>
     <string name="download_thumbnail_title">Muatkan thumbnail</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -134,8 +134,6 @@
     <string name="fragment_feed_title">Hva er nytt</string>
     <string name="controls_background_title">Bakgrunn</string>
     <string name="controls_popup_title">Oppsprett</string>
-    <string name="popup_remember_size_pos_title">Husk oppsprettsegenskaper</string>
-    <string name="popup_remember_size_pos_summary">Husk siste størrelse og posisjon for oppsprettsvinduet</string>
     <string name="show_search_suggestions_title">Søkeforslag</string>
     <string name="show_search_suggestions_summary">Vis søkeforslag ved søk</string>
     <string name="enable_search_history_title">Søkehistorikk</string>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -60,8 +60,6 @@
     <string name="light_theme_title">प्रकाश</string>
     <string name="dark_theme_title">गाढा</string>
     <string name="black_theme_title">कालो</string>
-    <string name="popup_remember_size_pos_title">पपअप आकार र स्थिति सम्झना</string>
-    <string name="popup_remember_size_pos_summary">पछिल्लो आकार र पपअप को स्थिति सम्झना</string>
     <string name="use_inexact_seek_title">तेज \'inexact\' खोज्न प्रयोग गर्नुहोस</string>
     <string name="use_inexact_seek_summary">\'Inexact\' प्लेयर कम सटीक छिटो स्थितिहरू गर्न खोज्न अनुमति दिन्छ खोज्छन्। 5, 15 वा 25 सेकेन्ड को लागि खोजी यो काम गर्दैन।</string>
     <string name="download_thumbnail_title">थम्बनेल लोड</string>

--- a/app/src/main/res/values-nl-rBE/strings.xml
+++ b/app/src/main/res/values-nl-rBE/strings.xml
@@ -58,8 +58,6 @@
     <string name="light_theme_title">Licht</string>
     <string name="dark_theme_title">Donker</string>
     <string name="black_theme_title">Zwart</string>
-    <string name="popup_remember_size_pos_title">Onthoud grootte en positie van pop-up</string>
-    <string name="popup_remember_size_pos_summary">Onthoud laatste grootte en positie van pop-up</string>
     <string name="use_inexact_seek_title">Snel, minder exact spoelen gebruiken</string>
     <string name="use_inexact_seek_summary">Minder exact spoelen laat de speler sneller posities zoeken met verminderde precisie</string>
     <string name="download_thumbnail_title">Miniatuurvoorbeelden laden</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -129,8 +129,6 @@
     <string name="filter">Filter</string>
     <string name="refresh">Verversen</string>
     <string name="clear">Wissen</string>
-    <string name="popup_remember_size_pos_title">Onthoud de eigenschappen van de pop-up</string>
-    <string name="popup_remember_size_pos_summary">Onthoud laatste grootte en positie van pop-up</string>
     <string name="settings_category_popup_title">Pop-up</string>
     <string name="popup_resizing_indicator_title">Bezig met wijzigen van grootte</string>
     <string name="use_external_video_player_summary">Verwijdert geluid bij sommige resoluties</string>

--- a/app/src/main/res/values-oc/strings.xml
+++ b/app/src/main/res/values-oc/strings.xml
@@ -62,8 +62,6 @@
     <string name="light_theme_title">Clar</string>
     <string name="dark_theme_title">Escur</string>
     <string name="black_theme_title">Negre</string>
-    <string name="popup_remember_size_pos_title">Se remembrar la talha e la posicion del fenestron</string>
-    <string name="popup_remember_size_pos_summary">Se remembrar las darrièras talha e posicion del fenestron</string>
     <string name="use_inexact_seek_title">Utilzar la recèrca rapida inexacta</string>
     <string name="use_inexact_seek_summary">La recèrca inexacta permet a l\'utilizaire de recercar mai rapidament una posicion amb mens de precision</string>
     <string name="seek_duration_title">Durada d\'avançada/reculada rapida</string>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -58,8 +58,6 @@
     <string name="light_theme_title">ਸਫੈਦ</string>
     <string name="dark_theme_title">ਗੂੜਾ</string>
     <string name="black_theme_title">ਕਾਲਾ</string>
-    <string name="popup_remember_size_pos_title">ਪੌਪ-ਅਪ ਦਾ ਆਕਾਰ ਅਤੇ ਸਥਿਤੀ ਯਾਦ ਰੱਖੋ</string>
-    <string name="popup_remember_size_pos_summary">ਪੌਪ-ਅਪ ਦਾ ਆਖਰੀ ਅਕਾਰ ਅਤੇ ਸਥਿਤੀ ਯਾਦ ਰੱਖੋ</string>
     <string name="use_inexact_seek_title">ਤੇਜ਼ ਪਰ inexact seek ਵਰਤੋ</string>
     <string name="use_inexact_seek_summary">Inexact seek ਵੀਡੀਓ ਨੂੰ ਤੇਜ਼ ਪਰ ਅਣ-ਸਟੀਕ ਢੰਗ ਨਾਲ ਅੱਗੇ-ਪਿੱਛੇ ਲਿਜਾਂਦਾ ਹੈ । ਇਸ ਨਾਲ ਅੱਗੇ-ਪਿੱਛੇ 5,15 ਜਾਂ 25 ਸੈਕੰਡ ਜਾਣਾ ਕੰਮ ਨਹੀਂ ਕਰੇਗਾ।</string>
     <string name="download_thumbnail_title">ਥੰਬਨੇਲ ਲੋਡ ਕਰੋ</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -113,8 +113,6 @@
     <string name="show_higher_resolutions_summary">Tylko niektóre urządzenia mogą odtwarzać filmy 2K/4K</string>
     <string name="default_video_format_title">Domyślny format filmu</string>
     <string name="black_theme_title">Czarny</string>
-    <string name="popup_remember_size_pos_title">Zapamiętaj właściwości wyskakującego okienka</string>
-    <string name="popup_remember_size_pos_summary">Zapamiętaj ostatni rozmiar i pozycję trybu okienkowego</string>
     <string name="player_gesture_controls_title">Sterowanie odtwarzaczem za pomocą gestów</string>
     <string name="player_gesture_controls_summary">Użyj gestów, aby sterować jasnością i głośnością odtwarzacza</string>
     <string name="show_search_suggestions_title">Podpowiedzi wyszukiwania</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -129,8 +129,6 @@
     <string name="clear">Limpar</string>
     <string name="controls_popup_title">Popup</string>
     <string name="controls_background_title">Segundo plano</string>
-    <string name="popup_remember_size_pos_title">Lembrar propriedades do popup</string>
-    <string name="popup_remember_size_pos_summary">Lembra do último tamanho e posição usado no popup</string>
     <string name="settings_category_popup_title">Popup</string>
     <string name="popup_resizing_indicator_title">Redimensionando</string>
     <string name="use_external_video_player_summary">Remove o som em algumas resoluções</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -449,7 +449,6 @@
     <string name="search_history_deleted">Histórico de pesquisa eliminado.</string>
     <string name="clear_search_history_title">Limpar o histórico de pesquisas</string>
     <string name="msg_error">Erro</string>
-    <string name="popup_remember_size_pos_title">Lembrar propriedades de popup</string>
     <string name="download_path_summary">Os ficheiros de vídeo transferidos são armazenados aqui</string>
     <string name="switch_to_main">Mudar para principal</string>
     <string name="msg_popup_permission">Esta permissão é necessária 
@@ -620,7 +619,6 @@
     <string name="clear_queue_confirmation_description">A fila do reprodutor ativo será substituída</string>
     <string name="clear_queue_confirmation_summary">Mudar de um reprodutor para outro pode substituir a sua fila</string>
     <string name="clear_queue_confirmation_title">Solicitar confirmação antes de limpar uma fila</string>
-    <string name="popup_remember_size_pos_summary">Lembrar do último tamanho e posição do popup</string>
     <string name="notification_action_nothing">Nada</string>
     <string name="notification_action_buffering">A pôr no buffer</string>
     <string name="notification_action_shuffle">Baralhar</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -125,14 +125,12 @@
     <string name="show_higher_resolutions_title">Mostrar resoluções mais altas</string>
     <string name="show_higher_resolutions_summary">Apenas alguns aparelhos suportam a reprodução de vídeos em 2K/4K</string>
     <string name="controls_popup_title">Popup</string>
-    <string name="popup_remember_size_pos_title">Lembrar propriedades de popup</string>
     <string name="settings_category_popup_title">Popup</string>
     <string name="filter">Filtrar</string>
     <string name="refresh">Atualizar</string>
     <string name="clear">Limpar</string>
     <string name="controls_background_title">Segundo plano</string>
     <string name="use_external_video_player_summary">Remove o áudio em algumas resoluções</string>
-    <string name="popup_remember_size_pos_summary">Lembrar do último tamanho e posição do popup</string>
     <string name="popup_resizing_indicator_title">Redimensionar</string>
     <string name="player_gesture_controls_title">Controlo de reprodução por gestos</string>
     <string name="player_gesture_controls_summary">Utilizar gestos para controlar o brilho e o volume do reprodutor</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -127,8 +127,6 @@ pentru a deschide în mod pop-up</string>
     <string name="use_external_video_player_summary">Sunetul poate lipsi la unele rezoluții</string>
     <string name="controls_background_title">Fundal</string>
     <string name="controls_popup_title">Pop-up</string>
-    <string name="popup_remember_size_pos_title">Reține dimensiunea și poziția pop-up-ului</string>
-    <string name="popup_remember_size_pos_summary">Reține ultima dimensiune și poziție a pop-up-ului</string>
     <string name="player_gesture_controls_title">Gesturi player</string>
     <string name="player_gesture_controls_summary">Folosește gesturile pentru a controla luminozitatea și volumul player-ului</string>
     <string name="show_search_suggestions_title">Arată sugestii</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -107,7 +107,6 @@
     <string name="show_higher_resolutions_summary">Только некоторые устройства поддерживают видео в 2K/4K</string>
     <string name="default_video_format_title">Формат видео по умолчанию</string>
     <string name="black_theme_title">Чёрная</string>
-    <string name="popup_remember_size_pos_title">Запомнить параметры всплывающего окна</string>
     <string name="player_gesture_controls_summary">Изменять яркость и громкость жестами</string>
     <string name="settings_category_popup_title">Всплывающее окно</string>
     <string name="popup_playing_toast">Воспроизведение во всплывающем окне</string>
@@ -132,7 +131,6 @@
     <string name="short_billion">" млрд"</string>
     <string name="short_thousand">" тыс."</string>
     <string name="default_popup_resolution_title">Разрешение всплывающего окна</string>
-    <string name="popup_remember_size_pos_summary">Помнить последние размер и позицию всплывающего окна</string>
     <string name="show_search_suggestions_title">Поисковые предложения</string>
     <string name="best_resolution">Лучшее разрешение</string>
     <string name="title_activity_recaptcha">Запрос reCAPTCHA</string>

--- a/app/src/main/res/values-sc/strings.xml
+++ b/app/src/main/res/values-sc/strings.xml
@@ -549,7 +549,6 @@
     <string name="seek_duration_title">Longària de s\'avantzamentu e de sa torrada in segus lestros</string>
     <string name="use_inexact_seek_summary">Su moimentu inesatu permitit a su riproduidore de si mòere cara a una positzione in manera prus lestra ma prus pagu pretzisa. Su de si mòere de 5, 15 o 25 segundos non funtzionat, cun custa optzione.</string>
     <string name="use_inexact_seek_title">Imprea su moimentu inesatu lestru</string>
-    <string name="popup_remember_size_pos_title">Ammenta sas propriedades de sa ventanedda</string>
     <string name="black_theme_title">Nieddu</string>
     <string name="dark_theme_title">Iscuru</string>
     <string name="light_theme_title">Craru</string>
@@ -633,5 +632,4 @@
     <string name="notification_action_1_title">Su de duos butones de atzione</string>
     <string name="notification_action_0_title">Su de unu butone de atzione</string>
     <string name="notification_scale_to_square_image_title">Pone in iscala sa miniadura in formadu 1:1</string>
-    <string name="popup_remember_size_pos_summary">Ammenta s\'ùrtima mannària e sa positzione in sa ventanedda</string>
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -130,8 +130,6 @@
     <string name="refresh">Obnoviť</string>
     <string name="clear">Vyčistiť</string>
     <string name="use_external_video_player_summary">Odoberie audio pri niektorých rozlíšeniach</string>
-    <string name="popup_remember_size_pos_title">Zapamätať si parametre mini okna</string>
-    <string name="popup_remember_size_pos_summary">Zapamätať si posledné nastavenie veľkosti a pozície mini okna</string>
     <string name="player_gesture_controls_title">Ovládanie prehrávača gestami</string>
     <string name="player_gesture_controls_summary">Používať gestá pre kontrolu jasu a hlasitosti prehrávača</string>
     <string name="show_search_suggestions_title">Hľadať návrhy</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -129,8 +129,6 @@ odpiranje v pojavnem načinu</string>
     <string name="filter">Filter</string>
     <string name="refresh">Osveži</string>
     <string name="clear">Počisti</string>
-    <string name="popup_remember_size_pos_title">Zapomni si položaj in velikost pojavnega okna</string>
-    <string name="popup_remember_size_pos_summary">Zapomni si položaj in velikost pojavnega okna</string>
     <string name="settings_category_popup_title">Pojavno okno</string>
     <string name="popup_resizing_indicator_title">Prilagajanje velikosti</string>
     <string name="use_external_video_player_summary">Pri nekaterih ločljivostih bo posnetek brez zvoka, če je ta možnost omogočena</string>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -571,8 +571,6 @@
     <string name="seek_duration_title">Kohëzgjatja e kërkimit me shtytje-përpara/-pas</string>
     <string name="use_inexact_seek_summary">Kërkuesi i pasaktë e lejon luajtësin që të kërkojë pozicionet më shpejt më saktësi të reduktuar. Kërkimi për 5, 15 ose 25 sekonda nuk punon me këtë.</string>
     <string name="use_inexact_seek_title">Përdor kërkuesin e pasaktë por të shpejtë</string>
-    <string name="popup_remember_size_pos_summary">Mbaj mend madhësinë e fundit dhe pozicionin e popup</string>
-    <string name="popup_remember_size_pos_title">Mbaj mend popup</string>
     <string name="dark_theme_title">E errët</string>
     <string name="light_theme_title">E bardhë</string>
     <string name="theme_title">Tema</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -130,8 +130,6 @@
     <string name="controls_background_title">Позадина</string>
     <string name="controls_popup_title">Прозорче</string>
     <string name="use_external_video_player_summary">Уклања звук на неким резолуцијама</string>
-    <string name="popup_remember_size_pos_title">Упамти величину и позицију искачућег прозора</string>
-    <string name="popup_remember_size_pos_summary">Памти последњу величину и позицију искачућег прозорчета</string>
     <string name="player_gesture_controls_title">Контроле прејера потезом</string>
     <string name="player_gesture_controls_summary">Користите потезе за управљање осветљајем у јачином звука</string>
     <string name="show_search_suggestions_title">Предлози у претрази</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -43,8 +43,6 @@
     <string name="light_theme_title">Ljust</string>
     <string name="dark_theme_title">Mörkt</string>
     <string name="black_theme_title">Svart</string>
-    <string name="popup_remember_size_pos_title">Kom ihåg popupstorlek och position</string>
-    <string name="popup_remember_size_pos_summary">Kom ihåg popup-rutans senaste storlek och position</string>
     <string name="player_gesture_controls_title">Gestkontroller för spelare</string>
     <string name="player_gesture_controls_summary">Använd gester för att kontrollera spelarens ljusstyrka och volym</string>
     <string name="show_search_suggestions_title">Sökförslag</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -55,8 +55,6 @@
     <string name="light_theme_title">வெளிர்</string>
     <string name="dark_theme_title">அடர்</string>
     <string name="black_theme_title">கருப்பு</string>
-    <string name="popup_remember_size_pos_title">திரைமேல் அளவையும் இடத்தையும் நினைவுகொள்</string>
-    <string name="popup_remember_size_pos_summary">திரைமேல் நிலையின் கடைசி அளவையும் இடத்தையும் நினைவுகொள்</string>
     <string name="download_thumbnail_title">வில்லைப்படத்தைக் காண்பி</string>
     <string name="thumbnail_cache_wipe_complete_notice">பட பதுக்ககம் அழிக்கப்பட்டது</string>
     <string name="metadata_cache_wipe_title">மேல்நிலைத்தரவின் பதுக்ககம் அழிக்கப்பட்டது</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -60,8 +60,6 @@
     <string name="light_theme_title">สว่าง</string>
     <string name="dark_theme_title">มืด</string>
     <string name="black_theme_title">สีดำ</string>
-    <string name="popup_remember_size_pos_title">จำขนาดและตำแหน่งของป๊อปอัพ</string>
-    <string name="popup_remember_size_pos_summary">จำขนาดและตำแหน่งสุดท้ายของป๊อปอัพ</string>
     <string name="use_inexact_seek_title">ใช้การข้ามที่ไม่แม่นยำ</string>
     <string name="use_inexact_seek_summary">การข้ามช่วงที่ไม่แม่นยำจะทำให้เลื่อนไปยังตำแหน่งเวลาที่ต้องการได้เร็วขึ้น แต่จะลดความแม่นยำในการลากตำแหน่งลง</string>
     <string name="download_thumbnail_title">โหลดภาพขนาดย่อ</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -129,8 +129,6 @@
     <string name="filter">Filtrele</string>
     <string name="refresh">Yenile</string>
     <string name="clear">Temizle</string>
-    <string name="popup_remember_size_pos_title">Açılır pencere özelliklerini hatırla</string>
-    <string name="popup_remember_size_pos_summary">Açılan pencerenin son boyutunu ve konumunu hatırla</string>
     <string name="settings_category_popup_title">Açılır pencere</string>
     <string name="popup_resizing_indicator_title">Yeniden boyutlandırılıyor</string>
     <string name="use_external_video_player_summary">Bazı çözünürlüklerde sesi kaldırır</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -124,8 +124,6 @@
     <string name="show_higher_resolutions_summary">Лише деякі пристрої можуть відтворювати 2K/4K-відео</string>
     <string name="show_higher_resolutions_title">Показувати вищі роздільні здатності</string>
     <string name="default_video_format_title">Типовий формат відео</string>
-    <string name="popup_remember_size_pos_title">Пам\'ятати розмір і позицію вікна</string>
-    <string name="popup_remember_size_pos_summary">Пам\'ятати останній розмір і позицію вікна</string>
     <string name="player_gesture_controls_title">Жести керування програвачем</string>
     <string name="player_gesture_controls_summary">Контролювати яскравость та гучність програвача жестами</string>
     <string name="show_search_suggestions_title">Пошукові пропозиції</string>

--- a/app/src/main/res/values-ur/strings.xml
+++ b/app/src/main/res/values-ur/strings.xml
@@ -58,8 +58,6 @@
     <string name="light_theme_title">روشن</string>
     <string name="dark_theme_title">تاریک</string>
     <string name="black_theme_title">سیاہ</string>
-    <string name="popup_remember_size_pos_title">پاپ اپ جسامت اور مقام کو یاد رکھیں</string>
-    <string name="popup_remember_size_pos_summary">پچھلی جسامت اور پوپ اپ کا مقام یاد رکھیں</string>
     <string name="use_inexact_seek_title">بالواسطہ رسائی استعمال کریں</string>
     <string name="use_inexact_seek_summary">بالواسطہ تلاش مشکلات کو کم کر کے پلیئر کو تیز رفتاری سے مقامات تک رسائی کرنے دیتی ہے</string>
     <string name="download_thumbnail_title">نظرِ انگشتی لوڈ کریں</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -44,8 +44,6 @@
     <string name="light_theme_title">Sáng</string>
     <string name="dark_theme_title">Tối</string>
     <string name="black_theme_title">Đen</string>
-    <string name="popup_remember_size_pos_title">Nhớ kích thước và vị trí của popup</string>
-    <string name="popup_remember_size_pos_summary">Nhớ kích thước và vị trí lần trước của popup</string>
     <string name="player_gesture_controls_title">Điều khiển cử chỉ trình phát</string>
     <string name="player_gesture_controls_summary">Sử dụng cử chỉ để điều chỉnh độ sáng và âm lượng</string>
     <string name="show_search_suggestions_title">Đề xuất tìm kiếm</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -209,8 +209,6 @@
     <string name="show_higher_resolutions_title">使用更高的分辨率</string>
     <string name="show_higher_resolutions_summary">仅某些设备支持播放2K / 4K视频</string>
     <string name="clear">清除</string>
-    <string name="popup_remember_size_pos_title">记住悬浮窗的尺寸与位置</string>
-    <string name="popup_remember_size_pos_summary">记住最后一次使用悬浮窗的大小和位置</string>
     <string name="settings_category_popup_title">悬浮窗</string>
     <string name="popup_resizing_indicator_title">调整大小</string>
     <string name="use_external_video_player_summary">隐藏部分没有音频的分辨率</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -124,8 +124,6 @@
     <string name="use_external_video_player_summary">移除某些解像度的影片的聲音</string>
     <string name="controls_background_title">背景播放</string>
     <string name="controls_popup_title">畫中畫播放</string>
-    <string name="popup_remember_size_pos_title">記住畫中畫大小及位置</string>
-    <string name="popup_remember_size_pos_summary">記住最近設定的畫中畫大小及位置</string>
     <string name="player_gesture_controls_title">以動作控制播放器</string>
     <string name="player_gesture_controls_summary">使用動作以控制播放器的亮度及音量</string>
     <string name="show_search_suggestions_title">搜尋建議</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -62,8 +62,6 @@
     <string name="show_higher_resolutions_summary">僅部份裝置可播放 2K/4K 影片</string>
     <string name="default_video_format_title">預設影片格式</string>
     <string name="black_theme_title">純黑</string>
-    <string name="popup_remember_size_pos_title">記住懸浮視窗屬性</string>
-    <string name="popup_remember_size_pos_summary">記住上次使用時懸浮視窗的大小和位置</string>
     <string name="player_gesture_controls_title">播放器手勢控制</string>
     <string name="player_gesture_controls_summary">使用手勢來控制播放器的亮度及音量</string>
     <string name="show_search_suggestions_title">搜尋建議</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -78,8 +78,6 @@
     <string name="light_theme_title">Light</string>
     <string name="dark_theme_title">Dark</string>
     <string name="black_theme_title">Black</string>
-    <string name="popup_remember_size_pos_title">Remember popup properties</string>
-    <string name="popup_remember_size_pos_summary">Remember last size and position of popup</string>
     <string name="use_inexact_seek_title">Use fast inexact seek</string>
     <string name="use_inexact_seek_summary">Inexact seek allows the player to seek to positions faster with reduced precision. Seeking for 5, 15 or 25 seconds doesn\'t work with this.</string>
     <string name="seek_duration_title">Fast-forward/-rewind seek duration</string>

--- a/app/src/main/res/xml/video_audio_settings.xml
+++ b/app/src/main/res/xml/video_audio_settings.xml
@@ -144,13 +144,6 @@
 
         <SwitchPreferenceCompat
             app:iconSpaceReserved="false"
-            android:defaultValue="true"
-            android:key="@string/popup_remember_size_pos_key"
-            android:summary="@string/popup_remember_size_pos_summary"
-            android:title="@string/popup_remember_size_pos_title"/>
-
-        <SwitchPreferenceCompat
-            app:iconSpaceReserved="false"
             android:defaultValue="false"
             android:key="@string/use_inexact_seek_key"
             android:summary="@string/use_inexact_seek_summary"


### PR DESCRIPTION
#### What is it?
- [ ] Bug fix (user facing)
- [x] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
- Removed "Remember popup properties" setting in video and audio settings. The app now remembers the size and position of the video player popup by default. 


#### Fixes the following issue(s)
-Issue #4329 

#### Testing apk
[removeRememberPopupPropertiesApk.zip](https://github.com/TeamNewPipe/NewPipe/files/5320671/removeRememberPopupPropertiesApk.zip)

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
