### PR TITLE
[media.ccc.de] Add "live" kiosk

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -179,7 +179,7 @@ dependencies {
 
     // NewPipe dependencies
     // You can use a local version by uncommenting a few lines in settings.gradle
-    implementation 'com.github.TeamNewPipe:NewPipeExtractor:674f2227f3a1ca11cbc9101a9d6211ad7babd42a'
+    implementation 'com.github.TeamNewPipe:NewPipeExtractor:b4e191397117447364d137791ec4b1ca3672d75b'
     implementation "com.github.TeamNewPipe:nanojson:1d9e1aea9049fc9f85e68b43ba39fe7be1c1f751"
 
     implementation "org.jsoup:jsoup:1.13.1"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -179,7 +179,7 @@ dependencies {
 
     // NewPipe dependencies
     // You can use a local version by uncommenting a few lines in settings.gradle
-    implementation 'com.github.TeamNewPipe:NewPipeExtractor:b2837698f55296e00aeca5cb1847755dd1174af4'
+    implementation 'com.github.TeamNewPipe:NewPipeExtractor:674f2227f3a1ca11cbc9101a9d6211ad7babd42a'
     implementation "com.github.TeamNewPipe:nanojson:1d9e1aea9049fc9f85e68b43ba39fe7be1c1f751"
 
     implementation "org.jsoup:jsoup:1.13.1"

--- a/app/src/main/java/org/schabi/newpipe/info_list/holder/StreamMiniInfoItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/holder/StreamMiniInfoItemHolder.java
@@ -70,7 +70,8 @@ public class StreamMiniInfoItemHolder extends InfoItemHolder {
             } else {
                 itemProgressView.setVisibility(View.GONE);
             }
-        } else if (item.getStreamType() == StreamType.LIVE_STREAM) {
+        } else if (item.getStreamType() == StreamType.LIVE_STREAM
+                || item.getStreamType() == StreamType.AUDIO_LIVE_STREAM) {
             itemDurationView.setText(R.string.duration_live);
             itemDurationView.setBackgroundColor(ContextCompat.getColor(itemBuilder.getContext(),
                     R.color.live_duration_background_color));

--- a/app/src/main/java/org/schabi/newpipe/util/KioskTranslator.java
+++ b/app/src/main/java/org/schabi/newpipe/util/KioskTranslator.java
@@ -44,6 +44,8 @@ public final class KioskTranslator {
                 return c.getString(R.string.most_liked);
             case "conferences":
                 return c.getString(R.string.conferences);
+            case "recent":
+                return c.getString(R.string.recent);
             default:
                 return kioskId;
         }
@@ -59,6 +61,7 @@ public final class KioskTranslator {
             case "Local":
                 return ThemeHelper.resolveResourceIdFromAttr(c, R.attr.ic_kiosk_local);
             case "Recently added":
+            case "recent":
                 return ThemeHelper.resolveResourceIdFromAttr(c, R.attr.ic_kiosk_recent);
             case "Most liked":
                 return ThemeHelper.resolveResourceIdFromAttr(c, R.attr.ic_thumb_up);

--- a/app/src/main/java/org/schabi/newpipe/util/KioskTranslator.java
+++ b/app/src/main/java/org/schabi/newpipe/util/KioskTranslator.java
@@ -46,6 +46,8 @@ public final class KioskTranslator {
                 return c.getString(R.string.conferences);
             case "recent":
                 return c.getString(R.string.recent);
+            case "live":
+                return c.getString(R.string.duration_live);
             default:
                 return kioskId;
         }
@@ -65,6 +67,8 @@ public final class KioskTranslator {
                 return ThemeHelper.resolveResourceIdFromAttr(c, R.attr.ic_kiosk_recent);
             case "Most liked":
                 return ThemeHelper.resolveResourceIdFromAttr(c, R.attr.ic_thumb_up);
+            case "live":
+                return ThemeHelper.resolveResourceIdFromAttr(c, R.attr.ic_live_tv);
             default:
                 return 0;
         }

--- a/app/src/main/res/drawable/ic_live_tv_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_live_tv_black_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:tint="?attr/colorControlNormal" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/black" android:pathData="M21,6h-7.59l3.29,-3.29L16,2l-4,4 -4,-4 -0.71,0.71L10.59,6L3,6c-1.1,0 -2,0.89 -2,2v12c0,1.1 0.9,2 2,2h18c1.1,0 2,-0.9 2,-2L23,8c0,-1.11 -0.9,-2 -2,-2zM21,20L3,20L3,8h18v12zM9,10v8l7,-4z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_live_tv_white_24dp.xml
+++ b/app/src/main/res/drawable/ic_live_tv_white_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:tint="#FFFFFF" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M21,6h-7.59l3.29,-3.29L16,2l-4,4 -4,-4 -0.71,0.71L10.59,6L3,6c-1.1,0 -2,0.89 -2,2v12c0,1.1 0.9,2 2,2h18c1.1,0 2,-0.9 2,-2L23,8c0,-1.11 -0.9,-2 -2,-2zM21,20L3,20L3,8h18v12zM9,10v8l7,-4z"/>
+</vector>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -82,6 +82,7 @@
     <attr name="ic_sort" format="reference" />
     <attr name="ic_help" format="reference" />
     <attr name="ic_arrow_back" format="reference" />
+    <attr name="ic_live_tv" format="reference" />
 
     <attr name="progress_horizontal_drawable" format="reference" />
     <!-- Can't refer to colors directly in drawable's xml-->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -691,4 +691,5 @@
     <string name="playlist_page_summary">Playlist page</string>
     <string name="show_thumbnail_title">Show thumbnail</string>
     <string name="show_thumbnail_summary">Use thumbnail for both lock screen background and notifications</string>
+    <string name="recent">Recent</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -48,6 +48,7 @@
         <item name="ic_kiosk_local">@drawable/ic_home_black_24dp</item>
         <item name="ic_kiosk_recent">@drawable/ic_add_circle_outline_black_24dp</item>
         <item name="ic_channel">@drawable/ic_tv_black_24dp</item>
+        <item name="ic_live_tv">@drawable/ic_live_tv_black_24dp</item>
         <item name="ic_bookmark">@drawable/ic_bookmark_black_24dp</item>
         <item name="ic_playlist_add">@drawable/ic_playlist_add_black_24dp</item>
         <item name="ic_playlist_check">@drawable/ic_playlist_add_check_black_24dp</item>
@@ -156,6 +157,7 @@
         <item name="ic_kiosk_local">@drawable/ic_home_white_24dp</item>
         <item name="ic_kiosk_recent">@drawable/ic_add_circle_outline_white_24dp</item>
         <item name="ic_channel">@drawable/ic_tv_white_24dp</item>
+        <item name="ic_live_tv">@drawable/ic_live_tv_white_24dp</item>
         <item name="ic_bookmark">@drawable/ic_bookmark_white_24dp</item>
         <item name="ic_playlist_add">@drawable/ic_playlist_add_white_24dp</item>
         <item name="ic_playlist_check">@drawable/ic_playlist_add_check_white_24dp</item>


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Add support for listing media.ccc.de live streams (Kiosk for streaming.media.ccc.de) [works!]

Viewing streams is not yet possible. I have had no chance the test the current implementation, but I believe it is not going to work,

#### Fixes the following issue(s)
Adresses #5271 

#### Relies on the following changes
- https://github.com/TeamNewPipe/NewPipeExtractor/pull/500
- #5251 

#### APK testing 
[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/5744545/app-debug.zip)

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).


#### Known issues /  to do
- [ ] rooms are listed in live kiosk, although no stream is playing