### PR TITLE
Recognize timestamps and hashtags in descriptions and do some sharing fixes and improvements

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/CheckForNewAppVersion.java
+++ b/app/src/main/java/org/schabi/newpipe/CheckForNewAppVersion.java
@@ -130,12 +130,11 @@ public final class CheckForNewAppVersion {
         if (BuildConfig.VERSION_CODE < versionCode) {
             // A pending intent to open the apk location url in the browser.
             final Intent viewIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(apkLocationUrl));
+            viewIntent.putExtra(Intent.EXTRA_TITLE, R.string.open_with);
 
             final Intent intent = new Intent(Intent.ACTION_CHOOSER);
             intent.putExtra(Intent.EXTRA_INTENT, viewIntent);
-            intent.putExtra(Intent.EXTRA_TITLE, R.string.open_with);
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-
             final PendingIntent pendingIntent
                     = PendingIntent.getActivity(application, 0, intent, 0);
 

--- a/app/src/main/java/org/schabi/newpipe/CheckForNewAppVersion.java
+++ b/app/src/main/java/org/schabi/newpipe/CheckForNewAppVersion.java
@@ -129,11 +129,7 @@ public final class CheckForNewAppVersion {
 
         if (BuildConfig.VERSION_CODE < versionCode) {
             // A pending intent to open the apk location url in the browser.
-            final Intent viewIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(apkLocationUrl));
-            viewIntent.putExtra(Intent.EXTRA_TITLE, R.string.open_with);
-
-            final Intent intent = new Intent(Intent.ACTION_CHOOSER);
-            intent.putExtra(Intent.EXTRA_INTENT, viewIntent);
+            final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(apkLocationUrl));
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             final PendingIntent pendingIntent
                     = PendingIntent.getActivity(application, 0, intent, 0);

--- a/app/src/main/java/org/schabi/newpipe/RouterActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/RouterActivity.java
@@ -69,7 +69,7 @@ import org.schabi.newpipe.util.ExtractorHelper;
 import org.schabi.newpipe.util.ListHelper;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.PermissionHelper;
-import org.schabi.newpipe.util.ShareUtils;
+import org.schabi.newpipe.util.external_communication.ShareUtils;
 import org.schabi.newpipe.util.ThemeHelper;
 import org.schabi.newpipe.util.urlfinder.UrlFinder;
 import org.schabi.newpipe.views.FocusOverlayView;

--- a/app/src/main/java/org/schabi/newpipe/RouterActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/RouterActivity.java
@@ -234,7 +234,7 @@ public class RouterActivity extends AppCompatActivity {
                 .setPositiveButton(R.string.open_in_browser,
                         (dialog, which) -> ShareUtils.openUrlInBrowser(this, url))
                 .setNegativeButton(R.string.share,
-                        (dialog, which) -> ShareUtils.shareText(this, "", url)) // no subject
+                        (dialog, which) -> ShareUtils.shareText(this, "", url, false)) //no subject
                 .setNeutralButton(R.string.cancel, null)
                 .setOnDismissListener(dialog -> finish())
                 .show();

--- a/app/src/main/java/org/schabi/newpipe/RouterActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/RouterActivity.java
@@ -234,7 +234,7 @@ public class RouterActivity extends AppCompatActivity {
                 .setPositiveButton(R.string.open_in_browser,
                         (dialog, which) -> ShareUtils.openUrlInBrowser(this, url))
                 .setNegativeButton(R.string.share,
-                        (dialog, which) -> ShareUtils.shareText(this, "", url, "")) //no subject
+                        (dialog, which) -> ShareUtils.shareText(this, "", url)) // no subject
                 .setNeutralButton(R.string.cancel, null)
                 .setOnDismissListener(dialog -> finish())
                 .show();

--- a/app/src/main/java/org/schabi/newpipe/RouterActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/RouterActivity.java
@@ -234,7 +234,7 @@ public class RouterActivity extends AppCompatActivity {
                 .setPositiveButton(R.string.open_in_browser,
                         (dialog, which) -> ShareUtils.openUrlInBrowser(this, url))
                 .setNegativeButton(R.string.share,
-                        (dialog, which) -> ShareUtils.shareText(this, "", url, false)) //no subject
+                        (dialog, which) -> ShareUtils.shareText(this, "", url, "")) //no subject
                 .setNeutralButton(R.string.cancel, null)
                 .setOnDismissListener(dialog -> finish())
                 .show();

--- a/app/src/main/java/org/schabi/newpipe/about/AboutActivity.kt
+++ b/app/src/main/java/org/schabi/newpipe/about/AboutActivity.kt
@@ -16,8 +16,8 @@ import org.schabi.newpipe.BuildConfig
 import org.schabi.newpipe.R
 import org.schabi.newpipe.databinding.ActivityAboutBinding
 import org.schabi.newpipe.databinding.FragmentAboutBinding
+import org.schabi.newpipe.util.external_communication.ShareUtils
 import org.schabi.newpipe.util.Localization
-import org.schabi.newpipe.util.ShareUtils
 import org.schabi.newpipe.util.ThemeHelper
 
 class AboutActivity : AppCompatActivity() {

--- a/app/src/main/java/org/schabi/newpipe/about/AboutActivity.kt
+++ b/app/src/main/java/org/schabi/newpipe/about/AboutActivity.kt
@@ -16,9 +16,9 @@ import org.schabi.newpipe.BuildConfig
 import org.schabi.newpipe.R
 import org.schabi.newpipe.databinding.ActivityAboutBinding
 import org.schabi.newpipe.databinding.FragmentAboutBinding
-import org.schabi.newpipe.util.external_communication.ShareUtils
 import org.schabi.newpipe.util.Localization
 import org.schabi.newpipe.util.ThemeHelper
+import org.schabi.newpipe.util.external_communication.ShareUtils
 
 class AboutActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/org/schabi/newpipe/about/LicenseFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/about/LicenseFragment.kt
@@ -19,7 +19,6 @@ import java.util.Objects
  */
 class LicenseFragment : Fragment() {
     private lateinit var softwareComponents: Array<SoftwareComponent>
-    private var componentForContextMenu: SoftwareComponent? = null
     private var activeLicense: License? = null
     private val compositeDisposable = CompositeDisposable()
 

--- a/app/src/main/java/org/schabi/newpipe/about/LicenseFragmentHelper.kt
+++ b/app/src/main/java/org/schabi/newpipe/about/LicenseFragmentHelper.kt
@@ -10,8 +10,8 @@ import io.reactivex.rxjava3.disposables.Disposable
 import io.reactivex.rxjava3.schedulers.Schedulers
 import org.schabi.newpipe.R
 import org.schabi.newpipe.util.Localization
-import org.schabi.newpipe.util.ShareUtils
 import org.schabi.newpipe.util.ThemeHelper
+import org.schabi.newpipe.util.external_communication.ShareUtils
 import java.io.BufferedReader
 import java.io.IOException
 import java.io.InputStreamReader

--- a/app/src/main/java/org/schabi/newpipe/error/ErrorActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/error/ErrorActivity.java
@@ -27,7 +27,7 @@ import org.schabi.newpipe.MainActivity;
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.databinding.ActivityErrorBinding;
 import org.schabi.newpipe.util.Localization;
-import org.schabi.newpipe.util.ShareUtils;
+import org.schabi.newpipe.util.external_communication.ShareUtils;
 import org.schabi.newpipe.util.ThemeHelper;
 
 import java.time.LocalDateTime;

--- a/app/src/main/java/org/schabi/newpipe/error/ErrorActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/error/ErrorActivity.java
@@ -220,13 +220,10 @@ public class ErrorActivity extends AppCompatActivity {
                                         + getString(R.string.app_name) + " "
                                         + BuildConfig.VERSION_NAME)
                                 .putExtra(Intent.EXTRA_TEXT, buildJson());
-                        if (i.resolveActivity(getPackageManager()) != null) {
-                            ShareUtils.openIntentInApp(context, i);
-                        }
+                        ShareUtils.openIntentInApp(context, i, true);
                     } else if (action.equals("GITHUB")) { // open the NewPipe issue page on GitHub
                         ShareUtils.openUrlInBrowser(this, ERROR_GITHUB_ISSUE_URL, false);
                     }
-
                 })
                 .setNegativeButton(R.string.decline, (dialog, which) -> {
                     // do nothing

--- a/app/src/main/java/org/schabi/newpipe/error/ErrorActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/error/ErrorActivity.java
@@ -195,7 +195,8 @@ public class ErrorActivity extends AppCompatActivity {
                 onBackPressed();
                 return true;
             case R.id.menu_item_share_error:
-                ShareUtils.shareText(this, getString(R.string.error_report_title), buildJson());
+                ShareUtils.shareText(getApplicationContext(),
+                        getString(R.string.error_report_title), buildJson());
                 return true;
             default:
                 return false;

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/DescriptionFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/DescriptionFragment.java
@@ -19,7 +19,6 @@ import org.schabi.newpipe.R;
 import org.schabi.newpipe.databinding.FragmentDescriptionBinding;
 import org.schabi.newpipe.databinding.ItemMetadataBinding;
 import org.schabi.newpipe.databinding.ItemMetadataTagsBinding;
-import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.stream.Description;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.util.Localization;
@@ -132,24 +131,19 @@ public class DescriptionFragment extends BaseFragment {
 
     private void loadDescriptionContent() {
         final Description description = streamInfo.getDescription();
-        final String contentUrl = streamInfo.getUrl();
-        final StreamingService service = streamInfo.getService();
-
         switch (description.getType()) {
             case Description.HTML:
-                descriptionDisposable = TextLinkifier.createLinksFromHtmlBlock(requireContext(),
-                        description.getContent(), binding.detailDescriptionView,
-                        service, contentUrl, HtmlCompat.FROM_HTML_MODE_LEGACY);
+                descriptionDisposable = TextLinkifier.createLinksFromHtmlBlock(
+                        binding.detailDescriptionView, description.getContent(),
+                        HtmlCompat.FROM_HTML_MODE_LEGACY, streamInfo);
                 break;
             case Description.MARKDOWN:
-                descriptionDisposable = TextLinkifier.createLinksFromMarkdownText(requireContext(),
-                        description.getContent(), binding.detailDescriptionView,
-                        service, contentUrl);
+                descriptionDisposable = TextLinkifier.createLinksFromMarkdownText(
+                        binding.detailDescriptionView, description.getContent(), streamInfo);
                 break;
             case Description.PLAIN_TEXT: default:
-                descriptionDisposable = TextLinkifier.createLinksFromPlainText(requireContext(),
-                        description.getContent(), binding.detailDescriptionView,
-                        service, contentUrl);
+                descriptionDisposable = TextLinkifier.createLinksFromPlainText(
+                        binding.detailDescriptionView, description.getContent(), streamInfo);
                 break;
         }
     }
@@ -204,8 +198,7 @@ public class DescriptionFragment extends BaseFragment {
         });
 
         if (linkifyContent) {
-            TextLinkifier.createLinksFromPlainText(requireContext(),
-                    content, itemBinding.metadataContentView, null, null);
+            TextLinkifier.createLinksFromPlainText(itemBinding.metadataContentView, content, null);
         } else {
             itemBinding.metadataContentView.setText(content);
         }

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/DescriptionFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/DescriptionFragment.java
@@ -19,6 +19,7 @@ import org.schabi.newpipe.R;
 import org.schabi.newpipe.databinding.FragmentDescriptionBinding;
 import org.schabi.newpipe.databinding.ItemMetadataBinding;
 import org.schabi.newpipe.databinding.ItemMetadataTagsBinding;
+import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.stream.Description;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.util.Localization;
@@ -131,19 +132,24 @@ public class DescriptionFragment extends BaseFragment {
 
     private void loadDescriptionContent() {
         final Description description = streamInfo.getDescription();
+        final String contentUrl = streamInfo.getUrl();
+        final StreamingService service = streamInfo.getService();
+
         switch (description.getType()) {
             case Description.HTML:
                 descriptionDisposable = TextLinkifier.createLinksFromHtmlBlock(requireContext(),
                         description.getContent(), binding.detailDescriptionView,
-                        HtmlCompat.FROM_HTML_MODE_LEGACY);
+                        service, contentUrl, HtmlCompat.FROM_HTML_MODE_LEGACY);
                 break;
             case Description.MARKDOWN:
                 descriptionDisposable = TextLinkifier.createLinksFromMarkdownText(requireContext(),
-                        description.getContent(), binding.detailDescriptionView);
+                        description.getContent(), binding.detailDescriptionView,
+                        service, contentUrl);
                 break;
             case Description.PLAIN_TEXT: default:
                 descriptionDisposable = TextLinkifier.createLinksFromPlainText(requireContext(),
-                        description.getContent(), binding.detailDescriptionView);
+                        description.getContent(), binding.detailDescriptionView,
+                        service, contentUrl);
                 break;
         }
     }
@@ -199,7 +205,7 @@ public class DescriptionFragment extends BaseFragment {
 
         if (linkifyContent) {
             TextLinkifier.createLinksFromPlainText(requireContext(),
-                    content, itemBinding.metadataContentView);
+                    content, itemBinding.metadataContentView, null, null);
         } else {
             itemBinding.metadataContentView.setText(content);
         }

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/DescriptionFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/DescriptionFragment.java
@@ -24,8 +24,8 @@ import org.schabi.newpipe.extractor.stream.Description;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.util.Localization;
 import org.schabi.newpipe.util.NavigationHelper;
-import org.schabi.newpipe.util.ShareUtils;
-import org.schabi.newpipe.util.TextLinkifier;
+import org.schabi.newpipe.util.external_communication.ShareUtils;
+import org.schabi.newpipe.util.external_communication.TextLinkifier;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -454,8 +454,8 @@ public final class VideoDetailFragment
                 break;
             case R.id.detail_controls_share:
                 if (currentInfo != null) {
-                    ShareUtils.shareText(requireContext(),
-                            currentInfo.getName(), currentInfo.getUrl());
+                    ShareUtils.shareText(requireContext(), currentInfo.getName(),
+                            currentInfo.getUrl(), currentInfo.getThumbnailUrl());
                 }
                 break;
             case R.id.detail_controls_open_in_browser:

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -1546,8 +1546,8 @@ public final class VideoDetailFragment
                 .getDefaultResolutionIndex(activity, sortedVideoStreams);
         updateProgressInfo(info);
         initThumbnailViews(info);
-        disposables.add(showMetaInfoInTextView(info.getMetaInfo(), binding.detailMetaInfoTextView,
-                binding.detailMetaInfoSeparator));
+        showMetaInfoInTextView(info.getMetaInfo(), binding.detailMetaInfoTextView,
+                binding.detailMetaInfoSeparator, disposables);
 
         if (player == null || player.isStopped()) {
             updateOverlayData(info.getName(), info.getUploaderName(), info.getThumbnailUrl());

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -91,12 +91,12 @@ import org.schabi.newpipe.util.Constants;
 import org.schabi.newpipe.util.DeviceUtils;
 import org.schabi.newpipe.util.ExtractorHelper;
 import org.schabi.newpipe.util.ImageDisplayConstants;
-import org.schabi.newpipe.util.KoreUtil;
+import org.schabi.newpipe.util.external_communication.KoreUtils;
 import org.schabi.newpipe.util.ListHelper;
 import org.schabi.newpipe.util.Localization;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.PermissionHelper;
-import org.schabi.newpipe.util.ShareUtils;
+import org.schabi.newpipe.util.external_communication.ShareUtils;
 import org.schabi.newpipe.util.ThemeHelper;
 
 import java.util.ArrayList;
@@ -472,7 +472,7 @@ public final class VideoDetailFragment
                         if (DEBUG) {
                             Log.i(TAG, "Failed to start kore", e);
                         }
-                        KoreUtil.showInstallKoreDialog(requireContext());
+                        KoreUtils.showInstallKoreDialog(requireContext());
                     }
                 }
                 break;
@@ -631,7 +631,7 @@ public final class VideoDetailFragment
         binding.detailControlsShare.setOnClickListener(this);
         binding.detailControlsOpenInBrowser.setOnClickListener(this);
         binding.detailControlsPlayWithKodi.setOnClickListener(this);
-        binding.detailControlsPlayWithKodi.setVisibility(KoreUtil.shouldShowPlayWithKodi(
+        binding.detailControlsPlayWithKodi.setVisibility(KoreUtils.shouldShowPlayWithKodi(
                 requireContext(), serviceId) ? View.VISIBLE : View.GONE);
 
         binding.overlayThumbnail.setOnClickListener(this);

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
@@ -33,7 +33,7 @@ import org.schabi.newpipe.fragments.OnScrollBelowItemsListener;
 import org.schabi.newpipe.info_list.InfoItemDialog;
 import org.schabi.newpipe.info_list.InfoListAdapter;
 import org.schabi.newpipe.player.helper.PlayerHolder;
-import org.schabi.newpipe.util.KoreUtil;
+import org.schabi.newpipe.util.external_communication.KoreUtils;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.OnClickGesture;
 import org.schabi.newpipe.util.StateSaver;
@@ -371,7 +371,7 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
             ));
         }
         entries.add(StreamDialogEntry.open_in_browser);
-        if (KoreUtil.shouldShowPlayWithKodi(context, item.getServiceId())) {
+        if (KoreUtils.shouldShowPlayWithKodi(context, item.getServiceId())) {
             entries.add(StreamDialogEntry.play_with_kodi);
         }
         if (!isNullOrEmpty(item.getUploaderUrl())) {

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
@@ -43,7 +43,7 @@ import org.schabi.newpipe.util.ExtractorHelper;
 import org.schabi.newpipe.util.ImageDisplayConstants;
 import org.schabi.newpipe.util.Localization;
 import org.schabi.newpipe.util.NavigationHelper;
-import org.schabi.newpipe.util.ShareUtils;
+import org.schabi.newpipe.util.external_communication.ShareUtils;
 import org.schabi.newpipe.util.ThemeHelper;
 
 import java.util.ArrayList;

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
@@ -203,7 +203,8 @@ public class ChannelFragment extends BaseListInfoFragment<ChannelInfo>
                 break;
             case R.id.menu_item_share:
                 if (currentInfo != null) {
-                    ShareUtils.shareText(requireContext(), name, currentInfo.getOriginalUrl());
+                    ShareUtils.shareText(requireContext(), name, currentInfo.getOriginalUrl(),
+                            currentInfo.getAvatarUrl());
                 }
                 break;
             default:

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
@@ -42,10 +42,10 @@ import org.schabi.newpipe.player.playqueue.PlayQueue;
 import org.schabi.newpipe.player.playqueue.PlaylistPlayQueue;
 import org.schabi.newpipe.util.ExtractorHelper;
 import org.schabi.newpipe.util.ImageDisplayConstants;
-import org.schabi.newpipe.util.KoreUtil;
+import org.schabi.newpipe.util.external_communication.KoreUtils;
 import org.schabi.newpipe.util.Localization;
 import org.schabi.newpipe.util.NavigationHelper;
-import org.schabi.newpipe.util.ShareUtils;
+import org.schabi.newpipe.util.external_communication.ShareUtils;
 import org.schabi.newpipe.util.StreamDialogEntry;
 
 import java.util.ArrayList;
@@ -162,7 +162,7 @@ public class PlaylistFragment extends BaseListInfoFragment<PlaylistInfo> {
             ));
         }
         entries.add(StreamDialogEntry.open_in_browser);
-        if (KoreUtil.shouldShowPlayWithKodi(context, item.getServiceId())) {
+        if (KoreUtils.shouldShowPlayWithKodi(context, item.getServiceId())) {
             entries.add(StreamDialogEntry.play_with_kodi);
         }
 

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
@@ -251,7 +251,7 @@ public class PlaylistFragment extends BaseListInfoFragment<PlaylistInfo> {
                 ShareUtils.openUrlInBrowser(requireContext(), url);
                 break;
             case R.id.menu_item_share:
-                ShareUtils.shareText(requireContext(), name, url);
+                ShareUtils.shareText(requireContext(), name, url, currentInfo.getThumbnailUrl());
                 break;
             case R.id.menu_item_bookmark:
                 onBookmarkClicked();

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/search/SearchFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/search/SearchFragment.java
@@ -278,8 +278,9 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
 
         handleSearchSuggestion();
 
-        disposables.add(showMetaInfoInTextView(metaInfo == null ? null : Arrays.asList(metaInfo),
-                    searchBinding.searchMetaInfoTextView, searchBinding.searchMetaInfoSeparator));
+        showMetaInfoInTextView(metaInfo == null ? null : Arrays.asList(metaInfo),
+                searchBinding.searchMetaInfoTextView, searchBinding.searchMetaInfoSeparator,
+                disposables);
 
         if (TextUtils.isEmpty(searchString) || wasSearchFocused) {
             showKeyboardSearch();
@@ -841,7 +842,7 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
         infoListAdapter.clearStreamItemList();
         hideSuggestionsPanel();
         showMetaInfoInTextView(null, searchBinding.searchMetaInfoTextView,
-                searchBinding.searchMetaInfoSeparator);
+                searchBinding.searchMetaInfoSeparator, disposables);
         hideKeyboardSearch();
 
         disposables.add(historyRecordManager.onSearched(serviceId, theSearchString)
@@ -986,8 +987,8 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
         // List<MetaInfo> cannot be bundled without creating some containers
         metaInfo = new MetaInfo[result.getMetaInfo().size()];
         metaInfo = result.getMetaInfo().toArray(metaInfo);
-        disposables.add(showMetaInfoInTextView(result.getMetaInfo(),
-                searchBinding.searchMetaInfoTextView, searchBinding.searchMetaInfoSeparator));
+        showMetaInfoInTextView(result.getMetaInfo(), searchBinding.searchMetaInfoTextView,
+                searchBinding.searchMetaInfoSeparator, disposables);
 
         handleSearchSuggestion();
 

--- a/app/src/main/java/org/schabi/newpipe/info_list/holder/CommentsMiniInfoItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/holder/CommentsMiniInfoItemHolder.java
@@ -24,7 +24,7 @@ import org.schabi.newpipe.util.DeviceUtils;
 import org.schabi.newpipe.util.ImageDisplayConstants;
 import org.schabi.newpipe.util.Localization;
 import org.schabi.newpipe.util.NavigationHelper;
-import org.schabi.newpipe.util.ShareUtils;
+import org.schabi.newpipe.util.external_communication.ShareUtils;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
@@ -36,7 +36,7 @@ import org.schabi.newpipe.player.helper.PlayerHolder;
 import org.schabi.newpipe.player.playqueue.PlayQueue;
 import org.schabi.newpipe.player.playqueue.SinglePlayQueue;
 import org.schabi.newpipe.settings.HistorySettingsFragment;
-import org.schabi.newpipe.util.KoreUtil;
+import org.schabi.newpipe.util.external_communication.KoreUtils;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.OnClickGesture;
 import org.schabi.newpipe.util.StreamDialogEntry;
@@ -359,7 +359,7 @@ public class StatisticsPlaylistFragment
             ));
         }
         entries.add(StreamDialogEntry.open_in_browser);
-        if (KoreUtil.shouldShowPlayWithKodi(context, infoItem.getServiceId())) {
+        if (KoreUtils.shouldShowPlayWithKodi(context, infoItem.getServiceId())) {
             entries.add(StreamDialogEntry.play_with_kodi);
         }
 

--- a/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
@@ -44,7 +44,7 @@ import org.schabi.newpipe.local.history.HistoryRecordManager;
 import org.schabi.newpipe.player.helper.PlayerHolder;
 import org.schabi.newpipe.player.playqueue.PlayQueue;
 import org.schabi.newpipe.player.playqueue.SinglePlayQueue;
-import org.schabi.newpipe.util.KoreUtil;
+import org.schabi.newpipe.util.external_communication.KoreUtils;
 import org.schabi.newpipe.util.Localization;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.OnClickGesture;
@@ -770,7 +770,7 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
             ));
         }
         entries.add(StreamDialogEntry.open_in_browser);
-        if (KoreUtil.shouldShowPlayWithKodi(context, infoItem.getServiceId())) {
+        if (KoreUtils.shouldShowPlayWithKodi(context, infoItem.getServiceId())) {
             entries.add(StreamDialogEntry.play_with_kodi);
         }
 

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
@@ -293,7 +293,8 @@ class SubscriptionFragment : BaseStateFragment<SubscriptionState>() {
 
         val actions = DialogInterface.OnClickListener { _, i ->
             when (i) {
-                0 -> ShareUtils.shareText(requireContext(), selectedItem.name, selectedItem.url)
+                0 -> ShareUtils.shareText(requireContext(), selectedItem.name, selectedItem.url,
+                    selectedItem.thumbnailUrl)
                 1 -> ShareUtils.openUrlInBrowser(requireContext(), selectedItem.url)
                 2 -> deleteChannel(selectedItem)
             }

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
@@ -56,9 +56,9 @@ import org.schabi.newpipe.local.subscription.services.SubscriptionsImportService
 import org.schabi.newpipe.local.subscription.services.SubscriptionsImportService.KEY_VALUE
 import org.schabi.newpipe.local.subscription.services.SubscriptionsImportService.PREVIOUS_EXPORT_MODE
 import org.schabi.newpipe.streams.io.StoredFileHelper
+import org.schabi.newpipe.util.external_communication.ShareUtils
 import org.schabi.newpipe.util.NavigationHelper
 import org.schabi.newpipe.util.OnClickGesture
-import org.schabi.newpipe.util.ShareUtils
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale

--- a/app/src/main/java/org/schabi/newpipe/player/PlayQueueActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayQueueActivity.java
@@ -313,7 +313,8 @@ public final class PlayQueueActivity extends AppCompatActivity
         final MenuItem share = popupMenu.getMenu().add(RECYCLER_ITEM_POPUP_MENU_GROUP_ID, 3,
                 Menu.NONE, R.string.share);
         share.setOnMenuItemClickListener(menuItem -> {
-            shareText(getApplicationContext(), item.getTitle(), item.getUrl());
+            shareText(getApplicationContext(), item.getTitle(), item.getUrl(),
+                    item.getThumbnailUrl());
             return true;
         });
 

--- a/app/src/main/java/org/schabi/newpipe/player/PlayQueueActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayQueueActivity.java
@@ -47,7 +47,7 @@ import java.util.List;
 
 import static org.schabi.newpipe.player.helper.PlayerHelper.formatSpeed;
 import static org.schabi.newpipe.util.Localization.assureCorrectAppLanguage;
-import static org.schabi.newpipe.util.ShareUtils.shareText;
+import static org.schabi.newpipe.util.external_communication.ShareUtils.shareText;
 
 public final class PlayQueueActivity extends AppCompatActivity
         implements PlayerEventListener, SeekBar.OnSeekBarChangeListener,

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -3593,7 +3593,8 @@ public final class Player implements
         } else if (v.getId() == binding.moreOptionsButton.getId()) {
             onMoreOptionsClicked();
         } else if (v.getId() == binding.share.getId()) {
-            ShareUtils.shareText(context, getVideoTitle(), getVideoUrlAtCurrentTime());
+            ShareUtils.shareText(context, getVideoTitle(), getVideoUrlAtCurrentTime(),
+                            currentItem.getThumbnailUrl());
         } else if (v.getId() == binding.playWithKodi.getId()) {
             onPlayWithKodiClicked();
         } else if (v.getId() == binding.openInBrowser.getId()) {

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -123,11 +123,11 @@ import org.schabi.newpipe.player.resolver.MediaSourceTag;
 import org.schabi.newpipe.player.resolver.VideoPlaybackResolver;
 import org.schabi.newpipe.util.DeviceUtils;
 import org.schabi.newpipe.util.ImageDisplayConstants;
-import org.schabi.newpipe.util.KoreUtil;
+import org.schabi.newpipe.util.external_communication.KoreUtils;
 import org.schabi.newpipe.util.ListHelper;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.SerializedCache;
-import org.schabi.newpipe.util.ShareUtils;
+import org.schabi.newpipe.util.external_communication.ShareUtils;
 import org.schabi.newpipe.views.ExpandableSurfaceView;
 
 import java.io.IOException;
@@ -1033,7 +1033,7 @@ public final class Player implements
         // show kodi button if it supports the current service and it is enabled in settings
         binding.playWithKodi.setVisibility(videoPlayerSelected()
                 && playQueue != null && playQueue.getItem() != null
-                && KoreUtil.shouldShowPlayWithKodi(context, playQueue.getItem().getServiceId())
+                && KoreUtils.shouldShowPlayWithKodi(context, playQueue.getItem().getServiceId())
                 ? View.VISIBLE : View.GONE);
     }
     //endregion
@@ -3725,7 +3725,7 @@ public final class Player implements
                 if (DEBUG) {
                     Log.i(TAG, "Failed to start kore", e);
                 }
-                KoreUtil.showInstallKoreDialog(getParentActivity());
+                KoreUtils.showInstallKoreDialog(getParentActivity());
             }
         }
     }

--- a/app/src/main/java/org/schabi/newpipe/util/CommentTextOnTouchListener.java
+++ b/app/src/main/java/org/schabi/newpipe/util/CommentTextOnTouchListener.java
@@ -13,6 +13,8 @@ import android.widget.TextView;
 import org.schabi.newpipe.util.external_communication.ShareUtils;
 import org.schabi.newpipe.util.external_communication.InternalUrlsHandler;
 
+import io.reactivex.rxjava3.disposables.CompositeDisposable;
+
 public class CommentTextOnTouchListener implements View.OnTouchListener {
     public static final CommentTextOnTouchListener INSTANCE = new CommentTextOnTouchListener();
 
@@ -50,8 +52,8 @@ public class CommentTextOnTouchListener implements View.OnTouchListener {
                     if (action == MotionEvent.ACTION_UP) {
                         if (link[0] instanceof URLSpan) {
                             final String url = ((URLSpan) link[0]).getURL();
-                            if (!InternalUrlsHandler.handleUrlCommentsTimestamp(v.getContext(),
-                                    url)) {
+                            if (!InternalUrlsHandler.handleUrlCommentsTimestamp(
+                                    new CompositeDisposable(), v.getContext(), url)) {
                                 ShareUtils.openUrlInBrowser(v.getContext(), url, false);
                             }
                         }

--- a/app/src/main/java/org/schabi/newpipe/util/CommentTextOnTouchListener.java
+++ b/app/src/main/java/org/schabi/newpipe/util/CommentTextOnTouchListener.java
@@ -50,7 +50,8 @@ public class CommentTextOnTouchListener implements View.OnTouchListener {
                     if (action == MotionEvent.ACTION_UP) {
                         if (link[0] instanceof URLSpan) {
                             final String url = ((URLSpan) link[0]).getURL();
-                            if (!InternalUrlsHandler.handleUrl(v.getContext(), url, 1)) {
+                            if (!InternalUrlsHandler.handleUrlCommentsTimestamp(v.getContext(),
+                                    url)) {
                                 ShareUtils.openUrlInBrowser(v.getContext(), url, false);
                             }
                         }

--- a/app/src/main/java/org/schabi/newpipe/util/CommentTextOnTouchListener.java
+++ b/app/src/main/java/org/schabi/newpipe/util/CommentTextOnTouchListener.java
@@ -47,7 +47,7 @@ public class CommentTextOnTouchListener implements View.OnTouchListener {
                     if (action == MotionEvent.ACTION_UP) {
                         boolean handled = false;
                         if (link[0] instanceof URLSpan) {
-                            handled = URLHandler.canHandleUrl(v.getContext(),
+                            handled = URLHandler.handleUrl(v.getContext(),
                                     ((URLSpan) link[0]).getURL(), 1);
                         }
                         if (!handled) {

--- a/app/src/main/java/org/schabi/newpipe/util/CommentTextOnTouchListener.java
+++ b/app/src/main/java/org/schabi/newpipe/util/CommentTextOnTouchListener.java
@@ -47,7 +47,7 @@ public class CommentTextOnTouchListener implements View.OnTouchListener {
                     if (action == MotionEvent.ACTION_UP) {
                         boolean handled = false;
                         if (link[0] instanceof URLSpan) {
-                            handled = URLHandler.handleUrl(v.getContext(),
+                            handled = URLHandler.canHandleUrl(v.getContext(),
                                     ((URLSpan) link[0]).getURL(), 1);
                         }
                         if (!handled) {

--- a/app/src/main/java/org/schabi/newpipe/util/CommentTextOnTouchListener.java
+++ b/app/src/main/java/org/schabi/newpipe/util/CommentTextOnTouchListener.java
@@ -48,14 +48,11 @@ public class CommentTextOnTouchListener implements View.OnTouchListener {
 
                 if (link.length != 0) {
                     if (action == MotionEvent.ACTION_UP) {
-                        boolean handled = false;
                         if (link[0] instanceof URLSpan) {
-                            handled = InternalUrlsHandler.handleUrl(v.getContext(),
-                                    ((URLSpan) link[0]).getURL(), 1);
-                        }
-                        if (!handled) {
-                            ShareUtils.openUrlInBrowser(v.getContext(),
-                                    ((URLSpan) link[0]).getURL(), false);
+                            final String url = ((URLSpan) link[0]).getURL();
+                            if (!InternalUrlsHandler.handleUrl(v.getContext(), url, 1)) {
+                                ShareUtils.openUrlInBrowser(v.getContext(), url, false);
+                            }
                         }
                     } else if (action == MotionEvent.ACTION_DOWN) {
                         Selection.setSelection(buffer,

--- a/app/src/main/java/org/schabi/newpipe/util/CommentTextOnTouchListener.java
+++ b/app/src/main/java/org/schabi/newpipe/util/CommentTextOnTouchListener.java
@@ -1,6 +1,5 @@
 package org.schabi.newpipe.util;
 
-import android.content.Context;
 import android.text.Layout;
 import android.text.Selection;
 import android.text.Spannable;
@@ -11,26 +10,8 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.widget.TextView;
 
-import org.schabi.newpipe.extractor.NewPipe;
-import org.schabi.newpipe.extractor.StreamingService;
-import org.schabi.newpipe.extractor.exceptions.ExtractionException;
-import org.schabi.newpipe.extractor.exceptions.ParsingException;
-import org.schabi.newpipe.extractor.linkhandler.LinkHandlerFactory;
-import org.schabi.newpipe.extractor.stream.StreamInfo;
-import org.schabi.newpipe.player.playqueue.PlayQueue;
-import org.schabi.newpipe.player.playqueue.SinglePlayQueue;
-
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
-import io.reactivex.rxjava3.core.Single;
-import io.reactivex.rxjava3.schedulers.Schedulers;
-
 public class CommentTextOnTouchListener implements View.OnTouchListener {
     public static final CommentTextOnTouchListener INSTANCE = new CommentTextOnTouchListener();
-
-    private static final Pattern TIMESTAMP_PATTERN = Pattern.compile("(.*)#timestamp=(\\d+)");
 
     @Override
     public boolean onTouch(final View v, final MotionEvent event) {
@@ -66,7 +47,8 @@ public class CommentTextOnTouchListener implements View.OnTouchListener {
                     if (action == MotionEvent.ACTION_UP) {
                         boolean handled = false;
                         if (link[0] instanceof URLSpan) {
-                            handled = handleUrl(v.getContext(), (URLSpan) link[0]);
+                            handled = URLHandler.handleUrl(v.getContext(),
+                                    ((URLSpan) link[0]).getURL(), 1);
                         }
                         if (!handled) {
                             ShareUtils.openUrlInBrowser(v.getContext(),
@@ -82,53 +64,5 @@ public class CommentTextOnTouchListener implements View.OnTouchListener {
             }
         }
         return false;
-    }
-
-    private boolean handleUrl(final Context context, final URLSpan urlSpan) {
-        String url = urlSpan.getURL();
-        int seconds = -1;
-        final Matcher matcher = TIMESTAMP_PATTERN.matcher(url);
-        if (matcher.matches()) {
-            url = matcher.group(1);
-            seconds = Integer.parseInt(matcher.group(2));
-        }
-        final StreamingService service;
-        final StreamingService.LinkType linkType;
-        try {
-            service = NewPipe.getServiceByUrl(url);
-            linkType = service.getLinkTypeByUrl(url);
-        } catch (final ExtractionException e) {
-            return false;
-        }
-        if (linkType == StreamingService.LinkType.NONE) {
-            return false;
-        }
-        if (linkType == StreamingService.LinkType.STREAM && seconds != -1) {
-            return playOnPopup(context, url, service, seconds);
-        } else {
-            NavigationHelper.openRouterActivity(context, url);
-            return true;
-        }
-    }
-
-    private boolean playOnPopup(final Context context, final String url,
-                                final StreamingService service, final int seconds) {
-        final LinkHandlerFactory factory = service.getStreamLHFactory();
-        final String cleanUrl;
-        try {
-            cleanUrl = factory.getUrl(factory.getId(url));
-        } catch (final ParsingException e) {
-            return false;
-        }
-        final Single single
-                = ExtractorHelper.getStreamInfo(service.getServiceId(), cleanUrl, false);
-        single.subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(info -> {
-                    final PlayQueue playQueue
-                            = new SinglePlayQueue((StreamInfo) info, seconds * 1000);
-                    NavigationHelper.playOnPopupPlayer(context, playQueue, false);
-                });
-        return true;
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/util/CommentTextOnTouchListener.java
+++ b/app/src/main/java/org/schabi/newpipe/util/CommentTextOnTouchListener.java
@@ -10,6 +10,9 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.widget.TextView;
 
+import org.schabi.newpipe.util.external_communication.ShareUtils;
+import org.schabi.newpipe.util.external_communication.InternalUrlsHandler;
+
 public class CommentTextOnTouchListener implements View.OnTouchListener {
     public static final CommentTextOnTouchListener INSTANCE = new CommentTextOnTouchListener();
 
@@ -47,7 +50,7 @@ public class CommentTextOnTouchListener implements View.OnTouchListener {
                     if (action == MotionEvent.ACTION_UP) {
                         boolean handled = false;
                         if (link[0] instanceof URLSpan) {
-                            handled = URLHandler.handleUrl(v.getContext(),
+                            handled = InternalUrlsHandler.handleUrl(v.getContext(),
                                     ((URLSpan) link[0]).getURL(), 1);
                         }
                         if (!handled) {

--- a/app/src/main/java/org/schabi/newpipe/util/ExtractorHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ExtractorHelper.java
@@ -311,7 +311,8 @@ public final class ExtractorHelper {
 
             metaInfoSeparator.setVisibility(View.VISIBLE);
             return TextLinkifier.createLinksFromHtmlBlock(context, stringBuilder.toString(),
-                    metaInfoTextView, HtmlCompat.FROM_HTML_SEPARATOR_LINE_BREAK_HEADING);
+                    metaInfoTextView, null, null,
+                    HtmlCompat.FROM_HTML_SEPARATOR_LINE_BREAK_HEADING);
         }
     }
 

--- a/app/src/main/java/org/schabi/newpipe/util/ExtractorHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ExtractorHelper.java
@@ -30,6 +30,7 @@ import androidx.preference.PreferenceManager;
 
 import org.schabi.newpipe.MainActivity;
 import org.schabi.newpipe.R;
+import org.schabi.newpipe.util.external_communication.TextLinkifier;
 import org.schabi.newpipe.extractor.Info;
 import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.ListExtractor.InfoItemsPage;

--- a/app/src/main/java/org/schabi/newpipe/util/ExtractorHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ExtractorHelper.java
@@ -55,7 +55,7 @@ import java.util.List;
 
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
-import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.disposables.CompositeDisposable;
 
 import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
 
@@ -269,18 +269,19 @@ public final class ExtractorHelper {
      * @param metaInfos a list of meta information, can be null or empty
      * @param metaInfoTextView the text view in which to show the formatted HTML
      * @param metaInfoSeparator another view to be shown or hidden accordingly to the text view
-     * @return a disposable to be stored somewhere and disposed when activity/fragment is destroyed
+     * @param disposables disposables created by the method are added here and their lifecycle
+     *                    should be handled by the calling class
      */
-    public static Disposable showMetaInfoInTextView(@Nullable final List<MetaInfo> metaInfos,
-                                                    final TextView metaInfoTextView,
-                                                    final View metaInfoSeparator) {
+    public static void showMetaInfoInTextView(@Nullable final List<MetaInfo> metaInfos,
+                                              final TextView metaInfoTextView,
+                                              final View metaInfoSeparator,
+                                              final CompositeDisposable disposables) {
         final Context context = metaInfoTextView.getContext();
         if (metaInfos == null || metaInfos.isEmpty()
                 || !PreferenceManager.getDefaultSharedPreferences(context).getBoolean(
                         context.getString(R.string.show_meta_info_key), true)) {
             metaInfoTextView.setVisibility(View.GONE);
             metaInfoSeparator.setVisibility(View.GONE);
-            return Disposable.empty();
 
         } else {
             final StringBuilder stringBuilder = new StringBuilder();
@@ -311,9 +312,8 @@ public final class ExtractorHelper {
             }
 
             metaInfoSeparator.setVisibility(View.VISIBLE);
-            return TextLinkifier.createLinksFromHtmlBlock(metaInfoTextView,
-                    stringBuilder.toString(), HtmlCompat.FROM_HTML_SEPARATOR_LINE_BREAK_HEADING,
-                    null);
+            TextLinkifier.createLinksFromHtmlBlock(metaInfoTextView, stringBuilder.toString(),
+                    HtmlCompat.FROM_HTML_SEPARATOR_LINE_BREAK_HEADING, null, disposables);
         }
     }
 

--- a/app/src/main/java/org/schabi/newpipe/util/ExtractorHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ExtractorHelper.java
@@ -311,9 +311,9 @@ public final class ExtractorHelper {
             }
 
             metaInfoSeparator.setVisibility(View.VISIBLE);
-            return TextLinkifier.createLinksFromHtmlBlock(context, stringBuilder.toString(),
-                    metaInfoTextView, null, null,
-                    HtmlCompat.FROM_HTML_SEPARATOR_LINE_BREAK_HEADING);
+            return TextLinkifier.createLinksFromHtmlBlock(metaInfoTextView,
+                    stringBuilder.toString(), HtmlCompat.FROM_HTML_SEPARATOR_LINE_BREAK_HEADING,
+                    null);
         }
     }
 

--- a/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
@@ -53,10 +53,11 @@ import org.schabi.newpipe.player.helper.PlayerHolder;
 import org.schabi.newpipe.player.playqueue.PlayQueue;
 import org.schabi.newpipe.player.playqueue.PlayQueueItem;
 import org.schabi.newpipe.settings.SettingsActivity;
+import org.schabi.newpipe.util.external_communication.ShareUtils;
 
 import java.util.ArrayList;
 
-import static org.schabi.newpipe.util.ShareUtils.installApp;
+import static org.schabi.newpipe.util.external_communication.ShareUtils.installApp;
 
 public final class NavigationHelper {
     public static final String MAIN_FRAGMENT_TAG = "main_fragment_tag";

--- a/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
@@ -252,7 +252,7 @@ public final class NavigationHelper {
 
     public static void resolveActivityOrAskToInstall(final Context context, final Intent intent) {
         if (intent.resolveActivity(context.getPackageManager()) != null) {
-            ShareUtils.openIntentInApp(context, intent);
+            ShareUtils.openIntentInApp(context, intent, false);
         } else {
             if (context instanceof Activity) {
                 new AlertDialog.Builder(context)

--- a/app/src/main/java/org/schabi/newpipe/util/ShareUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ShareUtils.java
@@ -213,13 +213,21 @@ public final class ShareUtils {
      * @param url     the url to share
      */
     public static void shareText(final Context context, final String subject, final String url) {
+        shareText(context, subject, url, true);
+    }
+
+
+    public static void shareText(final Context context,
+                                 final String subject,
+                                 final String url,
+                                 final boolean showPreviewText) {
         final Intent shareIntent = new Intent(Intent.ACTION_SEND);
         shareIntent.setType("text/plain");
-        if (!subject.isEmpty()) {
+        if (!subject.isEmpty() && showPreviewText) {
             shareIntent.putExtra(Intent.EXTRA_SUBJECT, subject);
+            shareIntent.putExtra(Intent.EXTRA_TITLE, subject);
         }
         shareIntent.putExtra(Intent.EXTRA_TEXT, url);
-        shareIntent.putExtra(Intent.EXTRA_TITLE, context.getString(R.string.share_dialog_title));
 
         openAppChooser(context, shareIntent, false);
     }

--- a/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
+++ b/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
@@ -88,7 +88,8 @@ public enum StreamDialogEntry {
     }),
 
     share(R.string.share, (fragment, item) ->
-            ShareUtils.shareText(fragment.getContext(), item.getName(), item.getUrl())),
+            ShareUtils.shareText(fragment.getContext(), item.getName(), item.getUrl(),
+                    item.getThumbnailUrl())),
 
     open_in_browser(R.string.open_in_browser, (fragment, item) ->
             ShareUtils.openUrlInBrowser(fragment.getContext(), item.getUrl()));

--- a/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
+++ b/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
@@ -12,6 +12,8 @@ import org.schabi.newpipe.local.dialog.PlaylistCreationDialog;
 import org.schabi.newpipe.player.MainPlayer;
 import org.schabi.newpipe.player.helper.PlayerHolder;
 import org.schabi.newpipe.player.playqueue.SinglePlayQueue;
+import org.schabi.newpipe.util.external_communication.KoreUtils;
+import org.schabi.newpipe.util.external_communication.ShareUtils;
 
 import java.util.Collections;
 import java.util.List;
@@ -83,7 +85,7 @@ public enum StreamDialogEntry {
         try {
             NavigationHelper.playWithKore(fragment.requireContext(), videoUrl);
         } catch (final Exception e) {
-            KoreUtil.showInstallKoreDialog(fragment.getActivity());
+            KoreUtils.showInstallKoreDialog(fragment.getActivity());
         }
     }),
 

--- a/app/src/main/java/org/schabi/newpipe/util/TextLinkifier.java
+++ b/app/src/main/java/org/schabi/newpipe/util/TextLinkifier.java
@@ -13,12 +13,19 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.core.text.HtmlCompat;
 
+import org.schabi.newpipe.extractor.StreamingService;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import io.noties.markwon.Markwon;
 import io.noties.markwon.linkify.LinkifyPlugin;
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.schedulers.Schedulers;
+
+import static org.schabi.newpipe.util.URLHandler.playOnPopup;
 
 public final class TextLinkifier {
     public static final String TAG = TextLinkifier.class.getSimpleName();
@@ -30,92 +37,173 @@ public final class TextLinkifier {
      * Create web links for contents with an HTML description.
      * <p>
      * This will call
-     * {@link TextLinkifier#changeIntentsOfDescriptionLinks(Context, CharSequence, TextView)}
+     * {@link TextLinkifier#changeIntentsOfDescriptionLinks(Context, CharSequence, TextView,
+     * StreamingService, String)}
      * after having linked the URLs with {@link HtmlCompat#fromHtml(String, int)}.
      *
-     * @param context        the context to use
-     * @param htmlBlock      the htmlBlock to be linked
-     * @param textView       the TextView to set the htmlBlock linked
-     * @param htmlCompatFlag the int flag to be set when {@link HtmlCompat#fromHtml(String, int)}
-     *                       will be called
+     * @param context          the context to use
+     * @param htmlBlock        the htmlBlock to be linked
+     * @param textView         the TextView to set the htmlBlock linked
+     * @param streamingService the {@link StreamingService} of the content
+     * @param contentUrl       the URL of the content
+     * @param htmlCompatFlag   the int flag to be set when {@link HtmlCompat#fromHtml(String, int)}
+     *                         will be called
      * @return a disposable to be stored somewhere and disposed when activity/fragment is destroyed
      */
     public static Disposable createLinksFromHtmlBlock(final Context context,
                                                       final String htmlBlock,
                                                       final TextView textView,
+                                                      final StreamingService streamingService,
+                                                      final String contentUrl,
                                                       final int htmlCompatFlag) {
         return changeIntentsOfDescriptionLinks(context,
-                HtmlCompat.fromHtml(htmlBlock, htmlCompatFlag), textView);
+                HtmlCompat.fromHtml(htmlBlock, htmlCompatFlag), textView, streamingService,
+                contentUrl);
     }
 
     /**
      * Create web links for contents with a plain text description.
      * <p>
      * This will call
-     * {@link TextLinkifier#changeIntentsOfDescriptionLinks(Context, CharSequence, TextView)}
+     * {@link TextLinkifier#changeIntentsOfDescriptionLinks(Context, CharSequence, TextView,
+     * StreamingService, String)}
      * after having linked the URLs with {@link TextView#setAutoLinkMask(int)} and
      * {@link TextView#setText(CharSequence, TextView.BufferType)}.
      *
-     * @param context        the context to use
-     * @param plainTextBlock the block of plain text to be linked
-     * @param textView       the TextView to set the plain text block linked
+     * @param context          the context to use
+     * @param plainTextBlock   the block of plain text to be linked
+     * @param textView         the TextView to set the plain text block linked
+     * @param streamingService the {@link StreamingService} of the content
+     * @param contentUrl       the URL of the content
      * @return a disposable to be stored somewhere and disposed when activity/fragment is destroyed
      */
     public static Disposable createLinksFromPlainText(final Context context,
                                                       final String plainTextBlock,
-                                                      final TextView textView) {
+                                                      final TextView textView,
+                                                      final StreamingService streamingService,
+                                                      final String contentUrl) {
         textView.setAutoLinkMask(Linkify.WEB_URLS);
         textView.setText(plainTextBlock, TextView.BufferType.SPANNABLE);
-        return changeIntentsOfDescriptionLinks(context, textView.getText(), textView);
+        return changeIntentsOfDescriptionLinks(context, textView.getText(), textView,
+                streamingService, contentUrl);
     }
 
     /**
      * Create web links for contents with a markdown description.
      * <p>
      * This will call
-     * {@link TextLinkifier#changeIntentsOfDescriptionLinks(Context, CharSequence, TextView)}
+     * {@link TextLinkifier#changeIntentsOfDescriptionLinks(Context, CharSequence, TextView,
+     * StreamingService, String)}
      * after creating an {@link Markwon} object and using
      * {@link Markwon#setMarkdown(TextView, String)}.
      *
-     * @param context       the context to use
-     * @param markdownBlock the block of markdown text to be linked
-     * @param textView      the TextView to set the plain text block linked
+     * @param context          the context to use
+     * @param markdownBlock    the block of markdown text to be linked
+     * @param textView         the TextView to set the plain text block linked
+     * @param streamingService the {@link StreamingService} of the content
+     * @param contentUrl       the URL of the content
      * @return a disposable to be stored somewhere and disposed when activity/fragment is destroyed
      */
     public static Disposable createLinksFromMarkdownText(final Context context,
                                                          final String markdownBlock,
-                                                         final TextView textView) {
+                                                         final TextView textView,
+                                                         final StreamingService streamingService,
+                                                         final String contentUrl) {
         final Markwon markwon = Markwon.builder(context).usePlugin(LinkifyPlugin.create()).build();
         markwon.setMarkdown(textView, markdownBlock);
-        return changeIntentsOfDescriptionLinks(context, textView.getText(), textView);
+        return changeIntentsOfDescriptionLinks(context, textView.getText(), textView,
+                streamingService, contentUrl);
+    }
+
+    private static final Pattern TIMESTAMPS_PATTERN_IN_PLAIN_TEXT =
+            Pattern.compile("(?:([0-5]?[0-9]):)?([0-5]?[0-9]):([0-5][0-9])");
+
+    /**
+     * Add click listeners which opens the popup player on timestamps in a plain text.
+     * <p>
+     * This method finds all timestamps in the {@link SpannableStringBuilder} of the description
+     * using a regular expression, adds for each a {@link ClickableSpan} which opens the popup
+     * player at the time indicated in the timestamps.
+     *
+     * @param context               the context to use
+     * @param spannableDescription  the SpannableStringBuilder with the text of the
+     *                              content description
+     * @param contentUrl            the URL of the content
+     * @param streamingService      the {@link StreamingService} of the content
+     */
+    private static void addClickListenersOnTimestamps(final Context context,
+                                                      final SpannableStringBuilder
+                                                              spannableDescription,
+                                                      final String contentUrl,
+                                                      final StreamingService streamingService) {
+        final String descriptionText = spannableDescription.toString();
+        final Matcher timestampMatches = TIMESTAMPS_PATTERN_IN_PLAIN_TEXT.matcher(descriptionText);
+
+        while (timestampMatches.find()) {
+            final int timestampStart = timestampMatches.start(0);
+            final int timestampEnd = timestampMatches.end(0);
+            final String parsedTimestamp = descriptionText.substring(timestampStart, timestampEnd);
+            final String[] timestampParts = parsedTimestamp.split(":");
+            final int seconds;
+            if (timestampParts.length == 3) { // timestamp format: XX:XX:XX
+                seconds = Integer.parseInt(timestampParts[0]) * 3600 + Integer.parseInt(
+                        timestampParts[1]) * 60 + Integer.parseInt(timestampParts[2]);
+                spannableDescription.setSpan(new ClickableSpan() {
+                    @Override
+                    public void onClick(@NonNull final View view) {
+                        playOnPopup(context, contentUrl, streamingService, seconds);
+                    }
+                }, timestampStart, timestampEnd, 0);
+            } else if (timestampParts.length == 2) { // timestamp format: XX:XX
+                seconds = Integer.parseInt(timestampParts[0]) * 60 + Integer.parseInt(
+                        timestampParts[1]);
+                spannableDescription.setSpan(new ClickableSpan() {
+                    @Override
+                    public void onClick(@NonNull final View view) {
+                        playOnPopup(context, contentUrl, streamingService, seconds);
+                    }
+                }, timestampStart, timestampEnd, 0);
+            }
+        }
     }
 
     /**
-     * Change links generated by libraries in the description of a content to a custom link action.
+     * Change links generated by libraries in the description of a content to a custom link action
+     * and add click listeners on timestamps in this description.
      * <p>
-     * Instead of using an {@link android.content.Intent#ACTION_VIEW} intent in the description of a
-     * content, this method will parse the {@link CharSequence} and replace all current web links
+     * Instead of using an {@link android.content.Intent#ACTION_VIEW} intent in the description of
+     * a content, this method will parse the {@link CharSequence} and replace all current web links
      * with {@link ShareUtils#openUrlInBrowser(Context, String, boolean)}.
+     * This method will also add click listeners on timestamps in this description, which will play
+     * the content in the popup player at the time indicated in the timestamp, by using
+     * {@link TextLinkifier#addClickListenersOnTimestamps(Context, SpannableStringBuilder, String,
+     * StreamingService)} method.
      * <p>
      * This method is required in order to intercept links and e.g. show a confirmation dialog
      * before opening a web link.
      *
-     * @param context  the context to use
-     * @param chars    the CharSequence to be parsed
-     * @param textView the TextView in which the converted CharSequence will be applied
+     * @param context          the context to use
+     * @param chars            the CharSequence to be parsed
+     * @param textView         the TextView in which the converted CharSequence will be applied
+     * @param streamingService the {@link StreamingService} of the content
+     * @param contentUrl       the URL of the content
      * @return a disposable to be stored somewhere and disposed when activity/fragment is destroyed
      */
     private static Disposable changeIntentsOfDescriptionLinks(final Context context,
                                                               final CharSequence chars,
-                                                              final TextView textView) {
+                                                              final TextView textView,
+                                                              final StreamingService
+                                                                      streamingService,
+                                                              final String contentUrl) {
         return Single.fromCallable(() -> {
+            // add custom click actions on web links
             final SpannableStringBuilder textBlockLinked = new SpannableStringBuilder(chars);
             final URLSpan[] urls = textBlockLinked.getSpans(0, chars.length(), URLSpan.class);
 
             for (final URLSpan span : urls) {
                 final ClickableSpan clickableSpan = new ClickableSpan() {
                     public void onClick(@NonNull final View view) {
-                        if (!URLHandler.handleUrl(context, span.getURL(), 0)) {
+                        if (!URLHandler.canHandleUrl(context, span.getURL(), 0)) {
                             ShareUtils.openUrlInBrowser(context, span.getURL(), false);
                         }
                     }
@@ -124,6 +212,13 @@ public final class TextLinkifier {
                 textBlockLinked.setSpan(clickableSpan, textBlockLinked.getSpanStart(span),
                         textBlockLinked.getSpanEnd(span), textBlockLinked.getSpanFlags(span));
                 textBlockLinked.removeSpan(span);
+            }
+
+            // add click actions on plain text timestamps only for description of contents,
+            // unneeded for metainfo TextViews
+            if (contentUrl != null || streamingService != null) {
+                addClickListenersOnTimestamps(context, textBlockLinked, contentUrl,
+                        streamingService);
             }
 
             return textBlockLinked;

--- a/app/src/main/java/org/schabi/newpipe/util/TextLinkifier.java
+++ b/app/src/main/java/org/schabi/newpipe/util/TextLinkifier.java
@@ -115,7 +115,9 @@ public final class TextLinkifier {
             for (final URLSpan span : urls) {
                 final ClickableSpan clickableSpan = new ClickableSpan() {
                     public void onClick(@NonNull final View view) {
-                        ShareUtils.openUrlInBrowser(context, span.getURL(), false);
+                        if (!URLHandler.handleUrl(context, span.getURL(), 0)) {
+                            ShareUtils.openUrlInBrowser(context, span.getURL(), false);
+                        }
                     }
                 };
 

--- a/app/src/main/java/org/schabi/newpipe/util/URLHandler.java
+++ b/app/src/main/java/org/schabi/newpipe/util/URLHandler.java
@@ -39,23 +39,29 @@ public final class URLHandler {
      * @param timestampType the type of timestamp
      * @return true if the URL can be handled by NewPipe, false if it cannot
      */
-    public static boolean handleUrl(final Context context, final String url, final int timestampType) {
+    public static boolean canHandleUrl(final Context context,
+                                       final String url,
+                                       final int timestampType) {
         String matchedUrl = "";
         int seconds = -1;
-        final Pattern TIMESTAMP_PATTERN;
+        final Pattern timestampPattern;
 
         if (timestampType == 0) {
-            TIMESTAMP_PATTERN = Pattern.compile("(.*)&t=(\\d+)");
+            timestampPattern = Pattern.compile("(.*)&t=(\\d+)");
         } else if (timestampType == 1) {
-            TIMESTAMP_PATTERN = Pattern.compile("(.*)#timestamp=(\\d+)");
+            timestampPattern = Pattern.compile("(.*)#timestamp=(\\d+)");
         } else {
             return false;
         }
 
-        final Matcher matcher = TIMESTAMP_PATTERN.matcher(url);
+        final Matcher matcher = timestampPattern.matcher(url);
         if (matcher.matches()) {
             matchedUrl = matcher.group(1);
             seconds = Integer.parseInt(matcher.group(2));
+        }
+
+        if (matchedUrl == null || matchedUrl.isEmpty()) {
+            return false;
         }
 
         final StreamingService service;
@@ -88,8 +94,10 @@ public final class URLHandler {
      * @param seconds the position in seconds at which the floating player will start
      * @return true if the playback of the content has successfully started or false if not
      */
-    private static boolean playOnPopup(final Context context, final String url,
-                                       final StreamingService service, final int seconds) {
+    public static boolean playOnPopup(final Context context,
+                                      final String url,
+                                      final StreamingService service,
+                                      final int seconds) {
         final LinkHandlerFactory factory = service.getStreamLHFactory();
         final String cleanUrl;
 

--- a/app/src/main/java/org/schabi/newpipe/util/URLHandler.java
+++ b/app/src/main/java/org/schabi/newpipe/util/URLHandler.java
@@ -1,0 +1,113 @@
+package org.schabi.newpipe.util;
+
+import android.content.Context;
+
+import org.schabi.newpipe.extractor.NewPipe;
+import org.schabi.newpipe.extractor.StreamingService;
+import org.schabi.newpipe.extractor.exceptions.ExtractionException;
+import org.schabi.newpipe.extractor.exceptions.ParsingException;
+import org.schabi.newpipe.extractor.linkhandler.LinkHandlerFactory;
+import org.schabi.newpipe.extractor.stream.StreamInfo;
+import org.schabi.newpipe.player.playqueue.PlayQueue;
+import org.schabi.newpipe.player.playqueue.SinglePlayQueue;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
+import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+
+public final class URLHandler {
+
+    private URLHandler() {
+    }
+
+    /**
+     * Check if an URL can be handled in NewPipe.
+     * <p>
+     * This method will check if the provided url can be handled in NewPipe or not. If this is a
+     * service URL with a timestamp, the popup player will be opened.
+     * <p>
+     * The timestamp param accepts two integers, corresponding to two timestamps types:
+     * 0 for {@code &t=} (used for timestamps in descriptions),
+     * 1 for {@code #timestamp=} (used for timestamps in comments).
+     * Any other value of this integer will return false.
+     *
+     * @param context       the context to be used
+     * @param url           the URL to check if it can be handled
+     * @param timestampType the type of timestamp
+     * @return true if the URL can be handled by NewPipe, false if it cannot
+     */
+    public static boolean handleUrl(final Context context, final String url, final int timestampType) {
+        String matchedUrl = "";
+        int seconds = -1;
+        final Pattern TIMESTAMP_PATTERN;
+
+        if (timestampType == 0) {
+            TIMESTAMP_PATTERN = Pattern.compile("(.*)&t=(\\d+)");
+        } else if (timestampType == 1) {
+            TIMESTAMP_PATTERN = Pattern.compile("(.*)#timestamp=(\\d+)");
+        } else {
+            return false;
+        }
+
+        final Matcher matcher = TIMESTAMP_PATTERN.matcher(url);
+        if (matcher.matches()) {
+            matchedUrl = matcher.group(1);
+            seconds = Integer.parseInt(matcher.group(2));
+        }
+
+        final StreamingService service;
+        final StreamingService.LinkType linkType;
+
+        try {
+            service = NewPipe.getServiceByUrl(matchedUrl);
+            linkType = service.getLinkTypeByUrl(matchedUrl);
+        } catch (final ExtractionException e) {
+            return false;
+        }
+
+        if (linkType == StreamingService.LinkType.NONE) {
+            return false;
+        }
+        if (linkType == StreamingService.LinkType.STREAM && seconds != -1) {
+            return playOnPopup(context, matchedUrl, service, seconds);
+        } else {
+            NavigationHelper.openRouterActivity(context, matchedUrl);
+            return true;
+        }
+    }
+
+    /**
+     * Play a content in the floating player.
+     *
+     * @param context the context to be used
+     * @param url     the URL of the content
+     * @param service the service of the content
+     * @param seconds the position in seconds at which the floating player will start
+     * @return true if the playback of the content has successfully started or false if not
+     */
+    private static boolean playOnPopup(final Context context, final String url,
+                                       final StreamingService service, final int seconds) {
+        final LinkHandlerFactory factory = service.getStreamLHFactory();
+        final String cleanUrl;
+
+        try {
+            cleanUrl = factory.getUrl(factory.getId(url));
+        } catch (final ParsingException e) {
+            return false;
+        }
+
+        final Single single
+                = ExtractorHelper.getStreamInfo(service.getServiceId(), cleanUrl, false);
+        single.subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(info -> {
+                    final PlayQueue playQueue
+                            = new SinglePlayQueue((StreamInfo) info, seconds * 1000);
+                    NavigationHelper.playOnPopupPlayer(context, playQueue, false);
+                });
+        return true;
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/util/external_communication/InternalUrlsHandler.java
+++ b/app/src/main/java/org/schabi/newpipe/util/external_communication/InternalUrlsHandler.java
@@ -2,6 +2,8 @@ package org.schabi.newpipe.util.external_communication;
 
 import android.content.Context;
 
+import androidx.annotation.NonNull;
+
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
@@ -44,9 +46,10 @@ public final class InternalUrlsHandler {
      * @param url         the URL to check if it can be handled
      * @return true if the URL can be handled by NewPipe, false if it cannot
      */
-    public static boolean handleUrlCommentsTimestamp(final CompositeDisposable disposables,
+    public static boolean handleUrlCommentsTimestamp(@NonNull final CompositeDisposable
+                                                             disposables,
                                                      final Context context,
-                                                     final String url) {
+                                                     @NonNull final String url) {
         return handleUrl(disposables, context, url, HASHTAG_TIMESTAMP_PATTERN);
     }
 
@@ -63,9 +66,10 @@ public final class InternalUrlsHandler {
      * @param url         the URL to check if it can be handled
      * @return true if the URL can be handled by NewPipe, false if it cannot
      */
-    public static boolean handleUrlDescriptionTimestamp(final CompositeDisposable disposables,
+    public static boolean handleUrlDescriptionTimestamp(@NonNull final CompositeDisposable
+                                                                disposables,
                                                         final Context context,
-                                                        final String url) {
+                                                        @NonNull final String url) {
         return handleUrl(disposables, context, url, AMPERSAND_TIMESTAMP_PATTERN);
     }
 
@@ -82,10 +86,10 @@ public final class InternalUrlsHandler {
      * @param pattern     the pattern to use
      * @return true if the URL can be handled by NewPipe, false if it cannot
      */
-    private static boolean handleUrl(final CompositeDisposable disposables,
+    private static boolean handleUrl(@NonNull final CompositeDisposable disposables,
                                      final Context context,
-                                     final String url,
-                                     final Pattern pattern) {
+                                     @NonNull final String url,
+                                     @NonNull final Pattern pattern) {
         final String matchedUrl;
         final StreamingService service;
         final StreamingService.LinkType linkType;
@@ -128,10 +132,10 @@ public final class InternalUrlsHandler {
      * @param seconds     the position in seconds at which the floating player will start
      * @return true if the playback of the content has successfully started or false if not
      */
-    public static boolean playOnPopup(final CompositeDisposable disposables,
+    public static boolean playOnPopup(@NonNull final CompositeDisposable disposables,
                                       final Context context,
                                       final String url,
-                                      final StreamingService service,
+                                      @NonNull final StreamingService service,
                                       final int seconds) {
         final LinkHandlerFactory factory = service.getStreamLHFactory();
         final String cleanUrl;

--- a/app/src/main/java/org/schabi/newpipe/util/external_communication/InternalUrlsHandler.java
+++ b/app/src/main/java/org/schabi/newpipe/util/external_communication/InternalUrlsHandler.java
@@ -1,4 +1,4 @@
-package org.schabi.newpipe.util;
+package org.schabi.newpipe.util.external_communication;
 
 import android.content.Context;
 
@@ -10,6 +10,8 @@ import org.schabi.newpipe.extractor.linkhandler.LinkHandlerFactory;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.player.playqueue.PlayQueue;
 import org.schabi.newpipe.player.playqueue.SinglePlayQueue;
+import org.schabi.newpipe.util.ExtractorHelper;
+import org.schabi.newpipe.util.NavigationHelper;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -18,12 +20,12 @@ import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 
-public final class URLHandler {
+public final class InternalUrlsHandler {
     private static final Pattern AMPERSAND_TIMESTAMP_PATTERN = Pattern.compile("(.*)&t=(\\d+)");
     private static final Pattern HASHTAG_TIMESTAMP_PATTERN =
             Pattern.compile("(.*)#timestamp=(\\d+)");
 
-    private URLHandler() {
+    private InternalUrlsHandler() {
     }
 
     /**

--- a/app/src/main/java/org/schabi/newpipe/util/external_communication/InternalUrlsHandler.java
+++ b/app/src/main/java/org/schabi/newpipe/util/external_communication/InternalUrlsHandler.java
@@ -49,22 +49,20 @@ public final class InternalUrlsHandler {
                                     final int timestampType) {
         String matchedUrl = "";
         int seconds = -1;
-        final Pattern timestampPattern;
+        final Matcher matcher;
 
         if (timestampType == 0) {
-            timestampPattern = AMPERSAND_TIMESTAMP_PATTERN;
+            matcher = AMPERSAND_TIMESTAMP_PATTERN.matcher(url);
         } else if (timestampType == 1) {
-            timestampPattern = HASHTAG_TIMESTAMP_PATTERN;
+            matcher = HASHTAG_TIMESTAMP_PATTERN.matcher(url);
         } else {
             return false;
         }
 
-        final Matcher matcher = timestampPattern.matcher(url);
         if (matcher.matches()) {
             matchedUrl = matcher.group(1);
             seconds = Integer.parseInt(matcher.group(2));
         }
-
         if (matchedUrl == null || matchedUrl.isEmpty()) {
             return false;
         }
@@ -78,7 +76,6 @@ public final class InternalUrlsHandler {
         } catch (final ExtractionException e) {
             return false;
         }
-
         if (linkType == StreamingService.LinkType.NONE) {
             return false;
         }

--- a/app/src/main/java/org/schabi/newpipe/util/external_communication/KoreUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/external_communication/KoreUtils.java
@@ -2,6 +2,7 @@ package org.schabi.newpipe.util.external_communication;
 
 import android.content.Context;
 
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.preference.PreferenceManager;
 
@@ -17,13 +18,14 @@ public final class KoreUtils {
                 || serviceId == ServiceList.SoundCloud.getServiceId());
     }
 
-    public static boolean shouldShowPlayWithKodi(final Context context, final int serviceId) {
+    public static boolean shouldShowPlayWithKodi(@NonNull final Context context,
+                                                 final int serviceId) {
         return isServiceSupportedByKore(serviceId)
                 && PreferenceManager.getDefaultSharedPreferences(context)
                 .getBoolean(context.getString(R.string.show_play_with_kodi_key), false);
     }
 
-    public static void showInstallKoreDialog(final Context context) {
+    public static void showInstallKoreDialog(@NonNull final Context context) {
         final AlertDialog.Builder builder = new AlertDialog.Builder(context);
         builder.setMessage(R.string.kore_not_found)
                 .setPositiveButton(R.string.install, (dialog, which) ->

--- a/app/src/main/java/org/schabi/newpipe/util/external_communication/KoreUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/external_communication/KoreUtils.java
@@ -1,4 +1,4 @@
-package org.schabi.newpipe.util;
+package org.schabi.newpipe.util.external_communication;
 
 import android.content.Context;
 
@@ -7,9 +7,10 @@ import androidx.preference.PreferenceManager;
 
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.extractor.ServiceList;
+import org.schabi.newpipe.util.NavigationHelper;
 
-public final class KoreUtil {
-    private KoreUtil() { }
+public final class KoreUtils {
+    private KoreUtils() { }
 
     public static boolean isServiceSupportedByKore(final int serviceId) {
         return (serviceId == ServiceList.YouTube.getServiceId()

--- a/app/src/main/java/org/schabi/newpipe/util/external_communication/ShareUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/external_communication/ShareUtils.java
@@ -1,4 +1,4 @@
-package org.schabi.newpipe.util;
+package org.schabi.newpipe.util.external_communication;
 
 import android.content.ActivityNotFoundException;
 import android.content.ClipData;
@@ -239,49 +239,35 @@ public final class ShareUtils {
     }
 
     /**
-     * Open the android share menu to share the current url.
-     *
-     * @param context         the context to use
-     * @param subject         the url subject, typically the title
-     * @param url             the url to share
-     * @param imagePreviewUrl the image of the subject
-     */
-    public static void shareText(final Context context,
-                                 final String subject,
-                                 final String url,
-                                 final String imagePreviewUrl) {
-        shareText(context, subject, url, imagePreviewUrl, true);
-    }
-
-    /**
-     * Open the android share sheet to share the current url.
+     * Open the android share sheet to share a content.
      *
      * For Android 10+ users, a content preview is shown, which includes the title of the shared
      * content.
      * Support sharing the image of the content needs to done, if possible.
      *
      * @param context         the context to use
-     * @param subject         the url subject, typically the title
-     * @param url             the url to share
+     * @param title           the title of the content
+     * @param content         the content to share
      * @param imagePreviewUrl the image of the subject
-     * @param showPreviewText show the subject as an extra title of the Android share sheet if true
      */
     public static void shareText(final Context context,
-                                 final String subject,
-                                 final String url,
-                                 final String imagePreviewUrl,
-                                 final boolean showPreviewText) {
+                                 final String title,
+                                 final String content,
+                                 final String imagePreviewUrl) {
         final Intent shareIntent = new Intent(Intent.ACTION_SEND);
         shareIntent.setType("text/plain");
-        if (!imagePreviewUrl.isEmpty() && !subject.isEmpty() && showPreviewText) {
-            shareIntent.putExtra(Intent.EXTRA_TITLE, subject);
-            /* TODO: add the image of the content to Android share sheet with setClipData after
-                generating a content URI of this image, then use ClipData.newUri(the content
-                resolver, null, the content URI) and set the ClipData to the share intent with
-                shareIntent.setClipData(generated ClipData).*/
-            //shareIntent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        if (!title.isEmpty()) {
+            shareIntent.putExtra(Intent.EXTRA_TITLE, title);
         }
-        shareIntent.putExtra(Intent.EXTRA_TEXT, url);
+
+        /* TODO: add the image of the content to Android share sheet with setClipData after
+            generating a content URI of this image, then use ClipData.newUri(the content resolver,
+            null, the content URI) and set the ClipData to the share intent with
+            shareIntent.setClipData(generated ClipData).
+        if (!imagePreviewUrl.isEmpty()) {
+            //shareIntent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        }*/
+        shareIntent.putExtra(Intent.EXTRA_TEXT, content);
 
         openAppChooser(context, shareIntent, false);
     }

--- a/app/src/main/java/org/schabi/newpipe/util/external_communication/ShareUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/external_communication/ShareUtils.java
@@ -11,6 +11,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 
 import org.schabi.newpipe.R;
@@ -33,7 +34,7 @@ public final class ShareUtils {
      * @param context   the context to use
      * @param packageId the package id of the app to be installed
      */
-    public static void installApp(final Context context, final String packageId) {
+    public static void installApp(@NonNull final Context context, final String packageId) {
         // Try market scheme
         final boolean marketSchemeResult = openIntentInApp(context, new Intent(Intent.ACTION_VIEW,
                 Uri.parse("market://details?id=" + packageId))
@@ -57,7 +58,7 @@ public final class ShareUtils {
      *                               for HTTP protocol or for the created intent
      * @return true if the URL can be opened or false if it cannot
      */
-    public static boolean openUrlInBrowser(final Context context,
+    public static boolean openUrlInBrowser(@NonNull final Context context,
                                            final String url,
                                            final boolean httpDefaultBrowserTest) {
         final String defaultPackageName;
@@ -107,7 +108,7 @@ public final class ShareUtils {
      * @param url     the url to browse
      * @return true if the URL can be opened or false if it cannot be
      **/
-    public static boolean openUrlInBrowser(final Context context, final String url) {
+    public static boolean openUrlInBrowser(@NonNull final Context context, final String url) {
         return openUrlInBrowser(context, url, true);
     }
 
@@ -126,8 +127,8 @@ public final class ShareUtils {
      *                  to open the intent (true) or not (false)
      * @return true if the intent can be opened or false if it cannot be
      */
-    public static boolean openIntentInApp(final Context context,
-                                          final Intent intent,
+    public static boolean openIntentInApp(@NonNull final Context context,
+                                          @NonNull final Intent intent,
                                           final boolean showToast) {
         final String defaultPackageName = getDefaultAppPackageName(context, intent);
 
@@ -159,8 +160,8 @@ public final class ShareUtils {
      * @param intent          the intent to open
      * @param setTitleChooser set the title "Open with" to the chooser if true, else not
      */
-    private static void openAppChooser(final Context context,
-                                       final Intent intent,
+    private static void openAppChooser(@NonNull final Context context,
+                                       @NonNull final Intent intent,
                                        final boolean setTitleChooser) {
         final Intent chooserIntent = new Intent(Intent.ACTION_CHOOSER);
         chooserIntent.putExtra(Intent.EXTRA_INTENT, intent);
@@ -214,7 +215,8 @@ public final class ShareUtils {
      * @return the package name of the default app, an empty string if there's no app installed to
      * handle the intent or the app chooser if there's no default
      */
-    private static String getDefaultAppPackageName(final Context context, final Intent intent) {
+    private static String getDefaultAppPackageName(@NonNull final Context context,
+                                                   @NonNull final Intent intent) {
         final ResolveInfo resolveInfo = context.getPackageManager().resolveActivity(intent,
                 PackageManager.MATCH_DEFAULT_ONLY);
 
@@ -237,8 +239,8 @@ public final class ShareUtils {
      * @param content         the content to share
      * @param imagePreviewUrl the image of the subject
      */
-    public static void shareText(final Context context,
-                                 final String title,
+    public static void shareText(@NonNull final Context context,
+                                 @NonNull final String title,
                                  final String content,
                                  final String imagePreviewUrl) {
         final Intent shareIntent = new Intent(Intent.ACTION_SEND);
@@ -272,7 +274,9 @@ public final class ShareUtils {
      * @param title   the title of the content
      * @param content the content to share
      */
-    public static void shareText(final Context context, final String title, final String content) {
+    public static void shareText(@NonNull final Context context,
+                                 @NonNull final String title,
+                                 final String content) {
         shareText(context, title, content, "");
     }
 
@@ -283,7 +287,7 @@ public final class ShareUtils {
      * @param context the context to use
      * @param text    the text to copy
      */
-    public static void copyToClipboard(final Context context, final String text) {
+    public static void copyToClipboard(@NonNull final Context context, final String text) {
         final ClipboardManager clipboardManager =
                 ContextCompat.getSystemService(context, ClipboardManager.class);
 

--- a/app/src/main/java/org/schabi/newpipe/util/external_communication/ShareUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/external_communication/ShareUtils.java
@@ -260,6 +260,23 @@ public final class ShareUtils {
     }
 
     /**
+     * Open the android share sheet to share a content.
+     *
+     * For Android 10+ users, a content preview is shown, which includes the title of the shared
+     * content.
+     * <p>
+     * This calls {@link #shareText(Context, String, String, String)} with an empty string for the
+     * imagePreviewUrl parameter.
+     *
+     * @param context the context to use
+     * @param title   the title of the content
+     * @param content the content to share
+     */
+    public static void shareText(final Context context, final String title, final String content) {
+        shareText(context, title, content, "");
+    }
+
+    /**
      * Copy the text to clipboard, and indicate to the user whether the operation was completed
      * successfully using a Toast.
      *

--- a/app/src/main/java/org/schabi/newpipe/util/external_communication/ShareUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/external_communication/ShareUtils.java
@@ -117,9 +117,8 @@ public final class ShareUtils {
      * The intent can be of every type, excepted a web intent for which
      * {@link #openUrlInBrowser(Context, String, boolean)} should be used.
      * <p>
-     * If no app is set as default, fallbacks to
-     * {@link #openAppChooser(Context, Intent, boolean)}.
-     * <p>
+     * If no app can open the intent, a toast with the message {@code No app on your device can
+     * open this} is shown.
      *
      * @param context   the context to use
      * @param intent    the intent to open
@@ -132,27 +131,15 @@ public final class ShareUtils {
                                           final boolean showToast) {
         final String defaultPackageName = getDefaultAppPackageName(context, intent);
 
-        if (defaultPackageName.equals("android")) {
-            // No app set as default (doesn't work on some devices)
-            openAppChooser(context, intent, true);
-        } else {
-            if (defaultPackageName.isEmpty()) {
-                // No app installed to open the intent
-                if (showToast) {
-                    Toast.makeText(context, R.string.no_app_to_open_intent, Toast.LENGTH_LONG)
-                            .show();
-                }
-                return false;
-            } else {
-                try {
-                    intent.setPackage(defaultPackageName);
-                    context.startActivity(intent);
-                } catch (final ActivityNotFoundException e) {
-                    // Not an app to open the intent but an app chooser because of OEMs changes
-                    intent.setPackage(null);
-                    openAppChooser(context, intent, true);
-                }
+        if (defaultPackageName.isEmpty()) {
+            // No app installed to open the intent
+            if (showToast) {
+                Toast.makeText(context, R.string.no_app_to_open_intent, Toast.LENGTH_LONG)
+                        .show();
             }
+            return false;
+        } else {
+            context.startActivity(intent);
         }
 
         return true;
@@ -256,6 +243,7 @@ public final class ShareUtils {
                                  final String imagePreviewUrl) {
         final Intent shareIntent = new Intent(Intent.ACTION_SEND);
         shareIntent.setType("text/plain");
+        shareIntent.putExtra(Intent.EXTRA_TEXT, content);
         if (!title.isEmpty()) {
             shareIntent.putExtra(Intent.EXTRA_TITLE, title);
         }
@@ -267,7 +255,6 @@ public final class ShareUtils {
         if (!imagePreviewUrl.isEmpty()) {
             //shareIntent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         }*/
-        shareIntent.putExtra(Intent.EXTRA_TEXT, content);
 
         openAppChooser(context, shareIntent, false);
     }

--- a/app/src/main/java/org/schabi/newpipe/util/external_communication/TextLinkifier.java
+++ b/app/src/main/java/org/schabi/newpipe/util/external_communication/TextLinkifier.java
@@ -245,7 +245,7 @@ public final class TextLinkifier {
                 final String url = span.getURL();
                 final ClickableSpan clickableSpan = new ClickableSpan() {
                     public void onClick(@NonNull final View view) {
-                        if (!InternalUrlsHandler.handleUrl(context, url, 0)) {
+                        if (!InternalUrlsHandler.handleUrlDescriptionTimestamp(context, url)) {
                             ShareUtils.openUrlInBrowser(context, url, false);
                         }
                     }

--- a/app/src/main/java/org/schabi/newpipe/util/external_communication/TextLinkifier.java
+++ b/app/src/main/java/org/schabi/newpipe/util/external_communication/TextLinkifier.java
@@ -55,6 +55,7 @@ public final class TextLinkifier {
      *                         will be called
      * @return a disposable to be stored somewhere and disposed when activity/fragment is destroyed
      */
+    @NonNull
     public static Disposable createLinksFromHtmlBlock(final Context context,
                                                       final String htmlBlock,
                                                       final TextView textView,
@@ -82,9 +83,10 @@ public final class TextLinkifier {
      * @param contentUrl       the URL of the content
      * @return a disposable to be stored somewhere and disposed when activity/fragment is destroyed
      */
+    @NonNull
     public static Disposable createLinksFromPlainText(final Context context,
                                                       final String plainTextBlock,
-                                                      final TextView textView,
+                                                      @NonNull final TextView textView,
                                                       final StreamingService streamingService,
                                                       final String contentUrl) {
         textView.setAutoLinkMask(Linkify.WEB_URLS);
@@ -109,6 +111,7 @@ public final class TextLinkifier {
      * @param contentUrl       the URL of the content
      * @return a disposable to be stored somewhere and disposed when activity/fragment is destroyed
      */
+    @NonNull
     public static Disposable createLinksFromMarkdownText(final Context context,
                                                          final String markdownBlock,
                                                          final TextView textView,
@@ -134,7 +137,7 @@ public final class TextLinkifier {
      * @param streamingService     the {@link StreamingService} of the content
      */
     private static void addClickListenersOnHashtags(final Context context,
-                                                    final SpannableStringBuilder
+                                                    @NonNull final SpannableStringBuilder
                                                             spannableDescription,
                                                     final StreamingService streamingService) {
         final String descriptionText = spannableDescription.toString();
@@ -174,7 +177,7 @@ public final class TextLinkifier {
      * @param streamingService     the {@link StreamingService} of the content
      */
     private static void addClickListenersOnTimestamps(final Context context,
-                                                      final SpannableStringBuilder
+                                                      @NonNull final SpannableStringBuilder
                                                               spannableDescription,
                                                       final String contentUrl,
                                                       final StreamingService streamingService) {
@@ -232,6 +235,7 @@ public final class TextLinkifier {
      * @param contentUrl       the URL of the content
      * @return a disposable to be stored somewhere and disposed when activity/fragment is destroyed
      */
+    @NonNull
     private static Disposable changeIntentsOfDescriptionLinks(final Context context,
                                                               final CharSequence chars,
                                                               final TextView textView,
@@ -279,7 +283,7 @@ public final class TextLinkifier {
                         });
     }
 
-    private static void setTextViewCharSequence(final TextView textView,
+    private static void setTextViewCharSequence(@NonNull final TextView textView,
                                                 final CharSequence charSequence) {
         textView.setText(charSequence);
         textView.setMovementMethod(LinkMovementMethod.getInstance());

--- a/app/src/main/java/org/schabi/newpipe/util/external_communication/TextLinkifier.java
+++ b/app/src/main/java/org/schabi/newpipe/util/external_communication/TextLinkifier.java
@@ -23,6 +23,7 @@ import io.noties.markwon.Markwon;
 import io.noties.markwon.linkify.LinkifyPlugin;
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.disposables.CompositeDisposable;
 import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 
@@ -201,7 +202,8 @@ public final class TextLinkifier {
             spannableDescription.setSpan(new ClickableSpan() {
                 @Override
                 public void onClick(@NonNull final View view) {
-                    playOnPopup(context, contentUrl, streamingService, time);
+                    playOnPopup(new CompositeDisposable(), context, contentUrl, streamingService,
+                            time);
                 }
             }, timestampStart, timestampEnd, 0);
         }
@@ -245,7 +247,8 @@ public final class TextLinkifier {
                 final String url = span.getURL();
                 final ClickableSpan clickableSpan = new ClickableSpan() {
                     public void onClick(@NonNull final View view) {
-                        if (!InternalUrlsHandler.handleUrlDescriptionTimestamp(context, url)) {
+                        if (!InternalUrlsHandler.handleUrlDescriptionTimestamp(
+                                new CompositeDisposable(), context, url)) {
                             ShareUtils.openUrlInBrowser(context, url, false);
                         }
                     }

--- a/app/src/main/java/org/schabi/newpipe/util/external_communication/TextLinkifier.java
+++ b/app/src/main/java/org/schabi/newpipe/util/external_communication/TextLinkifier.java
@@ -1,4 +1,4 @@
-package org.schabi.newpipe.util;
+package org.schabi.newpipe.util.external_communication;
 
 import android.content.Context;
 import android.text.SpannableStringBuilder;
@@ -25,12 +25,13 @@ import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 
-import static org.schabi.newpipe.util.URLHandler.playOnPopup;
+import static org.schabi.newpipe.util.external_communication.InternalUrlsHandler.playOnPopup;
 
 public final class TextLinkifier {
     public static final String TAG = TextLinkifier.class.getSimpleName();
     private static final Pattern TIMESTAMPS_PATTERN_IN_PLAIN_TEXT =
-            Pattern.compile("(?:([0-5]?[0-9]):)?([0-5]?[0-9]):([0-5][0-9])");
+            Pattern.compile("(?:^|(?![:])\\W)(?:([0-5]?[0-9]):)?([0-5]?[0-9]):"
+                    + "([0-5][0-9])(?=$|(?![:])\\W)");
 
     private TextLinkifier() {
     }
@@ -139,8 +140,8 @@ public final class TextLinkifier {
         final Matcher timestampMatches = TIMESTAMPS_PATTERN_IN_PLAIN_TEXT.matcher(descriptionText);
 
         while (timestampMatches.find()) {
-            final int timestampStart = timestampMatches.start(0);
-            final int timestampEnd = timestampMatches.end(0);
+            final int timestampStart = timestampMatches.start(2);
+            final int timestampEnd = timestampMatches.end(3);
             final String parsedTimestamp = descriptionText.substring(timestampStart, timestampEnd);
             final String[] timestampParts = parsedTimestamp.split(":");
             final int time;
@@ -203,7 +204,7 @@ public final class TextLinkifier {
             for (final URLSpan span : urls) {
                 final ClickableSpan clickableSpan = new ClickableSpan() {
                     public void onClick(@NonNull final View view) {
-                        if (!URLHandler.handleUrl(context, span.getURL(), 0)) {
+                        if (!InternalUrlsHandler.handleUrl(context, span.getURL(), 0)) {
                             ShareUtils.openUrlInBrowser(context, span.getURL(), false);
                         }
                     }

--- a/app/src/main/java/org/schabi/newpipe/util/external_communication/TextLinkifier.java
+++ b/app/src/main/java/org/schabi/newpipe/util/external_communication/TextLinkifier.java
@@ -15,6 +15,7 @@ import androidx.annotation.Nullable;
 import androidx.core.text.HtmlCompat;
 
 import org.schabi.newpipe.extractor.Info;
+import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.util.NavigationHelper;
 
 import java.util.regex.Matcher;
@@ -258,7 +259,10 @@ public final class TextLinkifier {
             // add click actions on plain text timestamps only for description of contents,
             // unneeded for meta-info or other TextViews
             if (relatedInfo != null) {
-                addClickListenersOnTimestamps(context, textBlockLinked, relatedInfo, disposables);
+                if (relatedInfo instanceof StreamInfo) {
+                    addClickListenersOnTimestamps(context, textBlockLinked, relatedInfo,
+                            disposables);
+                }
                 addClickListenersOnHashtags(context, textBlockLinked, relatedInfo);
             }
 

--- a/app/src/main/java/us/shandian/giga/ui/adapter/MissionAdapter.java
+++ b/app/src/main/java/us/shandian/giga/ui/adapter/MissionAdapter.java
@@ -2,7 +2,6 @@ package us.shandian.giga.ui.adapter;
 
 import android.annotation.SuppressLint;
 import android.app.NotificationManager;
-import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Color;
@@ -45,7 +44,7 @@ import org.schabi.newpipe.error.ErrorActivity;
 import org.schabi.newpipe.error.ErrorInfo;
 import org.schabi.newpipe.error.UserAction;
 import org.schabi.newpipe.util.NavigationHelper;
-import org.schabi.newpipe.util.ShareUtils;
+import org.schabi.newpipe.util.external_communication.ShareUtils;
 
 import java.io.File;
 import java.net.URI;

--- a/app/src/main/java/us/shandian/giga/ui/adapter/MissionAdapter.java
+++ b/app/src/main/java/us/shandian/giga/ui/adapter/MissionAdapter.java
@@ -348,10 +348,8 @@ public class MissionAdapter extends Adapter<ViewHolder> implements Handler.Callb
         if (BuildConfig.DEBUG)
             Log.v(TAG, "Mime: " + mimeType + " package: " + BuildConfig.APPLICATION_ID + ".provider");
 
-        final Uri uri = resolveShareableUri(mission);
-
         Intent intent = new Intent(Intent.ACTION_VIEW);
-        intent.setDataAndType(uri, mimeType);
+        intent.setDataAndType(resolveShareableUri(mission), mimeType);
         intent.addFlags(FLAG_GRANT_READ_URI_PERMISSION);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
@@ -361,10 +359,8 @@ public class MissionAdapter extends Adapter<ViewHolder> implements Handler.Callb
             intent.addFlags(FLAG_ACTIVITY_NEW_TASK);
         }
 
-        //mContext.grantUriPermission(packageName, uri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
-
         if (intent.resolveActivity(mContext.getPackageManager()) != null) {
-            ShareUtils.openIntentInApp(mContext, intent);
+            ShareUtils.openIntentInApp(mContext, intent, false);
         } else {
             Toast.makeText(mContext, R.string.toast_no_player, Toast.LENGTH_LONG).show();
         }
@@ -377,19 +373,13 @@ public class MissionAdapter extends Adapter<ViewHolder> implements Handler.Callb
         shareIntent.setType(resolveMimeType(mission));
         shareIntent.putExtra(Intent.EXTRA_STREAM, resolveShareableUri(mission));
         shareIntent.addFlags(FLAG_GRANT_READ_URI_PERMISSION);
+
         final Intent intent = new Intent(Intent.ACTION_CHOOSER);
         intent.putExtra(Intent.EXTRA_INTENT, shareIntent);
         intent.putExtra(Intent.EXTRA_TITLE, mContext.getString(R.string.share_dialog_title));
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 
-        try {
-            intent.setPackage("android");
-            mContext.startActivity(intent);
-        } catch (final ActivityNotFoundException e) {
-            // falling back to OEM chooser if Android's system chooser was removed by the OEM
-            intent.setPackage(null);
-            mContext.startActivity(intent);
-        }
+        mContext.startActivity(intent);
     }
 
     /**

--- a/app/src/main/java/us/shandian/giga/ui/adapter/MissionAdapter.java
+++ b/app/src/main/java/us/shandian/giga/ui/adapter/MissionAdapter.java
@@ -375,6 +375,8 @@ public class MissionAdapter extends Adapter<ViewHolder> implements Handler.Callb
 
         final Intent intent = new Intent(Intent.ACTION_CHOOSER);
         intent.putExtra(Intent.EXTRA_INTENT, shareIntent);
+        // unneeded to set a title to the chooser on Android P and higher because the system
+        // ignores this title on these versions
         if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.O_MR1) {
             intent.putExtra(Intent.EXTRA_TITLE, mContext.getString(R.string.share_dialog_title));
         }

--- a/app/src/main/java/us/shandian/giga/ui/adapter/MissionAdapter.java
+++ b/app/src/main/java/us/shandian/giga/ui/adapter/MissionAdapter.java
@@ -376,8 +376,11 @@ public class MissionAdapter extends Adapter<ViewHolder> implements Handler.Callb
 
         final Intent intent = new Intent(Intent.ACTION_CHOOSER);
         intent.putExtra(Intent.EXTRA_INTENT, shareIntent);
-        intent.putExtra(Intent.EXTRA_TITLE, mContext.getString(R.string.share_dialog_title));
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.O_MR1) {
+            intent.putExtra(Intent.EXTRA_TITLE, mContext.getString(R.string.share_dialog_title));
+        }
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        intent.addFlags(FLAG_GRANT_READ_URI_PERMISSION);
 
         mContext.startActivity(intent);
     }


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [x] Feature (user facing)

#### Description of the changes in your PR
This PR:
- removes a toast which is shown when no app is able to handle the maket scheme on user's device (a toast is only shown if no browser is installed).
- opens the popup player for timestamps in the description of contents.
- fixes action of open with Kodi button in the player
- adds title of the shared content in Android Share Sheet (only for Android 10+ users)
- does some other improvements.
- adds support for hashtags in descriptions, which open for each a search for the hastag in the current service of the content

~~**TO DO**: add a proper support of disposables (I can't do it myself)~~ done

#### Fixes the following issue(s)
Fixes #5507, fixes https://github.com/TeamNewPipe/NewPipe/issues/5455#issuecomment-770903090, fixes #5695

#### APK testing 
On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).

(Sorry in advance for my English)