### PR TITLE
Add functionality to rename Playlist Name from playlist interface

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
@@ -27,7 +27,6 @@ import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import org.schabi.newpipe.NewPipeDatabase;
 import org.schabi.newpipe.R;
-import org.schabi.newpipe.database.AppDatabase;
 import org.schabi.newpipe.database.LocalItem;
 import org.schabi.newpipe.database.history.model.StreamHistoryEntry;
 import org.schabi.newpipe.database.playlist.PlaylistStreamEntry;
@@ -73,7 +72,6 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
     // Save the list 10 seconds after the last change occurred
     private static final long SAVE_DEBOUNCE_MILLIS = 10000;
     private static final int MINIMUM_INITIAL_DRAG_VELOCITY = 12;
-
     @State
     protected Long playlistId;
     @State
@@ -341,7 +339,8 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
             }
 
             @Override
-            public void onComplete() { }
+            public void onComplete() {
+            }
         };
     }
 
@@ -363,41 +362,11 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
                         .show();
             }
         } else if (item.getItemId() == R.id.menu_item_rename_playlist) {
-            final View dialogView = View.inflate(getContext(), R.layout.dialog_bookmark, null);
-            final EditText editText = dialogView.findViewById(R.id.playlist_name_edit_text);
-            editText.setText(name);
-
-            if (DEBUG) {
-                Log.d(TAG, name);
-            }
-
-            final android.app.AlertDialog.Builder builder =
-                    new android.app.AlertDialog.Builder(activity);
-            builder.setView(dialogView)
-                    .setPositiveButton(R.string.rename_playlist, (dialog, which) ->
-                            changeLocalPlaylistName(playlistId, editText.getText().toString()))
-                    .setNegativeButton(R.string.cancel, null)
-                    .create()
-                    .show();
+            createRenameDialog();
         } else {
             return super.onOptionsItemSelected(item);
         }
         return true;
-    }
-
-    private void changeLocalPlaylistName(final long id, final String playlistName) {
-        final AppDatabase database = NewPipeDatabase.getInstance(activity);
-        final LocalPlaylistManager localPlaylistManager = new LocalPlaylistManager(database);
-        localPlaylistManager.renamePlaylist(id, playlistName);
-        final Disposable disposable = localPlaylistManager.renamePlaylist(id, playlistName)
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(longs -> { /*Do nothing on success*/ }, throwable -> showError(
-                        new ErrorInfo(throwable,
-                                UserAction.REQUESTED_BOOKMARK,
-                                "Changing playlist name")));
-        disposables.add(disposable);
-
-        setTitle(playlistName);
     }
 
     public void removeWatchedStreams(final boolean removePartiallyWatched) {
@@ -453,7 +422,7 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
                                     playlistItem.getStreamId());
 
                             final boolean hasState = streamStatesIter.next() != null;
-                            if (indexInHistory < 0 ||  hasState) {
+                            if (indexInHistory < 0 || hasState) {
                                 notWatchedItems.add(playlistItem);
                             } else if (!thumbnailVideoRemoved
                                     && playlistManager.getPlaylistThumbnail(playlistId)
@@ -755,7 +724,8 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
 
             @Override
             public void onSwiped(@NonNull final RecyclerView.ViewHolder viewHolder,
-                                 final int swipeDir) { }
+                                 final int swipeDir) {
+            }
         };
     }
 
@@ -788,7 +758,7 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
                     StreamDialogEntry.append_playlist,
                     StreamDialogEntry.share
             ));
-        } else  {
+        } else {
             entries.addAll(Arrays.asList(
                     StreamDialogEntry.start_here_on_background,
                     StreamDialogEntry.start_here_on_popup,

--- a/app/src/main/res/menu/menu_local_playlist.xml
+++ b/app/src/main/res/menu/menu_local_playlist.xml
@@ -3,6 +3,10 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
+        android:id="@+id/menu_item_rename_playlist"
+        android:title="Rename Playlist"
+        app:showAsAction="never" />
+    <item
         android:id="@+id/menu_item_remove_watched"
         android:title="@string/remove_watched"
         app:showAsAction="never" />

--- a/app/src/main/res/menu/menu_local_playlist.xml
+++ b/app/src/main/res/menu/menu_local_playlist.xml
@@ -4,7 +4,7 @@
 
     <item
         android:id="@+id/menu_item_rename_playlist"
-        android:title="Rename Playlist"
+        android:title="@string/rename_playlist"
         app:showAsAction="never" />
     <item
         android:id="@+id/menu_item_remove_watched"


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [X] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Functionality to rename Playlist Name from playlist interface

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #5570

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

#### Due diligence
- [X] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
