### PR TITLE
Add screen-lock functionality to fullscreen player

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -1698,9 +1698,7 @@ public final class Player implements
         final int hideTime = binding.playbackControlRoot.isInTouchMode()
             ? DEFAULT_CONTROLS_HIDE_TIME
             : DPAD_CONTROLS_HIDE_TIME;
-        showControls(DEFAULT_CONTROLS_DURATION, () -> {
-            hideControls(DEFAULT_CONTROLS_DURATION, hideTime);
-        });
+        showControls(DEFAULT_CONTROLS_DURATION, () -> hideControls(DEFAULT_CONTROLS_DURATION, hideTime));
     }
 
     public void showControls(final long duration) {
@@ -3662,9 +3660,9 @@ public final class Player implements
     }
 
     private void onUnlockClicked() {
-        hideControls(DEFAULT_CONTROLS_DURATION / 2, 0, () -> {
+        hideControls(DEFAULT_CONTROLS_DURATION, 0, () -> {
             unlockScreen();
-            showControls(DEFAULT_CONTROLS_DURATION / 2);
+            showControlsThenHide();
         });
     }
     //endregion

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -1698,7 +1698,10 @@ public final class Player implements
         final int hideTime = binding.playbackControlRoot.isInTouchMode()
             ? DEFAULT_CONTROLS_HIDE_TIME
             : DPAD_CONTROLS_HIDE_TIME;
-        showControls(DEFAULT_CONTROLS_DURATION, () -> hideControls(DEFAULT_CONTROLS_DURATION, hideTime));
+        showControls(
+            DEFAULT_CONTROLS_DURATION,
+            () -> hideControls(DEFAULT_CONTROLS_DURATION, hideTime)
+        );
     }
 
     public void showControls(final long duration) {

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -517,7 +517,7 @@ public final class Player implements
         binding.playPauseButton.setOnClickListener(this);
         binding.playPreviousButton.setOnClickListener(this);
         binding.playNextButton.setOnClickListener(this);
-        binding.unlockButton.setOnClickListener(this);
+        binding.unlockButton.setOnLongClickListener(this);
 
         binding.moreOptionsButton.setOnClickListener(this);
         binding.moreOptionsButton.setOnLongClickListener(this);
@@ -3472,9 +3472,6 @@ public final class Player implements
             playPrevious();
         } else if (v.getId() == binding.playNextButton.getId()) {
             playNext();
-        } else if (v.getId() == binding.unlockButton.getId()) {
-            onUnlockClicked();
-            return;
         } else if (v.getId() == binding.queueButton.getId()) {
             onQueueClicked();
             return;
@@ -3542,6 +3539,8 @@ public final class Player implements
             fragmentListener.onMoreOptionsLongClicked();
             hideControls(0, 0);
             hideSystemUIIfNeeded();
+        } else if (v.getId() == binding.unlockButton.getId()) {
+            onUnlockClicked();
         }
         return true;
     }

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -288,6 +288,7 @@ public final class Player implements
     private boolean isFullscreen = false;
     private boolean isVerticalVideo = false;
     private boolean fragmentIsVisible = false;
+    private boolean isLocked = false;
 
     private List<VideoStream> availableStreams;
     private int selectedStreamIndex;
@@ -523,6 +524,7 @@ public final class Player implements
         binding.screenRotationButton.setOnClickListener(this);
         binding.playWithKodi.setOnClickListener(this);
         binding.openInBrowser.setOnClickListener(this);
+        binding.screenLock.setOnClickListener(this);
         binding.playerCloseButton.setOnClickListener(this);
         binding.switchMute.setOnClickListener(this);
 
@@ -1682,16 +1684,23 @@ public final class Player implements
         if (DEBUG) {
             Log.d(TAG, "showControlsThenHide() called");
         }
-        showOrHideButtons();
-        showSystemUIPartially();
 
         final int hideTime = binding.playbackControlRoot.isInTouchMode()
-                ? DEFAULT_CONTROLS_HIDE_TIME
-                : DPAD_CONTROLS_HIDE_TIME;
+            ? DEFAULT_CONTROLS_HIDE_TIME
+            : DPAD_CONTROLS_HIDE_TIME;
 
-        showHideShadow(true, DEFAULT_CONTROLS_DURATION);
-        animate(binding.playbackControlRoot, true, DEFAULT_CONTROLS_DURATION,
+        if (isLocked) {
+            animate(binding.lockedRoot, true, DEFAULT_CONTROLS_DURATION,
                 AnimationType.ALPHA, 0, () -> hideControls(DEFAULT_CONTROLS_DURATION, hideTime));
+        } else {
+            showOrHideButtons();
+            showSystemUIPartially();
+
+            showHideShadow(true, DEFAULT_CONTROLS_DURATION);
+            animate(binding.playbackControlRoot, true, DEFAULT_CONTROLS_DURATION,
+                AnimationType.ALPHA, 0, () -> hideControls(DEFAULT_CONTROLS_DURATION, hideTime));
+        }
+
     }
 
     public void showControls(final long duration) {
@@ -3438,6 +3447,9 @@ public final class Player implements
             onPlayWithKodiClicked();
         } else if (v.getId() == binding.openInBrowser.getId()) {
             onOpenInBrowserClicked();
+        } else if (v.getId() == binding.screenLock.getId()) {
+            onScreenLockClicked();
+            return;
         } else if (v.getId() == binding.fullScreenButton.getId()) {
             setRecovery();
             NavigationHelper.playOnMainPlayer(context, playQueue, true);
@@ -3585,6 +3597,11 @@ public final class Player implements
             ShareUtils.openUrlInBrowser(getParentActivity(),
                     currentMetadata.getMetadata().getOriginalUrl());
         }
+    }
+
+    private void onScreenLockClicked() {
+        isLocked = true;
+        hideControls(DEFAULT_CONTROLS_DURATION, 0);
     }
     //endregion
 

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -1019,7 +1019,7 @@ public final class Player implements
     }
 
     private void showHideLockButton() {
-        boolean showLockButton = !DeviceUtils.isTv(context) && isFullscreen;
+        final boolean showLockButton = !DeviceUtils.isTv(context) && isFullscreen;
         binding.screenLock.setVisibility(showLockButton ? View.VISIBLE : View.GONE);
     }
 
@@ -1621,8 +1621,8 @@ public final class Player implements
 
     public boolean isControlsVisible() {
         return binding != null && (
-            binding.playbackControlRoot.getVisibility() == View.VISIBLE ||
-            binding.lockedRoot.getVisibility() == View.VISIBLE
+            binding.playbackControlRoot.getVisibility() == View.VISIBLE
+            || binding.lockedRoot.getVisibility() == View.VISIBLE
         );
     }
 
@@ -1707,12 +1707,12 @@ public final class Player implements
         showControls(duration, null);
     }
 
-    public void showControls(final long duration, Runnable callback) {
+    public void showControls(final long duration, final Runnable callback) {
         if (DEBUG) {
             Log.d(TAG, "showControls() called");
         }
 
-        RelativeLayout layoutToShow;
+        final RelativeLayout layoutToShow;
         if (!isLocked) {
             showOrHideButtons();
             showSystemUIPartially();
@@ -1737,13 +1737,13 @@ public final class Player implements
         hideControls(duration, delay, null);
     }
 
-    public void hideControls(final long duration, final long delay, Runnable callback) {
+    public void hideControls(final long duration, final long delay, final Runnable callback) {
         if (DEBUG) {
             Log.d(TAG, "hideControls() called with: duration = [" + duration
                     + "], delay = [" + delay + "]");
         }
 
-        RelativeLayout layoutToHide;
+        final RelativeLayout layoutToHide;
         if (!isLocked) {
             showOrHideButtons();
             layoutToHide = binding.playbackControlRoot;
@@ -2097,6 +2097,11 @@ public final class Player implements
         changePopupWindowFlags(IDLE_WINDOW_FLAGS);
 
         NotificationUtil.getInstance().createNotificationIfNeededAndUpdate(this, false);
+
+        if (isLocked) {
+            unlockScreen();
+        }
+
         if (isFullscreen) {
             toggleFullscreen();
         }
@@ -3468,7 +3473,7 @@ public final class Player implements
         } else if (v.getId() == binding.playNextButton.getId()) {
             playNext();
         } else if (v.getId() == binding.unlockButton.getId()) {
-            unlockScreen();
+            onUnlockClicked();
             return;
         } else if (v.getId() == binding.queueButton.getId()) {
             onQueueClicked();
@@ -3644,18 +3649,22 @@ public final class Player implements
 
     private void onScreenLockClicked() {
         hideControls(DEFAULT_CONTROLS_DURATION, 0, () -> {
-            getParentActivity().setRequestedOrientation(isVerticalVideo ?
-                ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT :
-                ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+            getParentActivity().setRequestedOrientation(isVerticalVideo
+                ? ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT
+                : ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
             );
             this.isLocked = true;
         });
     }
 
     private void unlockScreen() {
+        this.isLocked = false;
+        getParentActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
+    }
+
+    private void onUnlockClicked() {
         hideControls(DEFAULT_CONTROLS_DURATION / 2, 0, () -> {
-            this.isLocked = false;
-            getParentActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
+            unlockScreen();
             showControls(DEFAULT_CONTROLS_DURATION / 2);
         });
     }

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -941,6 +941,7 @@ public final class Player implements
             binding.secondaryControls.setTranslationY(0);
             binding.share.setVisibility(View.GONE);
             binding.playWithKodi.setVisibility(View.GONE);
+            binding.screenLock.setVisibility(View.GONE);
             binding.openInBrowser.setVisibility(View.GONE);
             binding.switchMute.setVisibility(View.GONE);
             binding.playerCloseButton.setVisibility(View.GONE);
@@ -2801,6 +2802,7 @@ public final class Player implements
         registerStreamViewed();
         updateStreamRelatedViews();
         showHideKodiButton();
+        showHideLockButton();
 
         binding.titleTextView.setText(tag.getMetadata().getName());
         binding.channelTextView.setText(tag.getMetadata().getUploaderName());
@@ -3754,16 +3756,15 @@ public final class Player implements
         if (isFullscreen) {
             binding.titleTextView.setVisibility(View.VISIBLE);
             binding.channelTextView.setVisibility(View.VISIBLE);
-            binding.screenLock.setVisibility(View.VISIBLE);
             binding.playerCloseButton.setVisibility(View.GONE);
         } else {
             binding.titleTextView.setVisibility(View.GONE);
             binding.channelTextView.setVisibility(View.GONE);
             binding.playerCloseButton.setVisibility(
                     videoPlayerSelected() ? View.VISIBLE : View.GONE);
-            binding.screenLock.setVisibility(View.GONE);
         }
         setupScreenRotationButton();
+        showHideLockButton();
     }
 
     public void checkLandscape() {

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -1709,7 +1709,7 @@ public final class Player implements
         showControls(duration, null);
     }
 
-    public void showControls(final long duration, final Runnable callback) {
+    public void showControls(final long duration, @Nullable final Runnable callback) {
         if (DEBUG) {
             Log.d(TAG, "showControls() called");
         }
@@ -1739,7 +1739,10 @@ public final class Player implements
         hideControls(duration, delay, null);
     }
 
-    public void hideControls(final long duration, final long delay, final Runnable callback) {
+    public void hideControls(
+        final long duration,
+        final long delay,
+        @Nullable final Runnable callback) {
         if (DEBUG) {
             Log.d(TAG, "hideControls() called with: duration = [" + duration
                     + "], delay = [" + delay + "]");

--- a/app/src/main/java/org/schabi/newpipe/player/event/PlayerGestureListener.java
+++ b/app/src/main/java/org/schabi/newpipe/player/event/PlayerGestureListener.java
@@ -104,8 +104,9 @@ public class PlayerGestureListener
         }
         if (playerType == MainPlayer.PlayerType.VIDEO) {
             final boolean isBrightnessGestureEnabled =
-                PlayerHelper.isBrightnessGestureEnabled(service);
-            final boolean isVolumeGestureEnabled = PlayerHelper.isVolumeGestureEnabled(service);
+                PlayerHelper.isBrightnessGestureEnabled(service) && !player.isLocked();
+            final boolean isVolumeGestureEnabled =
+                PlayerHelper.isVolumeGestureEnabled(service) && !player.isLocked();
 
             if (isBrightnessGestureEnabled && isVolumeGestureEnabled) {
                 if (portion == DisplayPortion.LEFT_HALF) {

--- a/app/src/main/java/org/schabi/newpipe/player/event/PlayerGestureListener.java
+++ b/app/src/main/java/org/schabi/newpipe/player/event/PlayerGestureListener.java
@@ -55,12 +55,16 @@ public class PlayerGestureListener
             player.hideControls(0, 0);
         }
 
-        if (portion == DisplayPortion.LEFT) {
-            player.fastRewind();
-        } else if (portion == DisplayPortion.MIDDLE) {
-            player.playPause();
-        } else if (portion == DisplayPortion.RIGHT) {
-            player.fastForward();
+        if (player.isLocked()) {
+            player.showControlsThenHide();
+        } else {
+            if (portion == DisplayPortion.LEFT) {
+                player.fastRewind();
+            } else if (portion == DisplayPortion.MIDDLE) {
+                player.playPause();
+            } else if (portion == DisplayPortion.RIGHT) {
+                player.fastForward();
+            }
         }
     }
 

--- a/app/src/main/res/drawable/ic_lock_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_lock_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z" />
+</vector>

--- a/app/src/main/res/drawable/ic_lock_open_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_lock_open_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12 17c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm6-9h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6h1.9c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm0 12H6V10h12v10z" />
+</vector>

--- a/app/src/main/res/drawable/ic_lock_open_white_24dp.xml
+++ b/app/src/main/res/drawable/ic_lock_open_white_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12 17c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm6-9h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6h1.9c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm0 12H6V10h12v10z" />
+</vector>

--- a/app/src/main/res/drawable/ic_lock_white_24dp.xml
+++ b/app/src/main/res/drawable/ic_lock_white_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z" />
+</vector>

--- a/app/src/main/res/layout-large-land/player.xml
+++ b/app/src/main/res/layout-large-land/player.xml
@@ -286,6 +286,20 @@
                         tools:ignore="RtlHardcoded" />
 
                     <androidx.appcompat.widget.AppCompatImageButton
+                        android:id="@+id/screenLock"
+                        android:layout_width="wrap_content"
+                        android:layout_height="35dp"
+                        android:layout_marginEnd="8dp"
+                        android:background="?attr/selectableItemBackground"
+                        android:clickable="true"
+                        android:contentDescription="@string/lock_screen"
+                        android:focusable="true"
+                        android:padding="@dimen/player_main_buttons_padding"
+                        android:scaleType="fitXY"
+                        app:srcCompat="@drawable/ic_lock_open_white_24dp"
+                        tools:ignore="RtlHardcoded" />
+
+                    <androidx.appcompat.widget.AppCompatImageButton
                         android:id="@+id/openInBrowser"
                         android:layout_width="wrap_content"
                         android:layout_height="35dp"
@@ -464,6 +478,47 @@
                 android:scaleType="fitCenter"
                 app:srcCompat="@drawable/ic_next_white_24dp"
                 tools:ignore="ContentDescription" />
+
+        </LinearLayout>
+
+    </RelativeLayout>
+
+    <RelativeLayout
+        android:id="@+id/lockedRoot"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/video_overlay_color"
+        android:visibility="gone"
+        tools:visibility="visible" >
+
+        <LinearLayout
+            android:id="@+id/unlockView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            android:orientation="vertical"
+            android:layout_centerHorizontal="true"
+            android:layout_alignParentBottom="true"
+            android:gravity="center"
+            tools:ignore="RtlHardcoded">
+
+            <androidx.appcompat.widget.AppCompatImageButton
+                android:id="@+id/unlockButton"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:scaleType="fitCenter"
+                app:srcCompat="@drawable/ic_lock_white_24dp"
+                tools:ignore="ContentDescription" />
+
+            <TextView
+                android:id="@+id/holdToUnlock"
+                android:text="@string/hold_to_unlock"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:padding="8dp"
+                android:textColor="@android:color/white"
+                android:textStyle="bold" />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/player.xml
+++ b/app/src/main/res/layout/player.xml
@@ -285,6 +285,20 @@
                         tools:ignore="RtlHardcoded" />
 
                     <androidx.appcompat.widget.AppCompatImageButton
+                        android:id="@+id/screenLock"
+                        android:layout_width="wrap_content"
+                        android:layout_height="35dp"
+                        android:layout_marginEnd="8dp"
+                        android:background="?attr/selectableItemBackground"
+                        android:clickable="true"
+                        android:contentDescription="@string/share"
+                        android:focusable="true"
+                        android:padding="@dimen/player_main_buttons_padding"
+                        android:scaleType="fitXY"
+                        app:srcCompat="@android:drawable/ic_lock_idle_lock"
+                        tools:ignore="RtlHardcoded" />
+
+                    <androidx.appcompat.widget.AppCompatImageButton
                         android:id="@+id/openInBrowser"
                         android:layout_width="wrap_content"
                         android:layout_height="35dp"
@@ -463,6 +477,26 @@
                 tools:ignore="ContentDescription" />
 
         </LinearLayout>
+
+    </RelativeLayout>
+
+    <RelativeLayout
+        android:id="@+id/lockedRoot"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/video_overlay_color"
+        android:visibility="gone"
+        tools:visibility="visible" >
+
+        <androidx.appcompat.widget.AppCompatImageButton
+            android:id="@+id/lockedButton"
+            android:layout_width="70dp"
+            android:layout_height="70dp"
+            android:layout_centerInParent="true"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:scaleType="fitCenter"
+            app:srcCompat="@drawable/ic_pause_white_24dp"
+            tools:ignore="ContentDescription" />
 
     </RelativeLayout>
 

--- a/app/src/main/res/layout/player.xml
+++ b/app/src/main/res/layout/player.xml
@@ -487,17 +487,36 @@
         android:visibility="gone"
         tools:visibility="visible" >
 
-        <androidx.appcompat.widget.AppCompatImageButton
-            android:id="@+id/unlockButton"
+        <LinearLayout
+            android:id="@+id/unlockView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             android:layout_margin="8dp"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
+            android:orientation="vertical"
             android:layout_centerHorizontal="true"
             android:layout_alignParentBottom="true"
-            android:background="?attr/selectableItemBackgroundBorderless"
-            android:scaleType="fitCenter"
-            app:srcCompat="@drawable/ic_lock_white_24dp"
-            tools:ignore="ContentDescription" />
+            android:gravity="center"
+            tools:ignore="RtlHardcoded">
+
+            <androidx.appcompat.widget.AppCompatImageButton
+                android:id="@+id/unlockButton"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:scaleType="fitCenter"
+                app:srcCompat="@drawable/ic_lock_white_24dp"
+                tools:ignore="ContentDescription" />
+
+            <TextView
+                android:id="@+id/holdToUnlock"
+                android:text="@string/hold_to_unlock"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:padding="8dp"
+                android:textColor="@android:color/white"
+                android:textStyle="bold" />
+
+        </LinearLayout>
 
     </RelativeLayout>
 

--- a/app/src/main/res/layout/player.xml
+++ b/app/src/main/res/layout/player.xml
@@ -295,7 +295,7 @@
                         android:focusable="true"
                         android:padding="@dimen/player_main_buttons_padding"
                         android:scaleType="fitXY"
-                        app:srcCompat="@android:drawable/ic_lock_idle_lock"
+                        app:srcCompat="@drawable/ic_lock_open_white_24dp"
                         tools:ignore="RtlHardcoded" />
 
                     <androidx.appcompat.widget.AppCompatImageButton
@@ -489,13 +489,14 @@
 
         <androidx.appcompat.widget.AppCompatImageButton
             android:id="@+id/unlockButton"
-            android:layout_width="70dp"
-            android:layout_height="70dp"
+            android:layout_margin="8dp"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
             android:layout_centerHorizontal="true"
             android:layout_alignParentBottom="true"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:scaleType="fitCenter"
-            app:srcCompat="@drawable/ic_done_white_24dp"
+            app:srcCompat="@drawable/ic_lock_white_24dp"
             tools:ignore="ContentDescription" />
 
     </RelativeLayout>

--- a/app/src/main/res/layout/player.xml
+++ b/app/src/main/res/layout/player.xml
@@ -291,7 +291,7 @@
                         android:layout_marginEnd="8dp"
                         android:background="?attr/selectableItemBackground"
                         android:clickable="true"
-                        android:contentDescription="@string/share"
+                        android:contentDescription="@string/lock_screen"
                         android:focusable="true"
                         android:padding="@dimen/player_main_buttons_padding"
                         android:scaleType="fitXY"

--- a/app/src/main/res/layout/player.xml
+++ b/app/src/main/res/layout/player.xml
@@ -452,7 +452,6 @@
                 app:srcCompat="@drawable/ic_previous_white_24dp"
                 tools:ignore="ContentDescription" />
 
-
             <androidx.appcompat.widget.AppCompatImageButton
                 android:id="@+id/playPauseButton"
                 android:layout_width="0dp"
@@ -489,13 +488,14 @@
         tools:visibility="visible" >
 
         <androidx.appcompat.widget.AppCompatImageButton
-            android:id="@+id/lockedButton"
+            android:id="@+id/unlockButton"
             android:layout_width="70dp"
             android:layout_height="70dp"
-            android:layout_centerInParent="true"
+            android:layout_centerHorizontal="true"
+            android:layout_alignParentBottom="true"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:scaleType="fitCenter"
-            app:srcCompat="@drawable/ic_pause_white_24dp"
+            app:srcCompat="@drawable/ic_done_white_24dp"
             tools:ignore="ContentDescription" />
 
     </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -706,5 +706,6 @@
     <string name="private_content">This content is private, so it cannot be streamed or downloaded by NewPipe.</string>
     <string name="youtube_music_premium_content">This video is available only to YouTube Music Premium members, so it cannot be streamed or downloaded by NewPipe.</string>
     <string name="paid_content">This content is only available to users who have paid, so it cannot be streamed or downloaded by NewPipe.</string>
+    <string name="lock_screen">Lock screen</string>
     <string name="hold_to_unlock">Hold to unlock</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -706,4 +706,5 @@
     <string name="private_content">This content is private, so it cannot be streamed or downloaded by NewPipe.</string>
     <string name="youtube_music_premium_content">This video is available only to YouTube Music Premium members, so it cannot be streamed or downloaded by NewPipe.</string>
     <string name="paid_content">This content is only available to users who have paid, so it cannot be streamed or downloaded by NewPipe.</string>
+    <string name="hold_to_unlock">Hold to unlock</string>
 </resources>


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
- Adds a lock button to the secondary menu of the player when in fullscreen on a non-tv device.
- Locked screen blocks all inputs, and is unlocked by long-pressing a lock icon that appears at the bottom.
- Adds locked & unlocked icons sourced from material.io

#### Fixes the following issue(s)
- #5740
- #5768  

#### Testing
[app-debug.apk](https://github.com/TeamNewPipe/NewPipe/suites/2228194991/artifacts/46166722)

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).

#### Screenshots
![Screenshot_1615314520](https://user-images.githubusercontent.com/80186227/110519854-aa0e3280-80c2-11eb-87dc-b86934db50e2.png)
![Screenshot_1615314535](https://user-images.githubusercontent.com/80186227/110519871-ae3a5000-80c2-11eb-94c7-419b074752cd.png)