### PR TITLE
Set all default settings at the beginning

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/settings/NewPipeSettings.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/NewPipeSettings.java
@@ -55,12 +55,14 @@ public final class NewPipeSettings {
             isFirstRun = true;
         }
 
-        PreferenceManager.setDefaultValues(context, R.xml.appearance_settings, true);
-        PreferenceManager.setDefaultValues(context, R.xml.content_settings, true);
-        PreferenceManager.setDefaultValues(context, R.xml.download_settings, true);
-        PreferenceManager.setDefaultValues(context, R.xml.history_settings, true);
         PreferenceManager.setDefaultValues(context, R.xml.main_settings, true);
         PreferenceManager.setDefaultValues(context, R.xml.video_audio_settings, true);
+        PreferenceManager.setDefaultValues(context, R.xml.download_settings, true);
+        PreferenceManager.setDefaultValues(context, R.xml.appearance_settings, true);
+        PreferenceManager.setDefaultValues(context, R.xml.history_settings, true);
+        PreferenceManager.setDefaultValues(context, R.xml.content_settings, true);
+        PreferenceManager.setDefaultValues(context, R.xml.notification_settings, true);
+        PreferenceManager.setDefaultValues(context, R.xml.update_settings, true);
         PreferenceManager.setDefaultValues(context, R.xml.debug_settings, true);
 
         getVideoDownloadFolder(context);


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
I noticed NewPipe does not call [`PreferenceManager.setDefaultValues()`](https://developer.android.com/reference/androidx/preference/PreferenceManager#setDefaultValues(android.content.Context,%20int,%20boolean)) for all settings screens. This PR fixes this, by adding `notification_settings` and `update_settings`.

#### Fixes the following issue(s)
Probably not doing this didn't cause any issue, since there are always fallbacks when getting preferences, but it surely does not hurt.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
