### PR TITLE
Dynamically get package name

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/App.java
+++ b/app/src/main/java/org/schabi/newpipe/App.java
@@ -67,8 +67,10 @@ import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 public class App extends MultiDexApplication {
     protected static final String TAG = App.class.toString();
     private static App app;
+    public static final String PACKAGE_NAME = BuildConfig.APPLICATION_ID;
 
-    @Nullable private Disposable disposable = null;
+    @Nullable
+    private Disposable disposable = null;
 
     @NonNull
     public static App getApp() {

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -145,15 +145,15 @@ public final class VideoDetailFragment
     private static final float MAX_PLAYER_HEIGHT = 0.7f;
 
     public static final String ACTION_SHOW_MAIN_PLAYER =
-            "org.schabi.newpipe.VideoDetailFragment.ACTION_SHOW_MAIN_PLAYER";
+            App.PACKAGE_NAME + ".VideoDetailFragment.ACTION_SHOW_MAIN_PLAYER";
     public static final String ACTION_HIDE_MAIN_PLAYER =
-            "org.schabi.newpipe.VideoDetailFragment.ACTION_HIDE_MAIN_PLAYER";
+            App.PACKAGE_NAME + ".VideoDetailFragment.ACTION_HIDE_MAIN_PLAYER";
     public static final String ACTION_PLAYER_STARTED =
-            "org.schabi.newpipe.VideoDetailFragment.ACTION_PLAYER_STARTED";
+            App.PACKAGE_NAME + ".VideoDetailFragment.ACTION_PLAYER_STARTED";
     public static final String ACTION_VIDEO_FRAGMENT_RESUMED =
-            "org.schabi.newpipe.VideoDetailFragment.ACTION_VIDEO_FRAGMENT_RESUMED";
+            App.PACKAGE_NAME + ".VideoDetailFragment.ACTION_VIDEO_FRAGMENT_RESUMED";
     public static final String ACTION_VIDEO_FRAGMENT_STOPPED =
-            "org.schabi.newpipe.VideoDetailFragment.ACTION_VIDEO_FRAGMENT_STOPPED";
+            App.PACKAGE_NAME + ".VideoDetailFragment.ACTION_VIDEO_FRAGMENT_STOPPED";
 
     private static final String COMMENTS_TAB_TAG = "COMMENTS";
     private static final String RELATED_TAB_TAG = "NEXT VIDEO";
@@ -494,10 +494,10 @@ public final class VideoDetailFragment
 
                     final PlaylistAppendDialog d = PlaylistAppendDialog.fromStreamInfo(currentInfo);
                     disposables.add(
-                        PlaylistAppendDialog.onPlaylistFound(getContext(),
-                            () -> d.show(getFM(), TAG),
-                            () -> PlaylistCreationDialog.newInstance(d).show(getFM(), TAG)
-                        )
+                            PlaylistAppendDialog.onPlaylistFound(getContext(),
+                                    () -> d.show(getFM(), TAG),
+                                    () -> PlaylistCreationDialog.newInstance(d).show(getFM(), TAG)
+                            )
                     );
                 }
                 break;

--- a/app/src/main/java/org/schabi/newpipe/local/feed/service/FeedLoadService.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/service/FeedLoadService.kt
@@ -43,6 +43,7 @@ import io.reactivex.rxjava3.processors.PublishProcessor
 import io.reactivex.rxjava3.schedulers.Schedulers
 import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
+import org.schabi.newpipe.App
 import org.schabi.newpipe.MainActivity.DEBUG
 import org.schabi.newpipe.R
 import org.schabi.newpipe.database.feed.model.FeedGroupEntity
@@ -68,7 +69,7 @@ class FeedLoadService : Service() {
     companion object {
         private val TAG = FeedLoadService::class.java.simpleName
         private const val NOTIFICATION_ID = 7293450
-        private const val ACTION_CANCEL = "org.schabi.newpipe.local.feed.service.FeedLoadService.CANCEL"
+        private const val ACTION_CANCEL = App.PACKAGE_NAME + ".local.feed.service.FeedLoadService.CANCEL"
 
         /**
          * How often the notification will be updated.

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/services/SubscriptionsExportService.java
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/services/SubscriptionsExportService.java
@@ -27,6 +27,7 @@ import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
+import org.schabi.newpipe.App;
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.database.subscription.SubscriptionEntity;
 import org.schabi.newpipe.extractor.subscription.SubscriptionItem;
@@ -50,7 +51,7 @@ public class SubscriptionsExportService extends BaseImportExportService {
      * A {@link LocalBroadcastManager local broadcast} will be made with this action
      * when the export is successfully completed.
      */
-    public static final String EXPORT_COMPLETE_ACTION = "org.schabi.newpipe.local.subscription"
+    public static final String EXPORT_COMPLETE_ACTION = App.PACKAGE_NAME + ".local.subscription"
             + ".services.SubscriptionsExportService.EXPORT_COMPLETE";
 
     private Subscription subscription;

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/services/SubscriptionsImportService.java
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/services/SubscriptionsImportService.java
@@ -29,6 +29,7 @@ import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
+import org.schabi.newpipe.App;
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.database.subscription.SubscriptionEntity;
 import org.schabi.newpipe.extractor.NewPipe;
@@ -66,7 +67,7 @@ public class SubscriptionsImportService extends BaseImportExportService {
      * A {@link LocalBroadcastManager local broadcast} will be made with this action
      * when the import is successfully completed.
      */
-    public static final String IMPORT_COMPLETE_ACTION = "org.schabi.newpipe.local.subscription"
+    public static final String IMPORT_COMPLETE_ACTION = App.PACKAGE_NAME + ".local.subscription"
             + ".services.SubscriptionsImportService.IMPORT_COMPLETE";
 
     /**

--- a/app/src/main/java/org/schabi/newpipe/player/MainPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/MainPlayer.java
@@ -33,6 +33,7 @@ import android.view.WindowManager;
 import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
 
+import org.schabi.newpipe.App;
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.util.ThemeHelper;
 
@@ -64,25 +65,25 @@ public final class MainPlayer extends Service {
     //////////////////////////////////////////////////////////////////////////*/
 
     static final String ACTION_CLOSE
-            = "org.schabi.newpipe.player.MainPlayer.CLOSE";
+            = App.PACKAGE_NAME + ".player.MainPlayer.CLOSE";
     static final String ACTION_PLAY_PAUSE
-            = "org.schabi.newpipe.player.MainPlayer.PLAY_PAUSE";
+            = App.PACKAGE_NAME + ".player.MainPlayer.PLAY_PAUSE";
     static final String ACTION_OPEN_CONTROLS
-            = "org.schabi.newpipe.player.MainPlayer.OPEN_CONTROLS";
+            = App.PACKAGE_NAME + ".player.MainPlayer.OPEN_CONTROLS";
     static final String ACTION_REPEAT
-            = "org.schabi.newpipe.player.MainPlayer.REPEAT";
+            = App.PACKAGE_NAME + ".player.MainPlayer.REPEAT";
     static final String ACTION_PLAY_NEXT
-            = "org.schabi.newpipe.player.MainPlayer.ACTION_PLAY_NEXT";
+            = App.PACKAGE_NAME + ".player.MainPlayer.ACTION_PLAY_NEXT";
     static final String ACTION_PLAY_PREVIOUS
-            = "org.schabi.newpipe.player.MainPlayer.ACTION_PLAY_PREVIOUS";
+            = App.PACKAGE_NAME + ".player.MainPlayer.ACTION_PLAY_PREVIOUS";
     static final String ACTION_FAST_REWIND
-            = "org.schabi.newpipe.player.MainPlayer.ACTION_FAST_REWIND";
+            = App.PACKAGE_NAME + ".player.MainPlayer.ACTION_FAST_REWIND";
     static final String ACTION_FAST_FORWARD
-            = "org.schabi.newpipe.player.MainPlayer.ACTION_FAST_FORWARD";
+            = App.PACKAGE_NAME + ".player.MainPlayer.ACTION_FAST_FORWARD";
     static final String ACTION_SHUFFLE
-            = "org.schabi.newpipe.player.MainPlayer.ACTION_SHUFFLE";
+            = App.PACKAGE_NAME + ".player.MainPlayer.ACTION_SHUFFLE";
     public static final String ACTION_RECREATE_NOTIFICATION
-            = "org.schabi.newpipe.player.MainPlayer.ACTION_RECREATE_NOTIFICATION";
+            = App.PACKAGE_NAME + ".player.MainPlayer.ACTION_RECREATE_NOTIFICATION";
 
     /*//////////////////////////////////////////////////////////////////////////
     // Service's LifeCycle


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- remove usage of harcoded package name `org.schabi.newpipe`
- it fixes issues with forks or debug builds, e.g. when you open two newpipe apps (with debug or fork apps), close one notification, it closes all newpipe notifications

#### Fixes the following issue(s)
<!-- Also add any other links relevant to your change. -->
- fixes https://github.com/TeamNewPipe/NewPipe/issues/4653
- https://github.com/TeamNewPipe/NewPipe/issues/4653#issuecomment-717509756
- When you pause a video, it resumes on the other newpipe instance
- https://github.com/polymorphicshade/NewPipe/issues/18
- other related bugs



#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
