### PR TITLE
Fix compile error caused by auto merging

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsManager.kt
@@ -15,9 +15,9 @@ class ContentSettingsManager(
     private val newpipeSettings: File
 ) {
 
-    constructor(homeDir: String) : this(
-        File("$homeDir/databases/newpipe.db"),
-        File("$homeDir/databases/newpipe.settings")
+    constructor(homeDir: File) : this(
+        File(homeDir, "databases/newpipe.db"),
+        File(homeDir, "databases/newpipe.settings")
     )
 
     /**


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#5176 changed `homeDir` from type `String` to `File`. #5059 was based on `homeDir` being a `String`. It was incorrectly auto-resolved by git.

@TobiGr @Stypox 
