### PR TITLE
Prevent IllegalArgumentException when closing popup

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/subscription/item/PickerSubscriptionItem.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/item/PickerSubscriptionItem.kt
@@ -46,6 +46,6 @@ data class PickerSubscriptionItem(
     fun updateSelected(containerView: View, isSelected: Boolean) {
         this.isSelected = isSelected
         PickerSubscriptionItemBinding.bind(containerView).selectedHighlight
-                .animate(isSelected, 150, AnimationType.LIGHT_SCALE_AND_ALPHA)
+            .animate(isSelected, 150, AnimationType.LIGHT_SCALE_AND_ALPHA)
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -1349,13 +1349,23 @@ public final class Player implements
 
     public void removePopupFromView() {
         if (windowManager != null) {
-            final boolean isCloseOverlayHasParent = closeOverlayBinding != null
-                    && closeOverlayBinding.closeButton.getParent() != null;
-            if (popupHasParent()) {
-                windowManager.removeView(binding.getRoot());
+            // wrap in try-catch since it could sometimes generate errors randomly
+            try {
+                if (popupHasParent()) {
+                    windowManager.removeView(binding.getRoot());
+                }
+            } catch (final IllegalArgumentException e) {
+                Log.w(TAG, "Failed to remove popup from window manager", e);
             }
-            if (isCloseOverlayHasParent) {
-                windowManager.removeView(closeOverlayBinding.getRoot());
+
+            try {
+                final boolean closeOverlayHasParent = closeOverlayBinding != null
+                        && closeOverlayBinding.getRoot().getParent() != null;
+                if (closeOverlayHasParent) {
+                    windowManager.removeView(closeOverlayBinding.getRoot());
+                }
+            } catch (final IllegalArgumentException e) {
+                Log.w(TAG, "Failed to remove popup overlay from window manager", e);
             }
         }
     }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR

This PR fixes a random crash when closing the popup player. I could reproduce it consistently on `dev` by closing the popup player via the `X` in the notification, but it also happens on `0.20.8` at random times.

#### Fixes
<details><summary><b>Crash log</b></summary><p>

```
java.lang.RuntimeException: Unable to stop service org.schabi.newpipe.player.MainPlayer@56760fc: java.lang.IllegalArgumentException: View=android.widget.FrameLayout{759337c V.E...... ........ 0,0-1080,1965} not attached to window manager
	at android.app.ActivityThread.handleStopService(ActivityThread.java:4136)
	at android.app.ActivityThread.access$1900(ActivityThread.java:219)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1896)
	at android.os.Handler.dispatchMessage(Handler.java:107)
	at android.os.Looper.loop(Looper.java:214)
	at android.app.ActivityThread.main(ActivityThread.java:7356)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:491)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:940)
Caused by: java.lang.IllegalArgumentException: View=android.widget.FrameLayout{759337c V.E...... ........ 0,0-1080,1965} not attached to window manager
	at android.view.WindowManagerGlobal.findViewLocked(WindowManagerGlobal.java:517)
	at android.view.WindowManagerGlobal.removeView(WindowManagerGlobal.java:426)
	at android.view.WindowManagerImpl.removeView(WindowManagerImpl.java:121)
	at org.schabi.newpipe.player.Player.removePopupFromView(Player.java:1358)
	at org.schabi.newpipe.player.MainPlayer.onDestroy(MainPlayer.java:192)
	at android.app.ActivityThread.handleStopService(ActivityThread.java:4116)
	... 8 more

```
</p></details>

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
