### PR TITLE
Fix: fragmentSize is below the minimum

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
@@ -297,7 +297,7 @@ public final class PlayerHelper {
     }
 
     public static long getPreferredFileSize() {
-        return 2 * 1024 * 1024L; // ExoPlayer CacheDataSink.MIN_RECOMMENDED_FRAGMENT_SIZE 
+        return 2 * 1024 * 1024L; // ExoPlayer CacheDataSink.MIN_RECOMMENDED_FRAGMENT_SIZE
     }
 
     /**

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
@@ -297,7 +297,7 @@ public final class PlayerHelper {
     }
 
     public static long getPreferredFileSize() {
-        return 512 * 1024L;
+        return 2 * 1024 * 1024L; // ExoPlayer CacheDataSink.MIN_RECOMMENDED_FRAGMENT_SIZE 
     }
 
     /**


### PR DESCRIPTION
noticed logs " CacheDataSink: fragmentSize is below the minimum recommended value of 2097152. This may cause poor cache performance.

this fixes the issue by using ExoPlayers MIN_RECOMMENDED_FRAGMENT_SIZE. Unfortunately that field is private:
https://github.com/google/ExoPlayer/blob/aeb306a164911aa1491b46c2db4da0d329c83c65/library/core/src/main/java/com/google/android/exoplayer2/upstream/cache/CacheDataSink.java#L123

<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [X] Codebase improvement (dev facing)

#### Fixes the following issue(s)
Discovered in https://github.com/TeamNewPipe/NewPipe/issues/6207

#### APK testing 
On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

#### Due diligence
- [X] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
