### PR TITLE
Ask for confirmation before clearing queue even if only 1 video in it

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -2074,8 +2074,7 @@ public class VideoDetailFragment
         if (isClearingQueueConfirmationRequired(activity)
                 && playerIsNotStopped()
                 && activeQueue != null
-                && !activeQueue.equals(playQueue)
-                && activeQueue.getStreams().size() > 1) {
+                && !activeQueue.equals(playQueue)) {
             showClearingQueueConfirmation(onAllow);
         } else {
             onAllow.run();


### PR DESCRIPTION

<!-- Hey there. Thank you so much for improving NewPipe. Please take a moment to fill out the following suggestion on how to structure this PR description. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bug fix (user facing)
- [ ] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write a text instead if you can't fit it in a list -->
- Removed the condition that there must be more than one video in the queue for the confirmation dialogue to be shown.

#### Fixes the following issue(s)
<!-- Also add reddit or other links which are relevant to your change. -->
- closes #4459

#### Testing apk

[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/5356348/app-debug.zip)

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
