### PR TITLE
Fix channel subscribe button causing crash on closing

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
@@ -131,14 +131,9 @@ public class ChannelFragment extends BaseListInfoFragment<ChannelInfo>
         if (subscribeButtonMonitor != null) {
             subscribeButtonMonitor.dispose();
         }
-    }
-
-    @Override
-    public void onDestroyView() {
         channelBinding = null;
         headerBinding = null;
         playlistControlBinding = null;
-        super.onDestroyView();
     }
 
     /*//////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This was probably caused by the binding being set to null since the activity was closing, but the async channel subscription disposable being run just after that. https://github.com/TeamNewPipe/NewPipe/issues/5455#issuecomment-763024066

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
