### PR TITLE
Fix crash deleting video refreshing

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/database/playlist/PlaylistStreamEntry.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/playlist/PlaylistStreamEntry.kt
@@ -9,7 +9,7 @@ import org.schabi.newpipe.database.stream.model.StreamStateEntity
 import org.schabi.newpipe.extractor.stream.StreamInfoItem
 import kotlin.jvm.Throws
 
-class PlaylistStreamEntry(
+data class PlaylistStreamEntry(
     @Embedded
     val streamEntity: StreamEntity,
 
@@ -35,21 +35,5 @@ class PlaylistStreamEntry(
 
     override fun getLocalItemType(): LocalItem.LocalItemType {
         return LocalItem.LocalItemType.PLAYLIST_STREAM_ITEM
-    }
-
-    override fun equals(other: Any?): Boolean {
-        if (other == null || other !is PlaylistStreamEntry || streamEntity != other.streamEntity ||
-                progressTime != other.progressTime || streamId != other.streamId || joinIndex != other.joinIndex
-        ) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = streamEntity.hashCode()
-        result = 31 * result + progressTime.hashCode()
-        result = 31 * result + streamId.hashCode()
-        result = 31 * result + joinIndex
-        return result
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/database/playlist/PlaylistStreamEntry.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/playlist/PlaylistStreamEntry.kt
@@ -7,7 +7,6 @@ import org.schabi.newpipe.database.playlist.model.PlaylistStreamEntity
 import org.schabi.newpipe.database.stream.model.StreamEntity
 import org.schabi.newpipe.database.stream.model.StreamStateEntity
 import org.schabi.newpipe.extractor.stream.StreamInfoItem
-import kotlin.jvm.Throws
 
 class PlaylistStreamEntry(
     @Embedded
@@ -35,5 +34,21 @@ class PlaylistStreamEntry(
 
     override fun getLocalItemType(): LocalItem.LocalItemType {
         return LocalItem.LocalItemType.PLAYLIST_STREAM_ITEM
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (other == null || other !is PlaylistStreamEntry || streamEntity != other.streamEntity ||
+                progressTime != other.progressTime || streamId != other.streamId || joinIndex != other.joinIndex
+        ) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = streamEntity.hashCode()
+        result = 31 * result + progressTime.hashCode()
+        result = 31 * result + streamId.hashCode()
+        result = 31 * result + joinIndex
+        return result
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/database/playlist/PlaylistStreamEntry.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/playlist/PlaylistStreamEntry.kt
@@ -7,6 +7,7 @@ import org.schabi.newpipe.database.playlist.model.PlaylistStreamEntity
 import org.schabi.newpipe.database.stream.model.StreamEntity
 import org.schabi.newpipe.database.stream.model.StreamStateEntity
 import org.schabi.newpipe.extractor.stream.StreamInfoItem
+import kotlin.jvm.Throws
 
 class PlaylistStreamEntry(
     @Embedded


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Method equals has been overridden in the PlaylistStreamEntry class so that the index (in the method 'removeItem' in the Class LocalItemListAdapter) does not return '-1' if the memory address is not the same. In this method, I compare all the different attributes to make sure it's the same object. The hashCode method was generated by Android Studio.

#### Fixes the following issue(s)
<!-- Also add any other links relevant to your change. -->
-  fixes #4874

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
app-deleting-video-refreshing-crashfix.zip

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
