### PR TITLE
Error handling in subscribe() in DownloadDialog

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
@@ -312,25 +312,27 @@ public class DownloadDialog extends DialogFragment
 
     private void fetchStreamsSize() {
         disposables.clear();
-
         disposables.add(StreamSizeWrapper.fetchSizeForWrapper(wrappedVideoStreams)
                 .subscribe(result -> {
-            if (dialogBinding.videoAudioGroup.getCheckedRadioButtonId() == R.id.video_button) {
-                setupVideoSpinner();
-            }
-        }));
+                    if (dialogBinding.videoAudioGroup.getCheckedRadioButtonId()
+                            == R.id.video_button) {
+                        setupVideoSpinner();
+                    }
+                }, throwable -> Log.e(TAG, "Throwable " + throwable.getMessage())));
         disposables.add(StreamSizeWrapper.fetchSizeForWrapper(wrappedAudioStreams)
                 .subscribe(result -> {
-            if (dialogBinding.videoAudioGroup.getCheckedRadioButtonId() == R.id.audio_button) {
-                setupAudioSpinner();
-            }
-        }));
+                    if (dialogBinding.videoAudioGroup.getCheckedRadioButtonId()
+                            == R.id.audio_button) {
+                        setupAudioSpinner();
+                    }
+                }, throwable -> Log.e(TAG, "Throwable " + throwable.getMessage())));
         disposables.add(StreamSizeWrapper.fetchSizeForWrapper(wrappedSubtitleStreams)
                 .subscribe(result -> {
-            if (dialogBinding.videoAudioGroup.getCheckedRadioButtonId() == R.id.subtitle_button) {
-                setupSubtitleSpinner();
-            }
-        }));
+                    if (dialogBinding.videoAudioGroup.getCheckedRadioButtonId()
+                            == R.id.subtitle_button) {
+                        setupSubtitleSpinner();
+                    }
+                }, throwable -> Log.e(TAG, "Throwable " + throwable.getMessage())));
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
@@ -318,21 +318,30 @@ public class DownloadDialog extends DialogFragment
                             == R.id.video_button) {
                         setupVideoSpinner();
                     }
-                }, throwable -> Log.e(TAG, "Throwable " + throwable.getMessage())));
+                }, throwable -> ErrorActivity.reportErrorInSnackbar(context,
+                        new ErrorInfo(throwable, UserAction.DOWNLOAD_OPEN_DIALOG,
+                                "Downloading video stream size",
+                                currentInfo.getServiceId()))));
         disposables.add(StreamSizeWrapper.fetchSizeForWrapper(wrappedAudioStreams)
                 .subscribe(result -> {
                     if (dialogBinding.videoAudioGroup.getCheckedRadioButtonId()
                             == R.id.audio_button) {
                         setupAudioSpinner();
                     }
-                }, throwable -> Log.e(TAG, "Throwable " + throwable.getMessage())));
+                }, throwable -> ErrorActivity.reportErrorInSnackbar(context,
+                        new ErrorInfo(throwable, UserAction.DOWNLOAD_OPEN_DIALOG,
+                                "Downloading audio stream size",
+                                currentInfo.getServiceId()))));
         disposables.add(StreamSizeWrapper.fetchSizeForWrapper(wrappedSubtitleStreams)
                 .subscribe(result -> {
                     if (dialogBinding.videoAudioGroup.getCheckedRadioButtonId()
                             == R.id.subtitle_button) {
                         setupSubtitleSpinner();
                     }
-                }, throwable -> Log.e(TAG, "Throwable " + throwable.getMessage())));
+                }, throwable -> ErrorActivity.reportErrorInSnackbar(context,
+                        new ErrorInfo(throwable, UserAction.DOWNLOAD_OPEN_DIALOG,
+                                "Downloading subtitle stream size",
+                                currentInfo.getServiceId()))));
     }
 
     @Override


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- The result output in subscribe may throw error and thus need to be handled, so I did it :)

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #6107

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
