### PR TITLE
Disable media tunneling on cvt_mt5886_eu_1g

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
@@ -26,6 +26,9 @@ public final class DeviceUtils {
     // Formuler Z8 Pro, Z8, CC, Z Alpha, Z+ Neo
     private static final boolean HI3798MV200 = Build.VERSION.SDK_INT == 24
             && Build.DEVICE.equals("Hi3798MV200");
+    // Zephir TS43UHD-2
+    private static final boolean CVT_MT5886_EU_1G = Build.VERSION.SDK_INT == 24
+            && Build.DEVICE.equals("cvt_mt5886_eu_1g");
 
     private DeviceUtils() {
     }
@@ -103,7 +106,6 @@ public final class DeviceUtils {
      */
     public static boolean shouldSupportMediaTunneling() {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
-                && !HI3798MV200;
+                && !HI3798MV200 && !CVT_MT5886_EU_1G;
     }
-
 }

--- a/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
@@ -106,6 +106,7 @@ public final class DeviceUtils {
      */
     public static boolean shouldSupportMediaTunneling() {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
-                && !HI3798MV200 && !CVT_MT5886_EU_1G;
+                && !HI3798MV200
+                && !CVT_MT5886_EU_1G;
     }
 }


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR

Disabled broken media tunneling for a single device.

#### Fixes the following issue(s)

https://github.com/TeamNewPipe/NewPipe/issues/3927#issuecomment-674350079

#### APK testing 

The workaround (https://github.com/TeamNewPipe/NewPipe/issues/3927#issuecomment-806571342) was tested, this pull request simply adds the affected device to the check implemented in #5969.

On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).