### PR TITLE
Checkout branch in CI process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: create and checkout branch
+        # push events already checked out the branch
+        if: github.event_name == 'pull_request'
+        run: git checkout -B ${{ github.head_ref }}
+
       - name: set up JDK 1.8
         uses: actions/setup-java@v1.4.3
         with:


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Checkout branch in CI process for pull request. CI process for push already checks out branch correctly https://github.com/XiangRongLin/NewPipe/runs/1703962796?check_suite_focus=true#step:2:456
- This way the debug build app id contains the branch name again. Currently the app id is "NewPipe HEAD"
- `github.head_ref & github.event_name` https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions#github-context
- `git checkout -B` https://git-scm.com/docs/git-checkout#Documentation/git-checkout.txt--Bltnewbranchgt
- PR job force switches the branch: https://github.com/XiangRongLin/NewPipe/pull/9/checks?check_run_id=1703963185#step:3:4
- Push jobs stays unchaged, since it gets skipped: https://github.com/XiangRongLin/NewPipe/runs/1703962796?check_suite_focus=true

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
