### PR TITLE
Fix release build by updating icon reference

### DIFF
--- a/app/src/release/res/xml/main_settings.xml
+++ b/app/src/release/res/xml/main_settings.xml
@@ -42,7 +42,7 @@
 
     <PreferenceScreen
         android:fragment="org.schabi.newpipe.settings.UpdateSettingsFragment"
-        android:icon="@drawable/ic_cloud_download_black"
+        android:icon="@drawable/ic_cloud_download"
         android:key="update_pref_screen_key"
         android:title="@string/settings_category_updates_title"
         app:iconSpaceReserved="false" />


### PR DESCRIPTION
Was changed in DayNight Theme, but only in debug resource and not release resource.

<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
-  Caused by #5927
- `gradle assempleRelease` now works again


#### Notes
- For the future this means that reviewers need to look out for changes in build flavor specific files and make sure that they are made in all flavours (debug and release). But even if it is missed, it will be caught by my nightly builds.
- https://github.com/XiangRongLin/NewPipe-nightly/runs/2261992423?check_suite_focus=true

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
