### PR TITLE
Fix opening VideoDetailFragment and much more

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -88,6 +88,7 @@ import org.schabi.newpipe.views.FocusOverlayView;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import static org.schabi.newpipe.util.Localization.assureCorrectAppLanguage;
 
@@ -822,15 +823,23 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void openMiniPlayerUponPlayerStarted() {
+        if (getIntent().getSerializableExtra(Constants.KEY_LINK_TYPE)
+                == StreamingService.LinkType.STREAM) {
+            // handleIntent() already takes care of opening video detail fragment
+            // due to an intent containing a STREAM link
+            return;
+        }
+
         if (PlayerHolder.isPlayerOpen()) {
-            // no need for a broadcast receiver if the player is already open
+            // if the player is already open, no need for a broadcast receiver
             openMiniPlayerIfMissing();
         } else {
-            // listen for player intents being sent around
+            // listen for player start intent being sent around
             broadcastReceiver = new BroadcastReceiver() {
                 @Override
                 public void onReceive(final Context context, final Intent intent) {
-                    if (intent.getAction().equals(VideoDetailFragment.ACTION_PLAYER_STARTED)) {
+                    if (Objects.equals(intent.getAction(),
+                            VideoDetailFragment.ACTION_PLAYER_STARTED)) {
                         openMiniPlayerIfMissing();
                         // At this point the player is added 100%, we can unregister. Other actions
                         // are useless since the fragment will not be removed after that.

--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -30,9 +30,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
-import androidx.preference.PreferenceManager;
 import android.util.Log;
-
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -46,6 +44,7 @@ import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.Spinner;
 import android.widget.TextView;
+
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.ActionBarDrawerToggle;
@@ -55,6 +54,7 @@ import androidx.core.view.GravityCompat;
 import androidx.drawerlayout.widget.DrawerLayout;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
+import androidx.preference.PreferenceManager;
 
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.android.material.navigation.NavigationView;
@@ -71,8 +71,8 @@ import org.schabi.newpipe.player.VideoPlayer;
 import org.schabi.newpipe.player.event.OnKeyDownListener;
 import org.schabi.newpipe.player.playqueue.PlayQueue;
 import org.schabi.newpipe.report.ErrorActivity;
-import org.schabi.newpipe.util.DeviceUtils;
 import org.schabi.newpipe.util.Constants;
+import org.schabi.newpipe.util.DeviceUtils;
 import org.schabi.newpipe.util.KioskTranslator;
 import org.schabi.newpipe.util.Localization;
 import org.schabi.newpipe.util.NavigationHelper;
@@ -758,32 +758,36 @@ public class MainActivity extends AppCompatActivity {
             if (intent.hasExtra(Constants.KEY_LINK_TYPE)) {
                 final String url = intent.getStringExtra(Constants.KEY_URL);
                 final int serviceId = intent.getIntExtra(Constants.KEY_SERVICE_ID, 0);
-                final String title = intent.getStringExtra(Constants.KEY_TITLE);
-                switch (((StreamingService.LinkType) intent
-                        .getSerializableExtra(Constants.KEY_LINK_TYPE))) {
+                String title = intent.getStringExtra(Constants.KEY_TITLE);
+                if (title == null) {
+                    title = "";
+                }
+
+                final StreamingService.LinkType linkType = ((StreamingService.LinkType) intent
+                        .getSerializableExtra(Constants.KEY_LINK_TYPE));
+                assert linkType != null;
+                switch (linkType) {
                     case STREAM:
-                        final boolean autoPlay = intent
-                                .getBooleanExtra(VideoDetailFragment.AUTO_PLAY, false);
-                        final String intentCacheKey = intent
-                                .getStringExtra(VideoPlayer.PLAY_QUEUE_KEY);
+                        final String intentCacheKey = intent.getStringExtra(
+                                VideoPlayer.PLAY_QUEUE_KEY);
                         final PlayQueue playQueue = intentCacheKey != null
                                 ? SerializedCache.getInstance()
                                 .take(intentCacheKey, PlayQueue.class)
                                 : null;
-                        NavigationHelper.openVideoDetailFragment(getSupportFragmentManager(),
-                                serviceId, url, title, autoPlay, playQueue);
+
+                        final boolean switchingPlayers = intent.getBooleanExtra(
+                                VideoDetailFragment.KEY_SWITCHING_PLAYERS, false);
+                        NavigationHelper.openVideoDetailFragment(
+                                getApplicationContext(), getSupportFragmentManager(),
+                                serviceId, url, title, playQueue, switchingPlayers);
                         break;
                     case CHANNEL:
                         NavigationHelper.openChannelFragment(getSupportFragmentManager(),
-                                serviceId,
-                                url,
-                                title);
+                                serviceId, url, title);
                         break;
                     case PLAYLIST:
                         NavigationHelper.openPlaylistFragment(getSupportFragmentManager(),
-                                serviceId,
-                                url,
-                                title);
+                                serviceId, url, title);
                         break;
                 }
             } else if (intent.hasExtra(Constants.KEY_OPEN_SEARCH)) {

--- a/app/src/main/java/org/schabi/newpipe/RouterActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/RouterActivity.java
@@ -685,7 +685,7 @@ public class RouterActivity extends AppCompatActivity {
                 }
 
                 if (choice.playerChoice.equals(videoPlayerKey)) {
-                    NavigationHelper.playOnMainPlayer(this, playQueue);
+                    NavigationHelper.playOnMainPlayer(this, playQueue, false);
                 } else if (choice.playerChoice.equals(backgroundPlayerKey)) {
                     NavigationHelper.playOnBackgroundPlayer(this, playQueue, true);
                 } else if (choice.playerChoice.equals(popupPlayerKey)) {

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -289,6 +289,7 @@ public final class VideoDetailFragment
                 || (currentInfo != null
                 && isAutoplayEnabled()
                 && player.getParentActivity() == null)) {
+            autoPlayEnabled = true; // forcefully start playing
             openVideoPlayer();
         }
     }
@@ -521,6 +522,7 @@ public final class VideoDetailFragment
                 }
                 break;
             case R.id.detail_thumbnail_root_layout:
+                autoPlayEnabled = true; // forcefully start playing
                 openVideoPlayer();
                 break;
             case R.id.detail_title_root_layout:
@@ -537,6 +539,7 @@ public final class VideoDetailFragment
                     player.hideControls(0, 0);
                     showSystemUi();
                 } else {
+                    autoPlayEnabled = true; // forcefully start playing
                     openVideoPlayer();
                 }
 

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -1097,7 +1097,7 @@ public final class VideoDetailFragment
 
     private void openMainPlayer() {
         if (playerService == null) {
-            PlayerHolder.startService(App.getApp(), true, this);
+            PlayerHolder.startService(App.getApp(), autoPlayEnabled, this);
             return;
         }
         if (currentInfo == null) {
@@ -1112,7 +1112,7 @@ public final class VideoDetailFragment
         addVideoPlayerView();
 
         final Intent playerIntent = NavigationHelper
-                .getPlayerIntent(requireContext(), MainPlayer.class, queue, null, true);
+                .getPlayerIntent(requireContext(), MainPlayer.class, queue, true, autoPlayEnabled);
         activity.startService(playerIntent);
     }
 

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -1111,7 +1111,9 @@ public final class VideoDetailFragment
 
         // Video view can have elements visible from popup,
         // We hide it here but once it ready the view will be shown in handleIntent()
-        playerService.getView().setVisibility(View.GONE);
+        if (playerService.getView() != null) {
+            playerService.getView().setVisibility(View.GONE);
+        }
         addVideoPlayerView();
 
         final Intent playerIntent = NavigationHelper

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -110,6 +110,7 @@ import org.schabi.newpipe.views.LargeTextMovementMethod;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import icepick.State;
@@ -128,7 +129,7 @@ import static org.schabi.newpipe.player.helper.PlayerHelper.isClearingQueueConfi
 import static org.schabi.newpipe.player.playqueue.PlayQueueItem.RECOVERY_UNSET;
 import static org.schabi.newpipe.util.AnimationUtils.animateView;
 
-public class VideoDetailFragment
+public final class VideoDetailFragment
         extends BaseStateFragment<StreamInfo>
         implements BackPressable,
         SharedPreferences.OnSharedPreferenceChangeListener,
@@ -136,7 +137,7 @@ public class VideoDetailFragment
         View.OnLongClickListener,
         PlayerServiceExtendedEventListener,
         OnKeyDownListener {
-    public static final String AUTO_PLAY = "auto_play";
+    public static final String KEY_SWITCHING_PLAYERS = "switching_players";
 
     private static final int RELATED_STREAMS_UPDATE_FLAG = 0x1;
     private static final int COMMENTS_UPDATE_FLAG = 0x2;
@@ -167,19 +168,23 @@ public class VideoDetailFragment
     @State
     protected int serviceId = Constants.NO_SERVICE_ID;
     @State
-    protected String name;
+    @NonNull
+    protected String title = "";
     @State
-    protected String url;
-    protected static PlayQueue playQueue;
+    @Nullable
+    protected String url = null;
+    @Nullable
+    protected PlayQueue playQueue = null;
     @State
     int bottomSheetState = BottomSheetBehavior.STATE_EXPANDED;
     @State
     protected boolean autoPlayEnabled = true;
 
-    private static StreamInfo currentInfo;
+    @Nullable
+    private StreamInfo currentInfo = null;
     private Disposable currentWorker;
     @NonNull
-    private CompositeDisposable disposables = new CompositeDisposable();
+    private final CompositeDisposable disposables = new CompositeDisposable();
     @Nullable
     private Disposable positionSubscriber = null;
 
@@ -298,8 +303,10 @@ public class VideoDetailFragment
 
     /*////////////////////////////////////////////////////////////////////////*/
 
-    public static VideoDetailFragment getInstance(final int serviceId, final String videoUrl,
-                                                  final String name, final PlayQueue queue) {
+    public static VideoDetailFragment getInstance(final int serviceId,
+                                                  @Nullable final String videoUrl,
+                                                  @NonNull final String name,
+                                                  @Nullable final PlayQueue queue) {
         final VideoDetailFragment instance = new VideoDetailFragment();
         instance.setInitialData(serviceId, videoUrl, name, queue);
         return instance;
@@ -444,8 +451,8 @@ public class VideoDetailFragment
         switch (requestCode) {
             case ReCaptchaActivity.RECAPTCHA_REQUEST:
                 if (resultCode == Activity.RESULT_OK) {
-                    NavigationHelper
-                            .openVideoDetailFragment(getFM(), serviceId, url, name);
+                    NavigationHelper.openVideoDetailFragment(requireContext(), getFM(),
+                            serviceId, url, title, null, false);
                 } else {
                     Log.e(TAG, "ReCaptcha failed");
                 }
@@ -791,7 +798,7 @@ public class VideoDetailFragment
                 player.onPause();
             }
             restoreDefaultOrientation();
-            setAutoplay(false);
+            setAutoPlay(false);
             return true;
         }
 
@@ -819,14 +826,11 @@ public class VideoDetailFragment
     }
 
     private void setupFromHistoryItem(final StackItem item) {
-        setAutoplay(false);
+        setAutoPlay(false);
         hideMainPlayer();
 
-        setInitialData(
-                item.getServiceId(),
-                item.getUrl(),
-                !TextUtils.isEmpty(item.getTitle()) ? item.getTitle() : "",
-                item.getPlayQueue());
+        setInitialData(item.getServiceId(), item.getUrl(),
+                item.getTitle() == null ? "" : item.getTitle(), item.getPlayQueue());
         startLoading(false);
 
         // Maybe an item was deleted in background activity
@@ -860,18 +864,17 @@ public class VideoDetailFragment
         }
     }
 
-    public void selectAndLoadVideo(final int sid, final String videoUrl, final String title,
-                                   final PlayQueue queue) {
-        // Situation when user switches from players to main player.
-        // All needed data is here, we can start watching
-        if (this.playQueue != null && this.playQueue.equals(queue)) {
-            openVideoPlayer();
-            return;
-        }
-        setInitialData(sid, videoUrl, title, queue);
-        if (player != null) {
+    public void selectAndLoadVideo(final int newServiceId,
+                                   @Nullable final String newUrl,
+                                   @NonNull final String newTitle,
+                                   @Nullable final PlayQueue newQueue) {
+        if (player != null && newQueue != null && playQueue != null
+                && !Objects.equals(newQueue.getItem(), playQueue.getItem())) {
+            // Preloading can be disabled since playback is surely being replaced.
             player.disablePreloadingOfCurrentTrack();
         }
+
+        setInitialData(newServiceId, newUrl, newTitle, newQueue);
         startLoading(false, true);
     }
 
@@ -956,7 +959,7 @@ public class VideoDetailFragment
                                 playQueue = new SinglePlayQueue(result);
                             }
                             if (stack.isEmpty() || !stack.peek().getPlayQueue().equals(playQueue)) {
-                                stack.push(new StackItem(serviceId, url, name, playQueue));
+                                stack.push(new StackItem(serviceId, url, title, playQueue));
                             }
                         }
                         if (isAutoplayEnabled()) {
@@ -977,7 +980,7 @@ public class VideoDetailFragment
 
         if (shouldShowComments()) {
             pageAdapter.addFragment(
-                    CommentsFragment.getInstance(serviceId, url, name), COMMENTS_TAB_TAG);
+                    CommentsFragment.getInstance(serviceId, url, title), COMMENTS_TAB_TAG);
         }
 
         if (showRelatedStreams && null == relatedStreamsLayout) {
@@ -1068,7 +1071,7 @@ public class VideoDetailFragment
         }
     }
 
-    private void openVideoPlayer() {
+    public void openVideoPlayer() {
         if (PreferenceManager.getDefaultSharedPreferences(activity)
                 .getBoolean(this.getString(R.string.use_external_video_player_key), false)) {
             showExternalPlaybackDialog();
@@ -1143,8 +1146,8 @@ public class VideoDetailFragment
     // Utils
     //////////////////////////////////////////////////////////////////////////*/
 
-    public void setAutoplay(final boolean autoplay) {
-        this.autoPlayEnabled = autoplay;
+    public void setAutoPlay(final boolean autoPlay) {
+        this.autoPlayEnabled = autoPlay;
     }
 
     private void startOnExternalPlayer(@NonNull final Context context,
@@ -1166,7 +1169,7 @@ public class VideoDetailFragment
                 .getBoolean(getString(R.string.use_external_video_player_key), false);
     }
 
-    // This method overrides default behaviour when setAutoplay() is called.
+    // This method overrides default behaviour when setAutoPlay() is called.
     // Don't auto play if the user selected an external player or disabled it in settings
     private boolean isAutoplayEnabled() {
         return autoPlayEnabled
@@ -1302,12 +1305,14 @@ public class VideoDetailFragment
         contentRootLayoutHiding.setVisibility(View.VISIBLE);
     }
 
-    protected void setInitialData(final int sid, final String u, final String title,
-                                  final PlayQueue queue) {
-        this.serviceId = sid;
-        this.url = u;
-        this.name = !TextUtils.isEmpty(title) ? title : "";
-        this.playQueue = queue;
+    protected void setInitialData(final int newServiceId,
+                                  @Nullable final String newUrl,
+                                  @NonNull final String newTitle,
+                                  @Nullable final PlayQueue newPlayQueue) {
+        this.serviceId = newServiceId;
+        this.url = newUrl;
+        this.title = newTitle;
+        this.playQueue = newPlayQueue;
     }
 
     private void setErrorImage(final int imageResource) {
@@ -1400,7 +1405,7 @@ public class VideoDetailFragment
         animateView(detailPositionView, false, 100);
         animateView(positionView, false, 50);
 
-        videoTitleTextView.setText(name != null ? name : "");
+        videoTitleTextView.setText(title);
         videoTitleTextView.setMaxLines(1);
         animateView(videoTitleTextView, true, 0);
 
@@ -1445,7 +1450,7 @@ public class VideoDetailFragment
             }
         }
         animateView(thumbnailPlayButton, true, 200);
-        videoTitleTextView.setText(name);
+        videoTitleTextView.setText(title);
 
         if (!TextUtils.isEmpty(info.getSubChannelName())) {
             displayBothUploaderAndSubChannel(info);
@@ -1738,7 +1743,7 @@ public class VideoDetailFragment
         if (DEBUG) {
             Log.d(TAG, "onQueueUpdate() called with: serviceId = ["
                     + serviceId + "], videoUrl = [" + url + "], name = ["
-                    + name + "], playQueue = [" + playQueue + "]");
+                    + title + "], playQueue = [" + playQueue + "]");
         }
 
         // This should be the only place where we push data to stack.
@@ -1823,7 +1828,7 @@ public class VideoDetailFragment
 
         currentInfo = info;
         setInitialData(info.getServiceId(), info.getUrl(), info.getName(), queue);
-        setAutoplay(false);
+        setAutoPlay(false);
         // Delay execution just because it freezes the main thread, and while playing
         // next/previous video you see visual glitches
         // (when non-vertical video goes after vertical video)
@@ -2037,7 +2042,7 @@ public class VideoDetailFragment
     private void checkLandscape() {
         if ((!player.isPlaying() && player.getPlayQueue() != playQueue)
                 || player.getPlayQueue() == null) {
-            setAutoplay(true);
+            setAutoPlay(true);
         }
 
         player.checkLandscape();
@@ -2287,10 +2292,10 @@ public class VideoDetailFragment
         });
     }
 
-    private void updateOverlayData(@Nullable final String title,
+    private void updateOverlayData(@Nullable final String overlayTitle,
                                    @Nullable final String uploader,
                                    @Nullable final String thumbnailUrl) {
-        overlayTitleTextView.setText(TextUtils.isEmpty(title) ? "" : title);
+        overlayTitleTextView.setText(TextUtils.isEmpty(overlayTitle) ? "" : overlayTitle);
         overlayChannelTextView.setText(TextUtils.isEmpty(uploader) ? "" : uploader);
         overlayThumbnailImageView.setImageResource(R.drawable.dummy_thumbnail_dark);
         if (!TextUtils.isEmpty(thumbnailUrl)) {

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
@@ -321,8 +321,9 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
 
     private void onStreamSelected(final StreamInfoItem selectedItem) {
         onItemSelected(selectedItem);
-        NavigationHelper.openVideoDetailFragment(getFM(),
-                selectedItem.getServiceId(), selectedItem.getUrl(), selectedItem.getName());
+        NavigationHelper.openVideoDetailFragment(requireContext(), getFM(),
+                selectedItem.getServiceId(), selectedItem.getUrl(), selectedItem.getName(),
+                null, false);
     }
 
     protected void onScrollToBottom() {

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
@@ -517,7 +517,7 @@ public class ChannelFragment extends BaseListInfoFragment<ChannelInfo>
         monitorSubscription(result);
 
         headerPlayAllButton.setOnClickListener(view -> NavigationHelper
-                .playOnMainPlayer(activity, getPlayQueue(), true));
+                .playOnMainPlayer(activity, getPlayQueue()));
         headerPopupButton.setOnClickListener(view -> NavigationHelper
                 .playOnPopupPlayer(activity, getPlayQueue(), false));
         headerBackgroundButton.setOnClickListener(view -> NavigationHelper

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
@@ -319,7 +319,7 @@ public class PlaylistFragment extends BaseListInfoFragment<PlaylistInfo> {
                 .subscribe(getPlaylistBookmarkSubscriber());
 
         headerPlayAllButton.setOnClickListener(view ->
-                NavigationHelper.playOnMainPlayer(activity, getPlayQueue(), true));
+                NavigationHelper.playOnMainPlayer(activity, getPlayQueue()));
         headerPopupButton.setOnClickListener(view ->
                 NavigationHelper.playOnPopupPlayer(activity, getPlayQueue(), false));
         headerBackgroundButton.setOnClickListener(view ->

--- a/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
@@ -25,6 +25,7 @@ import org.reactivestreams.Subscription;
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.database.LocalItem;
 import org.schabi.newpipe.database.stream.StreamStatisticsEntry;
+import org.schabi.newpipe.database.stream.model.StreamEntity;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.extractor.stream.StreamType;
 import org.schabi.newpipe.info_list.InfoItemDialog;
@@ -149,11 +150,10 @@ public class StatisticsPlaylistFragment
             @Override
             public void selected(final LocalItem selectedItem) {
                 if (selectedItem instanceof StreamStatisticsEntry) {
-                    final StreamStatisticsEntry item = (StreamStatisticsEntry) selectedItem;
-                    NavigationHelper.openVideoDetailFragment(getFM(),
-                            item.getStreamEntity().getServiceId(),
-                            item.getStreamEntity().getUrl(),
-                            item.getStreamEntity().getTitle());
+                    final StreamEntity item =
+                            ((StreamStatisticsEntry) selectedItem).getStreamEntity();
+                    NavigationHelper.openVideoDetailFragment(requireContext(), getFM(),
+                            item.getServiceId(), item.getUrl(), item.getTitle(), null, false);
                 }
             }
 
@@ -325,7 +325,7 @@ public class StatisticsPlaylistFragment
         }
 
         headerPlayAllButton.setOnClickListener(view ->
-                NavigationHelper.playOnMainPlayer(activity, getPlayQueue(), true));
+                NavigationHelper.playOnMainPlayer(activity, getPlayQueue()));
         headerPopupButton.setOnClickListener(view ->
                 NavigationHelper.playOnPopupPlayer(activity, getPlayQueue(), false));
         headerBackgroundButton.setOnClickListener(view ->

--- a/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
@@ -30,6 +30,7 @@ import org.schabi.newpipe.R;
 import org.schabi.newpipe.database.LocalItem;
 import org.schabi.newpipe.database.history.model.StreamHistoryEntry;
 import org.schabi.newpipe.database.playlist.PlaylistStreamEntry;
+import org.schabi.newpipe.database.stream.model.StreamEntity;
 import org.schabi.newpipe.database.stream.model.StreamStateEntity;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.extractor.stream.StreamType;
@@ -178,10 +179,10 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
             @Override
             public void selected(final LocalItem selectedItem) {
                 if (selectedItem instanceof PlaylistStreamEntry) {
-                    final PlaylistStreamEntry item = (PlaylistStreamEntry) selectedItem;
-                    NavigationHelper.openVideoDetailFragment(getFM(),
-                            item.getStreamEntity().getServiceId(), item.getStreamEntity().getUrl(),
-                            item.getStreamEntity().getTitle());
+                    final StreamEntity item =
+                            ((PlaylistStreamEntry) selectedItem).getStreamEntity();
+                    NavigationHelper.openVideoDetailFragment(requireContext(), getFM(),
+                            item.getServiceId(), item.getUrl(), item.getTitle(), null, false);
                 }
             }
 
@@ -494,7 +495,7 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
         setVideoCount(itemListAdapter.getItemsList().size());
 
         headerPlayAllButton.setOnClickListener(view ->
-                NavigationHelper.playOnMainPlayer(activity, getPlayQueue(), true));
+                NavigationHelper.playOnMainPlayer(activity, getPlayQueue()));
         headerPopupButton.setOnClickListener(view ->
                 NavigationHelper.playOnPopupPlayer(activity, getPlayQueue(), false));
         headerBackgroundButton.setOnClickListener(view ->

--- a/app/src/main/java/org/schabi/newpipe/player/BackgroundPlayerActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/player/BackgroundPlayerActivity.java
@@ -2,11 +2,8 @@ package org.schabi.newpipe.player;
 
 import android.content.Intent;
 import android.view.Menu;
-import android.view.MenuItem;
 
 import org.schabi.newpipe.R;
-import org.schabi.newpipe.util.NavigationHelper;
-import org.schabi.newpipe.util.PermissionHelper;
 
 public final class BackgroundPlayerActivity extends ServicePlayerActivity {
 
@@ -44,31 +41,6 @@ public final class BackgroundPlayerActivity extends ServicePlayerActivity {
     @Override
     public int getPlayerOptionMenuResource() {
         return R.menu.menu_play_queue_bg;
-    }
-
-    @Override
-    public boolean onPlayerOptionSelected(final MenuItem item) {
-        if (item.getItemId() == R.id.action_switch_popup) {
-
-            if (!PermissionHelper.isPopupEnabled(this)) {
-                PermissionHelper.showPopupEnablementToast(this);
-                return true;
-            }
-
-            this.player.setRecovery();
-            NavigationHelper.playOnPopupPlayer(
-                    getApplicationContext(), player.playQueue, this.player.isPlaying());
-            return true;
-        }
-
-        if (item.getItemId() == R.id.action_switch_background) {
-            this.player.setRecovery();
-            NavigationHelper.playOnBackgroundPlayer(
-                    getApplicationContext(), player.playQueue, this.player.isPlaying());
-            return true;
-        }
-
-        return false;
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/player/MainPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/MainPlayer.java
@@ -30,6 +30,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowManager;
 
+import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
 
 import org.schabi.newpipe.R;
@@ -231,6 +232,7 @@ public final class MainPlayer extends Service {
         return metrics.heightPixels < metrics.widthPixels;
     }
 
+    @Nullable
     public View getView() {
         if (playerImpl == null) {
             return null;

--- a/app/src/main/java/org/schabi/newpipe/player/MainPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/MainPlayer.java
@@ -240,7 +240,7 @@ public final class MainPlayer extends Service {
     }
 
     public void removeViewFromParent() {
-        if (getView().getParent() != null) {
+        if (getView() != null && getView().getParent() != null) {
             if (playerImpl.getParentActivity() != null) {
                 // This means view was added to fragment
                 final ViewGroup parent = (ViewGroup) getView().getParent();

--- a/app/src/main/java/org/schabi/newpipe/player/ServicePlayerActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ServicePlayerActivity.java
@@ -27,9 +27,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Player;
 
-import org.schabi.newpipe.MainActivity;
 import org.schabi.newpipe.R;
-import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.fragments.OnScrollBelowItemsListener;
 import org.schabi.newpipe.local.dialog.PlaylistAppendDialog;
@@ -42,9 +40,9 @@ import org.schabi.newpipe.player.playqueue.PlayQueueItem;
 import org.schabi.newpipe.player.playqueue.PlayQueueItemBuilder;
 import org.schabi.newpipe.player.playqueue.PlayQueueItemHolder;
 import org.schabi.newpipe.player.playqueue.PlayQueueItemTouchCallback;
-import org.schabi.newpipe.util.Constants;
 import org.schabi.newpipe.util.Localization;
 import org.schabi.newpipe.util.NavigationHelper;
+import org.schabi.newpipe.util.PermissionHelper;
 import org.schabi.newpipe.util.ThemeHelper;
 
 import java.util.Collections;
@@ -113,9 +111,8 @@ public abstract class ServicePlayerActivity extends AppCompatActivity
 
     public abstract int getPlayerOptionMenuResource();
 
-    public abstract boolean onPlayerOptionSelected(MenuItem item);
-
     public abstract void setupMenu(Menu m);
+
     ////////////////////////////////////////////////////////////////////////////
     // Activity Lifecycle
     ////////////////////////////////////////////////////////////////////////////
@@ -187,36 +184,28 @@ public abstract class ServicePlayerActivity extends AppCompatActivity
                 return true;
             case R.id.action_switch_main:
                 this.player.setRecovery();
-                getApplicationContext().startActivity(
-                        getSwitchIntent(MainActivity.class, MainPlayer.PlayerType.VIDEO)
-                                .putExtra(BasePlayer.START_PAUSED, !this.player.isPlaying()));
+                NavigationHelper.playOnMainPlayer(this, player.getPlayQueue(), true);
+                return true;
+            case R.id.action_switch_popup:
+                if (PermissionHelper.isPopupEnabled(this)) {
+                    this.player.setRecovery();
+                    NavigationHelper.playOnPopupPlayer(this, player.playQueue, true);
+                } else {
+                    PermissionHelper.showPopupEnablementToast(this);
+                }
+                return true;
+            case R.id.action_switch_background:
+                this.player.setRecovery();
+                NavigationHelper.playOnBackgroundPlayer(this, player.playQueue, true);
                 return true;
         }
-        return onPlayerOptionSelected(item) || super.onOptionsItemSelected(item);
+        return super.onOptionsItemSelected(item);
     }
 
     @Override
     protected void onDestroy() {
         super.onDestroy();
         unbind();
-    }
-
-    protected Intent getSwitchIntent(final Class clazz, final MainPlayer.PlayerType playerType) {
-        return NavigationHelper.getPlayerIntent(getApplicationContext(), clazz,
-                this.player.getPlayQueue(), this.player.getRepeatMode(),
-                this.player.getPlaybackSpeed(), this.player.getPlaybackPitch(),
-                this.player.getPlaybackSkipSilence(),
-                null,
-                true,
-                !this.player.isPlaying(),
-                this.player.isMuted())
-                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                .putExtra(Constants.KEY_LINK_TYPE, StreamingService.LinkType.STREAM)
-                .putExtra(Constants.KEY_URL, this.player.getVideoUrl())
-                .putExtra(Constants.KEY_TITLE, this.player.getVideoTitle())
-                .putExtra(Constants.KEY_SERVICE_ID,
-                        this.player.getCurrentMetadata().getMetadata().getServiceId())
-                .putExtra(VideoPlayer.PLAYER_TYPE, playerType);
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -368,8 +357,8 @@ public abstract class ServicePlayerActivity extends AppCompatActivity
                 Menu.NONE, R.string.play_queue_stream_detail);
         detail.setOnMenuItemClickListener(menuItem -> {
             // playQueue is null since we don't want any queue change
-            NavigationHelper.openVideoDetail(
-                    this, item.getServiceId(), item.getUrl(), item.getTitle(), null);
+            NavigationHelper.openVideoDetail(this, item.getServiceId(), item.getUrl(),
+                    item.getTitle(), null, false);
             return true;
         });
 

--- a/app/src/main/java/org/schabi/newpipe/player/ServicePlayerActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ServicePlayerActivity.java
@@ -367,7 +367,9 @@ public abstract class ServicePlayerActivity extends AppCompatActivity
         final MenuItem detail = popupMenu.getMenu().add(RECYCLER_ITEM_POPUP_MENU_GROUP_ID, 1,
                 Menu.NONE, R.string.play_queue_stream_detail);
         detail.setOnMenuItemClickListener(menuItem -> {
-            onOpenDetail(item.getServiceId(), item.getUrl(), item.getTitle());
+            // playQueue is null since we don't want any queue change
+            NavigationHelper.openVideoDetail(
+                    this, item.getServiceId(), item.getUrl(), item.getTitle(), null);
             return true;
         });
 
@@ -452,11 +454,6 @@ public abstract class ServicePlayerActivity extends AppCompatActivity
                 }
             }
         };
-    }
-
-    private void onOpenDetail(final int serviceId, final String videoUrl,
-                              final String videoTitle) {
-        NavigationHelper.openVideoDetail(this, serviceId, videoUrl, videoTitle);
     }
 
     private void scrollToSelected() {

--- a/app/src/main/java/org/schabi/newpipe/player/VideoPlayerImpl.java
+++ b/app/src/main/java/org/schabi/newpipe/player/VideoPlayerImpl.java
@@ -785,7 +785,7 @@ public class VideoPlayerImpl extends VideoPlayer
         intent.putExtra(Constants.KEY_LINK_TYPE, StreamingService.LinkType.STREAM);
         intent.putExtra(Constants.KEY_URL, getVideoUrl());
         intent.putExtra(Constants.KEY_TITLE, getVideoTitle());
-        intent.putExtra(VideoDetailFragment.AUTO_PLAY, true);
+        intent.putExtra(VideoDetailFragment.KEY_SWITCHING_PLAYERS, true);
         service.onDestroy();
         context.startActivity(intent);
     }

--- a/app/src/main/java/org/schabi/newpipe/player/event/BasePlayerGestureListener.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/event/BasePlayerGestureListener.kt
@@ -63,7 +63,7 @@ abstract class BasePlayerGestureListener(
     private var isMovingInPopup = false
     private var isResizing = false
 
-    private val tossFlingVelocity = PlayerHelper.getTossFlingVelocity(service)
+    private val tossFlingVelocity = PlayerHelper.getTossFlingVelocity()
 
     // [popup] initial coordinates and distance between fingers
     private var initPointerDistance = -1.0
@@ -104,9 +104,6 @@ abstract class BasePlayerGestureListener(
     }
 
     private fun onTouchInPopup(v: View, event: MotionEvent): Boolean {
-        if (playerImpl == null) {
-            return false
-        }
         playerImpl.gestureDetector.onTouchEvent(event)
         if (event.pointerCount == 2 && !isMovingInPopup && !isResizing) {
             if (DEBUG) {

--- a/app/src/main/java/org/schabi/newpipe/player/event/PlayerGestureListener.java
+++ b/app/src/main/java/org/schabi/newpipe/player/event/PlayerGestureListener.java
@@ -111,10 +111,10 @@ public class PlayerGestureListener
         }
         if (playerType == MainPlayer.PlayerType.VIDEO) {
             if (portion == DisplayPortion.LEFT_HALF) {
-                onScrollMainVolume(distanceX, distanceY);
+                onScrollMainBrightness(distanceX, distanceY);
 
             } else /* DisplayPortion.RIGHT_HALF */ {
-                onScrollMainBrightness(distanceX, distanceY);
+                onScrollMainVolume(distanceX, distanceY);
             }
 
         } else /* MainPlayer.PlayerType.POPUP */ {

--- a/app/src/main/java/org/schabi/newpipe/player/helper/AudioReactor.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/AudioReactor.java
@@ -164,7 +164,7 @@ public class AudioReactor implements AudioManager.OnAudioFocusChangeListener, An
 
     @Override
     public void onAudioSessionId(final EventTime eventTime, final int audioSessionId) {
-        if (!PlayerHelper.isUsingDSP(context)) {
+        if (!PlayerHelper.isUsingDSP()) {
             return;
         }
 

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
@@ -295,7 +295,7 @@ public final class PlayerHelper {
         return 60000;
     }
 
-    public static TrackSelection.Factory getQualitySelector(@NonNull final Context context) {
+    public static TrackSelection.Factory getQualitySelector() {
         return new AdaptiveTrackSelection.Factory(
                 1000,
                 AdaptiveTrackSelection.DEFAULT_MAX_DURATION_FOR_QUALITY_DECREASE_MS,
@@ -303,11 +303,11 @@ public final class PlayerHelper {
                 AdaptiveTrackSelection.DEFAULT_BANDWIDTH_FRACTION);
     }
 
-    public static boolean isUsingDSP(@NonNull final Context context) {
+    public static boolean isUsingDSP() {
         return true;
     }
 
-    public static int getTossFlingVelocity(@NonNull final Context context) {
+    public static int getTossFlingVelocity() {
         return 2500;
     }
 

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHolder.java
@@ -56,6 +56,10 @@ public final class PlayerHolder {
         return player.isPlaying();
     }
 
+    public static boolean isPlayerOpen() {
+        return player != null;
+    }
+
     public static void setListener(final PlayerServiceExtendedEventListener newListener) {
         listener = newListener;
         // Force reload data from service

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHolder.java
@@ -49,6 +49,13 @@ public final class PlayerHolder {
         return player.getPlayerType();
     }
 
+    public static boolean isPlaying() {
+        if (player == null) {
+            return false;
+        }
+        return player.isPlaying();
+    }
+
     public static void setListener(final PlayerServiceExtendedEventListener newListener) {
         listener = newListener;
         // Force reload data from service

--- a/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueue.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueue.java
@@ -1,12 +1,8 @@
 package org.schabi.newpipe.player.playqueue;
 
-import android.util.Log;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import org.reactivestreams.Subscriber;
-import org.reactivestreams.Subscription;
 import org.schabi.newpipe.MainActivity;
 import org.schabi.newpipe.player.playqueue.events.AppendEvent;
 import org.schabi.newpipe.player.playqueue.events.ErrorEvent;
@@ -43,7 +39,6 @@ import io.reactivex.subjects.BehaviorSubject;
  * </p>
  */
 public abstract class PlayQueue implements Serializable {
-    private final String TAG = "PlayQueue@" + Integer.toHexString(hashCode());
     public static final boolean DEBUG = MainActivity.DEBUG;
 
     private ArrayList<PlayQueueItem> backup;
@@ -55,7 +50,6 @@ public abstract class PlayQueue implements Serializable {
 
     private transient BehaviorSubject<PlayQueueEvent> eventBroadcast;
     private transient Flowable<PlayQueueEvent> broadcastReceiver;
-    private transient Subscription reportingReactor;
 
     private transient boolean disposed;
 
@@ -87,10 +81,6 @@ public abstract class PlayQueue implements Serializable {
         broadcastReceiver = eventBroadcast.toFlowable(BackpressureStrategy.BUFFER)
                 .observeOn(AndroidSchedulers.mainThread())
                 .startWith(new InitEvent());
-
-        if (DEBUG) {
-            broadcastReceiver.subscribe(getSelfReporter());
-        }
     }
 
     /**
@@ -100,13 +90,9 @@ public abstract class PlayQueue implements Serializable {
         if (eventBroadcast != null) {
             eventBroadcast.onComplete();
         }
-        if (reportingReactor != null) {
-            reportingReactor.cancel();
-        }
 
         eventBroadcast = null;
         broadcastReceiver = null;
-        reportingReactor = null;
         disposed = true;
     }
 
@@ -543,36 +529,6 @@ public abstract class PlayQueue implements Serializable {
         if (eventBroadcast != null) {
             eventBroadcast.onNext(event);
         }
-    }
-
-    private Subscriber<PlayQueueEvent> getSelfReporter() {
-        return new Subscriber<PlayQueueEvent>() {
-            @Override
-            public void onSubscribe(final Subscription s) {
-                if (reportingReactor != null) {
-                    reportingReactor.cancel();
-                }
-                reportingReactor = s;
-                reportingReactor.request(1);
-            }
-
-            @Override
-            public void onNext(final PlayQueueEvent event) {
-                Log.d(TAG, "Received broadcast: " + event.type().name() + ". "
-                        + "Current index: " + getIndex() + ", play queue length: " + size() + ".");
-                reportingReactor.request(1);
-            }
-
-            @Override
-            public void onError(final Throwable t) {
-                Log.e(TAG, "Received broadcast error", t);
-            }
-
-            @Override
-            public void onComplete() {
-                Log.d(TAG, "Broadcast is shutting down.");
-            }
-        };
     }
 }
 

--- a/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueueItem.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueueItem.java
@@ -64,6 +64,20 @@ public class PlayQueueItem implements Serializable {
         this.recoveryPosition = RECOVERY_UNSET;
     }
 
+    @Override
+    public boolean equals(final Object o) {
+        if (o instanceof PlayQueueItem) {
+            return url.equals(((PlayQueueItem) o).url);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return url.hashCode();
+    }
+
     @NonNull
     public String getTitle() {
         return title;

--- a/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
@@ -486,6 +486,7 @@ public final class NavigationHelper {
 
         final Intent intent = getOpenIntent(context, url, serviceId,
                 StreamingService.LinkType.STREAM);
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         intent.putExtra(Constants.KEY_TITLE, title);
         intent.putExtra(VideoDetailFragment.KEY_SWITCHING_PLAYERS, switchingPlayers);
 

--- a/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
@@ -18,7 +18,6 @@ import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
-import androidx.preference.PreferenceManager;
 
 import com.nostra13.universalimageloader.core.ImageLoader;
 
@@ -52,13 +51,14 @@ import org.schabi.newpipe.player.BackgroundPlayerActivity;
 import org.schabi.newpipe.player.BasePlayer;
 import org.schabi.newpipe.player.MainPlayer;
 import org.schabi.newpipe.player.VideoPlayer;
+import org.schabi.newpipe.player.helper.PlayerHelper;
+import org.schabi.newpipe.player.helper.PlayerHolder;
 import org.schabi.newpipe.player.playqueue.PlayQueue;
 import org.schabi.newpipe.player.playqueue.PlayQueueItem;
 import org.schabi.newpipe.settings.SettingsActivity;
 
 import java.util.ArrayList;
 
-@SuppressWarnings({"unused"})
 public final class NavigationHelper {
     public static final String MAIN_FRAGMENT_TAG = "main_fragment_tag";
     public static final String SEARCH_FRAGMENT_TAG = "search_fragment_tag";
@@ -130,42 +130,22 @@ public final class NavigationHelper {
     }
 
     public static void playOnMainPlayer(final AppCompatActivity activity,
-                                        final PlayQueue queue,
-                                        final boolean autoPlay) {
-        playOnMainPlayer(activity.getSupportFragmentManager(), queue, autoPlay);
+                                        @NonNull final PlayQueue playQueue) {
+        final PlayQueueItem item = playQueue.getItem();
+        assert item != null;
+        openVideoDetailFragment(activity, activity.getSupportFragmentManager(),
+                item.getServiceId(), item.getUrl(), item.getTitle(), playQueue, false);
     }
 
-    public static void playOnMainPlayer(final FragmentManager fragmentManager,
-                                        final PlayQueue queue,
-                                        final boolean autoPlay) {
-        final PlayQueueItem currentStream = queue.getItem();
-        openVideoDetailFragment(
-                fragmentManager,
-                currentStream.getServiceId(),
-                currentStream.getUrl(),
-                currentStream.getTitle(),
-                autoPlay,
-                queue);
+    public static void playOnMainPlayer(final Context context,
+                                        @NonNull final PlayQueue playQueue) {
+        final PlayQueueItem item = playQueue.getItem();
+        assert item != null;
+        openVideoDetail(context, item.getServiceId(), item.getUrl(), item.getTitle(), playQueue);
     }
 
-    public static void playOnMainPlayer(@NonNull final Context context,
-                                        @Nullable final PlayQueue queue,
-                                        @NonNull final StreamingService.LinkType linkType,
-                                        @NonNull final String url,
-                                        @NonNull final String title,
-                                        final boolean autoPlay,
-                                        final boolean resumePlayback) {
-
-        final Intent intent = getPlayerIntent(context, MainActivity.class, queue, resumePlayback);
-        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        intent.putExtra(Constants.KEY_LINK_TYPE, linkType);
-        intent.putExtra(Constants.KEY_URL, url);
-        intent.putExtra(Constants.KEY_TITLE, title);
-        intent.putExtra(VideoDetailFragment.AUTO_PLAY, autoPlay);
-        context.startActivity(intent);
-    }
-
-    public static void playOnPopupPlayer(final Context context, final PlayQueue queue,
+    public static void playOnPopupPlayer(final Context context,
+                                         final PlayQueue queue,
                                          final boolean resumePlayback) {
         if (!PermissionHelper.isPopupEnabled(context)) {
             PermissionHelper.showPopupEnablementToast(context);
@@ -300,9 +280,6 @@ public final class NavigationHelper {
                         .setNegativeButton(R.string.cancel, (dialog, which)
                                 -> Log.i("NavigationHelper", "You unlocked a secret unicorn."))
                         .show();
-//                Log.e("NavigationHelper",
-//                        "Either no Streaming player for audio was installed, "
-//                                + "or something important crashed:");
             } else {
                 Toast.makeText(context, R.string.no_player_found_toast, Toast.LENGTH_LONG).show();
             }
@@ -358,41 +335,6 @@ public final class NavigationHelper {
                 .commit();
     }
 
-    public static void openVideoDetailFragment(final FragmentManager fragmentManager,
-                                               final int serviceId, final String url,
-                                               final String title) {
-        openVideoDetailFragment(fragmentManager, serviceId, url, title, true, null);
-    }
-
-    public static void openVideoDetailFragment(
-            final FragmentManager fragmentManager,
-            final int serviceId,
-            final String url,
-            final String title,
-            final boolean autoPlay,
-            final PlayQueue playQueue) {
-        final Fragment fragment = fragmentManager.findFragmentById(R.id.fragment_player_holder);
-
-        if (fragment instanceof VideoDetailFragment && fragment.isVisible()) {
-            expandMainPlayer(fragment.requireActivity());
-            final VideoDetailFragment detailFragment = (VideoDetailFragment) fragment;
-            detailFragment.setAutoplay(autoPlay);
-            detailFragment
-                    .selectAndLoadVideo(serviceId, url, title == null ? "" : title, playQueue);
-            detailFragment.scrollToTop();
-            return;
-        }
-
-        final VideoDetailFragment instance = VideoDetailFragment
-                .getInstance(serviceId, url, title == null ? "" : title, playQueue);
-        instance.setAutoplay(autoPlay);
-
-        defaultTransaction(fragmentManager)
-                .replace(R.id.fragment_player_holder, instance)
-                .runOnCommit(() -> expandMainPlayer(instance.requireActivity()))
-                .commit();
-    }
-
     public static void expandMainPlayer(final Context context) {
         context.sendBroadcast(new Intent(VideoDetailFragment.ACTION_SHOW_MAIN_PLAYER));
     }
@@ -409,33 +351,86 @@ public final class NavigationHelper {
                 .commitAllowingStateLoss();
     }
 
+    private interface RunnableWithVideoDetailFragment {
+        void run(VideoDetailFragment detailFragment);
+    }
+
+    public static void openVideoDetailFragment(@NonNull final Context context,
+                                               @NonNull final FragmentManager fragmentManager,
+                                               final int serviceId,
+                                               @Nullable final String url,
+                                               @NonNull final String title,
+                                               @Nullable final PlayQueue playQueue,
+                                               final boolean switchingPlayers) {
+
+        final boolean autoPlay;
+        @Nullable final MainPlayer.PlayerType playerType = PlayerHolder.getType();
+        if (playerType == null) {
+            // no player open
+            autoPlay = PlayerHelper.isAutoplayAllowedByUser(context);
+        } else if (switchingPlayers) {
+            // switching player to main player
+            autoPlay = true;
+        } else if (playerType == MainPlayer.PlayerType.VIDEO) {
+            // opening new stream while already playing in main player
+            autoPlay = PlayerHelper.isAutoplayAllowedByUser(context);
+        } else {
+            // opening new stream while already playing in another player
+            autoPlay = false;
+        }
+
+        final RunnableWithVideoDetailFragment onVideoDetailFragmentReady = (detailFragment) -> {
+            expandMainPlayer(detailFragment.requireActivity());
+            detailFragment.setAutoPlay(autoPlay);
+            if (switchingPlayers) {
+                // Situation when user switches from players to main player. All needed data is
+                // here, we can start watching (assuming newQueue equals playQueue).
+                detailFragment.openVideoPlayer();
+            } else {
+                detailFragment.selectAndLoadVideo(serviceId, url, title, playQueue);
+            }
+            detailFragment.scrollToTop();
+        };
+
+        final Fragment fragment = fragmentManager.findFragmentById(R.id.fragment_player_holder);
+        if (fragment instanceof VideoDetailFragment && fragment.isVisible()) {
+            onVideoDetailFragmentReady.run((VideoDetailFragment) fragment);
+        } else {
+            final VideoDetailFragment instance = VideoDetailFragment
+                    .getInstance(serviceId, url, title, playQueue);
+            instance.setAutoPlay(autoPlay);
+
+            defaultTransaction(fragmentManager)
+                    .replace(R.id.fragment_player_holder, instance)
+                    .runOnCommit(() -> onVideoDetailFragmentReady.run(instance))
+                    .commit();
+        }
+    }
+
     public static void openChannelFragment(final FragmentManager fragmentManager,
                                            final int serviceId, final String url,
-                                           final String name) {
+                                           @NonNull final String name) {
         defaultTransaction(fragmentManager)
-                .replace(R.id.fragment_holder, ChannelFragment.getInstance(serviceId, url,
-                        name == null ? "" : name))
+                .replace(R.id.fragment_holder, ChannelFragment.getInstance(serviceId, url, name))
                 .addToBackStack(null)
                 .commit();
     }
 
     public static void openCommentsFragment(final FragmentManager fragmentManager,
                                             final int serviceId, final String url,
-                                            final String name) {
+                                            @NonNull final String name) {
         fragmentManager.beginTransaction()
                 .setCustomAnimations(R.anim.switch_service_in, R.anim.switch_service_out)
-                .replace(R.id.fragment_holder, CommentsFragment.getInstance(serviceId, url,
-                        name == null ? "" : name))
+                .replace(R.id.fragment_holder, CommentsFragment.getInstance(serviceId, url, name))
                 .addToBackStack(null)
                 .commit();
     }
 
     public static void openPlaylistFragment(final FragmentManager fragmentManager,
                                             final int serviceId, final String url,
-                                            final String name) {
+                                            @NonNull final String name) {
         defaultTransaction(fragmentManager)
-                .replace(R.id.fragment_holder, PlaylistFragment.getInstance(serviceId, url,
-                        name == null ? "" : name))
+                .replace(R.id.fragment_holder, PlaylistFragment.getInstance(serviceId, url, name))
                 .addToBackStack(null)
                 .commit();
     }
@@ -511,33 +506,31 @@ public final class NavigationHelper {
         context.startActivity(mIntent);
     }
 
-    public static void openChannel(final Context context, final int serviceId, final String url) {
-        openChannel(context, serviceId, url, null);
-    }
-
     public static void openChannel(final Context context, final int serviceId,
-                                   final String url, final String name) {
+                                   final String url, @NonNull final String name) {
         final Intent openIntent = getOpenIntent(context, url, serviceId,
                 StreamingService.LinkType.CHANNEL);
-        if (name != null && !name.isEmpty()) {
-            openIntent.putExtra(Constants.KEY_TITLE, name);
-        }
+        openIntent.putExtra(Constants.KEY_TITLE, name);
         context.startActivity(openIntent);
     }
 
-    public static void openVideoDetail(final Context context, final int serviceId,
-                                       final String url) {
-        openVideoDetail(context, serviceId, url, null);
-    }
+    public static void openVideoDetail(final Context context,
+                                       final int serviceId,
+                                       final String url,
+                                       @NonNull final String title,
+                                       @Nullable final PlayQueue playQueue) {
 
-    public static void openVideoDetail(final Context context, final int serviceId,
-                                       final String url, final String title) {
-        final Intent openIntent = getOpenIntent(context, url, serviceId,
+        final Intent intent = getOpenIntent(context, url, serviceId,
                 StreamingService.LinkType.STREAM);
-        if (title != null && !title.isEmpty()) {
-            openIntent.putExtra(Constants.KEY_TITLE, title);
+        intent.putExtra(Constants.KEY_TITLE, title);
+
+        if (playQueue != null) {
+            final String cacheKey = SerializedCache.getInstance().put(playQueue, PlayQueue.class);
+            if (cacheKey != null) {
+                intent.putExtra(VideoPlayer.PLAY_QUEUE_KEY, cacheKey);
+            }
         }
-        context.startActivity(openIntent);
+        context.startActivity(intent);
     }
 
     public static void openMainActivity(final Context context) {
@@ -550,7 +543,6 @@ public final class NavigationHelper {
     public static void openRouterActivity(final Context context, final String url) {
         final Intent mIntent = new Intent(context, RouterActivity.class);
         mIntent.setData(Uri.parse(url));
-        mIntent.putExtra(RouterActivity.INTERNAL_ROUTE_KEY, true);
         context.startActivity(mIntent);
     }
 
@@ -564,14 +556,12 @@ public final class NavigationHelper {
         context.startActivity(intent);
     }
 
-    public static boolean openDownloads(final Activity activity) {
-        if (!PermissionHelper.checkStoragePermissions(
+    public static void openDownloads(final Activity activity) {
+        if (PermissionHelper.checkStoragePermissions(
                 activity, PermissionHelper.DOWNLOADS_REQUEST_CODE)) {
-            return false;
+            final Intent intent = new Intent(activity, DownloadActivity.class);
+            activity.startActivity(intent);
         }
-        final Intent intent = new Intent(activity, DownloadActivity.class);
-        activity.startActivity(intent);
-        return true;
     }
 
     public static Intent getPlayQueueActivityIntent(final Context context) {
@@ -600,7 +590,8 @@ public final class NavigationHelper {
         return getIntentByLink(context, NewPipe.getServiceByUrl(url), url);
     }
 
-    public static Intent getIntentByLink(final Context context, final StreamingService service,
+    public static Intent getIntentByLink(final Context context,
+                                         final StreamingService service,
                                          final String url) throws ExtractionException {
         final StreamingService.LinkType linkType = service.getLinkTypeByUrl(url);
 
@@ -609,15 +600,7 @@ public final class NavigationHelper {
                     + " url=" + url);
         }
 
-        final Intent rIntent = getOpenIntent(context, url, service.getServiceId(), linkType);
-
-        if (linkType == StreamingService.LinkType.STREAM) {
-            rIntent.putExtra(VideoDetailFragment.AUTO_PLAY,
-                    PreferenceManager.getDefaultSharedPreferences(context).getBoolean(
-                            context.getString(R.string.autoplay_through_intent_key), false));
-        }
-
-        return rIntent;
+        return getOpenIntent(context, url, service.getServiceId(), linkType);
     }
 
     private static Uri openMarketUrl(final String packageName) {

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -21,7 +21,6 @@
 
     <string name="use_external_video_player_key" translatable="false">use_external_video_player</string>
     <string name="use_external_audio_player_key" translatable="false">use_external_audio_player</string>
-    <string name="autoplay_through_intent_key" translatable="false">autoplay_through_intent</string>
     <string name="use_old_player_key" translatable="false">use_oldplayer</string>
 
     <string name="volume_gesture_control_key" translatable="false">volume_gesture_control</string>


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
- Unify all ways of opening the VideoDetailFragment into two methods: `openVideoDetailFragment()` which sends the new data directly to the fragment manager, `openVideoDetail()` which sends an `Intent` received by `MainActivity` which in turn calls `openVideoDetailFragment()`.
- The arguments taken by `openVideoDetailFragment()` have changed: `autoPlay` is not there anymore, and `switchingPlayers` was added to be able to always determine correctly if the function was called as a way to switch players. `autoPlay` is now calculated based on the user's preference, on `switchingPlayers` and on whether there is already a background/popup player running. For more info see [these lines](https://github.com/TeamNewPipe/NewPipe/pull/4562/files#diff-7c684dc26bc21808937b0cd7c85de9810279b15b2ba4fdd2e31a0ad2c9e94962R347-R361). This makes it far more clear when the mini player will start playing (I think some situations were handled correcly only by accident before)
- Disable player stream preloading only if the current stream is going to be replaced for sure (see [this](https://github.com/TeamNewPipe/NewPipe/pull/4562/files#diff-b2e369e39e24aea82f68bcb17acd1135173d776a871986ac8ef85ad73e767333R871-R875)). `equals()` was implemented for `PlayQueueItem`s, so that (only) the url is compared when checking them.
- Add `@Nullable` and `@NotNull` to some variables in `VideoDetailFragment`, allowing me to enforce or remove some null checks. Rename `name` to `title` for consistency.
- Remove `static` qualifier from `currentInfo` and `playQueue` in `VideoDetailFragment`: they were never accessed as static members, and having them static caused random problems while replacing the `VideoDetailFragment` with a new instance of itself.
- [Do not force reopen](https://github.com/TeamNewPipe/NewPipe/pull/4562/files#diff-7c684dc26bc21808937b0cd7c85de9810279b15b2ba4fdd2e31a0ad2c9e94962R510-R511) `MainActivity` when sharing something to NewPipe and pressing on "Show info". This was introduced in 67d2b9131e7871505454d12dd1d245528b251228 by @yausername while handling urls in comments, but at that point there was no unified player, so probably without that it didn't work. But now everything works good even by keeping the current `MainActivity` instance, and this yields many improvements: opening urls in descriptions in NewPipe now does not erase backstack, nor does clicking `Open details` on queue items, and probably something else. :-D 
- Replace "Video player" with "Show info" when sharing a video to NewPipe but the background or popup players are running, and thus `autoPlay` would be `false`.
- Handle "Video player" in the exact same way as "Show info" for streams, i.e. do not start a service just to fetch the info, since `VideoDetailFragment` can fetch data itself without issues.
- When sharing a video to NewPipe and a play button is pressed, replace the current queue instead of enqueueing. Enqueueing can still be achieved opening info and then enqueueing, but enqueueing directly was bad UX since the user would not see what happened.
- When opening NewPipe from scratch but a player is already running, show the bottom mini player #4712
- Make sure play/pause state is preserved when switching players via the specific buttons. Also replace `START_PAUSED` with `PLAY_WHEN_READY` for better consistency (i.e. not inverting twice).
- Move menu listener to switch players from `BackgroundPlayerActivity` to `ServicePlayerActivity`, thus removing a useless abstract function.
- Remove [some unused code](https://github.com/TeamNewPipe/NewPipe/pull/4562/files#diff-01c2c8e04aff70b98bd2a94267e903d313f32a2e1df712a023e56ace95c9bf62R556-R557) in `RouterActivity`
- Refactor `getPlayerIntent()` functions in `NavigationHelper` and removed unused navigation functions.
- Remove testing-only code in [PlayQueue](https://github.com/TeamNewPipe/NewPipe/pull/4562/files#diff-00e000f7dc0e535b7d97ab5d6056c88e7191a7480725fb20ccd4c49e36b4aabc) `reportingReactor` was used to capture and log broadcast events in debug builds. This can be undone if unwanted.
- Remove unused preference `autoplay_through_intent_key` (left there by accident after 2907, probably)
- Some refactoring here and there: fix warnings in `openDownloadDialog`, in `openDownloads`, in `PlayerHelper` and more

#### Fixes the following issue(s)
Fixes #4541 
Probably fixes #4432
Fixes #4403
Fixes (maybe) #4687
Fixes #4712

#### APK testing 
Since this PR changes the logic of many things, the more people can test, the better.
@opusforlife2 @Jean757 @shadow00 @nbmrjuhneibkr could you test if the new share behaviour suits you, i.e. #4403?
@AnotherLife @pew-pew could you test if there are no more issues with playback breaking after opening details, i.e. #4541?
@aand18 @Medard22 @UserX404 @ventilaar @floral-qua-floral @Idiotten could you test if this solves #4432, i.e. background playback stopping at random after some (constant) time?
[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/5476731/app-debug.zip)

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
