### PR TITLE
Don't rearrange lists by dragging the thumbnails

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/holder/LocalPlaylistStreamItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/local/holder/LocalPlaylistStreamItemHolder.java
@@ -104,7 +104,6 @@ public class LocalPlaylistStreamItemHolder extends LocalItemHolder {
             return true;
         });
 
-        itemThumbnailView.setOnTouchListener(getOnTouchListener(item));
         itemHandleView.setOnTouchListener(getOnTouchListener(item));
     }
 

--- a/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueueItemBuilder.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueueItemBuilder.java
@@ -52,7 +52,6 @@ public class PlayQueueItemBuilder {
             return false;
         });
 
-        holder.itemThumbnailView.setOnTouchListener(getOnTouchListener(holder));
         holder.itemHandle.setOnTouchListener(getOnTouchListener(holder));
     }
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This PR removes touch listeners from thumbnails in playlists and queues, making the latter reorderable only using the handle on the right. Though I think the drag-by-thumbnail was introduced for some reason, so I'd be ok if this PR gets rejected because of a real-life use of the drag-by-thumbnail.

#### Fixes the following issue(s)
Closes #4523

#### APK testing 
@nbmrjuhneibkr @opusforlife2 @Swyter what do you think of this?
[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/5395830/app-debug.zip)

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
