### PR TITLE
Better error messages for SoundCloud and YouTube unavailable contents

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -180,7 +180,7 @@ dependencies {
 
     // NewPipe dependencies
     // You can use a local version by uncommenting a few lines in settings.gradle
-    implementation 'com.github.TeamNewPipe:NewPipeExtractor:v0.20.11'
+    implementation "com.github.TeamNewPipe:NewPipeExtractor:7e6f464407fc1a2c8fb0886d294093526a6ef0f1"
     implementation "com.github.TeamNewPipe:nanojson:1d9e1aea9049fc9f85e68b43ba39fe7be1c1f751"
 
     implementation "org.jsoup:jsoup:1.13.1"

--- a/app/src/main/java/org/schabi/newpipe/fragments/BaseStateFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/BaseStateFragment.java
@@ -20,9 +20,15 @@ import org.schabi.newpipe.BaseFragment;
 import org.schabi.newpipe.MainActivity;
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.ReCaptchaActivity;
+import org.schabi.newpipe.extractor.exceptions.AgeRestrictedContentException;
 import org.schabi.newpipe.extractor.exceptions.ContentNotAvailableException;
 import org.schabi.newpipe.extractor.exceptions.ContentNotSupportedException;
+import org.schabi.newpipe.extractor.exceptions.GeographicRestrictionException;
+import org.schabi.newpipe.extractor.exceptions.PaidContentException;
+import org.schabi.newpipe.extractor.exceptions.PrivateContentException;
 import org.schabi.newpipe.extractor.exceptions.ReCaptchaException;
+import org.schabi.newpipe.extractor.exceptions.SoundCloudGoPlusContentException;
+import org.schabi.newpipe.extractor.exceptions.YoutubeMusicPremiumContentException;
 import org.schabi.newpipe.ktx.ExceptionUtils;
 import org.schabi.newpipe.report.ErrorActivity;
 import org.schabi.newpipe.report.ErrorInfo;
@@ -223,11 +229,29 @@ public abstract class BaseStateFragment<I> extends BaseFragment implements ViewC
         if (exception instanceof ReCaptchaException) {
             onReCaptchaException((ReCaptchaException) exception);
             return true;
-        } else if (exception instanceof ContentNotAvailableException) {
-            showError(getString(R.string.content_not_available), false);
-            return true;
         } else if (ExceptionUtils.isNetworkRelated(exception)) {
             showError(getString(R.string.network_error), true);
+            return true;
+        } else if (exception instanceof AgeRestrictedContentException) {
+            showError(getString(R.string.restricted_video_no_stream), false);
+            return true;
+        } else if (exception instanceof GeographicRestrictionException) {
+            showError(getString(R.string.georestricted_content), false);
+            return true;
+        } else if (exception instanceof PaidContentException) {
+            showError(getString(R.string.paid_content), false);
+            return true;
+        } else if (exception instanceof PrivateContentException) {
+            showError(getString(R.string.private_content), false);
+            return true;
+        } else if (exception instanceof SoundCloudGoPlusContentException) {
+            showError(getString(R.string.soundcloud_go_plus_content), false);
+            return true;
+        } else if (exception instanceof YoutubeMusicPremiumContentException) {
+            showError(getString(R.string.youtube_music_premium_content), false);
+            return true;
+        } else if (exception instanceof ContentNotAvailableException) {
+            showError(getString(R.string.content_not_available), false);
             return true;
         } else if (exception instanceof ContentNotSupportedException) {
             showError(getString(R.string.content_not_supported), false);

--- a/app/src/main/java/org/schabi/newpipe/util/ExtractorHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ExtractorHelper.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2017 Mauricio Colli <mauriciocolli@outlook.com>
- * Extractors.java is part of NewPipe
+ * ExtractorHelper.java is part of NewPipe
  *
  * License: GPL-3.0+
  * This program is free software: you can redistribute it and/or modify
@@ -44,10 +44,16 @@ import org.schabi.newpipe.extractor.Page;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.channel.ChannelInfo;
 import org.schabi.newpipe.extractor.comments.CommentsInfo;
+import org.schabi.newpipe.extractor.exceptions.AgeRestrictedContentException;
 import org.schabi.newpipe.extractor.exceptions.ContentNotAvailableException;
 import org.schabi.newpipe.extractor.exceptions.ContentNotSupportedException;
+import org.schabi.newpipe.extractor.exceptions.GeographicRestrictionException;
+import org.schabi.newpipe.extractor.exceptions.PaidContentException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
+import org.schabi.newpipe.extractor.exceptions.PrivateContentException;
 import org.schabi.newpipe.extractor.exceptions.ReCaptchaException;
+import org.schabi.newpipe.extractor.exceptions.SoundCloudGoPlusContentException;
+import org.schabi.newpipe.extractor.exceptions.YoutubeMusicPremiumContentException;
 import org.schabi.newpipe.extractor.feed.FeedExtractor;
 import org.schabi.newpipe.extractor.feed.FeedInfo;
 import org.schabi.newpipe.extractor.kiosk.KioskInfo;
@@ -300,6 +306,21 @@ public final class ExtractorHelper {
                 context.startActivity(intent);
             } else if (ExceptionUtils.isNetworkRelated(exception)) {
                 Toast.makeText(context, R.string.network_error, Toast.LENGTH_LONG).show();
+            } else if (exception instanceof AgeRestrictedContentException) {
+                Toast.makeText(context, R.string.restricted_video_no_stream,
+                        Toast.LENGTH_LONG).show();
+            } else if (exception instanceof GeographicRestrictionException) {
+                Toast.makeText(context, R.string.georestricted_content, Toast.LENGTH_LONG).show();
+            } else if (exception instanceof PaidContentException) {
+                Toast.makeText(context, R.string.paid_content, Toast.LENGTH_LONG).show();
+            } else if (exception instanceof PrivateContentException) {
+                Toast.makeText(context, R.string.private_content, Toast.LENGTH_LONG).show();
+            } else if (exception instanceof SoundCloudGoPlusContentException) {
+                Toast.makeText(context, R.string.soundcloud_go_plus_content,
+                        Toast.LENGTH_LONG).show();
+            } else if (exception instanceof YoutubeMusicPremiumContentException) {
+                Toast.makeText(context, R.string.youtube_music_premium_content,
+                        Toast.LENGTH_LONG).show();
             } else if (exception instanceof ContentNotAvailableException) {
                 Toast.makeText(context, R.string.content_not_available, Toast.LENGTH_LONG).show();
             } else if (exception instanceof ContentNotSupportedException) {

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -665,4 +665,5 @@
     <string name="show_description_summary">Désactiver pour masquer la description de la vidéo et les informations supplémentaires</string>
     <string name="show_description_title">Afficher la description</string>
     <string name="crash_the_app">Plante l\'application</string>
+    <string name="georestricted_content">Ce contenu n\'est pas disponible dans votre pays.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="main_bg_subtitle">Tap \"Search\" to get started
 \n</string>
@@ -164,6 +164,7 @@
     <string name="youtube_restricted_mode_enabled_title">Turn on YouTube\'s \"Restricted Mode\"</string>
     <string name="youtube_restricted_mode_enabled_summary">YouTube provides a \"Restricted Mode\" which hides potentially mature content</string>
     <string name="restricted_video">This video is age restricted.\n\nTurn on \"%1$s\" in the settings if you want to see it.</string>
+    <string name="restricted_video_no_stream">This video is age-restricted.\nDue to new YouTube policies with age-restricted videos, NewPipe cannot access any of its video streams and thus is unable to play it.</string>
     <string name="duration_live">Live</string>
     <string name="downloads">Downloads</string>
     <string name="downloads_title">Downloads</string>
@@ -700,4 +701,9 @@
     <string name="recent">Recent</string>
     <string name="chapters">Chapters</string>
     <string name="no_app_to_open_intent">No app on your device can open this</string>
+    <string name="georestricted_content">This content is not available in your country.</string>
+    <string name="soundcloud_go_plus_content">This is a SoundCloud Go+ track, at least in your country, so it cannot be streamed or downloaded by NewPipe.</string>
+    <string name="private_content">This content is private, so it cannot be streamed or downloaded by NewPipe.</string>
+    <string name="youtube_music_premium_content">This video is available only to YouTube Music Premium members, so it cannot be streamed or downloaded by NewPipe.</string>
+    <string name="paid_content">This content is only available to users who have paid, so it cannot be streamed or downloaded by NewPipe.</string>
 </resources>


### PR DESCRIPTION
#### What is it?
- [x] Feature (user facing)

#### Description of the changes in your PR
This PR add new error messages (strings added in English and French), on SoundCloud and YouTube services, when a user tries to play:
- a SoundCloud Go+ track
- a SoundCloud track which is blocked in his/her/its country
- a YouTube Music Premium video
- a YouTube paid video (a YouTube movie or a YouTube video which requires a subscription to the video channel)
- a YouTube video which is blocked in his/her/its country (doesn't work for YouTube Music georestricted tracks because of the error message returned by YouTube)
- a YouTube age-restricted video which could not be played, due to YouTube changes for age-restricted videos

#### Screenshots of the error messages

| Screenshot of the error message | Content type of error message   |
|---------------------------------|-----------------------------|
|                                ![Georestricted content](https://user-images.githubusercontent.com/74829229/107978895-dc45dc00-6fbd-11eb-8643-853724c8c1f2.jpg) | Georestricted content       |
|                                ![Private content](https://user-images.githubusercontent.com/74829229/107978950-f7185080-6fbd-11eb-92ab-c5ceaa91e39b.jpg) | Private content             |
|                                ![Paid content](https://user-images.githubusercontent.com/74829229/107979398-c8e74080-6fbe-11eb-94c5-6dbd287d24e5.jpg) | Paid content                |
|                                ![YouTube Music Premium video](https://user-images.githubusercontent.com/74829229/107978984-01d2e580-6fbe-11eb-9f7b-0e6b69fac204.jpg) | YouTube Music Premium video |

**TO DO:** update extractor in app/build.gradle when Extractor PR is merged

#### Fixes the following issue(s)
#4979 **for SoundCloud and YouTube**

#### Relies on the following changes
TeamNewPipe/NewPipeExtractor#509

#### APK testing 
[app.zip](https://github.com/TeamNewPipe/NewPipe/suites/2096924712/artifacts/42569341) (from CI)

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).