### PR TITLE
Fix crash when no browser is present and use an ACTION_CHOOSER intent in the app update notification

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/CheckForNewAppVersion.java
+++ b/app/src/main/java/org/schabi/newpipe/CheckForNewAppVersion.java
@@ -132,7 +132,13 @@ public final class CheckForNewAppVersion {
 
         if (BuildConfig.VERSION_CODE < versionCode) {
             // A pending intent to open the apk location url in the browser.
-            final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(apkLocationUrl));
+            final Intent viewIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(apkLocationUrl));
+
+            final Intent intent = new Intent(Intent.ACTION_CHOOSER);
+            intent.putExtra(Intent.EXTRA_INTENT, viewIntent);
+            intent.putExtra(Intent.EXTRA_TITLE, R.string.open_with);
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+
             final PendingIntent pendingIntent
                     = PendingIntent.getActivity(application, 0, intent, 0);
 

--- a/app/src/main/java/org/schabi/newpipe/util/ShareUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ShareUtils.java
@@ -154,12 +154,12 @@ public final class ShareUtils {
      * If no app is set as default, it will return "android" (not on some devices because some
      * OEMs changed the app chooser).
      * <p>
-     * If no app is installed on user's device to handle the intent, it will return null.
+     * If no app is installed on user's device to handle the intent, it will return an empty string.
      *
      * @param context the context to use
      * @param intent  the intent to get default app
-     * @return the package name of the default app, an empty string if there's no app installed to
-     * handle the intent or the app chooser if there's no default
+     * @return the package name of the default app to open the intent, an empty string if there's no
+     * app installed to handle it or the app chooser if there's no default
      */
     private static String getDefaultAppPackageName(final Context context, final Intent intent) {
         final ResolveInfo resolveInfo = context.getPackageManager().resolveActivity(intent,
@@ -177,7 +177,7 @@ public final class ShareUtils {
      * If no browser is set as default, it will return "android" (not on some devices because some
      * OEMs changed the app chooser).
      * <p>
-     * If no app is installed on user's device to handle the intent, it will return null.
+     * If no browser is installed on user's device, it will return an empty string.
      * @param context the context to use
      * @return the package name of the default browser, an empty string if there's no browser
      * installed or the app chooser if there's no default

--- a/app/src/main/java/org/schabi/newpipe/util/ShareUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ShareUtils.java
@@ -6,6 +6,7 @@ import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import android.widget.Toast;
 
@@ -64,13 +65,18 @@ public final class ShareUtils {
             // No browser set as default (doesn't work on some devices)
             openInDefaultApp(context, intent);
         } else {
-            try {
-                intent.setPackage(defaultPackageName);
-                context.startActivity(intent);
-            } catch (final ActivityNotFoundException e) {
-                // Not a browser but an app chooser because of OEMs changes
-                intent.setPackage(null);
-                openInDefaultApp(context, intent);
+            if (defaultPackageName.isEmpty()) {
+                // No app installed to open a web url
+                Toast.makeText(context, R.string.no_app_to_open_intent, Toast.LENGTH_LONG).show();
+            } else {
+                try {
+                    intent.setPackage(defaultPackageName);
+                    context.startActivity(intent);
+                } catch (final ActivityNotFoundException e) {
+                    // Not a browser but an app chooser because of OEMs changes
+                    intent.setPackage(null);
+                    openInDefaultApp(context, intent);
+                }
             }
         }
     }
@@ -104,19 +110,24 @@ public final class ShareUtils {
      * @param intent  the intent to open
      */
     public static void openIntentInApp(final Context context, final Intent intent) {
-        final String defaultAppPackageName = getDefaultAppPackageName(context, intent);
+        final String defaultPackageName = getDefaultAppPackageName(context, intent);
 
-        if (defaultAppPackageName.equals("android")) {
+        if (defaultPackageName.equals("android")) {
             // No app set as default (doesn't work on some devices)
             openInDefaultApp(context, intent);
         } else {
-            try {
-                intent.setPackage(defaultAppPackageName);
-                context.startActivity(intent);
-            } catch (final ActivityNotFoundException e) {
-                // Not an app to open the intent but an app chooser because of OEMs changes
-                intent.setPackage(null);
-                openInDefaultApp(context, intent);
+            if (defaultPackageName.isEmpty()) {
+                // No app installed to open the intent
+                Toast.makeText(context, R.string.no_app_to_open_intent, Toast.LENGTH_LONG).show();
+            } else {
+                try {
+                    intent.setPackage(defaultPackageName);
+                    context.startActivity(intent);
+                } catch (final ActivityNotFoundException e) {
+                    // Not an app to open the intent but an app chooser because of OEMs changes
+                    intent.setPackage(null);
+                    openInDefaultApp(context, intent);
+                }
             }
         }
     }
@@ -140,33 +151,47 @@ public final class ShareUtils {
     /**
      * Get the default app package name.
      * <p>
-     * If no app is set as default, it will return "android".
+     * If no app is set as default, it will return "android" (not on some devices because some
+     * OEMs changed the app chooser).
      * <p>
-     * Note: it doesn't return "android" on some devices because some OEMs changed the app chooser.
+     * If no app is installed on user's device to handle the intent, it will return null.
      *
      * @param context the context to use
      * @param intent  the intent to get default app
-     * @return the package name of the default app, or the app chooser if there's no default
+     * @return the package name of the default app, an empty string if there's no app installed to
+     * handle the intent or the app chooser if there's no default
      */
     private static String getDefaultAppPackageName(final Context context, final Intent intent) {
-        return context.getPackageManager().resolveActivity(intent,
-                PackageManager.MATCH_DEFAULT_ONLY).activityInfo.packageName;
+        final ResolveInfo resolveInfo = context.getPackageManager().resolveActivity(intent,
+                PackageManager.MATCH_DEFAULT_ONLY);
+        if (resolveInfo == null) {
+            return "";
+        } else {
+            return resolveInfo.activityInfo.packageName;
+        }
     }
 
     /**
      * Get the default browser package name.
      * <p>
-     * If no browser is set as default, it will return "android"
-     * Note: it doesn't return "android" on some devices because some OEMs changed the app chooser.
-     *
+     * If no browser is set as default, it will return "android" (not on some devices because some
+     * OEMs changed the app chooser).
+     * <p>
+     * If no app is installed on user's device to handle the intent, it will return null.
      * @param context the context to use
-     * @return the package name of the default browser, or "android" if there's no default
+     * @return the package name of the default browser, an empty string if there's no browser
+     * installed or the app chooser if there's no default
      */
     private static String getDefaultBrowserPackageName(final Context context) {
         final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("http://"))
                 .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        return context.getPackageManager().resolveActivity(intent,
-                PackageManager.MATCH_DEFAULT_ONLY).activityInfo.packageName;
+        final ResolveInfo resolveInfo = context.getPackageManager().resolveActivity(intent,
+                PackageManager.MATCH_DEFAULT_ONLY);
+        if (resolveInfo == null) {
+            return "";
+        } else {
+            return resolveInfo.activityInfo.packageName;
+        }
     }
 
     /**

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -658,4 +658,5 @@
     <string name="hash_channel_name">Notification de hachage vidéo</string>
     <string name="show_meta_info_summary">Désactivez cette option pour masquer les zones de méta-informations contenant des informations supplémentaires sur le créateur du flux, le contenu du flux ou une demande de recherche.</string>
     <string name="show_meta_info_title">Afficher les méta-infos</string>
+    <string name="no_app_to_open_intent">Aucune application installée sur votre appareil ne peut ouvrir ceci</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -658,5 +658,5 @@
     <string name="hash_channel_name">Notification de hachage vidéo</string>
     <string name="show_meta_info_summary">Désactivez cette option pour masquer les zones de méta-informations contenant des informations supplémentaires sur le créateur du flux, le contenu du flux ou une demande de recherche.</string>
     <string name="show_meta_info_title">Afficher les méta-infos</string>
-    <string name="no_app_to_open_intent">Aucune application installée sur votre appareil ne peut ouvrir ceci</string>
+    <string name="no_app_to_open_intent">Aucune application sur votre appareil ne peut ouvrir ceci</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -699,4 +699,5 @@
     <string name="show_thumbnail_summary">Use thumbnail for both lock screen background and notifications</string>
     <string name="recent">Recent</string>
     <string name="chapters">Chapters</string>
+    <string name="no_app_to_open_intent">No app installed on your device can open this</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -699,5 +699,5 @@
     <string name="show_thumbnail_summary">Use thumbnail for both lock screen background and notifications</string>
     <string name="recent">Recent</string>
     <string name="chapters">Chapters</string>
-    <string name="no_app_to_open_intent">No app installed on your device can open this</string>
+    <string name="no_app_to_open_intent">No app on your device can open this</string>
 </resources>


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Show a Toast when no app is present on user's device to open a content in an app and in a browser and use an ACTION_CHOOSER intent with the ACTION_VIEW intent put as an extra intent in the update notification.

#### Fixes the following issue(s)
https://github.com/TeamNewPipe/NewPipe/pull/5187#issuecomment-761558752

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
