### PR TITLE
Run Instrumented tests in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,12 @@ on:
     branches:
       - dev
   push:
-    branches: 
+    branches:
       - dev
       - master
 
 jobs:
-  build-and-test:
+  build-and-test-jvm:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
 
-      - name: Build debug APK and run Tests
+      - name: Build debug APK and run jvm tests
         run: ./gradlew assembleDebug lintDebug testDebugUnitTest --stacktrace
 
       - name: Upload APK
@@ -40,6 +40,31 @@ jobs:
         with:
           name: app
           path: app/build/outputs/apk/debug/*.apk
+  test-android:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        api-level: [21, 29]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: set up JDK 1.8
+        uses: actions/setup-java@v1.4.3
+        with:
+          java-version: 1.8
+
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      - name: Run android tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          script: ./gradlew connectedCheck
 #   sonar:
 #     runs-on: ubuntu-latest
 #     steps:


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- expand ci.yml to run instrumeted test
- only run ci pipeline on push/pr against dev and master.
- uses https://github.com/marketplace/actions/android-emulator-runner
- showcase: XiangRongLin/NewPipe#8
- adds 7-8 min to CI pipeline, part of which is parallelized

#### Relies on the following changes
<!-- Delete this if it doesn't apply to you. -->
- #5359 needs to be adresses which i just did by updating kotlin here.

#### Notes
- There currently are only 2 instrumentet tests, which means this doesn't really add much value yet. But i think having this already in place for when it is needed is good.
- At first i wanted it to run it on API level 19 and 29 (min and max SDK) but it fails on 19 with it not being able to find the test (https://github.com/XiangRongLin/NewPipe/runs/1657271924?check_suite_focus=true#step:5:247). I assume its because of some problem with multidex and API < 21 since when i run it normally on API 19 emulator it logs a lot of errors with `Could not find class 'xyz'`.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
