### PR TITLE
Convert notification actions to a custom preference

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/settings/NotificationSettingsFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/NotificationSettingsFragment.kt
@@ -1,0 +1,10 @@
+package org.schabi.newpipe.settings
+
+import android.os.Bundle
+import org.schabi.newpipe.R
+
+class NotificationSettingsFragment : BasePreferenceFragment() {
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        addPreferencesFromResource(R.xml.notification_settings)
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/settings/custom/NotificationActionsPreference.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/custom/NotificationActionsPreference.java
@@ -1,10 +1,10 @@
-package org.schabi.newpipe.settings;
+package org.schabi.newpipe.settings.custom;
 
+import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.drawable.Drawable;
-import android.os.Bundle;
-import android.preference.PreferenceManager;
+import android.util.AttributeSet;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -13,18 +13,16 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.RadioButton;
 import android.widget.RadioGroup;
-import android.widget.Switch;
 import android.widget.TextView;
 import android.widget.Toast;
-
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.content.res.AppCompatResources;
 import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.core.widget.TextViewCompat;
-import androidx.fragment.app.Fragment;
-
+import androidx.preference.Preference;
+import androidx.preference.PreferenceViewHolder;
+import java.util.List;
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.player.MainPlayer;
 import org.schabi.newpipe.player.NotificationConstants;
@@ -32,56 +30,35 @@ import org.schabi.newpipe.util.DeviceUtils;
 import org.schabi.newpipe.util.ThemeHelper;
 import org.schabi.newpipe.views.FocusOverlayView;
 
-import java.util.List;
+public class NotificationActionsPreference extends Preference {
 
-public class NotificationSettingsFragment extends Fragment {
+    public NotificationActionsPreference(final Context context, final AttributeSet attrs) {
+        super(context, attrs);
+        setLayoutResource(R.layout.settings_notification);
+    }
 
-    private Switch scaleSwitch;
+
     private NotificationSlot[] notificationSlots;
 
-    private SharedPreferences pref;
     private List<Integer> compactSlots;
-    private String scaleKey;
 
     ////////////////////////////////////////////////////////////////////////////
     // Lifecycle
     ////////////////////////////////////////////////////////////////////////////
 
     @Override
-    public void onCreate(@Nullable final Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        pref = PreferenceManager.getDefaultSharedPreferences(requireContext());
-        scaleKey = getString(R.string.scale_to_square_image_in_notifications_key);
+    public void onBindViewHolder(final PreferenceViewHolder holder) {
+        super.onBindViewHolder(holder);
+
+        holder.itemView.setClickable(false);
+        setupActions(holder.itemView);
     }
 
     @Override
-    public View onCreateView(@NonNull final LayoutInflater inflater,
-                             final ViewGroup container,
-                             @Nullable final Bundle savedInstanceState) {
-        return inflater.inflate(R.layout.settings_notification, container, false);
-    }
-
-    @Override
-    public void onViewCreated(@NonNull final View rootView,
-                              @Nullable final Bundle savedInstanceState) {
-        super.onViewCreated(rootView, savedInstanceState);
-
-        setupScaleSwitch(rootView);
-        setupActions(rootView);
-    }
-
-    @Override
-    public void onResume() {
-        super.onResume();
-        ThemeHelper.setTitleToAppCompatActivity(getActivity(),
-                getString(R.string.settings_category_notification_title));
-    }
-
-    @Override
-    public void onPause() {
-        super.onPause();
+    public void onDetached() {
+        super.onDetached();
         saveChanges();
-        requireContext().sendBroadcast(new Intent(MainPlayer.ACTION_RECREATE_NOTIFICATION));
+        getContext().sendBroadcast(new Intent(MainPlayer.ACTION_RECREATE_NOTIFICATION));
     }
 
 
@@ -89,17 +66,10 @@ public class NotificationSettingsFragment extends Fragment {
     // Setup
     ////////////////////////////////////////////////////////////////////////////
 
-    private void setupScaleSwitch(@NonNull final View view) {
-        scaleSwitch = view.findViewById(R.id.notificationScaleSwitch);
-        scaleSwitch.setChecked(pref.getBoolean(scaleKey, false));
-
-        view.findViewById(R.id.notificationScaleSwitchClickableArea)
-                .setOnClickListener(v -> scaleSwitch.toggle());
-    }
-
     private void setupActions(@NonNull final View view) {
         compactSlots =
-                NotificationConstants.getCompactSlotsFromPreferences(requireContext(), pref, 5);
+                NotificationConstants.getCompactSlotsFromPreferences(
+                        getContext(), getSharedPreferences(), 5);
         notificationSlots = new NotificationSlot[5];
         for (int i = 0; i < 5; i++) {
             notificationSlots[i] = new NotificationSlot(i, view);
@@ -112,16 +82,15 @@ public class NotificationSettingsFragment extends Fragment {
     ////////////////////////////////////////////////////////////////////////////
 
     private void saveChanges() {
-        final SharedPreferences.Editor editor = pref.edit();
-        editor.putBoolean(scaleKey, scaleSwitch.isChecked());
+        final SharedPreferences.Editor editor = getSharedPreferences().edit();
 
         for (int i = 0; i < 3; i++) {
-            editor.putInt(getString(NotificationConstants.SLOT_COMPACT_PREF_KEYS[i]),
+            editor.putInt(getContext().getString(NotificationConstants.SLOT_COMPACT_PREF_KEYS[i]),
                     (i < compactSlots.size() ? compactSlots.get(i) : -1));
         }
 
         for (int i = 0; i < 5; i++) {
-            editor.putInt(getString(NotificationConstants.SLOT_PREF_KEYS[i]),
+            editor.putInt(getContext().getString(NotificationConstants.SLOT_PREF_KEYS[i]),
                     notificationSlots[i].selectedAction);
         }
 
@@ -183,7 +152,7 @@ public class NotificationSettingsFragment extends Fragment {
                         } else if (compactSlots.size() < 3) {
                             compactSlots.add(i);
                         } else {
-                            Toast.makeText(requireContext(),
+                            Toast.makeText(getContext(),
                                     R.string.notification_actions_at_most_three,
                                     Toast.LENGTH_SHORT).show();
                             return;
@@ -196,7 +165,8 @@ public class NotificationSettingsFragment extends Fragment {
         void setupSelectedAction(final View view) {
             icon = view.findViewById(R.id.notificationActionIcon);
             summary = view.findViewById(R.id.notificationActionSummary);
-            selectedAction = pref.getInt(getString(NotificationConstants.SLOT_PREF_KEYS[i]),
+            selectedAction = getSharedPreferences().getInt(
+                    getContext().getString(NotificationConstants.SLOT_PREF_KEYS[i]),
                     NotificationConstants.SLOT_DEFAULTS[i]);
             updateInfo();
         }
@@ -205,20 +175,20 @@ public class NotificationSettingsFragment extends Fragment {
             if (NotificationConstants.ACTION_ICONS[selectedAction] == 0) {
                 icon.setImageDrawable(null);
             } else {
-                icon.setImageDrawable(AppCompatResources.getDrawable(requireContext(),
+                icon.setImageDrawable(AppCompatResources.getDrawable(getContext(),
                         NotificationConstants.ACTION_ICONS[selectedAction]));
             }
 
-            summary.setText(NotificationConstants.getActionName(requireContext(), selectedAction));
+            summary.setText(NotificationConstants.getActionName(getContext(), selectedAction));
         }
 
         void openActionChooserDialog() {
-            final LayoutInflater inflater = LayoutInflater.from(requireContext());
+            final LayoutInflater inflater = LayoutInflater.from(getContext());
             final LinearLayout rootLayout = (LinearLayout) inflater.inflate(
                     R.layout.single_choice_dialog_view, null, false);
             final RadioGroup radioGroup = rootLayout.findViewById(android.R.id.list);
 
-            final AlertDialog alertDialog = new AlertDialog.Builder(requireContext())
+            final AlertDialog alertDialog = new AlertDialog.Builder(getContext())
                     .setTitle(SLOT_TITLES[i])
                     .setView(radioGroup)
                     .setCancelable(true)
@@ -237,10 +207,10 @@ public class NotificationSettingsFragment extends Fragment {
 
                 // if present set action icon with correct color
                 if (NotificationConstants.ACTION_ICONS[action] != 0) {
-                    Drawable drawable = AppCompatResources.getDrawable(requireContext(),
+                    Drawable drawable = AppCompatResources.getDrawable(getContext(),
                             NotificationConstants.ACTION_ICONS[action]);
                     if (drawable != null) {
-                        final int color = ThemeHelper.resolveColorFromAttr(requireContext(),
+                        final int color = ThemeHelper.resolveColorFromAttr(getContext(),
                                 android.R.attr.textColorPrimary);
                         drawable = DrawableCompat.wrap(drawable).mutate();
                         DrawableCompat.setTint(drawable, color);
@@ -249,7 +219,7 @@ public class NotificationSettingsFragment extends Fragment {
                     }
                 }
 
-                radioButton.setText(NotificationConstants.getActionName(requireContext(), action));
+                radioButton.setText(NotificationConstants.getActionName(getContext(), action));
                 radioButton.setChecked(action == selectedAction);
                 radioButton.setId(id);
                 radioButton.setLayoutParams(new RadioGroup.LayoutParams(
@@ -259,7 +229,7 @@ public class NotificationSettingsFragment extends Fragment {
             }
             alertDialog.show();
 
-            if (DeviceUtils.isTv(requireContext())) {
+            if (DeviceUtils.isTv(getContext())) {
                 FocusOverlayView.setupFocusObserver(alertDialog);
             }
         }

--- a/app/src/main/res/layout/settings_notification.xml
+++ b/app/src/main/res/layout/settings_notification.xml
@@ -8,71 +8,11 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-        <Switch
-            android:id="@+id/notificationScaleSwitch"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="16dp"
-            android:clickable="false"
-            android:focusable="false"
-            app:layout_constraintBottom_toBottomOf="@+id/textView2"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="@+id/textView" />
-
-        <TextView
-            android:id="@+id/textView"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="16dp"
-            android:layout_marginEnd="16dp"
-            android:text="@string/notification_scale_to_square_image_title"
-            android:textAppearance="?android:attr/textAppearanceLarge"
-            android:textSize="14sp"
-            app:layout_constraintEnd_toStartOf="@+id/notificationScaleSwitch"
-            app:layout_constraintHorizontal_bias="0.0"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <TextView
-            android:id="@+id/textView2"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginEnd="16dp"
-            android:text="@string/notification_scale_to_square_image_summary"
-            app:layout_constraintEnd_toStartOf="@+id/notificationScaleSwitch"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/textView" />
-
-        <View
-            android:id="@+id/notificationScaleSwitchClickableArea"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:background="?android:selectableItemBackground"
-            android:clickable="true"
-            android:focusable="true"
-            app:layout_constraintBottom_toTopOf="@+id/divider"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <View
-            android:id="@+id/divider"
-            android:layout_width="0dp"
-            android:layout_height="1dp"
-            android:layout_marginStart="32dp"
-            android:layout_marginTop="16dp"
-            android:layout_marginEnd="32dp"
-            android:background="?android:attr/listDivider"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/textView2" />
-
         <TextView
             android:id="@+id/textView4"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
-            android:layout_marginTop="16dp"
             android:layout_marginEnd="16dp"
             android:clickable="false"
             android:focusable="false"
@@ -81,7 +21,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="0.0"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/divider" />
+            app:layout_constraintTop_toTopOf="parent" />
 
         <include
             android:id="@+id/notificationAction0"

--- a/app/src/main/res/layout/settings_notification.xml
+++ b/app/src/main/res/layout/settings_notification.xml
@@ -1,15 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:paddingTop="16dp">
 
-        <TextView
-            android:id="@+id/textView4"
+    <TextView
+            android:id="@+id/textView"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
@@ -31,7 +30,7 @@
             android:layout_marginTop="8dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/textView4" />
+            app:layout_constraintTop_toBottomOf="@+id/textView" />
 
         <include
             android:id="@+id/notificationAction1"
@@ -70,4 +69,3 @@
             app:layout_constraintTop_toBottomOf="@+id/notificationAction3" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
-</ScrollView>

--- a/app/src/main/res/xml/notification_settings.xml
+++ b/app/src/main/res/xml/notification_settings.xml
@@ -3,18 +3,15 @@
         xmlns:app="http://schemas.android.com/apk/res-auto"
         android:title="@string/settings_category_notification_title">
 
-    <PreferenceCategory>
-        <SwitchPreferenceCompat
-                android:defaultValue="false"
-                android:key="@string/scale_to_square_image_in_notifications_key"
-                android:summary="@string/notification_scale_to_square_image_summary"
-                android:title="@string/notification_scale_to_square_image_title"
-                app:iconSpaceReserved="false" />
+    <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="@string/scale_to_square_image_in_notifications_key"
+            android:summary="@string/notification_scale_to_square_image_summary"
+            android:title="@string/notification_scale_to_square_image_title"
+            app:iconSpaceReserved="false" />
 
-    </PreferenceCategory>
-
-    <PreferenceCategory>
-        <org.schabi.newpipe.settings.custom.NotificationActionsPreference></org.schabi.newpipe.settings.custom.NotificationActionsPreference>
+    <PreferenceCategory android:layout="@layout/settings_category_header_layout">
+        <org.schabi.newpipe.settings.custom.NotificationActionsPreference />
     </PreferenceCategory>
 
 

--- a/app/src/main/res/xml/notification_settings.xml
+++ b/app/src/main/res/xml/notification_settings.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:title="@string/settings_category_notification_title">
+
+    <PreferenceCategory>
+        <SwitchPreferenceCompat
+                android:defaultValue="false"
+                android:key="@string/scale_to_square_image_in_notifications_key"
+                android:summary="@string/notification_scale_to_square_image_summary"
+                android:title="@string/notification_scale_to_square_image_title"
+                app:iconSpaceReserved="false" />
+
+    </PreferenceCategory>
+
+    <PreferenceCategory>
+        <org.schabi.newpipe.settings.custom.NotificationActionsPreference></org.schabi.newpipe.settings.custom.NotificationActionsPreference>
+    </PreferenceCategory>
+
+
+</PreferenceScreen>


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Codebase improvement (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Convert `NotificationSettingsFragment` into a custom `Preference`
  - extract scale switch out of this
- Create "standard" preference with scale switch and custom preference above

#### Fixes the following issue(s)
<!-- Also add any other links relevant to your change. -->
- closes  #4646

#### APK testing 
[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/5443584/app-debug.zip) (updated with Stypox suggestions)



### Site notes
- `Preference.onDetached()` seems to equivalent to `Fragment.onPause()` for the purpose of saving the preference and recreating the notification.
- From the doc on the 4 constructors of `Preference`, only modifying the one that i did should be enogh (I think).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
