### PR TITLE
Action to auto-comment on pull requests with a link to the artifact

### DIFF
--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -36,13 +36,16 @@ jobs:
             if (!artifacts.length) {
               return core.error(`No artifacts found`);
             }
-            let body = `Download the artifact for this pull request:`;
+            const prefix = '<!-- pr-comment workflow -->';
+            let body = `${prefix}\n\nDownload the artifact for this pull request:`;
             for (const art of artifacts) {
               body += ` [**${art.name}.zip**](https://nightly.link/${owner}/${repo}/actions/artifacts/${art.id}.zip)`;
             }
 
             const {data: comments} = await github.issues.listComments({repo, owner, issue_number});
-            const existing_comment = comments.find((c) => c.user.login === 'github-actions[bot]');
+            const existing_comment = comments.find((c) => {
+              return c.user.login === 'github-actions[bot]' && c.body.startsWith(prefix);
+            });
             if (existing_comment) {
               core.info(`Updating comment ${existing_comment.id}`);
               await github.issues.updateComment({repo, owner, comment_id: existing_comment.id, body});

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,0 +1,52 @@
+name: Comment on pull request
+on:
+  workflow_run:
+    workflows: ['CI']
+    types: [completed]
+jobs:
+  pr_comment:
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v3
+        with:
+          script: |
+            const {owner, repo} = context.repo;
+            const run_id = ${{github.event.workflow_run.id}};
+            const pull_head_sha = '${{github.event.workflow_run.head_sha}}';
+            const pull_user_id = ${{github.event.sender.id}};
+
+            const issue_number = await (async () => {
+              const pulls = await github.pulls.list({owner, repo});
+              for await (const {data} of github.paginate.iterator(pulls)) {
+                for (const pull of data) {
+                  if (pull.head.sha === pull_head_sha && pull.user.id === pull_user_id) {
+                    return pull.number;
+                  }
+                }
+              }
+            })();
+            if (issue_number) {
+              core.info(`Using pull request ${issue_number}`);
+            } else {
+              return core.error(`No matching pull request found`);
+            }
+
+            const {data: {artifacts}} = await github.actions.listWorkflowRunArtifacts({owner, repo, run_id});
+            if (!artifacts.length) {
+              return core.error(`No artifacts found`);
+            }
+            let body = `Download the artifact for this pull request:`;
+            for (const art of artifacts) {
+              body += ` [**${art.name}.zip**](https://nightly.link/${owner}/${repo}/actions/artifacts/${art.id}.zip)`;
+            }
+
+            const {data: comments} = await github.issues.listComments({repo, owner, issue_number});
+            const existing_comment = comments.find((c) => c.user.login === 'github-actions[bot]');
+            if (existing_comment) {
+              core.info(`Updating comment ${existing_comment.id}`);
+              await github.issues.updateComment({repo, owner, comment_id: existing_comment.id, body});
+            } else {
+              core.info(`Creating a comment`);
+              await github.issues.createComment({repo, owner, issue_number, body});
+            }


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [x] Meta improvement to the project (dev facing)

#### The issue

I first noticed that NewPipe has this issue via [this comment](https://github.com/TeamNewPipe/NewPipe/pull/4534#issuecomment-752342326) (because I was globally searching GitHub for mentions of "https://nightly.link/", which is my project):

> Github Actions doesn't allow guest users to download artifacts, which is pretty stupid. @Stypox and other PR authors, could you post nightly.link URLs so that users don't have to sign in just to access an APK? If not, then maybe @mhmdanas's bot could be used to download and upload the latest artifact to its comment somehow?
>
> -- @opusforlife2 [on Dec 30, 2020](https://github.com/TeamNewPipe/NewPipe/pull/4534#issuecomment-752342326)

(Also see the next few comments after that one)

So here I'm basically fulfilling both parts of this need: I'm adding a "bot" (really it's isolated entirely within GitHub Actions for this repo) that automatically posts such a link to the APK from the pull request *and* the link works for guest users.

#### Description of the changes in your PR

Whenever a CI build for a pull request succeeds, `github-actions[bot]` will comment (or edit the comment) with a link to directly download the artifact (i.e. the APK) from it. The bot's comment will tend to be near the start of the thread.

[***See an example of this in action here***](https://github.com/oprypin/nightly.link/pull/10)

The service https://nightly.link/ is used for the actual link because it allows downloads without logging in. It would be possible to instead make an equivalent link directly to GitHub, but [users who happen to not be logged into GitHub will just get a 404 error](https://github.com/actions/upload-artifact/issues/51).

Why this can't be done more simply:

* Running the comment API directly from the pull request's action can't be done due to permission boundaries.
* [workflow_run](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_run) is the intended place for commenting actions, but GitHub really just doesn't provide a way to find the originating pull request from this event, so we to have search for it through the SHA (and that basically takes up the top half of this). You can see what other hacks people have devised for this [here](https://github.com/nyurik/auto_pr_comments_from_forks) and [here](https://github.com/search?l=YAML&q=workflow_run+createComment&type=Code)

##### APK testing 
Well yes, APK testing is exactly what this improves, so this section will become unnecessary:

> On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).

Note that I am not involved with NewPipe whatsoever, only popping in for this particular contribution, but I intend to always follow up on anything relating to it (you can always @ me or find me on IRC).