### PR TITLE
Fix the crash that occurs on navigating back to the main fragment.

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/MainFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/MainFragment.java
@@ -117,11 +117,6 @@ public class MainFragment extends BaseFragment implements TabLayout.OnTabSelecte
     public void onDestroy() {
         super.onDestroy();
         tabsManager.unsetSavedTabsListener();
-    }
-
-    @Override
-    public void onDestroyView() {
-        super.onDestroyView();
         if (binding != null) {
             binding.pager.setAdapter(null);
             binding = null;

--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
@@ -251,7 +251,7 @@ class FeedFragment : BaseListFragment<FeedState, Unit>() {
         }
 
         feedBinding.loadingProgressBar.isIndeterminate = isIndeterminate ||
-                (progressState.maxProgress > 0 && progressState.currentProgress == 0)
+            (progressState.maxProgress > 0 && progressState.currentProgress == 0)
         feedBinding.loadingProgressBar.progress = progressState.currentProgress
 
         feedBinding.loadingProgressBar.max = progressState.maxProgress
@@ -269,8 +269,10 @@ class FeedFragment : BaseListFragment<FeedState, Unit>() {
         val loadedCount = loadedState.notLoadedCount > 0
         feedBinding.refreshSubtitleText.isVisible = loadedCount
         if (loadedCount) {
-            feedBinding.refreshSubtitleText.text = getString(R.string.feed_subscription_not_loaded_count,
-                    loadedState.notLoadedCount)
+            feedBinding.refreshSubtitleText.text = getString(
+                R.string.feed_subscription_not_loaded_count,
+                loadedState.notLoadedCount
+            )
         }
 
         if (loadedState.itemsErrors.isNotEmpty()) {

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
@@ -311,10 +311,10 @@ class SubscriptionFragment : BaseStateFragment<SubscriptionState>() {
         dialogTitleBinding.itemAdditionalDetails.visibility = View.GONE
 
         AlertDialog.Builder(requireContext())
-                .setCustomTitle(dialogTitleBinding.root)
-                .setItems(commands, actions)
-                .create()
-                .show()
+            .setCustomTitle(dialogTitleBinding.root)
+            .setItems(commands, actions)
+            .create()
+            .show()
     }
 
     private fun deleteChannel(selectedItem: ChannelInfoItem) {

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/dialog/FeedGroupDialog.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/dialog/FeedGroupDialog.kt
@@ -368,7 +368,8 @@ class FeedGroupDialog : DialogFragment(), BackPressable {
         val selectedCount = this.selectedSubscriptions.size
         val selectedCountText = resources.getQuantityString(
             R.plurals.feed_group_dialog_selection_count,
-            selectedCount, selectedCount)
+            selectedCount, selectedCount
+        )
         feedGroupCreateBinding.selectedSubscriptionCountView.text = selectedCountText
         feedGroupCreateBinding.subscriptionsHeaderInfo.text = selectedCountText
     }
@@ -423,10 +424,12 @@ class FeedGroupDialog : DialogFragment(), BackPressable {
         feedGroupCreateBinding.separator.onlyVisibleIn(SubscriptionsPickerScreen, IconPickerScreen)
         feedGroupCreateBinding.cancelButton.onlyVisibleIn(InitialScreen, DeleteScreen)
 
-        feedGroupCreateBinding.confirmButton.setText(when {
-            currentScreen == InitialScreen && groupId == NO_GROUP_SELECTED -> R.string.create
-            else -> android.R.string.ok
-        })
+        feedGroupCreateBinding.confirmButton.setText(
+            when {
+                currentScreen == InitialScreen && groupId == NO_GROUP_SELECTED -> R.string.create
+                else -> android.R.string.ok
+            }
+        )
 
         feedGroupCreateBinding.deleteButton.isGone = currentScreen != InitialScreen || groupId == NO_GROUP_SELECTED
 
@@ -471,27 +474,35 @@ class FeedGroupDialog : DialogFragment(), BackPressable {
 
     private fun showKeyboardSearch() {
         if (searchLayoutBinding.toolbarSearchEditText.requestFocus()) {
-            inputMethodManager.showSoftInput(searchLayoutBinding.toolbarSearchEditText,
-                    InputMethodManager.SHOW_IMPLICIT)
+            inputMethodManager.showSoftInput(
+                searchLayoutBinding.toolbarSearchEditText,
+                InputMethodManager.SHOW_IMPLICIT
+            )
         }
     }
 
     private fun hideKeyboardSearch() {
-        inputMethodManager.hideSoftInputFromWindow(searchLayoutBinding.toolbarSearchEditText.windowToken,
-            InputMethodManager.RESULT_UNCHANGED_SHOWN)
+        inputMethodManager.hideSoftInputFromWindow(
+            searchLayoutBinding.toolbarSearchEditText.windowToken,
+            InputMethodManager.RESULT_UNCHANGED_SHOWN
+        )
         searchLayoutBinding.toolbarSearchEditText.clearFocus()
     }
 
     private fun showKeyboard() {
         if (feedGroupCreateBinding.groupNameInput.requestFocus()) {
-            inputMethodManager.showSoftInput(feedGroupCreateBinding.groupNameInput,
-                    InputMethodManager.SHOW_IMPLICIT)
+            inputMethodManager.showSoftInput(
+                feedGroupCreateBinding.groupNameInput,
+                InputMethodManager.SHOW_IMPLICIT
+            )
         }
     }
 
     private fun hideKeyboard() {
-        inputMethodManager.hideSoftInputFromWindow(feedGroupCreateBinding.groupNameInput.windowToken,
-            InputMethodManager.RESULT_UNCHANGED_SHOWN)
+        inputMethodManager.hideSoftInputFromWindow(
+            feedGroupCreateBinding.groupNameInput.windowToken,
+            InputMethodManager.RESULT_UNCHANGED_SHOWN
+        )
         feedGroupCreateBinding.groupNameInput.clearFocus()
     }
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Move setting the pager adapter and view binding to `null` to `onDestroy` from `onDestroyView`.

#### Fixes the following issue(s)
<!-- Also add any other links relevant to your change. -->
- #5414 

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
[debug.zip](https://github.com/TeamNewPipe/NewPipe/files/5817874/debug.zip)

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
