### PR TITLE
Use @BeforeClass for ContentSettingsManagerTest.beforeClass

### DIFF
--- a/app/src/test/java/org/schabi/newpipe/settings/ContentSettingsManagerTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/settings/ContentSettingsManagerTest.kt
@@ -4,6 +4,7 @@ import android.content.SharedPreferences
 import org.junit.Assert
 import org.junit.Assume
 import org.junit.Before
+import org.junit.BeforeClass
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Suite
@@ -22,24 +23,27 @@ class ContentSettingsManagerTest {
     @RunWith(MockitoJUnitRunner::class)
     class ExportTest {
 
-        private lateinit var preferences: SharedPreferences
-        private lateinit var newpipeDb: File
-        private lateinit var newpipeSettings: File
+        companion object {
+            private lateinit var newpipeDb: File
+            private lateinit var newpipeSettings: File
 
-        @Before
-        fun beforeClass() {
+            @JvmStatic
+            @BeforeClass
+            fun setupFiles() {
+                val dbPath = ExportTest::class.java.classLoader?.getResource("settings/newpipe.db")?.file
+                val settingsPath = ExportTest::class.java.classLoader?.getResource("settings/newpipe.settings")?.path
+                Assume.assumeNotNull(dbPath)
+                Assume.assumeNotNull(settingsPath)
 
-            val dbPath = javaClass.classLoader?.getResource("settings/newpipe.db")?.file
-            val settingsPath = javaClass.classLoader?.getResource("settings/newpipe.settings")?.path
-            Assume.assumeNotNull(dbPath)
-            Assume.assumeNotNull(settingsPath)
-
-            newpipeDb = File(dbPath!!)
-            newpipeSettings = File(settingsPath!!)
+                newpipeDb = File(dbPath!!)
+                newpipeSettings = File(settingsPath!!)
+            }
         }
 
+        private lateinit var preferences: SharedPreferences
+
         @Before
-        fun before() {
+        fun setupMocks() {
             preferences = Mockito.mock(SharedPreferences::class.java, Mockito.withSettings().stubOnly())
         }
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Make initialization of `File`s in `ContentSettingsManagerTest.ExportTest` only run once per class and not before each test. They are only read from.

#### Fixes the following issue(s)
<!-- Also add any other links relevant to your change. -->
- followup to https://github.com/TeamNewPipe/NewPipe/pull/5059#discussion_r543297621

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
