### PR TITLE
Downloader: Deleter: Dismiss previous Snackbars

### DIFF
--- a/app/src/main/java/us/shandian/giga/ui/common/Deleter.java
+++ b/app/src/main/java/us/shandian/giga/ui/common/Deleter.java
@@ -55,6 +55,14 @@ public class Deleter {
     }
 
     public void append(Mission item) {
+
+        /* If a mission is removed from the list while the Snackbar for a previously
+         * removed item is still showing, commit the action for the previous item
+         * immediately. This prevents Snackbars from stacking up in reverse order.
+         */
+        mHandler.removeCallbacks(rCommit);
+        commit();
+
         mIterator.hide(item);
         items.add(0, item);
 


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)

#### Description of the changes in your PR
When running `append()`, trigger the `commit()` action immediately and cancel all delayed callbacks for `commit()`.

Snackbars no longer pile up. For previous behaviour, see https://github.com/TeamNewPipe/NewPipe/issues/5660

(Checking if there are any tasks running via [hasCallbacks()](https://developer.android.com/reference/android/os/Handler#hasCallbacks(java.lang.Runnable)) would be nice, but that method is only available in API 29+.)

For a visual comparison:

The current behaviour in NewPipe 0.20.10
[Screencast](https://ix5.org/files/newpipe.mp4) (note: Snackbars keep piling up)

With this PR applied:
[Screencast](https://ix5.org/files/newpipe-dismiss.mp4) (note: No piling up, but users can still undo actions)

#### Fixes the following issue(s)
https://github.com/TeamNewPipe/NewPipe/issues/5660

#### APK testing

[My server](https://sx.ix5.org/files/misc/newpipe-debug.apk)
[Generated from GitHub CI](https://github.com/TeamNewPipe/NewPipe/suites/2097924546/artifacts/42600853)

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
