### PR TITLE
Disable sending metrics to Google when using Android System WebView

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -318,6 +318,8 @@
             android:name=".RouterActivity$FetcherService"
             android:exported="false" />
 
+        <!-- opting out of sending metrics to Google in Android System WebView -->
+        <meta-data android:name="android.webkit.WebView.MetricsOptOut" android:value="true" />
         <!-- see https://github.com/TeamNewPipe/NewPipe/issues/3947 -->
         <!-- Version < 3.0. DeX Mode and Screen Mirroring support -->
         <meta-data android:name="com.samsung.android.keepalive.density" android:value="true"/>


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This PR disable sending metrics to Google when using Android System WebView in NewPipe by adding `<meta-data android:name="android.webkit.WebView.MetricsOptOut" android:value="true" />` in the manifest of the app, inside the `<application>` tag.

#### Fixes the following issue(s)
Fixes #5335

#### APK testing 
[app.zip](https://github.com/TeamNewPipe/NewPipe/suites/1755326542/artifacts/33399585) (from CI)

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
