### PR TITLE
Add workflows for action-template

### DIFF
--- a/.github/workflows/template-cron.yml
+++ b/.github/workflows/template-cron.yml
@@ -1,0 +1,19 @@
+name: Template action cron job
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  close-issues:
+    name: "Close issues that don't follow a template"
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: mhmdanas/action-template@v0.2.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          type: close
+          days-until-close: 4

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -1,0 +1,18 @@
+name: Template action
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  comment-on-issue:
+    name: "Comment on labeled issue"
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: mhmdanas/action-template@v0.2.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          type: comment
+          days-until-close: 4


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [X] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
Add workflows for the [template action](https://github.com/mhmdanas/action-template) that I wrote (you can see it in action [here](https://github.com/mhmdanas/action-template-test/issues?q=is%3Aissue)).
- There's a cron job workflow that runs daily (and can be run on demand too) and closes any issues that still have `doesnt-follow-template` or `template-not-used` (the labels are customizable) for a customizable amount of days.
- There is another workflow that runs on issue labeling, and if the label is `doesnt-follow-template` or `template-not-used`, it will make a comment (which has a different body depending on the label, and the comment bodies are customizable too).

My reasoning for using `template-not-used` and `doesnt-follow-template` instead of the existing `template-ignored` and `doesnt-follow-template` is the distinction. As far as I know, currently, we use `template-ignored` when an issue was opened from the GitHub website (we can know this by checking if a label was added automatically), and `doesnt-follow-template` when it was opened from somewhere else (e.g. third-party client). I believe a better distinction to make is when an issue removes the template completely (`template-not-used`) and it has the template but doesn't follow it properly (`doesnt-follow-template`).

Here are the default comment bodies for each label:
<details>
<summary><code>template-not-used</code></summary>

Hi @{authorLogin}! Thank you for opening an issue! Please choose the appropriate template at the bottom of this comment, edit your issue to follow it properly, and then make a comment that you edited the issue. If you do not edit your issue to follow a template properly in {daysUntilClose}, this issue will be closed. Thanks!

_Issue templates will be shown here_
</details>

<details>
<summary><code>doesnt-follow-template</code></summary>
Hi @{authorLogin}! Thank you for opening an issue! Unfortunately, it seems like you didn't follow the template's instructions properly. Please edit your issue to follow all of the template's instructions properly and then make a comment saying that you edited the issue. If you do not edit your issue to follow the template's instructions properly in {daysUntilClose}, this issue will be closed. Thanks!
</details>

I configured it to close an issue if it's not edited in 4 days, but if you find that too much time or too little feel free to comment.

Finally, I'm not sure if we should be merging this in a repo that has 700+ issues without being more confident in its reliability. I tested it and didn't find any bugs, but I don't want to risk it. Maybe we should try it in a smaller repo like NewPipe Legacy where the impact of a bug would be smaller?

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
Unnecessary.

#### Due diligence
- [X] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).