### PR TITLE
Fix last resize mode not being restored correctly

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
@@ -484,8 +484,9 @@ public final class PlayerHelper {
                 break;
         }
 
+        // save the new resize mode so it can be restored in a future session
         player.getPrefs().edit().putInt(
-                player.getContext().getString(R.string.last_resize_mode), resizeMode).apply();
+                player.getContext().getString(R.string.last_resize_mode), newResizeMode).apply();
         return newResizeMode;
     }
 


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
The player's resize mode / aspect ratio handling was not stored correctly. For this reason, the resize mode needed to be changed every time the player was started on devices with aspect ratios different to 16:9.

I think the settings key "last_resize_mode" is ambiguous. While it is used to get the recently used resize mode, someone working on the resize mode switcher thought, that the old (to be replaced) resize mode should be stored. 

I did not create a settings migration for this change, because we do not know which preferences were affected by this bug, and which were not.

#### Fixes the following issue(s)
<!-- Also add any other links relevant to your change. -->
Fixes #5613

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
