### PR TITLE
Replace FrameLayout with FragmentContainerView where applicable

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/settings/SettingsActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/SettingsActivity.java
@@ -56,11 +56,11 @@ public class SettingsActivity extends AppCompatActivity
                 SettingsLayoutBinding.inflate(getLayoutInflater());
         setContentView(settingsLayoutBinding.getRoot());
 
-        setSupportActionBar(settingsLayoutBinding.toolbarLayout.toolbar);
+        setSupportActionBar(settingsLayoutBinding.settingsToolbarLayout.toolbar);
 
         if (savedInstanceBundle == null) {
             getSupportFragmentManager().beginTransaction()
-                    .replace(R.id.fragment_holder, new MainSettingsFragment())
+                    .replace(R.id.settings_fragment_holder, new MainSettingsFragment())
                     .commit();
         }
 
@@ -102,7 +102,7 @@ public class SettingsActivity extends AppCompatActivity
         getSupportFragmentManager().beginTransaction()
                 .setCustomAnimations(R.animator.custom_fade_in, R.animator.custom_fade_out,
                         R.animator.custom_fade_in, R.animator.custom_fade_out)
-                .replace(R.id.fragment_holder, fragment)
+                .replace(R.id.settings_fragment_holder, fragment)
                 .addToBackStack(null)
                 .commit();
         return true;

--- a/app/src/main/res/layout-large-land/fragment_video_detail.xml
+++ b/app/src/main/res/layout-large-land/fragment_video_detail.xml
@@ -612,14 +612,12 @@
 
         </org.schabi.newpipe.views.FocusAwareCoordinator>
 
-        <FrameLayout
+        <androidx.fragment.app.FragmentContainerView
             android:id="@+id/relatedStreamsLayout"
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:layout_marginTop="10dp"
-            android:layout_weight="3">
-
-        </FrameLayout>
+            android:layout_weight="3" />
     </LinearLayout>
 
     <RelativeLayout

--- a/app/src/main/res/layout/activity_downloader.xml
+++ b/app/src/main/res/layout/activity_downloader.xml
@@ -7,7 +7,7 @@
         layout="@layout/toolbar_layout"
         android:id="@+id/toolbar_layout" />
 
-    <FrameLayout
+    <androidx.fragment.app.FragmentContainerView
         android:id="@+id/frame"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -8,7 +8,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <FrameLayout
+        <androidx.fragment.app.FragmentContainerView
             android:id="@+id/fragment_holder"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
@@ -18,14 +18,14 @@
             layout="@layout/toolbar_layout"
             android:id="@+id/toolbar_layout"/>
 
-        <FrameLayout
+        <androidx.fragment.app.FragmentContainerView
             android:id="@+id/fragment_player_holder"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_gravity="center_horizontal"
             app:behavior_hideable="true"
             app:behavior_peekHeight="0dp"
-            app:layout_behavior="org.schabi.newpipe.player.event.CustomBottomSheetBehavior"></FrameLayout>
+            app:layout_behavior="org.schabi.newpipe.player.event.CustomBottomSheetBehavior" />
 
     </org.schabi.newpipe.views.FocusAwareCoordinator>
 

--- a/app/src/main/res/layout/settings_layout.xml
+++ b/app/src/main/res/layout/settings_layout.xml
@@ -6,14 +6,14 @@
     android:orientation="vertical"
     tools:context="org.schabi.newpipe.MainActivity">
 
-    <FrameLayout
-        android:id="@+id/fragment_holder"
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/settings_fragment_holder"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_marginTop="?attr/actionBarSize" />
 
     <include
         layout="@layout/toolbar_layout"
-        android:id="@+id/toolbar_layout"/>
+        android:id="@+id/settings_toolbar_layout"/>
 
 </RelativeLayout>


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Replaces FrameLayout with FragmentContainerView where applicable (go [here](https://developer.android.com/jetpack/androidx/releases/fragment), do Ctrl + F, and put "FragmentContainerView" in the box to see related info and changes, as well as the [reasons for its creation](https://developer.android.com/jetpack/androidx/releases/fragment#1.2.0-alpha02))
  - A related post (a bit outdated, but they address the main stuff): https://proandroiddev.com/android-fragments-fragmentcontainerview-292f393f9ccf

#### Fixes the following issue(s)
<!-- Also add any other links relevant to your change. -->
- This fixes internal issues related to using FrameLayout; however, I don't know if there's any open NewPipe issues related to this that would be fixed by this change, other than the more dev-facing:
  - [Fixes animation z-ordering issues and window insets dispatching to Fragments.](https://developer.android.com/jetpack/androidx/releases/fragment#1.2.0-alpha02)

#### APK testing
https://github.com/TeamNewPipe/NewPipe/suites/2319358795/artifacts/48762467
I tested with my Android 10 phone and everything worked fine. However, I need people with tablets and tvs to test the video details page and make sure the related streams section works properly, please!

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
