### PR TITLE
Only show 'download has started' toast when download is started

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
@@ -671,9 +671,6 @@ public class DownloadDialog extends DialogFragment
         prefs.edit()
                 .putString(getString(R.string.last_used_download_type), selectedMediaType)
                 .apply();
-
-        Toast.makeText(context, getString(R.string.download_has_started),
-                Toast.LENGTH_SHORT).show();
     }
 
     private void checkSelectedDownload(final StoredDirectoryHelper mainStorage,
@@ -928,6 +925,9 @@ public class DownloadDialog extends DialogFragment
 
         DownloadManagerService.startMission(context, urls, storage, kind, threads,
                 currentInfo.getUrl(), psName, psArgs, nearLength, recoveryInfo);
+
+        Toast.makeText(context, getString(R.string.download_has_started),
+                Toast.LENGTH_SHORT).show();
 
         dismiss();
     }


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Only show the 'download has started' toast when a download has started. ~~Note, I haven't compiled and tested this.~~

#### Fixes the following issue(s)
- Fixes #6138 

#### APK testing 
https://github.com/TeamNewPipe/NewPipe/suites/2554180297/artifacts/55556817

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
