### PR TITLE
Use TeamNewPipe repo instead of Stypox repo as dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -176,7 +176,7 @@ dependencies {
 
     // NewPipe dependencies
     // You can use a local version by uncommenting a few lines in settings.gradle
-    implementation 'com.github.Stypox:NewPipeExtractor:501ec30152642ad49ce0a1825410d200942d174c'
+    implementation 'com.github.TeamNewPipe:NewPipeExtractor:501ec30152642ad49ce0a1825410d200942d174c'
     implementation "com.github.TeamNewPipe:nanojson:1d9e1aea9049fc9f85e68b43ba39fe7be1c1f751"
 
     implementation "org.jsoup:jsoup:1.13.1"


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Codebase improvement (dev facing)

Well there i was wondering why dependency substitution wasn't working and what setting i forgot to import from my old pc this time. 
And see there! It cant subtitute `com.github.TeamNewPipe:NewPipeExtractor`, because it's not used!

Edit: btw whats up with the security/synk check always failing?
