### PR TITLE
#5263: Allow the user to pause while a video is buffering

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -2686,7 +2686,7 @@ public final class Player implements
             Log.d(TAG, "onPlayPause() called");
         }
 
-        if (isPlaying()) {
+        if (isPlayingWhenReady()) {
             pause();
         } else {
             play();
@@ -4010,6 +4010,10 @@ public final class Player implements
 
     public boolean isPlaying() {
         return !exoPlayerIsNull() && simpleExoPlayer.isPlaying();
+    }
+
+    public boolean isPlayingWhenReady() {
+        return !exoPlayerisNull() && simpleExoPlayer.getPlayWhenReady()
     }
 
     private boolean isLoading() {

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -4013,7 +4013,7 @@ public final class Player implements
     }
 
     public boolean isPlayingWhenReady() {
-        return !exoPlayerisNull() && simpleExoPlayer.getPlayWhenReady()
+        return !exoPlayerIsNull() && simpleExoPlayer.getPlayWhenReady();
     }
 
     private boolean isLoading() {

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -706,7 +706,7 @@ public final class Player implements
             // Android TV: without it focus will frame the whole player
             binding.playPauseButton.requestFocus();
 
-            if (simpleExoPlayer.getPlayWhenReady()) {
+            if (getPlayWhenReady()) {
                 play();
             } else {
                 pause();
@@ -1687,7 +1687,7 @@ public final class Player implements
     }
 
     public void saveWasPlaying() {
-        this.wasPlaying = simpleExoPlayer.getPlayWhenReady();
+        this.wasPlaying = getPlayWhenReady();
     }
     //endregion
 

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -2686,7 +2686,7 @@ public final class Player implements
             Log.d(TAG, "onPlayPause() called");
         }
 
-        if (isPlayingWhenReady()) {
+        if (getPlayWhenReady()) {
             pause();
         } else {
             play();
@@ -4012,7 +4012,7 @@ public final class Player implements
         return !exoPlayerIsNull() && simpleExoPlayer.isPlaying();
     }
 
-    public boolean isPlayingWhenReady() {
+    public boolean getPlayWhenReady() {
         return !exoPlayerIsNull() && simpleExoPlayer.getPlayWhenReady();
     }
 

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -706,11 +706,7 @@ public final class Player implements
             // Android TV: without it focus will frame the whole player
             binding.playPauseButton.requestFocus();
 
-            if (getPlayWhenReady()) {
-                play();
-            } else {
-                pause();
-            }
+            playPause();
         }
         NavigationHelper.sendPlayerStartedEvent(context);
     }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Allow the user to pause/unpause while a video is buffering
  - Check whether the `playWhenReady` is true instead of `isPlaying`: `isPlaying` returns false if the video is buffering

#### Fixes the following issue(s)
<!-- Also add any other links relevant to your change. -->
- fixes #5263 

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
