### PR TITLE
Add check for valid zip contents during import

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
@@ -15,6 +15,7 @@ import androidx.core.content.ContextCompat;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceManager;
 
+import com.google.android.material.snackbar.Snackbar;
 import com.nononsenseapps.filepicker.Utils;
 import com.nostra13.universalimageloader.core.ImageLoader;
 
@@ -214,6 +215,19 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
         try {
             if (!manager.ensureDbDirectoryExists()) {
                 throw new Exception("Could not create databases dir");
+            }
+
+            if (!manager.isValidBackupFile(filePath)) {
+                final Snackbar snackbar = Snackbar.make(
+                        requireActivity().findViewById(android.R.id.content),
+                        getString(R.string.no_valid_zip_file), Snackbar.LENGTH_LONG);
+                snackbar.setDuration(3000);
+                snackbar.setAction(R.string.show_info, v -> {
+                    snackbar.dismiss();
+                    onError(new Exception("The provided zip was not created by NewPipe."));
+                });
+                snackbar.show();
+                return;
             }
 
             if (!manager.extractDb(filePath)) {

--- a/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
@@ -116,6 +116,7 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
         final Preference importDataPreference = findPreference(getString(R.string.import_data));
         importDataPreference.setOnPreferenceClickListener(p -> {
             final Intent i = new Intent(getActivity(), FilePickerActivityHelper.class)
+                    .putExtra(FilePickerActivityHelper.EXTRA_FILTER_EXTENSION, "zip")
                     .putExtra(FilePickerActivityHelper.EXTRA_ALLOW_MULTIPLE, false)
                     .putExtra(FilePickerActivityHelper.EXTRA_ALLOW_CREATE_DIR, false)
                     .putExtra(FilePickerActivityHelper.EXTRA_MODE,

--- a/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsManager.kt
@@ -8,6 +8,7 @@ import java.io.FileOutputStream
 import java.io.IOException
 import java.io.ObjectInputStream
 import java.io.ObjectOutputStream
+import java.util.zip.ZipFile
 import java.util.zip.ZipOutputStream
 
 class ContentSettingsManager(private val fileLocator: NewPipeFileLocator) {
@@ -46,6 +47,33 @@ class ContentSettingsManager(private val fileLocator: NewPipeFileLocator) {
      */
     fun ensureDbDirectoryExists(): Boolean {
         return fileLocator.dbDir.exists() || fileLocator.dbDir.mkdir()
+    }
+
+    fun isValidBackupFile(filePath: String): Boolean {
+        try {
+            val zipFile = ZipFile(filePath)
+            if (zipFile.size() != 2)
+                return false
+
+            val entries = zipFile.entries()
+            var containsDbFile = false
+            var containsSettingsFile = false
+
+            while (entries.hasMoreElements()) {
+                val entry = entries.nextElement()
+                if (entry.name == "newpipe.db")
+                    containsDbFile = true
+                else if (entry.name == "newpipe.settings")
+                    containsSettingsFile = true
+            }
+
+            return containsDbFile && containsSettingsFile
+        } catch (e: IOException) {
+            e.printStackTrace()
+        } catch (e: IllegalStateException) {
+            e.printStackTrace()
+        }
+        return false
     }
 
     fun extractDb(filePath: String): Boolean {

--- a/app/src/test/java/org/schabi/newpipe/settings/ContentSettingsManagerTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/settings/ContentSettingsManagerTest.kt
@@ -167,6 +167,18 @@ class ContentSettingsManagerTest {
     }
 
     @Test
+    fun `IsValid must return false if the zip has not the two necessary files`() {
+        val newpipe = File(classloader.getResource("settings/newpipe.zip")?.file!!)
+        val empty = File(classloader.getResource("settings/empty.zip")?.file!!)
+
+        val newpipeValid = ContentSettingsManager(fileLocator).isValidBackupFile(newpipe.path)
+        val emptyValid = ContentSettingsManager(fileLocator).isValidBackupFile(empty.path)
+
+        assertTrue(newpipeValid)
+        assertFalse(emptyValid)
+    }
+
+    @Test
     fun `Preferences must be set from the settings file`() {
         val settings = File(classloader.getResource("settings/newpipe.settings")!!.path)
         `when`(fileLocator.settings).thenReturn(settings)


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
This PR 
- adds a filter to the import FilePicker, so that only zip files are shown (no more possible to pick a wrong type)
- adds the method `isValidBackupFile` to `ContentsettingsManager` (in short: checks whether the zip has exactly 2 files and whether they're the necessary ones)
- shows a `SnackBar` if the zip is invalid with the action "Show info" which throws `onError` (that the zip file wasn't created by NewPipe)

#### Fixes the following issue(s)
<!-- Also add any other links relevant to your change. -->
- fixes #5055 

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
