### PR TITLE
Add a confirmation button when deleting all files in downloader

### DIFF
--- a/app/src/main/java/us/shandian/giga/ui/fragment/MissionsFragment.java
+++ b/app/src/main/java/us/shandian/giga/ui/fragment/MissionsFragment.java
@@ -192,14 +192,7 @@ public class MissionsFragment extends Fragment {
                 updateList();
                 return true;
             case R.id.clear_list:
-                AlertDialog.Builder prompt = new AlertDialog.Builder(mContext);
-                prompt.setTitle(R.string.clear_download_history);
-                prompt.setMessage(R.string.confirm_prompt);
-                // Intentionally misusing button's purpose in order to achieve good order
-                prompt.setNegativeButton(R.string.clear_download_history, (dialog, which) -> mAdapter.clearFinishedDownloads(false));
-                prompt.setPositiveButton(R.string.delete_downloaded_files, (dialog, which) -> mAdapter.clearFinishedDownloads(true));
-                prompt.setNeutralButton(R.string.cancel, null);
-                prompt.create().show();
+                showClearDownloadHistoryPrompt();
                 return true;
             case R.id.start_downloads:
                 mBinder.getDownloadManager().startAllMissions();
@@ -210,6 +203,32 @@ public class MissionsFragment extends Fragment {
             default:
                 return super.onOptionsItemSelected(item);
         }
+    }
+
+    public void showClearDownloadHistoryPrompt() {
+        // ask the user whether he wants to just clear history or instead delete files on disk
+        new AlertDialog.Builder(mContext)
+                .setTitle(R.string.clear_download_history)
+                .setMessage(R.string.confirm_prompt)
+                // Intentionally misusing buttons' purpose in order to achieve good order
+                .setNegativeButton(R.string.clear_download_history,
+                        (dialog, which) -> mAdapter.clearFinishedDownloads(false))
+                .setNeutralButton(R.string.cancel, null)
+                .setPositiveButton(R.string.delete_downloaded_files,
+                        (dialog, which) -> showDeleteDownloadedFilesConfirmationPrompt())
+                .create()
+                .show();
+    }
+
+    public void showDeleteDownloadedFilesConfirmationPrompt() {
+        // make sure the user confirms once more before deleting files on disk
+        new AlertDialog.Builder(mContext)
+                .setTitle(R.string.delete_downloaded_files_confirm)
+                .setNegativeButton(R.string.cancel, null)
+                .setPositiveButton(R.string.ok,
+                        (dialog, which) -> mAdapter.clearFinishedDownloads(true))
+                .create()
+                .show();
     }
 
     private void updateList() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -580,6 +580,7 @@
     <string name="clear_download_history">Clear download history</string>
     <string name="confirm_prompt">Do you want to clear your download history or delete all downloaded files?</string>
     <string name="delete_downloaded_files">Delete downloaded files</string>
+    <string name="delete_downloaded_files_confirm">Erase all downloaded files from disk?</string>
     <plurals name="deleted_downloads_toast">
         <item quantity="one">Deleted %1$s download</item>
         <item quantity="other">Deleted %1$s downloads</item>


### PR DESCRIPTION
Adding an confirmation button while deleting all files.

#### Fixes the following issue(s)
<!-- Also add any other links relevant to your change. -->
- Fixes #5419
