### PR TITLE
Dispose of RxViews disposable in BaseStateFragment.

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/BaseStateFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/BaseStateFragment.java
@@ -35,6 +35,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import icepick.State;
 import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.disposables.Disposable;
 
 import static org.schabi.newpipe.util.AnimationUtils.animateView;
 
@@ -47,6 +48,8 @@ public abstract class BaseStateFragment<I> extends BaseFragment implements ViewC
     private View emptyStateView;
     @Nullable
     private ProgressBar loadingProgressBar;
+
+    private Disposable errorDisposable;
 
     protected View errorPanelRoot;
     private Button errorButtonRetry;
@@ -62,6 +65,14 @@ public abstract class BaseStateFragment<I> extends BaseFragment implements ViewC
     public void onPause() {
         super.onPause();
         wasLoading.set(isLoading.get());
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        if (errorDisposable != null) {
+            errorDisposable.dispose();
+        }
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -83,7 +94,7 @@ public abstract class BaseStateFragment<I> extends BaseFragment implements ViewC
     @Override
     protected void initListeners() {
         super.initListeners();
-        RxView.clicks(errorButtonRetry)
+        errorDisposable = RxView.clicks(errorButtonRetry)
                 .debounce(300, TimeUnit.MILLISECONDS)
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(o -> onRetryButtonClicked());


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Dispose of the `Disposable` created by `RxView.clicks()` in `BaseStateFragment`.

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
debug.zip

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
