### PR TITLE
Extract export database logic into own class

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
@@ -30,25 +30,23 @@ import org.schabi.newpipe.report.UserAction;
 import org.schabi.newpipe.util.FilePickerActivityHelper;
 import org.schabi.newpipe.util.ZipHelper;
 
-import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 import java.util.Map;
 import java.util.zip.ZipFile;
-import java.util.zip.ZipOutputStream;
 
 import static org.schabi.newpipe.util.Localization.assureCorrectAppLanguage;
 
 public class ContentSettingsFragment extends BasePreferenceFragment {
     private static final int REQUEST_IMPORT_PATH = 8945;
     private static final int REQUEST_EXPORT_PATH = 30945;
+
+    private ContentSettingsManager manager;
 
     private File databasesDir;
     private File newpipeDb;
@@ -131,6 +129,8 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
         newpipeSettings = new File(homeDir + "/databases/newpipe.settings");
         newpipeSettings.delete();
 
+        manager = new ContentSettingsManager(homeDir);
+
         addPreferencesFromResource(R.xml.content_settings);
 
         final Preference importDataPreference = findPreference(getString(R.string.import_data));
@@ -212,30 +212,13 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
             //checkpoint before export
             NewPipeDatabase.checkpoint();
 
-            try (ZipOutputStream outZip = new ZipOutputStream(new BufferedOutputStream(
-                            new FileOutputStream(path)))) {
-                ZipHelper.addFileToZip(outZip, newpipeDb.getPath(), "newpipe.db");
+            final SharedPreferences preferences = PreferenceManager
+                .getDefaultSharedPreferences(requireContext());
+            manager.exportDatabase(preferences, path);
 
-                saveSharedPreferencesToFile(newpipeSettings);
-                ZipHelper.addFileToZip(outZip, newpipeSettings.getPath(),
-                        "newpipe.settings");
-            }
-
-            Toast.makeText(getContext(), R.string.export_complete_toast, Toast.LENGTH_SHORT)
-                    .show();
+            Toast.makeText(getContext(), R.string.export_complete_toast, Toast.LENGTH_SHORT).show();
         } catch (final Exception e) {
             onError(e);
-        }
-    }
-
-    private void saveSharedPreferencesToFile(final File dst) {
-        try (ObjectOutputStream output = new ObjectOutputStream(new FileOutputStream(dst))) {
-            final SharedPreferences pref
-                    = PreferenceManager.getDefaultSharedPreferences(requireContext());
-            output.writeObject(pref.getAll());
-            output.flush();
-        } catch (final IOException e) {
-            e.printStackTrace();
         }
     }
 

--- a/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsManager.kt
@@ -1,0 +1,45 @@
+package org.schabi.newpipe.settings
+
+import android.content.SharedPreferences
+import org.schabi.newpipe.util.ZipHelper
+import java.io.BufferedOutputStream
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.io.ObjectOutputStream
+import java.lang.Exception
+import java.util.zip.ZipOutputStream
+
+class ContentSettingsManager(
+    private val newpipeDb: File,
+    private val newpipeSettings: File
+) {
+
+    constructor(homeDir: String) : this(
+        File("$homeDir/databases/newpipe.db"),
+        File("$homeDir/databases/newpipe.settings")
+    )
+
+    /**
+     * Exports given [SharedPreferences] to the file in given outputPath.
+     * It also creates the file.
+     */
+    @Throws(Exception::class)
+    fun exportDatabase(preferences: SharedPreferences, outputPath: String) {
+        ZipOutputStream(BufferedOutputStream(FileOutputStream(outputPath)))
+            .use { outZip ->
+                ZipHelper.addFileToZip(outZip, newpipeDb.path, "newpipe.db")
+
+                try {
+                    ObjectOutputStream(FileOutputStream(newpipeSettings)).use { output ->
+                        output.writeObject(preferences.all)
+                        output.flush()
+                    }
+                } catch (e: IOException) {
+                    e.printStackTrace()
+                }
+
+                ZipHelper.addFileToZip(outZip, newpipeSettings.path, "newpipe.settings")
+            }
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/settings/ContentSettingsManagerTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/settings/ContentSettingsManagerTest.kt
@@ -1,0 +1,72 @@
+package org.schabi.newpipe.settings
+
+import android.content.SharedPreferences
+import org.junit.Assert
+import org.junit.Assume
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Suite
+import org.mockito.Mockito
+import org.mockito.Mockito.`when`
+import org.mockito.junit.MockitoJUnitRunner
+import org.schabi.newpipe.settings.ContentSettingsManagerTest.ExportTest
+import java.io.File
+import java.io.ObjectInputStream
+import java.util.zip.ZipFile
+
+@RunWith(Suite::class)
+@Suite.SuiteClasses(ExportTest::class)
+class ContentSettingsManagerTest {
+
+    @RunWith(MockitoJUnitRunner::class)
+    class ExportTest {
+
+        private lateinit var preferences: SharedPreferences
+        private lateinit var newpipeDb: File
+        private lateinit var newpipeSettings: File
+
+        @Before
+        fun beforeClass() {
+
+            val dbPath = javaClass.classLoader?.getResource("settings/newpipe.db")?.file
+            val settingsPath = javaClass.classLoader?.getResource("settings/newpipe.settings")?.path
+            Assume.assumeNotNull(dbPath)
+            Assume.assumeNotNull(settingsPath)
+
+            newpipeDb = File(dbPath!!)
+            newpipeSettings = File(settingsPath!!)
+        }
+
+        @Before
+        fun before() {
+            preferences = Mockito.mock(SharedPreferences::class.java, Mockito.withSettings().stubOnly())
+        }
+
+        @Test
+        fun `The settings must be exported successfully in the correct format`() {
+            val expectedPreferences = mapOf("such pref" to "much wow")
+            `when`(preferences.all).thenReturn(expectedPreferences)
+
+            val manager = ContentSettingsManager(newpipeDb, newpipeSettings)
+
+            val output = File.createTempFile("newpipe_", "")
+            manager.exportDatabase(preferences, output.absolutePath)
+
+            val zipFile = ZipFile(output.absoluteFile)
+            val entries = zipFile.entries().toList()
+            Assert.assertEquals(2, entries.size)
+
+            zipFile.getInputStream(entries.first { it.name == "newpipe.db" }).use { actual ->
+                newpipeDb.inputStream().use { expected ->
+                    Assert.assertEquals(expected.reader().readText(), actual.reader().readText())
+                }
+            }
+
+            zipFile.getInputStream(entries.first { it.name == "newpipe.settings" }).use { actual ->
+                val actualPreferences = ObjectInputStream(actual).readObject()
+                Assert.assertEquals(expectedPreferences, actualPreferences)
+            }
+        }
+    }
+}

--- a/app/src/test/resources/settings/newpipe.db
+++ b/app/src/test/resources/settings/newpipe.db
@@ -1,0 +1,1 @@
+such db much wow

--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -17,7 +17,7 @@
 
   <suppress checks="EmptyBlock"
       files="ContentSettingsFragment.java"
-      lines="244,245"/>
+      lines="227,245"/>
 
   <!-- org.schabi.newpipe.streams -->
   <suppress checks="LineLength"


### PR DESCRIPTION

<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Codebase improvement (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Separate database/settings generation logic from the UI.
- Add happy path unit test.

With this seperation, unit tests can be introduced. I just added one as proof of concept for now.
If this style is ok i would work on extracting more stuff out.

This also allows cheap unit tests instead of comparatively expensive androidTests.

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/5624885/app-debug.zip)


#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
