### PR TITLE
Remove pbj=1 parameter from YouYube urls in recaptcha activity

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/ReCaptchaActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/ReCaptchaActivity.java
@@ -53,6 +53,16 @@ public class ReCaptchaActivity extends AppCompatActivity {
     public static final String YT_URL = "https://www.youtube.com";
     public static final String RECAPTCHA_COOKIES_KEY = "recaptcha_cookies";
 
+    public static String sanitizeRecaptchaUrl(@Nullable final String url) {
+        if (url == null || url.trim().isEmpty()) {
+            return YT_URL; // YouTube is the most likely service to have thrown a recaptcha
+        } else {
+            // remove "pbj=1" parameter from YouYube urls, as it makes the page JSON and not HTML
+            return url.replace("&pbj=1", "").replace("pbj=1&", "").replace("?pbj=1", "");
+        }
+    }
+
+
     private WebView webView;
     private String foundCookies = "";
 
@@ -64,14 +74,9 @@ public class ReCaptchaActivity extends AppCompatActivity {
         final Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
 
-        String url = getIntent().getStringExtra(RECAPTCHA_URL_EXTRA);
-        if (url == null || url.isEmpty()) {
-            url = YT_URL;
-        }
-
+        final String url = sanitizeRecaptchaUrl(getIntent().getStringExtra(RECAPTCHA_URL_EXTRA));
         // set return to Cancel by default
         setResult(RESULT_CANCELED);
-
 
         webView = findViewById(R.id.reCaptchaWebView);
 

--- a/app/src/test/java/org/schabi/newpipe/ReCaptchaActivityTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/ReCaptchaActivityTest.kt
@@ -1,0 +1,27 @@
+package org.schabi.newpipe
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.schabi.newpipe.ReCaptchaActivity.YT_URL
+
+class ReCaptchaActivityTest {
+    private fun assertSanitized(expected: String, actual: String?) {
+        assertEquals(expected, ReCaptchaActivity.sanitizeRecaptchaUrl(actual))
+    }
+
+    @Test fun `null, empty or blank url is sanitized correctly`() {
+        assertSanitized(YT_URL, null)
+        assertSanitized(YT_URL, "")
+        assertSanitized(YT_URL, "  \n \t ")
+    }
+
+    @Test fun `YouTube url containing pbj=1 is sanitized correctly`() {
+        val sanitizedUrl = "https://m.youtube.com/results?search_query=test"
+        assertSanitized(sanitizedUrl, "https://m.youtube.com/results?search_query=test")
+        assertSanitized(sanitizedUrl, "https://m.youtube.com/results?search_query=test&pbj=1&pbj=1")
+        assertSanitized(sanitizedUrl, "https://m.youtube.com/results?pbj=1&search_query=test")
+        assertSanitized("pbj://pbj.pbj.pbj/pbj", "pbj://pbj.pbj.pbj/pbj?pbj=1")
+        assertSanitized("http://www.host.com/b?p1=7&p2=9", "http://www.host.com/b?p1=7&pbj=1&p2=9")
+        assertSanitized("http://www.host.com/a?pbj=0", "http://www.host.com/a?pbj=0")
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/ktx/OffsetDateTimeToCalendarTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/ktx/OffsetDateTimeToCalendarTest.kt
@@ -4,7 +4,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.time.LocalDate
 import java.time.OffsetDateTime
-import java.time.ZoneId
 import java.time.ZoneOffset
 import java.util.Calendar
 import java.util.TimeZone
@@ -13,7 +12,7 @@ class OffsetDateTimeToCalendarTest {
     @Test
     fun testRelativeTimeWithCurrentOffsetDateTime() {
         val calendar = LocalDate.of(2020, 1, 1).atStartOfDay().atOffset(ZoneOffset.UTC)
-                .toCalendar()
+            .toCalendar()
 
         assertEquals(2020, calendar[Calendar.YEAR])
         assertEquals(0, calendar[Calendar.MONTH])


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This PR removes the `pbj=1` parameter from the URLs loaded in the reCAPTCHA webview, so that an actual HTML page is loaded instead of the ajax json requested by the extractor, which would render as a blank page.

#### Fixes the following issue(s)
Hopefully fixes #3714

#### APK testing 
This apk throws a `ReCaptchaException` on every request, with the first request being the "test" search, always run on app opening.
[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/5710472/app-debug.zip)

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
