### PR TITLE
Fix tab layout visibility with age restricted videos

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -33,7 +33,6 @@ import android.widget.FrameLayout;
 import android.widget.RelativeLayout;
 
 import androidx.annotation.AttrRes;
-import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
@@ -1329,13 +1328,21 @@ public final class VideoDetailFragment
 
     @Override
     public void showError(final String message, final boolean showRetryButton) {
-        showError(message, showRetryButton, R.drawable.not_available_monkey);
+        super.showError(message, showRetryButton);
+        setErrorImage(R.drawable.not_available_monkey);
+
+        if (binding.relatedStreamsLayout != null) { // hide related streams for tablets
+            binding.relatedStreamsLayout.setVisibility(View.INVISIBLE);
+        }
+
+        // hide comments / related streams / description tabs
+        binding.viewPager.setVisibility(View.GONE);
+        binding.tabLayout.setVisibility(View.GONE);
     }
 
-    protected void showError(final String message, final boolean showRetryButton,
-                             @DrawableRes final int imageError) {
-        super.showError(message, showRetryButton);
-        setErrorImage(imageError);
+    private void hideAgeRestrictedContent() {
+        showError(getString(R.string.restricted_video,
+                getString(R.string.show_age_restricted_content_title)), false);
     }
 
     private void setupBroadcastReceiver() {
@@ -1558,18 +1565,6 @@ public final class VideoDetailFragment
         binding.detailControlsPopup.setVisibility(noVideoStreams ? View.GONE : View.VISIBLE);
         binding.detailThumbnailPlayButton.setImageResource(
                 noVideoStreams ? R.drawable.ic_headset_shadow : R.drawable.ic_play_arrow_shadow);
-    }
-
-    private void hideAgeRestrictedContent() {
-        showError(getString(R.string.restricted_video,
-                getString(R.string.show_age_restricted_content_title)), false);
-
-        if (binding.relatedStreamsLayout != null) { // tablet
-            binding.relatedStreamsLayout.setVisibility(View.INVISIBLE);
-        }
-
-        binding.viewPager.setVisibility(View.GONE);
-        binding.tabLayout.setVisibility(View.GONE);
     }
 
     private void displayUploaderAsSubChannel(final StreamInfo info) {

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -580,6 +580,7 @@ public final class VideoDetailFragment
                     Player.DEFAULT_CONTROLS_DURATION, 0);
             binding.detailSecondaryControlPanel.setVisibility(View.GONE);
         }
+        // view pager height has changed, update the tab layout
         updateTabLayoutVisibility();
     }
 
@@ -650,6 +651,7 @@ public final class VideoDetailFragment
             // prevent useless updates to tab layout visibility if nothing changed
             if (verticalOffset != lastAppBarVerticalOffset) {
                 lastAppBarVerticalOffset = verticalOffset;
+                // the view was scrolled
                 updateTabLayoutVisibility();
             }
         });
@@ -952,6 +954,7 @@ public final class VideoDetailFragment
             }
             updateTabIconsAndContentDescriptions();
         }
+        // the page adapter now contains tabs: show the tab layout
         updateTabLayoutVisibility();
     }
 
@@ -974,12 +977,10 @@ public final class VideoDetailFragment
     private void updateTabs(@NonNull final StreamInfo info) {
         if (showRelatedStreams) {
             if (binding.relatedStreamsLayout == null) { // phone
-                pageAdapter.updateItem(RELATED_TAB_TAG,
-                        RelatedVideosFragment.getInstance(info));
+                pageAdapter.updateItem(RELATED_TAB_TAG, RelatedVideosFragment.getInstance(info));
             } else { // tablet + TV
                 getChildFragmentManager().beginTransaction()
-                        .replace(R.id.relatedStreamsLayout,
-                                RelatedVideosFragment.getInstance(info))
+                        .replace(R.id.relatedStreamsLayout, RelatedVideosFragment.getInstance(info))
                         .commitAllowingStateLoss();
                 binding.relatedStreamsLayout.setVisibility(
                         player != null && player.isFullscreen() ? View.GONE : View.VISIBLE);
@@ -987,10 +988,12 @@ public final class VideoDetailFragment
         }
 
         if (showDescription) {
-            pageAdapter.updateItem(DESCRIPTION_TAB_TAG,
-                    new DescriptionFragment(info));
+            pageAdapter.updateItem(DESCRIPTION_TAB_TAG, new DescriptionFragment(info));
         }
 
+        binding.viewPager.setVisibility(View.VISIBLE);
+        // make sure the tab layout is visible
+        updateTabLayoutVisibility();
         pageAdapter.notifyDataSetUpdate();
         updateTabIconsAndContentDescriptions();
     }
@@ -1007,9 +1010,12 @@ public final class VideoDetailFragment
     }
 
     public void updateTabLayoutVisibility() {
-        if (pageAdapter.getCount() < 2) {
+        if (pageAdapter.getCount() < 2 || binding.viewPager.getVisibility() != View.VISIBLE) {
+            // hide tab layout if there is only one tab or if the view pager is also hidden
             binding.tabLayout.setVisibility(View.GONE);
         } else {
+            // call `post()` to be sure `viewPager.getHitRect()`
+            // is up to date and not being currently recomputed
             binding.tabLayout.post(() -> {
                 if (getContext() != null) {
                     final Rect pagerHitRect = new Rect();
@@ -1020,7 +1026,7 @@ public final class VideoDetailFragment
                             WindowManager.class)).getDefaultDisplay().getSize(displaySize);
 
                     final int viewPagerVisibleHeight = displaySize.y - pagerHitRect.top;
-                    // see TabLayout.DEFAULT_HEIGHT
+                    // see TabLayout.DEFAULT_HEIGHT, which is equal to 48dp
                     final float tabLayoutHeight = TypedValue.applyDimension(
                             TypedValue.COMPLEX_UNIT_DIP, 48, getResources().getDisplayMetrics());
 
@@ -1030,6 +1036,7 @@ public final class VideoDetailFragment
                                 Math.max(0, tabLayoutHeight * 3 - viewPagerVisibleHeight));
                         binding.tabLayout.setVisibility(View.VISIBLE);
                     } else {
+                        // view pager is not visible enough
                         binding.tabLayout.setVisibility(View.GONE);
                     }
                 }
@@ -1039,6 +1046,7 @@ public final class VideoDetailFragment
 
     public void scrollToTop() {
         binding.appBarLayout.setExpanded(true, true);
+        // notify tab layout of scrolling
         updateTabLayoutVisibility();
     }
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This fixes the tab layout visibility in video detail fragment when showing age restricted videos:
- never show tab layout if view pager is hidden
- always show view pager and tab layout again when a new stream info has to be shown in video detail fragment 

#### Fixes the following issue(s)
<!-- Also add any other links relevant to your change. -->
- https://github.com/TeamNewPipe/NewPipe/issues/5455#issuecomment-774741197

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
