### PR TITLE
Add crash button to debug settings

### DIFF
--- a/app/src/debug/java/org/schabi/newpipe/settings/DebugSettingsFragment.java
+++ b/app/src/debug/java/org/schabi/newpipe/settings/DebugSettingsFragment.java
@@ -3,6 +3,7 @@ package org.schabi.newpipe.settings;
 import android.os.Bundle;
 
 import androidx.annotation.Nullable;
+import androidx.preference.Preference;
 
 import org.schabi.newpipe.R;
 
@@ -13,11 +14,22 @@ public class DebugSettingsFragment extends BasePreferenceFragment {
     public void onCreate(@Nullable final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        findPreference(getString(R.string.show_memory_leaks_key))
-                .setOnPreferenceClickListener(preference -> {
-                    startActivity(LeakCanary.INSTANCE.newLeakDisplayActivityIntent());
-                    return true;
-                });
+        final Preference showMemoryLeaksPreference
+                = findPreference(getString(R.string.show_memory_leaks_key));
+        final Preference crashTheAppPreference
+                = findPreference(getString(R.string.crash_the_app_key));
+
+        assert showMemoryLeaksPreference != null;
+        assert crashTheAppPreference != null;
+
+        showMemoryLeaksPreference.setOnPreferenceClickListener(preference -> {
+            startActivity(LeakCanary.INSTANCE.newLeakDisplayActivityIntent());
+            return true;
+        });
+
+        crashTheAppPreference.setOnPreferenceClickListener(preference -> {
+            throw new RuntimeException();
+        });
     }
 
     @Override

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -172,6 +172,7 @@
     <string name="show_memory_leaks_key" translatable="false">show_memory_leaks_key</string>
     <string name="allow_disposed_exceptions_key" translatable="false">allow_disposed_exceptions_key</string>
     <string name="show_original_time_ago_key" translatable="false">show_original_time_ago_text_key</string>
+    <string name="crash_the_app_key" translatable="false">crash_the_app_key</string>
 
     <!-- THEMES -->
     <string name="theme_key" translatable="false">theme</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -518,6 +518,7 @@
     <string name="enable_disposed_exceptions_summary">Force reporting of undeliverable Rx exceptions outside of fragment or activity lifecycle after disposal</string>
     <string name="show_original_time_ago_title">Show original time ago on items</string>
     <string name="show_original_time_ago_summary">Original texts from services will be visible in stream items</string>
+    <string name="crash_the_app">Crash the app</string>
     <!-- Subscriptions import/export -->
     <string name="import_export_title">Import/export</string>
     <string name="import_title">Import</string>

--- a/app/src/main/res/xml/debug_settings.xml
+++ b/app/src/main/res/xml/debug_settings.xml
@@ -29,4 +29,9 @@
         android:summary="@string/show_original_time_ago_summary"
         android:title="@string/show_original_time_ago_title"
         app:iconSpaceReserved="false" />
+
+    <Preference
+        android:key="@string/crash_the_app_key"
+        android:title="@string/crash_the_app"
+        app:iconSpaceReserved="false" />
 </PreferenceScreen>


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This PR just adds a "Crash the app" button to the Debug settings, which are only visible in debug builds. This could come in handy sooner or later to debug ACRA.

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
