### PR TITLE
Remove timestamp from share url for all services except youtube

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/VideoPlayerImpl.java
+++ b/app/src/main/java/org/schabi/newpipe/player/VideoPlayerImpl.java
@@ -103,6 +103,7 @@ import org.schabi.newpipe.util.ShareUtils;
 
 import java.util.List;
 
+import static org.schabi.newpipe.extractor.ServiceList.YouTube;
 import static org.schabi.newpipe.player.MainPlayer.ACTION_CLOSE;
 import static org.schabi.newpipe.player.MainPlayer.ACTION_FAST_FORWARD;
 import static org.schabi.newpipe.player.MainPlayer.ACTION_FAST_REWIND;
@@ -889,10 +890,17 @@ public class VideoPlayerImpl extends VideoPlayer
     private void onShareClicked() {
         // share video at the current time (youtube.com/watch?v=ID&t=SECONDS)
         // Timestamp doesn't make sense in a live stream so drop it
-        final String ts = isLive() ? "" : ("&t=" + (getPlaybackSeekBar().getProgress() / 1000));
+
+        final int ts = getPlaybackSeekBar().getProgress() / 1000;
+        final MediaSourceTag metadata = getCurrentMetadata();
+        String videoUrl = getVideoUrl();
+        if (!isLive() && ts >= 0 && metadata != null
+                && metadata.getMetadata().getServiceId() == YouTube.getServiceId()) {
+            videoUrl += ("&t=" + ts);
+        }
         ShareUtils.shareUrl(service,
                 getVideoTitle(),
-                getVideoUrl() + ts);
+                videoUrl);
     }
 
     private void onPlayWithKodiClicked() {


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
Remove timestamp from share url unless it's youtube.
It produced not found error for PeerTube, media.ccc.de, SoundCloud.

Ideally we should implement this
https://github.com/TeamNewPipe/NewPipe/issues/4316#issuecomment-698948468
> we also shouldn't even use URL there client-side, but add an extractor-side API for getting an URL with timestamp.

but it has been three months and no one is willing to work on this, then I'd like to get this PR merged for the next release.

#### Fixes the following issue(s)
<!-- Also add any other links relevant to your change. -->
- fixes https://github.com/TeamNewPipe/NewPipe/issues/4316

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/5720264/app-debug.zip)
#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
