### PR TITLE
fix a wrong translation

### DIFF
--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -314,7 +314,7 @@
     <string name="delete_all_history_prompt">是否确实要从历史记录中删除所有项目？</string>
     <string name="title_last_played">最后播放</string>
     <string name="title_most_played">播放最多</string>
-    <string name="always_ask_open_action">总是寻问</string>
+    <string name="always_ask_open_action">总是询问</string>
     <string name="create_playlist">新建播放列表</string>
     <string name="delete_playlist">删除</string>
     <string name="rename_playlist">重 命名</string>


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- translation fix.

#### Fixes the following issue(s)
<!-- Also add any other links relevant to your change. -->
- Fixed a wrong translation in zh_CN. It's correct in [Weblate](https://hosted.weblate.org/translate/newpipe/strings/zh_Hans/?offset=1&q=always_ask_open_action) but wrong in newest branch and in F-Droid.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
