### PR TITLE
fix Rotation crash on „Video not available“ page (#5941)

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/EmptyFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/EmptyFragment.java
@@ -11,15 +11,20 @@ import org.schabi.newpipe.BaseFragment;
 import org.schabi.newpipe.R;
 
 public class EmptyFragment extends BaseFragment {
-    final boolean showMessage;
+    private static final String SHOW_MESSAGE = "SHOW_MESSAGE";
 
-    public EmptyFragment(final boolean showMessage) {
-        this.showMessage = showMessage;
+    public static final EmptyFragment newInstance(final boolean showMessage) {
+        final EmptyFragment emptyFragment = new EmptyFragment();
+        final Bundle bundle = new Bundle(1);
+        bundle.putBoolean(SHOW_MESSAGE, showMessage);
+        emptyFragment.setArguments(bundle);
+        return emptyFragment;
     }
 
     @Override
     public View onCreateView(final LayoutInflater inflater, @Nullable final ViewGroup container,
                              final Bundle savedInstanceState) {
+        final boolean showMessage = getArguments().getBoolean(SHOW_MESSAGE);
         final View view = inflater.inflate(R.layout.fragment_empty, container, false);
         view.findViewById(R.id.empty_state_view).setVisibility(
                 showMessage ? View.VISIBLE : View.GONE);

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -929,20 +929,20 @@ public final class VideoDetailFragment
 
         if (showRelatedItems && binding.relatedItemsLayout == null) {
             // temp empty fragment. will be updated in handleResult
-            pageAdapter.addFragment(new EmptyFragment(false), RELATED_TAB_TAG);
+            pageAdapter.addFragment(EmptyFragment.newInstance(false), RELATED_TAB_TAG);
             tabIcons.add(R.drawable.ic_art_track);
             tabContentDescriptions.add(R.string.related_items_tab_description);
         }
 
         if (showDescription) {
             // temp empty fragment. will be updated in handleResult
-            pageAdapter.addFragment(new EmptyFragment(false), DESCRIPTION_TAB_TAG);
+            pageAdapter.addFragment(EmptyFragment.newInstance(false), DESCRIPTION_TAB_TAG);
             tabIcons.add(R.drawable.ic_description);
             tabContentDescriptions.add(R.string.description_tab_description);
         }
 
         if (pageAdapter.getCount() == 0) {
-            pageAdapter.addFragment(new EmptyFragment(true), EMPTY_TAB_TAG);
+            pageAdapter.addFragment(EmptyFragment.newInstance(true), EMPTY_TAB_TAG);
         }
         pageAdapter.notifyDataSetUpdate();
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
- The EmptyFragment should not have a constructor at all.
- Now a static methods creates the Fragment and arguments are handled via a Bundle.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #5941

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
