### PR TITLE
Fix respecting brightness-volume-gesture settings

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/event/PlayerGestureListener.java
+++ b/app/src/main/java/org/schabi/newpipe/player/event/PlayerGestureListener.java
@@ -36,15 +36,10 @@ public class PlayerGestureListener
     private static final String TAG = ".PlayerGestureListener";
     private static final boolean DEBUG = BasePlayer.DEBUG;
 
-    private final boolean isVolumeGestureEnabled;
-    private final boolean isBrightnessGestureEnabled;
     private final int maxVolume;
 
     public PlayerGestureListener(final VideoPlayerImpl playerImpl, final MainPlayer service) {
         super(playerImpl, service);
-
-        isVolumeGestureEnabled = PlayerHelper.isVolumeGestureEnabled(service);
-        isBrightnessGestureEnabled = PlayerHelper.isBrightnessGestureEnabled(service);
         maxVolume = playerImpl.getAudioReactor().getMaxVolume();
     }
 
@@ -110,10 +105,20 @@ public class PlayerGestureListener
                 + portion + "]");
         }
         if (playerType == MainPlayer.PlayerType.VIDEO) {
-            if (portion == DisplayPortion.LEFT_HALF) {
-                onScrollMainBrightness(distanceX, distanceY);
+            final boolean isBrightnessGestureEnabled =
+                PlayerHelper.isBrightnessGestureEnabled(service);
+            final boolean isVolumeGestureEnabled = PlayerHelper.isVolumeGestureEnabled(service);
 
-            } else /* DisplayPortion.RIGHT_HALF */ {
+            if (isBrightnessGestureEnabled && isVolumeGestureEnabled) {
+                if (portion == DisplayPortion.LEFT_HALF) {
+                    onScrollMainBrightness(distanceX, distanceY);
+
+                } else /* DisplayPortion.RIGHT_HALF */ {
+                    onScrollMainVolume(distanceX, distanceY);
+                }
+            } else if (isBrightnessGestureEnabled) {
+                onScrollMainBrightness(distanceX, distanceY);
+            } else if (isVolumeGestureEnabled) {
                 onScrollMainVolume(distanceX, distanceY);
             }
 
@@ -132,75 +137,71 @@ public class PlayerGestureListener
     }
 
     private void onScrollMainVolume(final float distanceX, final float distanceY) {
-        if (isVolumeGestureEnabled) {
-            playerImpl.getVolumeProgressBar().incrementProgressBy((int) distanceY);
-            final float currentProgressPercent = (float) playerImpl
-                    .getVolumeProgressBar().getProgress() / playerImpl.getMaxGestureLength();
-            final int currentVolume = (int) (maxVolume * currentProgressPercent);
-            playerImpl.getAudioReactor().setVolume(currentVolume);
+        playerImpl.getVolumeProgressBar().incrementProgressBy((int) distanceY);
+        final float currentProgressPercent = (float) playerImpl
+                .getVolumeProgressBar().getProgress() / playerImpl.getMaxGestureLength();
+        final int currentVolume = (int) (maxVolume * currentProgressPercent);
+        playerImpl.getAudioReactor().setVolume(currentVolume);
 
-            if (DEBUG) {
-                Log.d(TAG, "onScroll().volumeControl, currentVolume = " + currentVolume);
-            }
+        if (DEBUG) {
+            Log.d(TAG, "onScroll().volumeControl, currentVolume = " + currentVolume);
+        }
 
-            playerImpl.getVolumeImageView().setImageDrawable(
-                    AppCompatResources.getDrawable(service, currentProgressPercent <= 0
-                            ? R.drawable.ic_volume_off_white_24dp
-                            : currentProgressPercent < 0.25 ? R.drawable.ic_volume_mute_white_24dp
-                            : currentProgressPercent < 0.75 ? R.drawable.ic_volume_down_white_24dp
-                            : R.drawable.ic_volume_up_white_24dp)
-            );
+        playerImpl.getVolumeImageView().setImageDrawable(
+                AppCompatResources.getDrawable(service, currentProgressPercent <= 0
+                        ? R.drawable.ic_volume_off_white_24dp
+                        : currentProgressPercent < 0.25 ? R.drawable.ic_volume_mute_white_24dp
+                        : currentProgressPercent < 0.75 ? R.drawable.ic_volume_down_white_24dp
+                        : R.drawable.ic_volume_up_white_24dp)
+        );
 
-            if (playerImpl.getVolumeRelativeLayout().getVisibility() != View.VISIBLE) {
-                animateView(playerImpl.getVolumeRelativeLayout(), SCALE_AND_ALPHA, true, 200);
-            }
-            if (playerImpl.getBrightnessRelativeLayout().getVisibility() == View.VISIBLE) {
-                playerImpl.getBrightnessRelativeLayout().setVisibility(View.GONE);
-            }
+        if (playerImpl.getVolumeRelativeLayout().getVisibility() != View.VISIBLE) {
+            animateView(playerImpl.getVolumeRelativeLayout(), SCALE_AND_ALPHA, true, 200);
+        }
+        if (playerImpl.getBrightnessRelativeLayout().getVisibility() == View.VISIBLE) {
+            playerImpl.getBrightnessRelativeLayout().setVisibility(View.GONE);
         }
     }
 
     private void onScrollMainBrightness(final float distanceX, final float distanceY) {
-        if (isBrightnessGestureEnabled) {
-            final Activity parent = playerImpl.getParentActivity();
-            if (parent == null) {
-                return;
-            }
+        final Activity parent = playerImpl.getParentActivity();
+        if (parent == null) {
+            return;
+        }
 
-            final Window window = parent.getWindow();
-            final WindowManager.LayoutParams layoutParams = window.getAttributes();
-            final ProgressBar bar = playerImpl.getBrightnessProgressBar();
-            final float oldBrightness = layoutParams.screenBrightness;
-            bar.setProgress((int) (bar.getMax() * Math.max(0, Math.min(1, oldBrightness))));
-            bar.incrementProgressBy((int) distanceY);
+        final Window window = parent.getWindow();
+        final WindowManager.LayoutParams layoutParams = window.getAttributes();
+        final ProgressBar bar = playerImpl.getBrightnessProgressBar();
+        final float oldBrightness = layoutParams.screenBrightness;
+        bar.setProgress((int) (bar.getMax() * Math.max(0, Math.min(1, oldBrightness))));
+        bar.incrementProgressBy((int) distanceY);
 
-            final float currentProgressPercent = (float) bar.getProgress() / bar.getMax();
-            layoutParams.screenBrightness = currentProgressPercent;
-            window.setAttributes(layoutParams);
+        final float currentProgressPercent = (float) bar.getProgress() / bar.getMax();
+        layoutParams.screenBrightness = currentProgressPercent;
+        window.setAttributes(layoutParams);
 
-            // Save current brightness level
-            PlayerHelper.setScreenBrightness(parent, currentProgressPercent);
+        // Save current brightness level
+        PlayerHelper.setScreenBrightness(parent, currentProgressPercent);
 
-            if (DEBUG) {
-                Log.d(TAG, "onScroll().brightnessControl, "
-                        + "currentBrightness = " + currentProgressPercent);
-            }
+        if (DEBUG) {
+            Log.d(TAG, "onScroll().brightnessControl, "
+                    + "currentBrightness = " + currentProgressPercent);
+        }
 
-            playerImpl.getBrightnessImageView().setImageDrawable(
-                    AppCompatResources.getDrawable(service,
-                            currentProgressPercent < 0.25
-                                    ? R.drawable.ic_brightness_low_white_24dp
-                                    : currentProgressPercent < 0.75
-                                    ? R.drawable.ic_brightness_medium_white_24dp
-                                    : R.drawable.ic_brightness_high_white_24dp)
-            );
+        playerImpl.getBrightnessImageView().setImageDrawable(
+                AppCompatResources.getDrawable(service,
+                        currentProgressPercent < 0.25
+                                ? R.drawable.ic_brightness_low_white_24dp
+                                : currentProgressPercent < 0.75
+                                ? R.drawable.ic_brightness_medium_white_24dp
+                                : R.drawable.ic_brightness_high_white_24dp)
+        );
 
-            if (playerImpl.getBrightnessRelativeLayout().getVisibility() != View.VISIBLE) {
-                animateView(playerImpl.getBrightnessRelativeLayout(), SCALE_AND_ALPHA, true, 200);
-            }
-            if (playerImpl.getVolumeRelativeLayout().getVisibility() == View.VISIBLE) {
-                playerImpl.getVolumeRelativeLayout().setVisibility(View.GONE);
-            }
+        if (playerImpl.getBrightnessRelativeLayout().getVisibility() != View.VISIBLE) {
+            animateView(playerImpl.getBrightnessRelativeLayout(), SCALE_AND_ALPHA, true, 200);
+        }
+        if (playerImpl.getVolumeRelativeLayout().getVisibility() == View.VISIBLE) {
+            playerImpl.getVolumeRelativeLayout().setVisibility(View.GONE);
         }
     }
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
This PR fixes the issue that the player didn't respected the brightness/volume gesture setting. When disabling one of them while the other is enabled should change the value for the whole screen instead of just disable the display portion. I didn't know of this behavior :`)

I also moved the `isBrightnessEnabled` and `isVolumeEnabled` to the actual `onScroll`-callback. If a stream is opened or playing and you'll change one or both toggle states the setting won't be applied for this opened `Fragment` (checked on 0.20.2).

#### Fixes the following issue(s)
<!-- Also add any other links relevant to your change. -->
- fixes #4926 

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/5575851/app-debug.zip)


#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
