### PR TITLE
add list item to play video on kodi

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
@@ -333,7 +333,6 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
         }
     }
 
-
     protected void showStreamDialog(final StreamInfoItem item) {
         final Context context = getContext();
         final Activity activity = getActivity();
@@ -360,7 +359,7 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
                     StreamDialogEntry.share
             ));
         }
-        if (KoreUtil.shouldShowPlayWithKodi(context, item)) {
+        if (KoreUtil.shouldShowPlayWithKodi(context, item.getServiceId())) {
             entries.add(StreamDialogEntry.play_with_kodi);
         }
         StreamDialogEntry.setEnabledEntries(entries);

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
@@ -360,11 +360,8 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
                     StreamDialogEntry.share
             ));
         }
-        final boolean enableKodiEntry = KoreUtil.isServiceSupportedByKore(item.getServiceId())
-                && PreferenceManager.getDefaultSharedPreferences(context)
-                .getBoolean(context.getString(R.string.show_play_with_kodi_key), false);
-        if (enableKodiEntry) {
-            entries.add(StreamDialogEntry.play_on_kodi);
+        if (KoreUtil.shouldShowPlayWithKodi(context, item)) {
+            entries.add(StreamDialogEntry.play_with_kodi);
         }
         StreamDialogEntry.setEnabledEntries(entries);
 

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
@@ -31,6 +31,7 @@ import org.schabi.newpipe.info_list.InfoItemDialog;
 import org.schabi.newpipe.info_list.InfoListAdapter;
 import org.schabi.newpipe.player.helper.PlayerHolder;
 import org.schabi.newpipe.report.ErrorActivity;
+import org.schabi.newpipe.util.KoreUtil;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.OnClickGesture;
 import org.schabi.newpipe.util.StateSaver;
@@ -358,6 +359,12 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
                     StreamDialogEntry.append_playlist,
                     StreamDialogEntry.share
             ));
+        }
+        final boolean enableKodiEntry = KoreUtil.isServiceSupportedByKore(item.getServiceId())
+                && PreferenceManager.getDefaultSharedPreferences(context)
+                .getBoolean(context.getString(R.string.show_play_with_kodi_key), false);
+        if (enableKodiEntry) {
+            entries.add(StreamDialogEntry.play_on_kodi);
         }
         StreamDialogEntry.setEnabledEntries(entries);
 

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
@@ -17,7 +17,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.content.res.AppCompatResources;
-import androidx.preference.PreferenceManager;
 
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -176,11 +175,8 @@ public class PlaylistFragment extends BaseListInfoFragment<PlaylistInfo> {
                     StreamDialogEntry.share
             ));
         }
-        final boolean enableKodiEntry = KoreUtil.isServiceSupportedByKore(item.getServiceId())
-                && PreferenceManager.getDefaultSharedPreferences(context)
-                .getBoolean(context.getString(R.string.show_play_with_kodi_key), false);
-        if (enableKodiEntry) {
-            entries.add(StreamDialogEntry.play_on_kodi);
+        if (KoreUtil.shouldShowPlayWithKodi(context, item)) {
+            entries.add(StreamDialogEntry.play_with_kodi);
         }
         StreamDialogEntry.setEnabledEntries(entries);
 

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
@@ -175,7 +175,7 @@ public class PlaylistFragment extends BaseListInfoFragment<PlaylistInfo> {
                     StreamDialogEntry.share
             ));
         }
-        if (KoreUtil.shouldShowPlayWithKodi(context, item)) {
+        if (KoreUtil.shouldShowPlayWithKodi(context, item.getServiceId())) {
             entries.add(StreamDialogEntry.play_with_kodi);
         }
         StreamDialogEntry.setEnabledEntries(entries);

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
@@ -17,6 +17,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.content.res.AppCompatResources;
+import androidx.preference.PreferenceManager;
 
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -42,6 +43,7 @@ import org.schabi.newpipe.report.ErrorActivity;
 import org.schabi.newpipe.report.UserAction;
 import org.schabi.newpipe.util.ExtractorHelper;
 import org.schabi.newpipe.util.ImageDisplayConstants;
+import org.schabi.newpipe.util.KoreUtil;
 import org.schabi.newpipe.util.Localization;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.ShareUtils;
@@ -173,6 +175,12 @@ public class PlaylistFragment extends BaseListInfoFragment<PlaylistInfo> {
                     StreamDialogEntry.append_playlist,
                     StreamDialogEntry.share
             ));
+        }
+        final boolean enableKodiEntry = KoreUtil.isServiceSupportedByKore(item.getServiceId())
+                && PreferenceManager.getDefaultSharedPreferences(context)
+                .getBoolean(context.getString(R.string.show_play_with_kodi_key), false);
+        if (enableKodiEntry) {
+            entries.add(StreamDialogEntry.play_on_kodi);
         }
         StreamDialogEntry.setEnabledEntries(entries);
 

--- a/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
@@ -17,6 +17,7 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
+import androidx.preference.PreferenceManager;
 
 import com.google.android.material.snackbar.Snackbar;
 
@@ -37,6 +38,7 @@ import org.schabi.newpipe.report.ErrorActivity;
 import org.schabi.newpipe.report.ErrorInfo;
 import org.schabi.newpipe.report.UserAction;
 import org.schabi.newpipe.settings.SettingsActivity;
+import org.schabi.newpipe.util.KoreUtil;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.OnClickGesture;
 import org.schabi.newpipe.util.StreamDialogEntry;
@@ -412,6 +414,12 @@ public class StatisticsPlaylistFragment
                     StreamDialogEntry.append_playlist,
                     StreamDialogEntry.share
             ));
+        }
+        final boolean enableKodiEntry = KoreUtil.isServiceSupportedByKore(infoItem.getServiceId())
+                && PreferenceManager.getDefaultSharedPreferences(context)
+                .getBoolean(context.getString(R.string.show_play_with_kodi_key), false);
+        if (enableKodiEntry) {
+            entries.add(StreamDialogEntry.play_on_kodi);
         }
         StreamDialogEntry.setEnabledEntries(entries);
 

--- a/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
@@ -17,7 +17,6 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
-import androidx.preference.PreferenceManager;
 
 import com.google.android.material.snackbar.Snackbar;
 
@@ -415,11 +414,8 @@ public class StatisticsPlaylistFragment
                     StreamDialogEntry.share
             ));
         }
-        final boolean enableKodiEntry = KoreUtil.isServiceSupportedByKore(infoItem.getServiceId())
-                && PreferenceManager.getDefaultSharedPreferences(context)
-                .getBoolean(context.getString(R.string.show_play_with_kodi_key), false);
-        if (enableKodiEntry) {
-            entries.add(StreamDialogEntry.play_on_kodi);
+        if (KoreUtil.shouldShowPlayWithKodi(context, infoItem)) {
+            entries.add(StreamDialogEntry.play_with_kodi);
         }
         StreamDialogEntry.setEnabledEntries(entries);
 

--- a/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
@@ -414,7 +414,7 @@ public class StatisticsPlaylistFragment
                     StreamDialogEntry.share
             ));
         }
-        if (KoreUtil.shouldShowPlayWithKodi(context, infoItem)) {
+        if (KoreUtil.shouldShowPlayWithKodi(context, infoItem.getServiceId())) {
             entries.add(StreamDialogEntry.play_with_kodi);
         }
         StreamDialogEntry.setEnabledEntries(entries);

--- a/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
@@ -782,7 +782,7 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
                     StreamDialogEntry.share
             ));
         }
-        if (KoreUtil.shouldShowPlayWithKodi(context, infoItem)) {
+        if (KoreUtil.shouldShowPlayWithKodi(context, infoItem.getServiceId())) {
             entries.add(StreamDialogEntry.play_with_kodi);
         }
         StreamDialogEntry.setEnabledEntries(entries);

--- a/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
@@ -20,6 +20,7 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
+import androidx.preference.PreferenceManager;
 import androidx.recyclerview.widget.ItemTouchHelper;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -41,6 +42,7 @@ import org.schabi.newpipe.player.helper.PlayerHolder;
 import org.schabi.newpipe.player.playqueue.PlayQueue;
 import org.schabi.newpipe.player.playqueue.SinglePlayQueue;
 import org.schabi.newpipe.report.UserAction;
+import org.schabi.newpipe.util.KoreUtil;
 import org.schabi.newpipe.util.Localization;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.OnClickGesture;
@@ -780,6 +782,12 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
                     StreamDialogEntry.append_playlist,
                     StreamDialogEntry.share
             ));
+        }
+        final boolean enableKodiEntry = KoreUtil.isServiceSupportedByKore(infoItem.getServiceId())
+                && PreferenceManager.getDefaultSharedPreferences(context)
+                .getBoolean(context.getString(R.string.show_play_with_kodi_key), false);
+        if (enableKodiEntry) {
+            entries.add(StreamDialogEntry.play_on_kodi);
         }
         StreamDialogEntry.setEnabledEntries(entries);
 

--- a/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
@@ -20,7 +20,6 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
-import androidx.preference.PreferenceManager;
 import androidx.recyclerview.widget.ItemTouchHelper;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -783,11 +782,8 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
                     StreamDialogEntry.share
             ));
         }
-        final boolean enableKodiEntry = KoreUtil.isServiceSupportedByKore(infoItem.getServiceId())
-                && PreferenceManager.getDefaultSharedPreferences(context)
-                .getBoolean(context.getString(R.string.show_play_with_kodi_key), false);
-        if (enableKodiEntry) {
-            entries.add(StreamDialogEntry.play_on_kodi);
+        if (KoreUtil.shouldShowPlayWithKodi(context, infoItem)) {
+            entries.add(StreamDialogEntry.play_with_kodi);
         }
         StreamDialogEntry.setEnabledEntries(entries);
 

--- a/app/src/main/java/org/schabi/newpipe/player/VideoPlayerImpl.java
+++ b/app/src/main/java/org/schabi/newpipe/player/VideoPlayerImpl.java
@@ -932,9 +932,7 @@ public class VideoPlayerImpl extends VideoPlayer
                 service.getString(R.string.show_play_with_kodi_key), false);
         // show kodi button if it supports the current service and it is enabled in settings
         final boolean showKodiButton = playQueue != null && playQueue.getItem() != null
-                && KoreUtil.isServiceSupportedByKore(playQueue.getItem().getServiceId())
-                && PreferenceManager.getDefaultSharedPreferences(context)
-                .getBoolean(context.getString(R.string.show_play_with_kodi_key), false);
+                && KoreUtil.shouldShowPlayWithKodi(context, playQueue.getItem().getServiceId());
         playWithKodi.setVisibility(videoPlayerSelected() && kodiEnabled && showKodiButton
                 ? View.VISIBLE : View.GONE);
     }

--- a/app/src/main/java/org/schabi/newpipe/util/KoreUtil.java
+++ b/app/src/main/java/org/schabi/newpipe/util/KoreUtil.java
@@ -1,6 +1,5 @@
 package org.schabi.newpipe.util;
 
-
 import android.content.Context;
 
 import androidx.appcompat.app.AlertDialog;
@@ -8,7 +7,6 @@ import androidx.preference.PreferenceManager;
 
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.extractor.ServiceList;
-import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 
 public final class KoreUtil {
     private KoreUtil() { }
@@ -18,8 +16,8 @@ public final class KoreUtil {
                 || serviceId == ServiceList.SoundCloud.getServiceId());
     }
 
-    public static boolean shouldShowPlayWithKodi(final Context context, final StreamInfoItem item) {
-        return isServiceSupportedByKore(item.getServiceId())
+    public static boolean shouldShowPlayWithKodi(final Context context, final int serviceId) {
+        return isServiceSupportedByKore(serviceId)
                 && PreferenceManager.getDefaultSharedPreferences(context)
                 .getBoolean(context.getString(R.string.show_play_with_kodi_key), false);
     }

--- a/app/src/main/java/org/schabi/newpipe/util/KoreUtil.java
+++ b/app/src/main/java/org/schabi/newpipe/util/KoreUtil.java
@@ -4,9 +4,11 @@ package org.schabi.newpipe.util;
 import android.content.Context;
 
 import androidx.appcompat.app.AlertDialog;
+import androidx.preference.PreferenceManager;
 
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.extractor.ServiceList;
+import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 
 public final class KoreUtil {
     private KoreUtil() { }
@@ -14,6 +16,12 @@ public final class KoreUtil {
     public static boolean isServiceSupportedByKore(final int serviceId) {
         return (serviceId == ServiceList.YouTube.getServiceId()
                 || serviceId == ServiceList.SoundCloud.getServiceId());
+    }
+
+    public static boolean shouldShowPlayWithKodi(final Context context, final StreamInfoItem item) {
+        return isServiceSupportedByKore(item.getServiceId())
+                && PreferenceManager.getDefaultSharedPreferences(context)
+                .getBoolean(context.getString(R.string.show_play_with_kodi_key), false);
     }
 
     public static void showInstallKoreDialog(final Context context) {

--- a/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
+++ b/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
@@ -1,6 +1,7 @@
 package org.schabi.newpipe.util;
 
 import android.content.Context;
+import android.net.Uri;
 
 import androidx.fragment.app.Fragment;
 
@@ -67,6 +68,15 @@ public enum StreamDialogEntry {
                 () -> PlaylistCreationDialog.newInstance(d)
                         .show(fragment.getFragmentManager(), "StreamDialogEntry@create_playlist")
             );
+        }
+    }),
+
+    play_on_kodi(R.string.play_with_kodi_title, (fragment, item) -> {
+        final Uri videoUrl = Uri.parse(item.getUrl());
+        try {
+            NavigationHelper.playWithKore(fragment.getContext(), videoUrl);
+        } catch (final Exception e) {
+            KoreUtil.showInstallKoreDialog(fragment.getActivity());
         }
     }),
 

--- a/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
+++ b/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
@@ -71,7 +71,7 @@ public enum StreamDialogEntry {
         }
     }),
 
-    play_on_kodi(R.string.play_with_kodi_title, (fragment, item) -> {
+    play_with_kodi(R.string.play_with_kodi_title, (fragment, item) -> {
         final Uri videoUrl = Uri.parse(item.getUrl());
         try {
             NavigationHelper.playWithKore(fragment.getContext(), videoUrl);


### PR DESCRIPTION
this allows the user to long press on a video in any list (search, history, playlist, etc) and send it directly to Kodi. this change honors the existing `Show "Play with Kodi" option` setting and only displays on streams supported by Kore.

there is opportunity to reduce duplication in this part of the code base generally.

closes: #5157

<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- add list context menu item to "Play on Kodi"

#### Fixes the following issue(s)
<!-- Also add any other links relevant to your change. -->
- #5157

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/5752846/app-debug.zip)

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
