### PR TITLE
Use a notification instead of a ProgressDialog in MissionAdapter.

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/App.java
+++ b/app/src/main/java/org/schabi/newpipe/App.java
@@ -242,8 +242,9 @@ public class App extends MultiDexApplication {
         String name = getString(R.string.notification_channel_name);
         String description = getString(R.string.notification_channel_description);
 
-        // Keep this below DEFAULT to avoid making noise on every notification update
-        final int importance = NotificationManager.IMPORTANCE_LOW;
+        // Keep this below DEFAULT to avoid making noise on every notification update for the main
+        // and update channels
+        int importance = NotificationManager.IMPORTANCE_LOW;
 
         final NotificationChannel mainChannel = new NotificationChannel(id, name, importance);
         mainChannel.setDescription(description);
@@ -255,9 +256,17 @@ public class App extends MultiDexApplication {
         final NotificationChannel appUpdateChannel = new NotificationChannel(id, name, importance);
         appUpdateChannel.setDescription(description);
 
+        id = getString(R.string.hash_channel_id);
+        name = getString(R.string.hash_channel_name);
+        description = getString(R.string.hash_channel_description);
+        importance = NotificationManager.IMPORTANCE_HIGH;
+
+        final NotificationChannel hashChannel = new NotificationChannel(id, name, importance);
+        hashChannel.setDescription(description);
+
         final NotificationManager notificationManager = getSystemService(NotificationManager.class);
         notificationManager.createNotificationChannels(Arrays.asList(mainChannel,
-                appUpdateChannel));
+                appUpdateChannel, hashChannel));
     }
 
     protected boolean isDisposedRxExceptionsReported() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -195,6 +195,9 @@
     <string name="app_update_notification_channel_id" translatable="false">newpipeAppUpdate</string>
     <string name="app_update_notification_channel_name">App Update Notification</string>
     <string name="app_update_notification_channel_description">Notifications for new NewPipe version</string>
+    <string name="hash_channel_id" translatable="false">newpipeHash</string>
+    <string name="hash_channel_name">Video Hash Notification</string>
+    <string name="hash_channel_description">Notifications for video hashing progress</string>
     <string name="unknown_content">[Unknown]</string>
     <string name="toggle_orientation">Toggle Orientation</string>
     <string name="switch_to_background">Switch to Background</string>
@@ -347,6 +350,7 @@
     <string name="msg_url_malform">Malformed URL or Internet not available</string>
     <string name="msg_running">NewPipe Downloading</string>
     <string name="msg_running_detail">Tap for details</string>
+    <string name="msg_calculating_hash">Calculating hash</string>
     <string name="msg_wait">Please wait…</string>
     <string name="msg_copied">Copied to clipboard</string>
     <string name="no_available_dir">Please define a download folder later in settings</string>


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Display the progress of the hash calculation in `MissionAdapter` using a notification instead of a `ProgressDialog`, as the latter has been deprecated in favor of either a `ProgressBar` or a progress notification.

![Screenshot_20201211-074647748](https://user-images.githubusercontent.com/31027858/101854325-53f32700-3b87-11eb-9fc8-f1b934d1f05d.jpg)

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/5676788/app-debug.zip)

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
