### PR TITLE
Fix popup closing x button animation

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -4003,7 +4003,7 @@ public final class Player implements
     }
 
     public View getClosingOverlayView() {
-        return closeOverlayBinding.getRoot();
+        return binding.closingOverlay;
     }
 
     public ProgressBar getVolumeProgressBar() {

--- a/app/src/main/java/org/schabi/newpipe/player/event/PlayerGestureListener.java
+++ b/app/src/main/java/org/schabi/newpipe/player/event/PlayerGestureListener.java
@@ -124,11 +124,11 @@ public class PlayerGestureListener
             final View closingOverlayView = player.getClosingOverlayView();
             if (player.isInsideClosingRadius(movingEvent)) {
                 if (closingOverlayView.getVisibility() == View.GONE) {
-                    animate(closingOverlayView, true, 250);
+                    animate(closingOverlayView, true, 200);
                 }
             } else {
                 if (closingOverlayView.getVisibility() == View.VISIBLE) {
-                    animate(closingOverlayView, false, 0);
+                    animate(closingOverlayView, false, 200);
                 }
             }
         }
@@ -234,12 +234,9 @@ public class PlayerGestureListener
 
             if (player.isInsideClosingRadius(event)) {
                 player.closePopup();
-            } else {
-                animate(player.getClosingOverlayView(), false, 0);
-
-                if (!player.isPopupClosing()) {
-                    animate(player.getCloseOverlayButton(), false, 200);
-                }
+            } else if (!player.isPopupClosing()) {
+                animate(player.getCloseOverlayButton(), false, 200);
+                animate(player.getClosingOverlayView(), false, 200);
             }
         }
     }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This fixes the animation of the X button (which is now always shown while the popup is drag aroung) and the animation of the red overlay above the player.

#### Fixes the following issue(s)
https://github.com/TeamNewPipe/NewPipe/issues/5455#issuecomment-762604619

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
