### PR TITLE
Add stream segments to player controls

### DIFF
--- a/app/src/main/java/com/google/android/material/appbar/FlingBehavior.java
+++ b/app/src/main/java/com/google/android/material/appbar/FlingBehavior.java
@@ -27,7 +27,7 @@ public final class FlingBehavior extends AppBarLayout.Behavior {
     private boolean allowScroll = true;
     private final Rect globalRect = new Rect();
     private final List<Integer> skipInterceptionOfElements = Arrays.asList(
-            R.id.playQueuePanel, R.id.playbackSeekBar,
+            R.id.itemsListPanel, R.id.playbackSeekBar,
             R.id.playPauseButton, R.id.playPreviousButton, R.id.playNextButton);
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -2283,7 +2283,7 @@ public final class VideoDetailFragment
                         // Re-enable clicks
                         setOverlayElementsClickable(true);
                         if (player != null) {
-                            player.closeQueue();
+                            player.closeItemsList();
                         }
                         setOverlayLook(appBarLayout, behavior, 0);
                         break;

--- a/app/src/main/java/org/schabi/newpipe/info_list/StreamSegmentAdapter.kt
+++ b/app/src/main/java/org/schabi/newpipe/info_list/StreamSegmentAdapter.kt
@@ -1,0 +1,66 @@
+package org.schabi.newpipe.info_list
+
+import android.util.Log
+import com.xwray.groupie.GroupAdapter
+import com.xwray.groupie.GroupieViewHolder
+import org.schabi.newpipe.extractor.stream.StreamInfo
+import kotlin.math.max
+
+/**
+ * Custom RecyclerView.Adapter/GroupieAdapter for [StreamSegmentItem] for handling selection state.
+ */
+class StreamSegmentAdapter(
+    private val listener: StreamSegmentListener
+) : GroupAdapter<GroupieViewHolder>() {
+
+    var currentIndex: Int = 0
+        private set
+
+    /**
+     * Returns `true` if the provided [StreamInfo] contains segments, `false` otherwise.
+     */
+    fun setItems(info: StreamInfo): Boolean {
+        if (info.streamSegments.isNotEmpty()) {
+            clear()
+            addAll(info.streamSegments.map { StreamSegmentItem(it, listener) })
+            return true
+        }
+        return false
+    }
+
+    fun selectSegment(segment: StreamSegmentItem) {
+        unSelectCurrentSegment()
+        currentIndex = max(0, getAdapterPosition(segment))
+        segment.isSelected = true
+        segment.notifyChanged(StreamSegmentItem.PAYLOAD_SELECT)
+    }
+
+    fun selectSegmentAt(position: Int) {
+        try {
+            selectSegment(getGroupAtAdapterPosition(position) as StreamSegmentItem)
+        } catch (e: IndexOutOfBoundsException) {
+            // Just to make sure that getGroupAtAdapterPosition doesn't close the app
+            // Shouldn't happen since setItems is always called before select-methods but just in case
+            currentIndex = 0
+            Log.e("StreamSegmentAdapter", "selectSegmentAt: ${e.message}")
+        }
+    }
+
+    private fun unSelectCurrentSegment() {
+        try {
+            val segmentItem = getGroupAtAdapterPosition(currentIndex) as StreamSegmentItem
+            currentIndex = 0
+            segmentItem.isSelected = false
+            segmentItem.notifyChanged(StreamSegmentItem.PAYLOAD_SELECT)
+        } catch (e: IndexOutOfBoundsException) {
+            // Just to make sure that getGroupAtAdapterPosition doesn't close the app
+            // Shouldn't happen since setItems is always called before select-methods but just in case
+            currentIndex = 0
+            Log.e("StreamSegmentAdapter", "unSelectCurrentSegment: ${e.message}")
+        }
+    }
+
+    interface StreamSegmentListener {
+        fun onItemClick(item: StreamSegmentItem, seconds: Int)
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/info_list/StreamSegmentItem.kt
+++ b/app/src/main/java/org/schabi/newpipe/info_list/StreamSegmentItem.kt
@@ -1,0 +1,47 @@
+package org.schabi.newpipe.info_list
+
+import android.widget.ImageView
+import android.widget.TextView
+import com.nostra13.universalimageloader.core.ImageLoader
+import com.xwray.groupie.GroupieViewHolder
+import com.xwray.groupie.Item
+import org.schabi.newpipe.R
+import org.schabi.newpipe.extractor.stream.StreamSegment
+import org.schabi.newpipe.util.ImageDisplayConstants
+import org.schabi.newpipe.util.Localization
+
+class StreamSegmentItem(
+    private val item: StreamSegment,
+    private val onClick: StreamSegmentAdapter.StreamSegmentListener
+) : Item<GroupieViewHolder>() {
+
+    companion object {
+        const val PAYLOAD_SELECT = 1
+    }
+
+    var isSelected = false
+
+    override fun bind(viewHolder: GroupieViewHolder, position: Int) {
+        item.previewUrl?.let {
+            ImageLoader.getInstance().displayImage(
+                it, viewHolder.root.findViewById<ImageView>(R.id.previewImage),
+                ImageDisplayConstants.DISPLAY_THUMBNAIL_OPTIONS
+            )
+        }
+        viewHolder.root.findViewById<TextView>(R.id.textViewTitle).text = item.title
+        viewHolder.root.findViewById<TextView>(R.id.textViewStartSeconds).text =
+            Localization.getDurationString(item.startTimeSeconds.toLong())
+        viewHolder.root.setOnClickListener { onClick.onItemClick(this, item.startTimeSeconds) }
+        viewHolder.root.isSelected = isSelected
+    }
+
+    override fun bind(viewHolder: GroupieViewHolder, position: Int, payloads: MutableList<Any>) {
+        if (payloads.contains(PAYLOAD_SELECT)) {
+            viewHolder.root.isSelected = isSelected
+            return
+        }
+        super.bind(viewHolder, position, payloads)
+    }
+
+    override fun getLayout() = R.layout.item_stream_segment
+}

--- a/app/src/main/java/org/schabi/newpipe/player/MainPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/MainPlayer.java
@@ -151,7 +151,7 @@ public final class MainPlayer extends Service {
             // Android TV will handle back button in case controls will be visible
             // (one more additional unneeded click while the player is hidden)
             player.hideControls(0, 0);
-            player.closeQueue();
+            player.closeItemsList();
             // Notification shows information about old stream but if a user selects
             // a stream from backStack it's not actual anymore
             // So we should hide the notification at all.

--- a/app/src/main/java/org/schabi/newpipe/player/event/CustomBottomSheetBehavior.java
+++ b/app/src/main/java/org/schabi/newpipe/player/event/CustomBottomSheetBehavior.java
@@ -24,7 +24,7 @@ public class CustomBottomSheetBehavior extends BottomSheetBehavior<FrameLayout> 
     private boolean skippingInterception = false;
     private final List<Integer> skipInterceptionOfElements = Arrays.asList(
             R.id.detail_content_root_layout, R.id.relatedStreamsLayout,
-            R.id.playQueuePanel, R.id.viewpager, R.id.bottomControls,
+            R.id.itemsListPanel, R.id.viewpager, R.id.bottomControls,
             R.id.playPauseButton, R.id.playPreviousButton, R.id.playNextButton);
 
     @Override

--- a/app/src/main/res/drawable/ic_format_list_numbered_white_24.xml
+++ b/app/src/main/res/drawable/ic_format_list_numbered_white_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#FFFFFF"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M2,17h2v0.5L3,17.5v1h1v0.5L2,19v1h3v-4L2,16v1zM3,8h1L4,4L2,4v1h1v3zM2,11h1.8L2,13.1v0.9h3v-1L3.2,13L5,10.9L5,10L2,10v1zM7,5v2h14L21,5L7,5zM7,19h14v-2L7,17v2zM7,13h14v-2L7,11v2z" />
+</vector>

--- a/app/src/main/res/layout-large-land/player.xml
+++ b/app/src/main/res/layout-large-land/player.xml
@@ -192,6 +192,24 @@
                         tools:visibility="visible" />
 
                     <androidx.appcompat.widget.AppCompatImageButton
+                        android:id="@+id/segmentsButton"
+                        android:layout_width="35dp"
+                        android:layout_height="35dp"
+                        android:layout_marginEnd="8dp"
+                        android:background="?attr/selectableItemBackground"
+                        android:clickable="true"
+                        android:focusable="true"
+                        android:paddingStart="3dp"
+                        android:paddingTop="5dp"
+                        android:paddingEnd="3dp"
+                        android:paddingBottom="3dp"
+                        android:scaleType="fitCenter"
+                        android:visibility="gone"
+                        app:srcCompat="@drawable/ic_format_list_numbered_white_24"
+                        tools:ignore="ContentDescription,RtlHardcoded"
+                        tools:visibility="visible" />
+
+                    <androidx.appcompat.widget.AppCompatImageButton
                         android:id="@+id/moreOptionsButton"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
@@ -452,7 +470,7 @@
     </RelativeLayout>
 
     <RelativeLayout
-        android:id="@+id/playQueuePanel"
+        android:id="@+id/itemsListPanel"
         android:layout_width="380dp"
         android:layout_height="match_parent"
         android:layout_alignParentEnd="true"
@@ -461,14 +479,30 @@
         tools:visibility="visible">
 
         <RelativeLayout
-            android:id="@+id/playQueueControl"
+            android:id="@+id/itemsListControl"
             android:layout_width="match_parent"
             android:layout_height="60dp"
             android:clickable="true"
             android:focusable="true">
 
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/itemsListHeaderTitle"
+                style="@style/TextAppearance.AppCompat.Medium"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignEnd="@id/itemsListClose"
+                android:layout_alignParentStart="true"
+                android:layout_centerVertical="true"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="56dp"
+                android:ellipsize="end"
+                android:maxLines="2"
+                android:text="@string/chapters"
+                android:textColor="@android:color/white"
+                android:visibility="gone" />
+
             <androidx.appcompat.widget.AppCompatImageButton
-                android:id="@+id/playQueueClose"
+                android:id="@+id/itemsListClose"
                 android:layout_width="50dp"
                 android:layout_height="50dp"
                 android:layout_alignParentEnd="true"
@@ -517,10 +551,10 @@
         </RelativeLayout>
 
         <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/playQueue"
+            android:id="@+id/itemsList"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_below="@id/playQueueControl"
+            android:layout_below="@id/itemsListControl"
             android:scrollbars="vertical"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             tools:listitem="@layout/play_queue_item" />

--- a/app/src/main/res/layout/item_stream_segment.xml
+++ b/app/src/main/res/layout/item_stream_segment.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/selector"
+    android:clickable="true"
+    android:focusable="true"
+    android:foreground="?attr/selectableItemBackground"
+    android:paddingStart="16dp"
+    android:paddingTop="4dp"
+    android:paddingEnd="16dp"
+    android:paddingBottom="4dp">
+
+    <ImageView
+        android:id="@+id/previewImage"
+        android:layout_width="0dp"
+        android:layout_height="@dimen/play_queue_thumbnail_width"
+        android:scaleType="centerCrop"
+        android:src="@drawable/dummy_thumbnail"
+        app:layout_constraintDimensionRatio="16:9"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:ignore="ContentDescription" />
+
+    <LinearLayout
+        android:id="@+id/textContainer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:orientation="vertical"
+        android:paddingStart="8dp"
+        android:paddingEnd="0dp"
+        app:layout_constraintBottom_toBottomOf="@id/previewImage"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/previewImage"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/textViewTitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:maxLines="2"
+            android:textAppearance="?android:attr/textAppearanceLarge"
+            android:textSize="@dimen/video_item_search_title_text_size"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="Lorem ipusum is widely used to create long sample text which is used here too" />
+
+        <TextView
+            android:id="@+id/textViewStartSeconds"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="2dp"
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:textSize="@dimen/video_item_search_upload_date_text_size"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/textViewTitle"
+            tools:text="04:26" />
+
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/player.xml
+++ b/app/src/main/res/layout/player.xml
@@ -193,6 +193,23 @@
                         tools:ignore="ContentDescription,RtlHardcoded" />
 
                     <androidx.appcompat.widget.AppCompatImageButton
+                        android:id="@+id/segmentsButton"
+                        android:layout_width="35dp"
+                        android:layout_height="35dp"
+                        android:layout_marginEnd="8dp"
+                        android:background="?attr/selectableItemBackground"
+                        android:clickable="true"
+                        android:focusable="true"
+                        android:paddingStart="6dp"
+                        android:paddingTop="5dp"
+                        android:paddingEnd="6dp"
+                        android:paddingBottom="3dp"
+                        android:scaleType="fitCenter"
+                        android:visibility="gone"
+                        app:srcCompat="@drawable/ic_format_list_numbered_white_24"
+                        tools:ignore="ContentDescription,RtlHardcoded" />
+
+                    <androidx.appcompat.widget.AppCompatImageButton
                         android:id="@+id/moreOptionsButton"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
@@ -450,7 +467,7 @@
     </RelativeLayout>
 
     <RelativeLayout
-        android:id="@+id/playQueuePanel"
+        android:id="@+id/itemsListPanel"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="?attr/queue_background_color"
@@ -458,14 +475,30 @@
         tools:visibility="visible">
 
         <RelativeLayout
-            android:id="@+id/playQueueControl"
+            android:id="@+id/itemsListControl"
             android:layout_width="match_parent"
             android:layout_height="60dp"
             android:clickable="true"
             android:focusable="true">
 
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/itemsListHeaderTitle"
+                style="@style/TextAppearance.AppCompat.Medium"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignEnd="@id/itemsListClose"
+                android:layout_alignParentStart="true"
+                android:layout_centerVertical="true"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="56dp"
+                android:ellipsize="end"
+                android:maxLines="2"
+                android:text="@string/chapters"
+                android:textColor="@android:color/white"
+                android:visibility="gone" />
+
             <androidx.appcompat.widget.AppCompatImageButton
-                android:id="@+id/playQueueClose"
+                android:id="@+id/itemsListClose"
                 android:layout_width="50dp"
                 android:layout_height="50dp"
                 android:layout_alignParentEnd="true"
@@ -514,10 +547,10 @@
         </RelativeLayout>
 
         <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/playQueue"
+            android:id="@+id/itemsList"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_below="@id/playQueueControl"
+            android:layout_below="@id/itemsListControl"
             android:scrollbars="vertical"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             tools:listitem="@layout/play_queue_item" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -692,4 +692,5 @@
     <string name="show_thumbnail_title">Show thumbnail</string>
     <string name="show_thumbnail_summary">Use thumbnail for both lock screen background and notifications</string>
     <string name="recent">Recent</string>
+    <string name="chapters">Chapters</string>
 </resources>


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
This PR adds stream segments for the YouTube service to player controls. The feature provides the following behaviors:

- Highlights the current segment depending on the current position of the video (see Preview) / by click
- Scrolls automatically to the current playing segment when the list is opened
- Segments list is visible and the video is changed: if the new video has also segments then the new segments are loaded and it scrolls to the correct position, otherwise the list closes.

Code changes:

- Adds a new button near to the top controls bar
- Uses same layout elements like the play queue => they've been renamed to more generic id/field names, for example `queueLayout` to `itemsListLayout`

#### Fixes the following issue(s)
<!-- Also add any other links relevant to your change. -->
- closes #5098 

#### APK testing 
Check the build artifact page for the debug apk.

#### Preview
Demo (dynamically changing at 0:22) : https://streamable.com/e/0v66wn

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
