### PR TITLE
[background player] Fix very small thumbnails

### DIFF
--- a/app/src/main/res/layout/fragment_video_detail.xml
+++ b/app/src/main/res/layout/fragment_video_detail.xml
@@ -41,6 +41,7 @@
                         android:id="@+id/detail_thumbnail_image_view"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
+                        android:minHeight="200dp"
                         android:background="@android:color/transparent"
                         android:contentDescription="@string/detail_thumbnail_view_description"
                         android:scaleType="fitCenter"


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
When there are small thumbnails, e.g. with SoundCloud, and one is playing streams in background, the thumbnail was very small in the video detail fragment. This is fixed by setting a min height of `200dp` which is equivalent to the dummy thumbnail's height. 
| Before | After |
| -------- | ------- |
| ![screenshot](https://matrix-client.matrix.org/_matrix/media/r0/download/matrix.org/XKMygPfkWvCFXHTSQePEYqqo) | ![Screenshot_1615656123](https://user-images.githubusercontent.com/17365767/111038416-078ae200-8429-11eb-9dcf-619881e6485b.png) |

#### Fixes the following issue(s)
<!-- Also add any other links relevant to your change. -->
- no related issues found yet

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
