### PR TITLE
Notification fixes

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/NotificationUtil.java
+++ b/app/src/main/java/org/schabi/newpipe/player/NotificationUtil.java
@@ -116,10 +116,11 @@ public final class NotificationUtil {
                     .setMediaSession(player.mediaSessionManager.getSessionToken())
                     .setShowActionsInCompactView(compactSlots))
                 .setPriority(NotificationCompat.PRIORITY_HIGH)
-                .setSmallIcon(R.drawable.ic_newpipe_triangle_white)
                 .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
-                .setColor(ContextCompat.getColor(player.context, R.color.gray))
                 .setCategory(NotificationCompat.CATEGORY_TRANSPORT)
+                .setShowWhen(false)
+                .setSmallIcon(R.drawable.ic_newpipe_triangle_white)
+                .setColor(ContextCompat.getColor(player.context, R.color.gray))
                 .setDeleteIntent(PendingIntent.getBroadcast(player.context, NOTIFICATION_ID,
                         new Intent(ACTION_CLOSE), FLAG_UPDATE_CURRENT));
 

--- a/app/src/main/java/org/schabi/newpipe/player/NotificationUtil.java
+++ b/app/src/main/java/org/schabi/newpipe/player/NotificationUtil.java
@@ -148,7 +148,10 @@ public final class NotificationUtil {
 
     @SuppressLint("RestrictedApi")
     boolean shouldUpdateBufferingSlot() {
-        if (notificationBuilder.mActions.size() < 3) {
+        if (notificationBuilder == null) {
+            // if there is no notification active, there is no point in updating it
+            return false;
+        } else if (notificationBuilder.mActions.size() < 3) {
             // this should never happen, but let's make sure notification actions are populated
             return true;
         }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe. Please take a moment to fill out the following suggestion on how to structure this PR description. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bug fix (user facing)
- [ ] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Fixes the following issue(s)
- Fixes #4390 by just adding a null check.
- Prevents Android from showing how much time ago a notification was created or updated: seeing when a notification was last updated is mostly useless, since it is distracting and does not really provide a useful information due to it being changed every time the notification is updated; also other players hide it. The freed space could be used to show other useful information in the future (or now, if you have any suggestion)

#### Testing apk
@baraa272 @opusforlife2 
[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/5327845/app-debug.zip)

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
