### PR TITLE
VideoDetailFragment: Don't exit fullscreen on rotation in tablet UI

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -274,7 +274,9 @@ public final class VideoDetailFragment
             // If the video is playing but orientation changed
             // let's make the video in fullscreen again
             checkLandscape();
-        } else if (player.isFullscreen() && !player.isVerticalVideo()) {
+        } else if (player.isFullscreen() && !player.isVerticalVideo()
+                // Tablet UI has orientation-independent fullscreen
+                && !DeviceUtils.isTablet(activity)) {
             // Device is in portrait orientation after rotation but UI is in fullscreen.
             // Return back to non-fullscreen state
             player.toggleFullscreen();


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->

Going from portrait to landscape doesn't toggle fullscreen in tablet mode, so
the reverse action shouldn't do it either.

#### Fixes the following issue(s)
<!-- Also add any other links relevant to your change. -->
- https://github.com/TeamNewPipe/NewPipe/issues/4936

#### Relies on the following changes
<!-- Delete this if it doesn't apply to you. -->

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->

~~(Upload doesn't work, gets stuck :/)~~

€: It was localCDN

[app-debug.apk.zip](https://github.com/TeamNewPipe/NewPipe/files/5578022/app-debug.apk.zip)

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
