### PR TITLE
Re-add APK testing section to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,5 +20,10 @@
 <!-- Delete this if it doesn't apply to you. -->
 - 
 
+#### APK testing 
+<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
+<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
+On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.
+
 #### Due diligence
 - [ ] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Re-add APK testing section to PR template
- Add instructions on how to navigate to the APK created by the CI pipeline
- basically reverts #5284

#### Fixes the following issue(s)
<!-- Also add any other links relevant to your change. -->
- Here i asked a user to test the bug fix, but he did not know where to install the apk from https://github.com/TeamNewPipe/NewPipe/pull/5464#issuecomment-763735114

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK. Directly linking is preferred if you need to let users test.-->
On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).

fyi @mhmdanas 

@brnwlshubh Would you find the description under the APK testing section sufficient for someone who hasn't used github beforehand?