### PR TITLE
Fix number being shown instead of corresponding string resorce in feed

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
@@ -236,7 +236,7 @@ class FeedFragment : BaseListFragment<FeedState, Unit>() {
         feedBinding.loadingProgressText.text = if (!isIndeterminate) {
             "${progressState.currentProgress}/${progressState.maxProgress}"
         } else if (progressState.progressMessage > 0) {
-            progressState.progressMessage.toString()
+            getString(progressState.progressMessage)
         } else {
             "∞/∞"
         }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Fixes 2131755371 appearing when the feed finishes loading due to an int string resource not being converted using `getString()` 

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
