### PR TITLE
Fix display of channel details when it has no videos

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListInfoFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListInfoFragment.java
@@ -12,6 +12,7 @@ import org.schabi.newpipe.error.UserAction;
 import org.schabi.newpipe.extractor.ListExtractor;
 import org.schabi.newpipe.extractor.ListInfo;
 import org.schabi.newpipe.extractor.Page;
+import org.schabi.newpipe.extractor.channel.ChannelInfo;
 import org.schabi.newpipe.extractor.exceptions.ContentNotSupportedException;
 import org.schabi.newpipe.util.Constants;
 import org.schabi.newpipe.views.NewPipeRecyclerView;
@@ -227,7 +228,11 @@ public abstract class BaseListInfoFragment<I extends ListInfo>
                 showListFooter(hasMoreItems());
             } else {
                 infoListAdapter.clearStreamItemList();
-                showEmptyState();
+                // showEmptyState should be called only if there is no item as
+                // well as no header in infoListAdapter
+                if (!(result instanceof ChannelInfo && infoListAdapter.getItemCount() == 1)) {
+                    showEmptyState();
+                }
             }
         }
 

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
@@ -449,8 +449,8 @@ public class ChannelFragment extends BaseListInfoFragment<ChannelInfo>
 
         if (!TextUtils.isEmpty(currentInfo.getParentChannelName())) {
             headerBinding.subChannelTitleView.setText(String.format(
-                            getString(R.string.channel_created_by),
-                            currentInfo.getParentChannelName())
+                    getString(R.string.channel_created_by),
+                    currentInfo.getParentChannelName())
             );
             headerBinding.subChannelTitleView.setVisibility(View.VISIBLE);
             headerBinding.subChannelAvatarView.setVisibility(View.VISIBLE);
@@ -462,7 +462,13 @@ public class ChannelFragment extends BaseListInfoFragment<ChannelInfo>
             menuRssButton.setVisible(!TextUtils.isEmpty(result.getFeedUrl()));
         }
 
-        playlistControlBinding.getRoot().setVisibility(View.VISIBLE);
+        // PlaylistControls should be visible only if there is some item in
+        // infoListAdapter other than header
+        if (infoListAdapter.getItemCount() != 1) {
+            playlistControlBinding.getRoot().setVisibility(View.VISIBLE);
+        } else {
+            playlistControlBinding.getRoot().setVisibility(View.GONE);
+        }
 
         for (final Throwable throwable : result.getErrors()) {
             if (throwable instanceof ContentNotSupportedException) {


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- in ChannelFragment.java do not throw emptyStateView error if no videos are present as there will be header in list which shows channel metadata and thus should be visible to user as expected by issue fix, also when there is no video the playlistController is hidden to prevent the app crash


- showEmptySpace() hides all the views in list including header when there is some error so it should be not called when there is header in the list, so changes are done accordingly in BaseListInfoFragment.java

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #5959


#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
