### PR TITLE
Add option to not colorize notification

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/NotificationUtil.java
+++ b/app/src/main/java/org/schabi/newpipe/player/NotificationUtil.java
@@ -120,7 +120,10 @@ public final class NotificationUtil {
                 .setCategory(NotificationCompat.CATEGORY_TRANSPORT)
                 .setShowWhen(false)
                 .setSmallIcon(R.drawable.ic_newpipe_triangle_white)
-                .setColor(ContextCompat.getColor(player.context, R.color.gray))
+                .setColor(ContextCompat.getColor(player.context, R.color.dark_background_color))
+                .setColorized(player.sharedPreferences.getBoolean(
+                        player.context.getString(R.string.notification_colorize_key),
+                        true))
                 .setDeleteIntent(PendingIntent.getBroadcast(player.context, NOTIFICATION_ID,
                         new Intent(ACTION_CLOSE), FLAG_UPDATE_CURRENT));
 

--- a/app/src/main/java/org/schabi/newpipe/settings/NotificationSettingsFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/NotificationSettingsFragment.kt
@@ -1,10 +1,19 @@
 package org.schabi.newpipe.settings
 
+import android.os.Build
 import android.os.Bundle
+import androidx.preference.Preference
 import org.schabi.newpipe.R
 
 class NotificationSettingsFragment : BasePreferenceFragment() {
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         addPreferencesFromResource(R.xml.notification_settings)
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            val colorizePref: Preference? = findPreference(getString(R.string.notification_colorize_key))
+            colorizePref?.let {
+                preferenceScreen.removePreference(it)
+            }
+        }
     }
 }

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -132,6 +132,8 @@
     <string name="notification_slot_compact_1_key" translatable="false">notification_slot_compact_1_key</string>
     <string name="notification_slot_compact_2_key" translatable="false">notification_slot_compact_2_key</string>
 
+    <string name="notification_colorize_key" translatable="false">notification_colorize_key</string>
+
     <string name="video_mp4_key" translatable="false">video_mp4</string>
     <string name="video_webm_key" translatable="false">video_webm</string>
     <string name="video_3gp_key" translatable="false">video_3gp</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,6 +72,8 @@
     <string name="notification_action_shuffle">Shuffle</string>
     <string name="notification_action_buffering">Buffering</string>
     <string name="notification_action_nothing">Nothing</string>
+    <string name="notification_colorize_title">Colorize notification</string>
+    <string name="notification_colorize_summary">Have Android customize the notification\'s color according to the main color in the thumbnail (note that this is not available on all devices)</string>
     <string name="play_audio">Audio</string>
     <string name="default_audio_format_title">Default audio format</string>
     <string name="default_video_format_title">Default video format</string>

--- a/app/src/main/res/xml/notification_settings.xml
+++ b/app/src/main/res/xml/notification_settings.xml
@@ -10,6 +10,13 @@
         android:title="@string/notification_scale_to_square_image_title"
         app:iconSpaceReserved="false" />
 
+    <SwitchPreferenceCompat
+        android:defaultValue="true"
+        android:key="@string/notification_colorize_key"
+        android:summary="@string/notification_colorize_summary"
+        android:title="@string/notification_colorize_title"
+        app:iconSpaceReserved="false" />
+
     <PreferenceCategory
         android:layout="@layout/settings_category_header_layout"
         app:iconSpaceReserved="false">


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Feature (user facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Add option to not colorize notifications
- Setting is located under notifcation

#### Fixes the following issue(s)
<!-- Also add any other links relevant to your change. -->
- closes #4488

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
updated after rebase
[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/5471377/app-debug.zip)


#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
