### PR TITLE
Fix settings switches are not red anymore

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/settings/SettingsActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/SettingsActivity.java
@@ -48,7 +48,7 @@ public class SettingsActivity extends AppCompatActivity
 
     @Override
     protected void onCreate(final Bundle savedInstanceBundle) {
-        ThemeHelper.setTheme(this);
+        setTheme(ThemeHelper.getSettingsThemeStyle(this));
         assureCorrectAppLanguage(this);
         super.onCreate(savedInstanceBundle);
 

--- a/app/src/main/java/org/schabi/newpipe/util/ThemeHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ThemeHelper.java
@@ -169,6 +169,39 @@ public final class ThemeHelper {
         return baseTheme;
     }
 
+    @StyleRes
+    public static int getSettingsThemeStyle(final Context context) {
+        final Resources res = context.getResources();
+        final String lightTheme = res.getString(R.string.light_theme_key);
+        final String blackTheme = res.getString(R.string.black_theme_key);
+        final String automaticDeviceTheme = res.getString(R.string.auto_device_theme_key);
+
+
+        final String selectedTheme = getSelectedThemeKey(context);
+
+        if (selectedTheme.equals(lightTheme)) {
+            return R.style.LightSettingsTheme;
+        } else if (selectedTheme.equals(blackTheme)) {
+            return R.style.BlackSettingsTheme;
+        } else if (selectedTheme.equals(automaticDeviceTheme)) {
+            if (isDeviceDarkThemeEnabled(context)) {
+                // use the dark theme variant preferred by the user
+                final String selectedNightTheme = getSelectedNightThemeKey(context);
+                if (selectedNightTheme.equals(blackTheme)) {
+                    return R.style.BlackSettingsTheme;
+                } else {
+                    return R.style.DarkSettingsTheme;
+                }
+            } else {
+                // there is only one day theme
+                return R.style.LightSettingsTheme;
+            }
+        } else {
+            // default to dark theme
+            return R.style.DarkSettingsTheme;
+        }
+    }
+
     /**
      * Get a resource id from a resource styled according to the context's theme.
      *


### PR DESCRIPTION


<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Reverts part of 731c65cd59e72921389c114f5f5ba4da8374336c, while rebasing I didn't notice that different themes were being used for settings.

#### Fixes the following issue(s)
Fixes color switches in settings being white instead of red.

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
