### PR TITLE
Fix trying to delete object not in list

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/LocalItemListAdapter.java
+++ b/app/src/main/java/org/schabi/newpipe/local/LocalItemListAdapter.java
@@ -126,8 +126,19 @@ public class LocalItemListAdapter extends RecyclerView.Adapter<RecyclerView.View
 
     public void removeItem(final LocalItem data) {
         final int index = localItems.indexOf(data);
-        localItems.remove(index);
-        notifyItemRemoved(index + (header != null ? 1 : 0));
+        if (index != -1) {
+            localItems.remove(index);
+            notifyItemRemoved(index + (header != null ? 1 : 0));
+        } else {
+            // this happens when
+            // 1) removeItem is called on infoItemDuplicate as in showStreamItemDialog of
+            // LocalPlaylistFragment in this case need to implement delete object by it's duplicate
+
+            // OR
+
+            // 2)data not in itemList and UI is still not updated so notifyDataSetChanged()
+            notifyDataSetChanged();
+        }
     }
 
     public boolean swapItems(final int fromAdapterPosition, final int toAdapterPosition) {

--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -5,7 +5,7 @@
 <suppressions>
   <suppress checks="FinalParameters"
     files="LocalItemListAdapter.java"
-    lines="221,293"/>
+    lines="232,304"/>
 
   <suppress checks="FinalParameters"
     files="InfoListAdapter.java"


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
-When the removeItem() is called it might happen somehow that object is not in list , in this case indexOf() will return -1 and in this case we should not try to delete object by it's index (i.e is -1)
-Coming to "somehow" this may happen when  
1)the removeItem() is called on duplicate of item in list , in this case we need to implement a way to remove item by it's duplicate as duplicate is not in list
2)the object is already deleted and the UI is not updated (handled this in this PR)

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #3891

#### Relies on the following changes
<!-- Delete this if it doesn't apply to you. -->
- 

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
