### PR TITLE
Fix IllegalStateException after onSaveInstanceState

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
@@ -406,7 +406,7 @@ public final class NavigationHelper {
         defaultTransaction(fragmentManager)
                 .replace(R.id.fragment_player_holder, instance)
                 .runOnCommit(() -> sendPlayerStartedEvent(instance.requireActivity()))
-                .commit();
+                .commitAllowingStateLoss();
     }
 
     public static void openChannelFragment(final FragmentManager fragmentManager,


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This PR fixes a random crash happening sometimes when messing with the miniplayer while it's still starting. According to [this SO](https://stackoverflow.com/questions/7575921/illegalstateexception-can-not-perform-this-action-after-onsaveinstancestate-wit) the solution is just to replace `commit()` with `commitAllowingStateLoss()`, which may not be a real solution (state loss should never happen in theory) but is surely better than making the app crash completely.

This was the stack trace:
```
java.lang.IllegalStateException: Can not perform this action after onSaveInstanceState
        at androidx.fragment.app.FragmentManager.checkStateLoss(FragmentManager.java:1691)
        at androidx.fragment.app.FragmentManager.enqueueAction(FragmentManager.java:1731)
        at androidx.fragment.app.BackStackRecord.commitInternal(BackStackRecord.java:321)
        at androidx.fragment.app.BackStackRecord.commit(BackStackRecord.java:286)
        at org.schabi.newpipe.util.NavigationHelper.showMiniPlayer(NavigationHelper.java:409)
        at org.schabi.newpipe.MainActivity$3.onReceive(MainActivity.java:822)
        at android.app.LoadedApk$ReceiverDispatcher$Args.run(LoadedApk.java:1218)
        at android.os.Handler.handleCallback(Handler.java:761) 
        at android.os.Handler.dispatchMessage(Handler.java:98) 
        at android.os.Looper.loop(Looper.java:156) 
        at android.app.ActivityThread.main(ActivityThread.java:6517) 
        at java.lang.reflect.Method.invoke(Native Method) 
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:942) 
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:832) 
```

#### APK testing 
[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/5395820/app-debug.zip)

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
