### PR TITLE
Also delete stream state when deleting stream history

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/history/HistoryRecordManager.java
+++ b/app/src/main/java/org/schabi/newpipe/local/history/HistoryRecordManager.java
@@ -20,9 +20,9 @@ package org.schabi.newpipe.local.history;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import androidx.preference.PreferenceManager;
 
 import androidx.annotation.NonNull;
+import androidx.preference.PreferenceManager;
 
 import org.schabi.newpipe.NewPipeDatabase;
 import org.schabi.newpipe.R;
@@ -101,9 +101,11 @@ public class HistoryRecordManager {
         })).subscribeOn(Schedulers.io());
     }
 
-    public Single<Integer> deleteStreamHistory(final long streamId) {
-        return Single.fromCallable(() -> streamHistoryTable.deleteStreamHistory(streamId))
-                .subscribeOn(Schedulers.io());
+    public Completable deleteStreamHistoryAndState(final long streamId) {
+        return Completable.fromAction(() -> {
+            streamStateTable.deleteState(streamId);
+            streamHistoryTable.deleteStreamHistory(streamId);
+        }).subscribeOn(Schedulers.io());
     }
 
     public Single<Integer> deleteWholeStreamHistory() {
@@ -111,7 +113,7 @@ public class HistoryRecordManager {
                 .subscribeOn(Schedulers.io());
     }
 
-    public Single<Integer> deleteCompelteStreamStateHistory() {
+    public Single<Integer> deleteCompleteStreamStateHistory() {
         return Single.fromCallable(streamStateTable::deleteAll)
                 .subscribeOn(Schedulers.io());
     }

--- a/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
@@ -420,14 +420,14 @@ public class StatisticsPlaylistFragment
     }
 
     private void deleteEntry(final int index) {
-        final LocalItem infoItem = itemListAdapter.getItemsList()
-                .get(index);
+        final LocalItem infoItem = itemListAdapter.getItemsList().get(index);
         if (infoItem instanceof StreamStatisticsEntry) {
             final StreamStatisticsEntry entry = (StreamStatisticsEntry) infoItem;
-            final Disposable onDelete = recordManager.deleteStreamHistory(entry.getStreamId())
+            final Disposable onDelete = recordManager
+                    .deleteStreamHistoryAndState(entry.getStreamId())
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe(
-                            howManyDeleted -> {
+                            () -> {
                                 if (getView() != null) {
                                     Snackbar.make(getView(), R.string.one_item_deleted,
                                             Snackbar.LENGTH_SHORT).show();

--- a/app/src/main/java/org/schabi/newpipe/settings/HistorySettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/HistorySettingsFragment.java
@@ -55,7 +55,7 @@ public class HistorySettingsFragment extends BasePreferenceFragment {
                     .setNegativeButton(R.string.cancel, ((dialog, which) -> dialog.dismiss()))
                     .setPositiveButton(R.string.delete, ((dialog, which) -> {
                         final Disposable onDeletePlaybackStates
-                                = recordManager.deleteCompelteStreamStateHistory()
+                                = recordManager.deleteCompleteStreamStateHistory()
                                 .observeOn(AndroidSchedulers.mainThread())
                                 .subscribe(
                                         howManyDeleted -> Toast.makeText(getActivity(),
@@ -113,7 +113,7 @@ public class HistorySettingsFragment extends BasePreferenceFragment {
                     .setPositiveButton(R.string.delete, ((dialog, which) -> {
 
                         final Disposable onDeletePlaybackStates
-                                = recordManager.deleteCompelteStreamStateHistory()
+                                = recordManager.deleteCompleteStreamStateHistory()
                                 .observeOn(AndroidSchedulers.mainThread())
                                 .subscribe(
                                         howManyDeleted -> Toast.makeText(getActivity(),


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe. Please take a moment to fill out the following suggestion on how to structure this PR description. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bug fix (user facing)
- [ ] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This PR fixes an inconsistent behaviour when deleting a stream from history: the stream state was not being deleted, thus potentially leaving trace of the fact that that specific video was watched. Also see #4393. This PR just adds a line to also delete the stream state when deleting a single stream from the history fragment.

#### Fixes the following issue(s)
Fixes #4393 

#### Testing apk
@e-edgren
[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/5328446/app-debug.zip)

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
