### PR TITLE
Fixed player not automatically playing

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -714,7 +714,11 @@ public final class Player implements
             // Android TV: without it focus will frame the whole player
             binding.playPauseButton.requestFocus();
 
-            playPause();
+            if (getPlayWhenReady()) {
+                play();
+            } else {
+                pause();
+            }
         }
         NavigationHelper.sendPlayerStartedEvent(context);
     }

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -714,6 +714,7 @@ public final class Player implements
             // Android TV: without it focus will frame the whole player
             binding.playPauseButton.requestFocus();
 
+            // Note: This is for automatically playing (when "Resume playback" is off), see #6179
             if (getPlayWhenReady()) {
                 play();
             } else {


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
- reverted changes of https://github.com/TeamNewPipe/NewPipe/pull/5929/commits/749c937b8e72758b5b59a2590d717cf5945689b0 to fix #6179
- also checkout https://github.com/TeamNewPipe/NewPipe/issues/6179#issuecomment-837278251 for more details

#### Fixes the following issue(s)
- Fixes #6179
- Note: The problem only occurs, when the option "History and cache>Resume playback" is set to off


#### Relies on the following changes


#### APK testing 
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
