### PR TITLE
Update to ExoPlayer 2.12.3

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -96,7 +96,7 @@ ext {
     checkstyleVersion = '8.38'
     stethoVersion = '1.5.1'
     leakCanaryVersion = '2.5'
-    exoPlayerVersion = '2.11.8'
+    exoPlayerVersion = '2.12.3'
     androidxLifecycleVersion = '2.2.0'
     androidxRoomVersion = '2.3.0-alpha03'
     groupieVersion = '2.8.1'

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -1433,7 +1433,7 @@ public final class Player implements
     }
 
     public boolean getPlaybackSkipSilence() {
-        return simpleExoPlayer != null
+        return !exoPlayerIsNull() && simpleExoPlayer.getAudioComponent() != null
                 && simpleExoPlayer.getAudioComponent().getSkipSilenceEnabled();
     }
 
@@ -1460,7 +1460,9 @@ public final class Player implements
         savePlaybackParametersToPrefs(this, roundedSpeed, roundedPitch, skipSilence);
         simpleExoPlayer.setPlaybackParameters(
                 new PlaybackParameters(roundedSpeed, roundedPitch));
-        simpleExoPlayer.getAudioComponent().setSkipSilenceEnabled(skipSilence);
+        if (simpleExoPlayer.getAudioComponent() != null) {
+            simpleExoPlayer.getAudioComponent().setSkipSilenceEnabled(skipSilence);
+        }
     }
     //endregion
 
@@ -2336,6 +2338,7 @@ public final class Player implements
             case ExoPlaybackException.TYPE_OUT_OF_MEMORY:
             case ExoPlaybackException.TYPE_REMOTE:
             case ExoPlaybackException.TYPE_RENDERER:
+            case ExoPlaybackException.TYPE_TIMEOUT:
             default:
                 showUnrecoverableError(error);
                 onPlaybackShutdown();
@@ -3358,7 +3361,7 @@ public final class Player implements
         final List<String> availableLanguages = new ArrayList<>(textTracks.length);
         for (int i = 0; i < textTracks.length; i++) {
             final TrackGroup textTrack = textTracks.get(i);
-            if (textTrack.length > 0 && textTrack.getFormat(0) != null) {
+            if (textTrack.length > 0) {
                 availableLanguages.add(textTrack.getFormat(0).language);
             }
         }

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -601,7 +601,8 @@ public final class Player implements
         final PlaybackParameters savedParameters = retrievePlaybackParametersFromPrefs(this);
         final float playbackSpeed = savedParameters.speed;
         final float playbackPitch = savedParameters.pitch;
-        final boolean playbackSkipSilence = savedParameters.skipSilence;
+        final boolean playbackSkipSilence = getPrefs().getBoolean(getContext().getString(
+                R.string.playback_skip_silence_key), getPlaybackSkipSilence());
 
         final boolean samePlayQueue = playQueue != null && playQueue.equals(newQueue);
         final int repeatMode = intent.getIntExtra(REPEAT_MODE, getRepeatMode());
@@ -1432,7 +1433,8 @@ public final class Player implements
     }
 
     public boolean getPlaybackSkipSilence() {
-        return getPlaybackParameters().skipSilence;
+        return simpleExoPlayer != null
+                && simpleExoPlayer.getAudioComponent().getSkipSilenceEnabled();
     }
 
     public PlaybackParameters getPlaybackParameters() {
@@ -1457,7 +1459,8 @@ public final class Player implements
 
         savePlaybackParametersToPrefs(this, roundedSpeed, roundedPitch, skipSilence);
         simpleExoPlayer.setPlaybackParameters(
-                new PlaybackParameters(roundedSpeed, roundedPitch, skipSilence));
+                new PlaybackParameters(roundedSpeed, roundedPitch));
+        simpleExoPlayer.getAudioComponent().setSkipSilenceEnabled(skipSilence);
     }
     //endregion
 

--- a/app/src/main/java/org/schabi/newpipe/player/helper/LoadController.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/LoadController.java
@@ -80,12 +80,13 @@ public class LoadController implements LoadControl {
     }
 
     @Override
-    public boolean shouldContinueLoading(final long bufferedDurationUs,
-                                         final float playbackSpeed) {
+    public boolean shouldContinueLoading(final long playbackPositionUs,
+                                         final long bufferedDurationUs, final float playbackSpeed) {
         if (!preloadingEnabled) {
             return false;
         }
-        return internalLoadControl.shouldContinueLoading(bufferedDurationUs, playbackSpeed);
+        return internalLoadControl.shouldContinueLoading(playbackPositionUs, bufferedDurationUs,
+                playbackSpeed);
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/player/helper/LoadController.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/LoadController.java
@@ -81,12 +81,13 @@ public class LoadController implements LoadControl {
 
     @Override
     public boolean shouldContinueLoading(final long playbackPositionUs,
-                                         final long bufferedDurationUs, final float playbackSpeed) {
+                                         final long bufferedDurationUs,
+                                         final float playbackSpeed) {
         if (!preloadingEnabled) {
             return false;
         }
-        return internalLoadControl.shouldContinueLoading(playbackPositionUs, bufferedDurationUs,
-                playbackSpeed);
+        return internalLoadControl.shouldContinueLoading(
+                playbackPositionUs, bufferedDurationUs, playbackSpeed);
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
@@ -494,9 +494,7 @@ public final class PlayerHelper {
                 R.string.playback_speed_key), player.getPlaybackSpeed());
         final float pitch = player.getPrefs().getFloat(player.getContext().getString(
                 R.string.playback_pitch_key), player.getPlaybackPitch());
-        final boolean skipSilence = player.getPrefs().getBoolean(player.getContext().getString(
-                R.string.playback_skip_silence_key), player.getPlaybackSkipSilence());
-        return new PlaybackParameters(speed, pitch, skipSilence);
+        return new PlaybackParameters(speed, pitch);
     }
 
     public static void savePlaybackParametersToPrefs(final Player player,

--- a/app/src/main/java/org/schabi/newpipe/player/mediasource/FailedMediaSource.java
+++ b/app/src/main/java/org/schabi/newpipe/player/mediasource/FailedMediaSource.java
@@ -5,6 +5,7 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.google.android.exoplayer2.MediaItem;
 import com.google.android.exoplayer2.source.BaseMediaSource;
 import com.google.android.exoplayer2.source.MediaPeriod;
 import com.google.android.exoplayer2.upstream.Allocator;
@@ -52,6 +53,14 @@ public class FailedMediaSource extends BaseMediaSource implements ManagedMediaSo
 
     private boolean canRetry() {
         return System.currentTimeMillis() >= retryTimestamp;
+    }
+
+    /**
+     * Returns the {@link MediaItem} whose media is provided by the source.
+     */
+    @Override
+    public MediaItem getMediaItem() {
+        return MediaItem.fromUri(playQueueItem.getUrl());
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/player/mediasource/LoadedMediaSource.java
+++ b/app/src/main/java/org/schabi/newpipe/player/mediasource/LoadedMediaSource.java
@@ -5,6 +5,8 @@ import android.os.Handler;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.google.android.exoplayer2.MediaItem;
+import com.google.android.exoplayer2.drm.DrmSessionEventListener;
 import com.google.android.exoplayer2.source.MediaPeriod;
 import com.google.android.exoplayer2.source.MediaSource;
 import com.google.android.exoplayer2.source.MediaSourceEventListener;
@@ -81,6 +83,38 @@ public class LoadedMediaSource implements ManagedMediaSource {
     @Override
     public void removeEventListener(final MediaSourceEventListener eventListener) {
         source.removeEventListener(eventListener);
+    }
+
+    /**
+     * Adds a {@link DrmSessionEventListener} to the list of listeners which are notified of DRM
+     * events for this media source.
+     *
+     * @param handler       A handler on the which listener events will be posted.
+     * @param eventListener The listener to be added.
+     */
+    @Override
+    public void addDrmEventListener(final Handler handler,
+                                    final DrmSessionEventListener eventListener) {
+        source.addDrmEventListener(handler, eventListener);
+    }
+
+    /**
+     * Removes a {@link DrmSessionEventListener} from the list of listeners which are notified of
+     * DRM events for this media source.
+     *
+     * @param eventListener The listener to be removed.
+     */
+    @Override
+    public void removeDrmEventListener(final DrmSessionEventListener eventListener) {
+        source.removeDrmEventListener(eventListener);
+    }
+
+    /**
+     * Returns the {@link MediaItem} whose media is provided by the source.
+     */
+    @Override
+    public MediaItem getMediaItem() {
+        return source.getMediaItem();
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/player/mediasource/PlaceholderMediaSource.java
+++ b/app/src/main/java/org/schabi/newpipe/player/mediasource/PlaceholderMediaSource.java
@@ -3,6 +3,7 @@ package org.schabi.newpipe.player.mediasource;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.google.android.exoplayer2.MediaItem;
 import com.google.android.exoplayer2.source.BaseMediaSource;
 import com.google.android.exoplayer2.source.MediaPeriod;
 import com.google.android.exoplayer2.upstream.Allocator;
@@ -11,6 +12,14 @@ import com.google.android.exoplayer2.upstream.TransferListener;
 import org.schabi.newpipe.player.playqueue.PlayQueueItem;
 
 public class PlaceholderMediaSource extends BaseMediaSource implements ManagedMediaSource {
+    /**
+     * Returns the {@link MediaItem} whose media is provided by the source.
+     */
+    @Override
+    public MediaItem getMediaItem() {
+        return null;
+    }
+
     // Do nothing, so this will stall the playback
     @Override
     public void maybeThrowSourceInfoRefreshError() { }


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [X] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Updates ExoPlayer from 2.11 to 2.12

Note that we will have to do another PR to migrate from deprecated mediasession to media2.
However this will most likely require to also rework everything to the new MediaItems instead of working with MediaSources.
For now however this can stay and if ExoPlayer stays being compatible with mediasession we aren't in a rush.

#### Due diligence
- [X] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
