### PR TITLE
Add instrumented tests for LocalPlaylistManager.createPlaylist

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/local/playlist/LocalPlaylistManagerTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/local/playlist/LocalPlaylistManagerTest.kt
@@ -1,0 +1,85 @@
+package org.schabi.newpipe.local.playlist
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.Timeout
+import org.schabi.newpipe.database.AppDatabase
+import org.schabi.newpipe.database.stream.model.StreamEntity
+import org.schabi.newpipe.extractor.stream.StreamType
+import org.schabi.newpipe.testUtil.TrampolineSchedulerRule
+import java.util.concurrent.TimeUnit
+
+class LocalPlaylistManagerTest {
+
+    private lateinit var manager: LocalPlaylistManager
+    private lateinit var database: AppDatabase
+
+    @get:Rule
+    val trampolineScheduler = TrampolineSchedulerRule()
+
+    @get:Rule
+    val timeout = Timeout(10, TimeUnit.SECONDS)
+
+    @Before
+    fun setup() {
+        database = Room.inMemoryDatabaseBuilder(
+                ApplicationProvider.getApplicationContext(),
+                AppDatabase::class.java
+        )
+                .allowMainThreadQueries()
+                .build()
+
+        manager = LocalPlaylistManager(database)
+    }
+
+    @After
+    fun cleanUp() {
+        database.close()
+    }
+
+    @Test
+    fun createPlaylist() {
+        val stream = StreamEntity(
+                serviceId = 1, url = "https://newpipe.net/", title = "title",
+                streamType = StreamType.VIDEO_STREAM, duration = 1, uploader = "uploader"
+        )
+
+        val result = manager.createPlaylist("name", listOf(stream))
+
+        // This should not behave like this.
+        // Currently list of all stream ids is returned instead of playlist id
+        result.test().await().assertValue(listOf(1L))
+    }
+
+    @Test
+    fun createPlaylist_emptyPlaylistMustReturnEmpty() {
+        val result = manager.createPlaylist("name", emptyList())
+
+        // This should not behave like this.
+        // It should throw an error because currently the result is null
+        result.test().await().assertComplete()
+        manager.playlists.test().awaitCount(1).assertValue(emptyList())
+    }
+
+    @Test()
+    fun createPlaylist_nonExistentStreamsAreUpserted() {
+        val stream = StreamEntity(
+                serviceId = 1, url = "https://newpipe.net/", title = "title",
+                streamType = StreamType.VIDEO_STREAM, duration = 1, uploader = "uploader"
+        )
+        database.streamDAO().insert(stream)
+        val upserted = StreamEntity(
+                serviceId = 1, url = "https://newpipe.net/2", title = "title2",
+                streamType = StreamType.VIDEO_STREAM, duration = 1, uploader = "uploader"
+        )
+
+        val result = manager.createPlaylist("name", listOf(stream, upserted))
+
+        result.test().await().assertComplete()
+        database.streamDAO().all.test().awaitCount(1).assertValue(listOf(stream, upserted))
+    }
+}

--- a/app/src/androidTest/java/org/schabi/newpipe/testUtil/TrampolineSchedulerRule.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/testUtil/TrampolineSchedulerRule.kt
@@ -8,7 +8,10 @@ import org.junit.runner.Description
 import org.junit.runners.model.Statement
 
 /**
- * Always run on [Schedulers.trampoline]
+ * Always run on [Schedulers.trampoline].
+ * This executes the task in the current thread in FIFO manner.
+ * This ensures that tasks are run quickly inside the tests
+ * and not scheduled away to another thread for later execution
  */
 class TrampolineSchedulerRule : TestRule {
 

--- a/app/src/androidTest/java/org/schabi/newpipe/testUtil/TrampolineSchedulerRule.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/testUtil/TrampolineSchedulerRule.kt
@@ -1,0 +1,34 @@
+package org.schabi.newpipe.testUtil
+
+import io.reactivex.rxjava3.android.plugins.RxAndroidPlugins
+import io.reactivex.rxjava3.plugins.RxJavaPlugins
+import io.reactivex.rxjava3.schedulers.Schedulers
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+/**
+ * Always run on [Schedulers.trampoline]
+ */
+class TrampolineSchedulerRule : TestRule {
+
+    private val scheduler = Schedulers.trampoline()
+
+    override fun apply(base: Statement, description: Description): Statement =
+            object : Statement() {
+                override fun evaluate() {
+                    try {
+                        RxJavaPlugins.setComputationSchedulerHandler { scheduler }
+                        RxJavaPlugins.setIoSchedulerHandler { scheduler }
+                        RxJavaPlugins.setNewThreadSchedulerHandler { scheduler }
+                        RxJavaPlugins.setSingleSchedulerHandler { scheduler }
+                        RxAndroidPlugins.setInitMainThreadSchedulerHandler { scheduler }
+
+                        base.evaluate()
+                    } finally {
+                        RxJavaPlugins.reset()
+                        RxAndroidPlugins.reset()
+                    }
+                }
+            }
+}


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Codebase improvement (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Add instrumented tests for LocalPlaylistManager.createPlaylist

#### Fixes the following issue(s)
<!-- Also add any other links relevant to your change. -->
- No automated tests!

#### Relies on the following changes
<!-- Delete this if it doesn't apply to you. -->
- #5360 So instrumented tests are actually run in the CI pipeline

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).

#### Notes
- Besides testing the code, this should also serve as a "how-to" which can be referenced when asking contributors to add tests to classes like this one
- There are 2 weird behaviours which i commented. They should be adressed somewhere seperatly and not here.
- The manager layer and DAO layer is tested together here. Mocking the DAO with Mockito makes the tests very brittle. The example here, also does it like this. See `TaskLocalDataSource` which should be the equivalent layout to our `LocalPlaylistManager` https://github.com/android/architecture-samples
- RxJava is unpleasant to test
