### PR TITLE
Fix NullPointerException in queue handling

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -1728,31 +1728,33 @@ public class VideoDetailFragment
     @Override
     public void onQueueUpdate(final PlayQueue queue) {
         playQueue = queue;
-        // This should be the only place where we push data to stack.
-        // It will allow to have live instance of PlayQueue with actual information about
-        // deleted/added items inside Channel/Playlist queue and makes possible to have
-        // a history of played items
-        if ((stack.isEmpty() || !stack.peek().getPlayQueue().equals(queue)
-                && queue.getItem() != null)) {
-            stack.push(new StackItem(queue.getItem().getServiceId(),
-                    queue.getItem().getUrl(),
-                    queue.getItem().getTitle(),
-                    queue));
-        } else {
-            final StackItem stackWithQueue = findQueueInStack(queue);
-            if (stackWithQueue != null) {
-                // On every MainPlayer service's destroy() playQueue gets disposed and
-                // no longer able to track progress. That's why we update our cached disposed
-                // queue with the new one that is active and have the same history.
-                // Without that the cached playQueue will have an old recovery position
-                stackWithQueue.setPlayQueue(queue);
-            }
-        }
-
         if (DEBUG) {
             Log.d(TAG, "onQueueUpdate() called with: serviceId = ["
                     + serviceId + "], videoUrl = [" + url + "], name = ["
                     + name + "], playQueue = [" + playQueue + "]");
+        }
+
+        // This should be the only place where we push data to stack.
+        // It will allow to have live instance of PlayQueue with actual information about
+        // deleted/added items inside Channel/Playlist queue and makes possible to have
+        // a history of played items
+        @Nullable final StackItem stackPeek = stack.peek();
+        if (stackPeek != null && stackPeek.getPlayQueue().equals(queue)) {
+            @Nullable final PlayQueueItem playQueueItem = queue.getItem();
+            if (playQueueItem != null) {
+                stack.push(new StackItem(playQueueItem.getServiceId(), playQueueItem.getUrl(),
+                        playQueueItem.getTitle(), queue));
+                return;
+            } // else continue below
+        }
+
+        @Nullable final StackItem stackWithQueue = findQueueInStack(queue);
+        if (stackWithQueue != null) {
+            // On every MainPlayer service's destroy() playQueue gets disposed and
+            // no longer able to track progress. That's why we update our cached disposed
+            // queue with the new one that is active and have the same history.
+            // Without that the cached playQueue will have an old recovery position
+            stackWithQueue.setPlayQueue(queue);
         }
     }
 
@@ -2055,6 +2057,7 @@ public class VideoDetailFragment
         return url == null;
     }
 
+    @Nullable
     private StackItem findQueueInStack(final PlayQueue queue) {
         StackItem item = null;
         final Iterator<StackItem> iterator = stack.descendingIterator();

--- a/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueue.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueue.java
@@ -167,19 +167,20 @@ public abstract class PlayQueue implements Serializable {
     }
 
     /**
-     * @return the current item that should be played
+     * @return the current item that should be played, or null if the queue is empty
      */
+    @Nullable
     public PlayQueueItem getItem() {
         return getItem(getIndex());
     }
 
     /**
      * @param index the index of the item to return
-     * @return the item at the given index
-     * @throws IndexOutOfBoundsException
+     * @return the item at the given index, or null if the index is out of bounds
      */
+    @Nullable
     public PlayQueueItem getItem(final int index) {
-        if (index < 0 || index >= streams.size() || streams.get(index) == null) {
+        if (index < 0 || index >= streams.size()) {
             return null;
         }
         return streams.get(index);


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This fixes a NullPointerException caused by repeated `getItem()` calls on a queue which could possibly change in the meantime. So even though the result of `getItem()` was checked for nullity even before, its nullity state could change throughout time, and therefore a NPE was possible (still, really rare, and this is the best explanation I could give). Anyway, this simple fix only calls `getItem()` once, which should solve this problem and also possibly improving performance

#### Fixes the following issue(s)
Fixes part of #4546 (not linking though)

#### APK testing 
@yashpalgoyal1304 if you are able to reproduce your issue, could you test this?
[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/5397189/app-debug.zip)

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
