### PR TITLE
Hide Leaks launcher icon

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/settings/DebugSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/DebugSettingsFragment.java
@@ -2,9 +2,24 @@ package org.schabi.newpipe.settings;
 
 import android.os.Bundle;
 
+import androidx.annotation.Nullable;
+
 import org.schabi.newpipe.R;
 
+import leakcanary.LeakCanary;
+
 public class DebugSettingsFragment extends BasePreferenceFragment {
+    @Override
+    public void onCreate(@Nullable final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        findPreference(getString(R.string.show_memory_leaks_key))
+                .setOnPreferenceClickListener(preference -> {
+                    startActivity(LeakCanary.INSTANCE.newLeakDisplayActivityIntent());
+                    return true;
+                });
+    }
+
     @Override
     public void onCreatePreferences(final Bundle savedInstanceState, final String rootKey) {
         addPreferencesFromResource(R.xml.debug_settings);

--- a/app/src/main/res/values/bools.xml
+++ b/app/src/main/res/values/bools.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="leak_canary_add_launcher_icon">false</bool>
+</resources>

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -166,6 +166,7 @@
     <!-- DEBUG ONLY -->
     <string name="debug_pref_screen_key" translatable="false">debug_pref_screen_key</string>
     <string name="allow_heap_dumping_key" translatable="false">allow_heap_dumping_key</string>
+    <string name="show_memory_leaks_key" translatable="false">show_memory_leaks_key</string>
     <string name="allow_disposed_exceptions_key" translatable="false">allow_disposed_exceptions_key</string>
     <string name="show_original_time_ago_key" translatable="false">show_original_time_ago_text_key</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -493,6 +493,7 @@
     <!-- Debug Settings -->
     <string name="leakcanary" translatable="false">LeakCanary</string>
     <string name="enable_leak_canary_summary">Memory leak monitoring may cause the app to become unresponsive when heap dumping</string>
+    <string name="show_memory_leaks">Show memory leaks</string>
     <string name="enable_disposed_exceptions_title">Report out-of-lifecycle errors</string>
     <string name="enable_disposed_exceptions_summary">Force reporting of undeliverable Rx exceptions outside of fragment or activity lifecycle after disposal</string>
     <string name="show_original_time_ago_title">Show original time ago on items</string>

--- a/app/src/main/res/xml/debug_settings.xml
+++ b/app/src/main/res/xml/debug_settings.xml
@@ -12,6 +12,11 @@
         android:title="@string/leakcanary"
         android:summary="@string/enable_leak_canary_summary"/>
 
+    <Preference
+        app:iconSpaceReserved="false"
+        android:key="@string/show_memory_leaks_key"
+        android:title="@string/show_memory_leaks"/>
+
     <SwitchPreferenceCompat
         app:iconSpaceReserved="false"
         android:defaultValue="false"


### PR DESCRIPTION
#### What is it?
- [ ] Bug fix (user facing)
- [x] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Don't show the Leaks launcher icon. Now there's a button in the debug settings to open it. Btw it was already possible to open it in new Android versions by long pressing NewPipe's launcher icon and then tapping on Leaks.

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
