### PR TITLE
Use TextViewCompat.setCompoundDrawablesRelativeWithIntrinsicBounds().

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/RouterActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/RouterActivity.java
@@ -8,7 +8,6 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
-import androidx.preference.PreferenceManager;
 import android.text.TextUtils;
 import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
@@ -27,7 +26,9 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.content.res.AppCompatResources;
 import androidx.core.app.NotificationCompat;
+import androidx.core.widget.TextViewCompat;
 import androidx.fragment.app.FragmentManager;
+import androidx.preference.PreferenceManager;
 
 import org.schabi.newpipe.download.DownloadDialog;
 import org.schabi.newpipe.extractor.Info;
@@ -45,8 +46,8 @@ import org.schabi.newpipe.player.playqueue.PlayQueue;
 import org.schabi.newpipe.player.playqueue.PlaylistPlayQueue;
 import org.schabi.newpipe.player.playqueue.SinglePlayQueue;
 import org.schabi.newpipe.report.UserAction;
-import org.schabi.newpipe.util.DeviceUtils;
 import org.schabi.newpipe.util.Constants;
+import org.schabi.newpipe.util.DeviceUtils;
 import org.schabi.newpipe.util.ExtractorHelper;
 import org.schabi.newpipe.util.ListHelper;
 import org.schabi.newpipe.util.NavigationHelper;
@@ -326,7 +327,7 @@ public class RouterActivity extends AppCompatActivity {
             final RadioButton radioButton
                     = (RadioButton) inflater.inflate(R.layout.list_radio_icon_item, null);
             radioButton.setText(item.description);
-            radioButton.setCompoundDrawablesWithIntrinsicBounds(
+            TextViewCompat.setCompoundDrawablesRelativeWithIntrinsicBounds(radioButton,
                     AppCompatResources.getDrawable(getApplicationContext(), item.icon),
                     null, null, null);
             radioButton.setChecked(false);

--- a/app/src/main/java/org/schabi/newpipe/settings/NotificationSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/NotificationSettingsFragment.java
@@ -23,6 +23,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.content.res.AppCompatResources;
+import androidx.core.widget.TextViewCompat;
 import androidx.fragment.app.Fragment;
 
 import org.schabi.newpipe.R;
@@ -247,7 +248,7 @@ public class NotificationSettingsFragment extends Fragment {
                         } else {
                             drawable.mutate().setColorFilter(color, PorterDuff.Mode.SRC_IN);
                         }
-                        radioButton.setCompoundDrawablesWithIntrinsicBounds(
+                        TextViewCompat.setCompoundDrawablesRelativeWithIntrinsicBounds(radioButton,
                                 null, null, drawable, null);
                     }
                 }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Use `TextViewCompat`'s `setCompoundDrawablesRelativeWithIntrinsicBounds()` method to support displaying drawables properly with RTL layouts on API level 17 and higher while allowing this change to be used in NewPipe Legacy.

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
[debug.zip](https://github.com/TeamNewPipe/NewPipe/files/5419339/debug.zip)

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
