### PR TITLE
Make ErrorInfo contructor public

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/report/ErrorInfo.kt
+++ b/app/src/main/java/org/schabi/newpipe/report/ErrorInfo.kt
@@ -5,7 +5,7 @@ import androidx.annotation.StringRes
 import kotlinx.android.parcel.Parcelize
 
 @Parcelize
-class ErrorInfo private constructor(
+class ErrorInfo(
     val userAction: UserAction?,
     val serviceName: String,
     val request: String,


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)

#### Fixes the following issue(s)
<!-- Also add any other links relevant to your change. -->
-  closes #4980

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/5591852/app-debug.zip)
Note that loading comments always throws an error in this apk, since i changed the extractor for easier manual testing

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).

@TobiGr @Stypox 
