### PR TITLE
[media.ccc.de] Fix service color

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -266,7 +266,7 @@
                 <data android:mimeType="text/plain" />
             </intent-filter>
 
-            <!-- MediaCCC filter -->
+            <!-- media.ccc.de filter -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.media.action.MEDIA_PLAY_FROM_SEARCH" />

--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -129,7 +129,7 @@ public class MainActivity extends AppCompatActivity {
                     + "savedInstanceState = [" + savedInstanceState + "]");
         }
 
-        // enable TLS1.1/1.2 for kitkat devices, to fix download and play for mediaCCC sources
+        // enable TLS1.1/1.2 for kitkat devices, to fix download and play for media.ccc.de sources
         if (Build.VERSION.SDK_INT == Build.VERSION_CODES.KITKAT) {
             TLSSocketFactoryCompat.setAsDefault();
         }

--- a/app/src/main/res/values-v21/styles_services.xml
+++ b/app/src/main/res/values-v21/styles_services.xml
@@ -12,6 +12,7 @@
     <style name="BlackTheme.YouTube" parent="BlackTheme">
         <item name="colorPrimaryDark">@color/dark_youtube_statusbar_color</item>
     </style>
+
     <!-- SoundCloud -->
     <style name="LightTheme.SoundCloud" parent="LightTheme">
         <item name="colorPrimary">@color/light_soundcloud_primary_color</item>
@@ -50,20 +51,20 @@
         <item name="colorAccent">@color/dark_peertube_accent_color</item>
     </style>
 
-    <!-- Media.ccc -->
-    <style name="LightTheme.MediaCCC" parent="LightTheme">
+    <!-- media.ccc.de -->
+    <style name="LightTheme.media.ccc.de" parent="LightTheme">
         <item name="colorPrimary">@color/light_media_ccc_primary_color</item>
         <item name="colorPrimaryDark">@color/light_media_ccc_statusbar_color</item>
         <item name="colorAccent">@color/light_media_ccc_accent_color</item>
     </style>
 
-    <style name="DarkTheme.MediaCCC" parent="DarkTheme">
+    <style name="DarkTheme.media.ccc.de" parent="DarkTheme">
         <item name="colorPrimary">@color/dark_media_ccc_primary_color</item>
         <item name="colorPrimaryDark">@color/dark_media_ccc_statusbar_color</item>
         <item name="colorAccent">@color/dark_media_ccc_accent_color</item>
     </style>
 
-    <style name="BlackTheme.MediaCCC" parent="BlackTheme">
+    <style name="BlackTheme.media.ccc.de" parent="BlackTheme">
         <item name="colorPrimary">@color/dark_media_ccc_primary_color</item>
         <item name="colorPrimaryDark">@color/dark_media_ccc_statusbar_color</item>
         <item name="colorAccent">@color/dark_media_ccc_accent_color</item>

--- a/app/src/main/res/values/colors_services.xml
+++ b/app/src/main/res/values/colors_services.xml
@@ -33,7 +33,7 @@
     <color name="dark_peertube_accent_color">#FFFFFF</color>
     <color name="dark_peertube_statusbar_color">#ff6f00</color>
 
-    <!-- Media.CCC -->
+    <!-- media.ccc.de -->
     <color name="light_media_ccc_primary_color">#9e9e9e</color>
     <color name="light_media_ccc_dark_color">#616161</color>
     <color name="light_media_ccc_accent_color">#000000</color>

--- a/app/src/main/res/values/styles_services.xml
+++ b/app/src/main/res/values/styles_services.xml
@@ -51,20 +51,20 @@
         <item name="colorAccent">@color/dark_peertube_accent_color</item>
     </style>
 
-    <!-- Media.ccc -->
-    <style name="LightTheme.MediaCCC" parent="LightTheme">
+    <!-- media.ccc.de -->
+    <style name="LightTheme.media.ccc.de" parent="LightTheme">
         <item name="colorPrimary">@color/light_media_ccc_primary_color</item>
         <item name="colorPrimaryDark">@color/light_media_ccc_statusbar_color</item>
         <item name="colorAccent">@color/light_media_ccc_accent_color</item>
     </style>
 
-    <style name="DarkTheme.MediaCCC" parent="DarkTheme">
+    <style name="DarkTheme.media.ccc.de" parent="DarkTheme">
         <item name="colorPrimary">@color/dark_media_ccc_primary_color</item>
         <item name="colorPrimaryDark">@color/dark_media_ccc_statusbar_color</item>
         <item name="colorAccent">@color/dark_media_ccc_accent_color</item>
     </style>
 
-    <style name="BlackTheme.MediaCCC" parent="BlackTheme">
+    <style name="BlackTheme.media.ccc.de" parent="BlackTheme">
         <item name="colorPrimary">@color/dark_media_ccc_primary_color</item>
         <item name="colorPrimaryDark">@color/dark_media_ccc_statusbar_color</item>
         <item name="colorAccent">@color/dark_media_ccc_accent_color</item>


### PR DESCRIPTION
Caused by changing service name in TeamNewPipe/NewPipeExtractor#472

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Fixed `media.ccc.de` service color not used (NewPipe used the default color theme (YouTube) instead).
This was caused by changing the service's name in TeamNewPipe/NewPipeExtractor#472

#### APK testing 
[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/5735782/app-debug.zip)


#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
