### PR TITLE
Add channel details option to long-press menu

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
@@ -124,8 +124,8 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
     /**
      * If the default implementation of {@link StateSaver.WriteRead} should be used.
      *
-     * @see StateSaver
      * @param useDefaultStateSaving Whether the default implementation should be used
+     * @see StateSaver
      */
     public void setUseDefaultStateSaving(final boolean useDefaultStateSaving) {
         this.useDefaultStateSaving = useDefaultStateSaving;
@@ -350,7 +350,8 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
             return;
         }
 
-        final ArrayList<StreamDialogEntry> entries = new ArrayList<>();
+        final ArrayList<StreamDialogEntry> entries =
+                new ArrayList<>(Arrays.asList(StreamDialogEntry.show_channel_details));
 
         if (PlayerHolder.getType() != null) {
             entries.add(StreamDialogEntry.enqueue);
@@ -361,7 +362,7 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
                     StreamDialogEntry.append_playlist,
                     StreamDialogEntry.share
             ));
-        } else  {
+        } else {
             entries.addAll(Arrays.asList(
                     StreamDialogEntry.start_here_on_background,
                     StreamDialogEntry.start_here_on_popup,

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
@@ -350,8 +350,8 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
             return;
         }
 
-        final List<StreamDialogEntry> entries =
-                new ArrayList<>(Arrays.asList(StreamDialogEntry.show_channel_details));
+        final List<StreamDialogEntry> entries = new ArrayList<>();
+        entries.add(StreamDialogEntry.show_channel_details)
 
         if (PlayerHolder.getType() != null) {
             entries.add(StreamDialogEntry.enqueue);

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
@@ -351,7 +351,6 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
         }
 
         final List<StreamDialogEntry> entries = new ArrayList<>();
-        entries.add(StreamDialogEntry.show_channel_details)
 
         if (PlayerHolder.getType() != null) {
             entries.add(StreamDialogEntry.enqueue);
@@ -373,6 +372,9 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
         if (KoreUtil.shouldShowPlayWithKodi(context, item.getServiceId())) {
             entries.add(StreamDialogEntry.play_with_kodi);
         }
+
+        entries.add(StreamDialogEntry.show_channel_details)
+
         StreamDialogEntry.setEnabledEntries(entries);
 
         new InfoItemDialog(activity, item, StreamDialogEntry.getCommands(context),

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
@@ -350,7 +350,7 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
             return;
         }
 
-        final ArrayList<StreamDialogEntry> entries =
+        final List<StreamDialogEntry> entries =
                 new ArrayList<>(Arrays.asList(StreamDialogEntry.show_channel_details));
 
         if (PlayerHolder.getType() != null) {

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
@@ -373,7 +373,7 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
             entries.add(StreamDialogEntry.play_with_kodi);
         }
 
-        entries.add(StreamDialogEntry.show_channel_details)
+        entries.add(StreamDialogEntry.show_channel_details);
 
         StreamDialogEntry.setEnabledEntries(entries);
 

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
@@ -45,6 +45,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Queue;
 
+import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
 import static org.schabi.newpipe.ktx.ViewUtils.animate;
 import static org.schabi.newpipe.ktx.ViewUtils.animateHideRecyclerViewAllowingScrolling;
 
@@ -373,7 +374,9 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
             entries.add(StreamDialogEntry.play_with_kodi);
         }
 
-        entries.add(StreamDialogEntry.show_channel_details);
+        if (!isNullOrEmpty(item.getUploaderUrl())) {
+            entries.add(StreamDialogEntry.show_channel_details);
+        }
 
         StreamDialogEntry.setEnabledEntries(entries);
 

--- a/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
+++ b/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
@@ -24,12 +24,12 @@ public enum StreamDialogEntry {
     // enum values with DEFAULT actions //
     //////////////////////////////////////
 
-    show_channel_details(R.string.show_channel_details, (fragment, item) -> {
+    show_channel_details(R.string.show_channel_details, (fragment, item) ->
         // TODO(mhmdanas): investigate why `getActivity().getSupportFragmentManager()` works but
         // `getParentFragmentManager` doesn't.
         NavigationHelper.openChannelFragment(fragment.getActivity().getSupportFragmentManager(),
-                item.getServiceId(), item.getUploaderUrl(), item.getUploaderName());
-    }),
+                item.getServiceId(), item.getUploaderUrl(), item.getUploaderName())
+    ),
 
     /**
      * Enqueues the stream automatically to the current PlayerType.<br>

--- a/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
+++ b/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
@@ -25,7 +25,8 @@ public enum StreamDialogEntry {
     //////////////////////////////////////
 
     show_channel_details(R.string.show_channel_details, (fragment, item) -> {
-        NavigationHelper.openChannelFragment(fragment.getChildFragmentManager(), item.getServiceId(), item.getUploaderUrl(), item.getUploaderName());
+        NavigationHelper.openChannelFragment(fragment.getChildFragmentManager(),
+                item.getServiceId(), item.getUploaderUrl(), item.getUploaderName());
     }),
 
     /**

--- a/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
+++ b/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
@@ -1,4 +1,3 @@
-
 package org.schabi.newpipe.util;
 
 import android.content.Context;

--- a/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
+++ b/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
@@ -25,6 +25,8 @@ public enum StreamDialogEntry {
     //////////////////////////////////////
 
     show_channel_details(R.string.show_channel_details, (fragment, item) -> {
+        // TODO(mhmdanas): investigate why `getActivity().getSupportFragmentManager()` works but
+        // `getParentFragmentManager` doesn't.
         NavigationHelper.openChannelFragment(fragment.getActivity().getSupportFragmentManager(),
                 item.getServiceId(), item.getUploaderUrl(), item.getUploaderName());
     }),

--- a/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
+++ b/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
@@ -1,3 +1,4 @@
+
 package org.schabi.newpipe.util;
 
 import android.content.Context;
@@ -25,7 +26,7 @@ public enum StreamDialogEntry {
     //////////////////////////////////////
 
     show_channel_details(R.string.show_channel_details, (fragment, item) -> {
-        NavigationHelper.openChannelFragment(fragment.getChildFragmentManager(),
+        NavigationHelper.openChannelFragment(fragment.getActivity().getSupportFragmentManager(),
                 item.getServiceId(), item.getUploaderUrl(), item.getUploaderName());
     }),
 

--- a/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
+++ b/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
@@ -24,6 +24,10 @@ public enum StreamDialogEntry {
     // enum values with DEFAULT actions //
     //////////////////////////////////////
 
+    show_channel_details(R.string.show_channel_details, (fragment, item) -> {
+        NavigationHelper.openChannelFragment(fragment.getChildFragmentManager(), item.getServiceId(), item.getUploaderUrl(), item.getUploaderName());
+    }),
+
     /**
      * Enqueues the stream automatically to the current PlayerType.<br>
      * <br>

--- a/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
+++ b/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
@@ -25,8 +25,7 @@ public enum StreamDialogEntry {
     //////////////////////////////////////
 
     show_channel_details(R.string.show_channel_details, (fragment, item) ->
-        // TODO(mhmdanas): investigate why `getActivity().getSupportFragmentManager()` works but
-        // `getParentFragmentManager` doesn't.
+        // For some reason `getParentFragmentManager()` doesn't work, but this does.
         NavigationHelper.openChannelFragment(fragment.getActivity().getSupportFragmentManager(),
                 item.getServiceId(), item.getUploaderUrl(), item.getUploaderName())
     ),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -466,6 +466,7 @@
     <string name="play_queue_stream_detail">Details</string>
     <string name="play_queue_audio_settings">Audio Settings</string>
     <string name="hold_to_append">Hold to enqueue</string>
+    <string name="show_channel_details">Show channel details</string>
     <string name="enqueue_stream">Enqueue</string>
     <string name="enqueued">Enqueued</string>
     <string name="start_here_on_main">Start playing here</string>


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Feature (user facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
Add option to open channel details page when long-pressing items.

#### Fixes the following issue(s)
<!-- Also add any other links relevant to your change. -->
- Fixes #5447.

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).