### PR TITLE
Respect expires header when checking for new versions

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/CheckForNewAppVersion.java
+++ b/app/src/main/java/org/schabi/newpipe/CheckForNewAppVersion.java
@@ -179,6 +179,8 @@ public final class CheckForNewAppVersion {
             return null;
         }
 
+        // Check if the last request has happened a certain time ago
+        // to reduce the number of API requests.
         final long expiry = prefs.getLong(app.getString(R.string.update_expiry_key), 0);
         if (!manager.isExpired(expiry)) {
             return null;
@@ -198,6 +200,8 @@ public final class CheckForNewAppVersion {
                 .subscribe(
                         response -> {
                             try {
+                                // Store a timestamp which needs to be exceeded,
+                                // before a new request to the API is made.
                                 final long newExpiry = manager
                                     .coerceExpiry(response.getHeader("expires"));
                                 prefs.edit()

--- a/app/src/main/java/org/schabi/newpipe/CheckForNewAppVersion.java
+++ b/app/src/main/java/org/schabi/newpipe/CheckForNewAppVersion.java
@@ -180,7 +180,7 @@ public final class CheckForNewAppVersion {
         }
 
         final long expiry = prefs.getLong(app.getString(R.string.update_expiry_key), 0);
-        if (manager.isExpired(expiry)) {
+        if (!manager.isExpired(expiry)) {
             return null;
         }
 

--- a/app/src/main/java/org/schabi/newpipe/NewVersionManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/NewVersionManager.kt
@@ -1,0 +1,28 @@
+package org.schabi.newpipe
+
+import java.time.Instant
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
+class NewVersionManager {
+
+    fun isExpired(expiry: Long): Boolean {
+        return Instant.ofEpochSecond(expiry).isBefore(Instant.now())
+    }
+
+    /**
+     * Coerce expiry date time in between 6 hours and 72 hours from now
+     *
+     * @return Epoch second of expiry date time
+     */
+    fun coerceExpiry(expiryString: String?): Long {
+        val now = ZonedDateTime.now()
+        return expiryString?.let {
+
+            var expiry = ZonedDateTime.from(DateTimeFormatter.RFC_1123_DATE_TIME.parse(expiryString))
+            expiry = maxOf(expiry, now.plusHours(6))
+            expiry = minOf(expiry, now.plusHours(72))
+            expiry.toEpochSecond()
+        } ?: now.plusHours(6).toEpochSecond()
+    }
+}

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -342,6 +342,7 @@
     <!-- Updates -->
     <string name="update_app_key" translatable="false">update_app_key</string>
     <string name="update_pref_screen_key" translatable="false">update_pref_screen_key</string>
+    <string name="update_expiry_key" translatable="false">update_expiry_key</string>
 
     <!-- Localizations   -->
     <string name="default_localization_key" translatable="false">system</string>

--- a/app/src/test/java/org/schabi/newpipe/NewVersionManagerTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/NewVersionManagerTest.kt
@@ -1,0 +1,72 @@
+package org.schabi.newpipe
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import kotlin.math.abs
+
+class NewVersionManagerTest {
+
+    private lateinit var manager: NewVersionManager
+
+    @Before
+    fun setup() {
+        manager = NewVersionManager()
+    }
+
+    @Test
+    fun `Expiry is reached`() {
+        val oneHourEarlier = Instant.now().atZone(ZoneId.of("GMT")).minusHours(1)
+
+        val expired = manager.isExpired(oneHourEarlier.toEpochSecond())
+
+        assertTrue(expired)
+    }
+
+    @Test
+    fun `Expiry is not reached`() {
+        val oneHourLater = Instant.now().atZone(ZoneId.of("GMT")).plusHours(1)
+
+        val expired = manager.isExpired(oneHourLater.toEpochSecond())
+
+        assertFalse(expired)
+    }
+
+    /**
+     * Equal within a range of 5 seconds
+     */
+    private fun assertNearlyEqual(a: Long, b: Long) {
+        assertTrue(abs(a - b) < 5)
+    }
+
+    @Test
+    fun `Expiry must be returned as is because it is inside the acceptable range of 6-72 hours`() {
+        val sixHoursLater = Instant.now().atZone(ZoneId.of("GMT")).plusHours(6)
+
+        val coerced = manager.coerceExpiry(DateTimeFormatter.RFC_1123_DATE_TIME.format(sixHoursLater))
+
+        assertNearlyEqual(sixHoursLater.toEpochSecond(), coerced)
+    }
+
+    @Test
+    fun `Expiry must be increased to 6 hours if below`() {
+        val tooLow = Instant.now().atZone(ZoneId.of("GMT")).plusHours(5)
+
+        val coerced = manager.coerceExpiry(DateTimeFormatter.RFC_1123_DATE_TIME.format(tooLow))
+
+        assertNearlyEqual(tooLow.plusHours(1).toEpochSecond(), coerced)
+    }
+
+    @Test
+    fun `Expiry must be decreased to 72 hours if above`() {
+        val tooHigh = Instant.now().atZone(ZoneId.of("GMT")).plusHours(73)
+
+        val coerced = manager.coerceExpiry(DateTimeFormatter.RFC_1123_DATE_TIME.format(tooHigh))
+
+        assertNearlyEqual(tooHigh.minusHours(1).toEpochSecond(), coerced)
+    }
+}


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Save expires header into preferences on version check
  - Coerce it between 6 and 72 hours 
- Check expires date before making network request to check for new versions

#### Fixes the following issue(s)
<!-- Also add any other links relevant to your change. -->
- #5467

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).

I'd to do some refactoring and add some test if time permitts.

#### APK
https://github.com/XiangRongLin/NewPipe/actions/runs/501846770
https://github.com/XiangRongLin/NewPipe/pull/10

this apk ignores usual checks for when to run the request