### PR TITLE
Add "Screen layout" dropdown

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
@@ -10,8 +10,10 @@ import android.view.KeyEvent;
 
 import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
+import androidx.preference.PreferenceManager;
 
 import org.schabi.newpipe.App;
+import org.schabi.newpipe.R;
 
 public final class DeviceUtils {
 
@@ -21,9 +23,37 @@ public final class DeviceUtils {
     private DeviceUtils() {
     }
 
+    /**
+     * Checks if the screen layout was forced to the given layout.
+     * @param context Application context
+     * @param resId The resource ID of the wanted screen layout
+     * @return true if the layout was forced, false if the layout was forced to something else,
+     * and null if the screen layout is auto
+     */
+    private static Boolean layoutForcedTo(final Context context, final int resId) {
+        final String screenLayoutKey = context.getString(R.string.screen_layout_key);
+        final String autoKey = context.getString(R.string.screen_layout_auto_key);
+        final String wantedKey = context.getString(resId);
+        final String screenLayout = PreferenceManager.getDefaultSharedPreferences(context)
+                .getString(screenLayoutKey, autoKey);
+
+        if (screenLayout.equals(wantedKey)) {
+            return true;
+        } else if (!screenLayout.equals(autoKey)) {
+            return false;
+        }
+
+        return null;
+    }
+
     public static boolean isTv(final Context context) {
         if (isTV != null) {
             return isTV;
+        }
+
+        final Boolean forcedToTv = layoutForcedTo(context, R.string.screen_layout_tv_key);
+        if (forcedToTv != null) {
+            return forcedToTv;
         }
 
         final PackageManager pm = App.getApp().getPackageManager();
@@ -53,6 +83,11 @@ public final class DeviceUtils {
     }
 
     public static boolean isTablet(@NonNull final Context context) {
+        final Boolean forcedToTablet = layoutForcedTo(context, R.string.screen_layout_tablet_key);
+        if (forcedToTablet != null) {
+            return forcedToTablet;
+        }
+
         return (context
                 .getResources()
                 .getConfiguration().screenLayout & Configuration.SCREENLAYOUT_SIZE_MASK)

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -199,6 +199,7 @@
     <string name="show_comments_key" translatable="false">show_comments</string>
     <string name="stream_info_selected_tab_key" translatable="false">stream_info_selected_tab</string>
     <string name="show_hold_to_append_key" translatable="false">show_hold_to_append</string>
+    <string name="screen_layout_key" translatable="false">screen_layout</string>
     <string name="content_language_key" translatable="false">content_language</string>
     <string name="peertube_instance_setup_key" translatable="false">peertube_instance_setup</string>
     <string name="peertube_selected_instance_key" translatable="false">peertube_selected_instance</string>
@@ -1193,6 +1194,25 @@
         <item>@string/auto</item>
         <item>@string/list</item>
         <item>@string/grid</item>
+    </string-array>
+
+    <string name="screen_layout_auto_key" translatable="false">auto</string>
+    <string name="screen_layout_phone_key" translatable="false">phone</string>
+    <string name="screen_layout_tablet_key" translatable="false">tablet</string>
+    <string name="screen_layout_tv_key" translatable="false">tv</string>
+
+    <string name="screen_layout_value" translatable="false">@string/screen_layout_auto_key</string>
+    <string-array name="screen_layout_values" translatable="false">
+        <item>@string/screen_layout_auto_key</item>
+        <item>@string/screen_layout_phone_key</item>
+        <item>@string/screen_layout_tablet_key</item>
+        <item>@string/screen_layout_tv_key</item>
+    </string-array>
+    <string-array name="screen_layout_description" translatable="false">
+        <item>@string/auto</item>
+        <item>@string/screen_layout_phone</item>
+        <item>@string/screen_layout_tablet</item>
+        <item>@string/screen_layout_tv</item>
     </string-array>
 
     <string name="recaptcha_cookies_key" translatable="false">recaptcha_cookies_key</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -123,6 +123,10 @@
     <string name="autoplay_title">Autoplay</string>
     <string name="show_next_and_similar_title">Show \'Next\' and \'Similar\' videos</string>
     <string name="show_hold_to_append_title">Show \"Hold to append\" tip</string>
+    <string name="screen_layout_title">Screen layout</string>
+    <string name="screen_layout_phone">Phone</string>
+    <string name="screen_layout_tablet">Tablet</string>
+    <string name="screen_layout_tv">TV</string>
     <string name="show_hold_to_append_summary">Show tip when pressing the background or the popup button in video \"Details:\"</string>
     <string name="unsupported_url">Unsupported URL</string>
     <string name="unsupported_url_dialog_message">Could not recognize the URL. Open with another app?</string>

--- a/app/src/main/res/xml/appearance_settings.xml
+++ b/app/src/main/res/xml/appearance_settings.xml
@@ -34,4 +34,13 @@
         android:title="@string/caption_setting_title"
         app:iconSpaceReserved="false" />
 
+    <ListPreference
+        android:defaultValue="@string/screen_layout_value"
+        android:entries="@array/screen_layout_description"
+        android:entryValues="@array/screen_layout_values"
+        android:key="@string/screen_layout_key"
+        android:summary="%s"
+        android:title="@string/screen_layout_title"
+        app:iconSpaceReserved="false" />
+
 </PreferenceScreen>


### PR DESCRIPTION

#### What is it?
- [ ] Bugfix (user facing)
- [X] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Some ROMs allow users to set their screen density. Beyond a certain density,
NewPipe treats screens with high density as "tablet". This can be undesirable.
This patch adds a dropdown to the Appearance menu to allow users to force
the screen layout to specific values.

#### APK testing 
[debug.zip](https://github.com/TeamNewPipe/NewPipe/files/5594323/debug.zip)

#### Due diligence
- [X] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
