### PR TITLE
Fix error panel created in onViewCreated() but disposed in onDestroy()

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/BaseStateFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/BaseStateFragment.java
@@ -56,12 +56,6 @@ public abstract class BaseStateFragment<I> extends BaseFragment implements ViewC
         }
     }
 
-    @Override
-    public void onDestroy() {
-        super.onDestroy();
-        errorPanelHelper.dispose();
-    }
-
     /*//////////////////////////////////////////////////////////////////////////
     // Init
     //////////////////////////////////////////////////////////////////////////*/
@@ -72,6 +66,14 @@ public abstract class BaseStateFragment<I> extends BaseFragment implements ViewC
         emptyStateView = rootView.findViewById(R.id.empty_state_view);
         loadingProgressBar = rootView.findViewById(R.id.loading_progress_bar);
         errorPanelHelper = new ErrorPanelHelper(this, rootView, this::onRetryButtonClicked);
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        if (errorPanelHelper != null) {
+            errorPanelHelper.dispose();
+        }
     }
 
     protected void onRetryButtonClicked() {


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
The error panel is now destroyed in `onDestroyView()` and is checked for nullity just in case.

#### Fixes the following issue(s)
https://github.com/TeamNewPipe/NewPipe/issues/5872#issuecomment-804194124 @B0pol 

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
