### PR TITLE
Play directly in fullscreen when long-pressing on thumbnail

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -243,9 +243,15 @@ public class VideoDetailFragment
     private TabLayout tabLayout;
     private FrameLayout relatedStreamsLayout;
 
+
+    /*//////////////////////////////////////////////////////////////////////////
+    // Service
+    //////////////////////////////////////////////////////////////////////////*/
+
     private ContentObserver settingsContentObserver;
     private MainPlayer playerService;
     private VideoPlayerImpl player;
+    private boolean makeFullscreenWhenPlaybackStarts = false;
 
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -550,6 +556,10 @@ public class VideoDetailFragment
         }
 
         switch (v.getId()) {
+            case R.id.detail_thumbnail_root_layout:
+                openVideoPlayer();
+                makeFullscreenWhenPlaybackStarts = true;
+                break;
             case R.id.detail_controls_background:
                 openBackgroundPlayer(true);
                 break;
@@ -683,6 +693,7 @@ public class VideoDetailFragment
         uploaderRootLayout.setOnLongClickListener(this);
         videoTitleRoot.setOnClickListener(this);
         thumbnailBackgroundButton.setOnClickListener(this);
+        thumbnailBackgroundButton.setOnLongClickListener(this);
         detailControlsBackground.setOnClickListener(this);
         detailControlsPopup.setOnClickListener(this);
         detailControlsAddToPlaylist.setOnClickListener(this);
@@ -1771,6 +1782,16 @@ public class VideoDetailFragment
                         && player.getPlayQueue().getItem().getUrl().equals(url)) {
                     animateView(positionView, true, 100);
                     animateView(detailPositionView, true, 100);
+                }
+                break;
+            case BasePlayer.STATE_BUFFERING:
+                if (makeFullscreenWhenPlaybackStarts) {
+                    // This will only run after the user long clicked on a video to start
+                    // playback directly in fullscreen.
+                    makeFullscreenWhenPlaybackStarts = false;
+                    if (globalScreenOrientationLocked(requireContext())) {
+                        player.onScreenRotationButtonClicked();
+                    }
                 }
                 break;
         }

--- a/app/src/main/java/org/schabi/newpipe/player/VideoPlayerImpl.java
+++ b/app/src/main/java/org/schabi/newpipe/player/VideoPlayerImpl.java
@@ -790,6 +790,17 @@ public class VideoPlayerImpl extends VideoPlayer
         context.startActivity(intent);
     }
 
+    public void onScreenRotationButtonClicked() {
+        // Only if it's not a vertical video or vertical video but in landscape with locked
+        // orientation a screen orientation can be changed automatically
+        if (!isVerticalVideo
+                || (service.isLandscape() && globalScreenOrientationLocked(service))) {
+            fragmentListener.onScreenRotationButtonClicked();
+        } else {
+            toggleFullscreen();
+        }
+    }
+
     @Override
     public void onClick(final View v) {
         super.onClick(v);
@@ -819,14 +830,7 @@ public class VideoPlayerImpl extends VideoPlayer
         } else if (v.getId() == fullscreenButton.getId()) {
             switchFromPopupToMain();
         } else if (v.getId() == screenRotationButton.getId()) {
-            // Only if it's not a vertical video or vertical video but in landscape with locked
-            // orientation a screen orientation can be changed automatically
-            if (!isVerticalVideo
-                    || (service.isLandscape() && globalScreenOrientationLocked(service))) {
-                fragmentListener.onScreenRotationButtonClicked();
-            } else {
-                toggleFullscreen();
-            }
+            onScreenRotationButtonClicked();
         } else if (v.getId() == muteButton.getId()) {
             onMuteUnmuteButtonClicked();
         } else if (v.getId() == playerCloseButton.getId()) {


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This PR implements a long-press gesture on the video thumbnail to start playing the video directly in fullscreen. This gesture obviously applies only if autoplay is disabled and autorotation is disabled.

#### Fixes the following issue(s)
Fixes #4152

#### APK testing 
@opusforlife2 @EliasKomar @nikhilCad @sanityormadness @johanw666 @DuskyVoltage what do you think of this?
[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/5395812/app-debug.zip)

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
