### PR TITLE
Disable media tunneling on Hi3798MV200

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -74,6 +74,7 @@ import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
 import com.google.android.exoplayer2.ui.AspectRatioFrameLayout;
 import com.google.android.exoplayer2.ui.SubtitleView;
 import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
+import com.google.android.exoplayer2.util.Util;
 import com.google.android.exoplayer2.video.VideoListener;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.nostra13.universalimageloader.core.ImageLoader;
@@ -488,8 +489,13 @@ public final class Player implements
         // Setup subtitle view
         simpleExoPlayer.addTextOutput(binding.subtitleView);
 
-        // Setup audio session with onboard equalizer
-        trackSelector.setParameters(trackSelector.buildUponParameters().setTunnelingEnabled(true));
+        // enable media tunneling
+        if (DeviceUtils.shouldSupportMediaTunneling()) {
+            trackSelector.setParameters(
+                    trackSelector.buildUponParameters().setTunnelingEnabled(true));
+        } else if (DEBUG) {
+            Log.d(TAG, "[" + Util.DEVICE_DEBUG_INFO + "] does not support media tunneling");
+        }
     }
 
     private void initListeners() {

--- a/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
@@ -20,6 +20,13 @@ public final class DeviceUtils {
     private static final String AMAZON_FEATURE_FIRE_TV = "amazon.hardware.fire_tv";
     private static Boolean isTV = null;
 
+    /*
+     * Devices that do not support media tunneling
+     */
+    // Formuler Z8 Pro, Z8, CC, Z Alpha, Z+ Neo
+    private static final boolean HI3798MV200 = Build.VERSION.SDK_INT == 24
+            && Build.DEVICE.equals("Hi3798MV200");
+
     private DeviceUtils() {
     }
 
@@ -88,4 +95,15 @@ public final class DeviceUtils {
                 sp,
                 context.getResources().getDisplayMetrics());
     }
+
+    /**
+     * Some devices have broken tunneled video playback but claim to support it.
+     * See https://github.com/TeamNewPipe/NewPipe/issues/5911
+     * @return false if Kitkat (does not support tunneling) or affected device
+     */
+    public static boolean shouldSupportMediaTunneling() {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
+                && !HI3798MV200;
+    }
+
 }


### PR DESCRIPTION
#### What is it?
- [X] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Disabled media tunneling on affected devices.
In this PR: Formuler Z8 Pro, Z8, CC, Z Alpha, Z+ Neo

#### Fixes the following issue(s)
- Fixes #3927
- Fixes #5911

#### APK testing 
This workaround was already tested, now it was just implemented in a more meaningful way.
APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

#### Due diligence
- [X] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
