### PR TITLE
handle long names in different places

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/database/playlist/model/PlaylistRemoteEntity.java
+++ b/app/src/main/java/org/schabi/newpipe/database/playlist/model/PlaylistRemoteEntity.java
@@ -132,6 +132,10 @@ public class PlaylistRemoteEntity implements PlaylistLocalItem {
         return uploader;
     }
 
+    public String getShortedUploaderName() {
+        return uploader.substring(0, Math.min(uploader.length(), 35)) + "...";
+    }
+
     public void setUploader(final String uploader) {
         this.uploader = uploader;
     }

--- a/app/src/main/java/org/schabi/newpipe/local/holder/RemotePlaylistItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/local/holder/RemotePlaylistItemHolder.java
@@ -38,7 +38,7 @@ public class RemotePlaylistItemHolder extends PlaylistItemHolder {
                 itemStreamCountView.getContext(), item.getStreamCount()));
         // Here is where the uploader name is set in the bookmarked playlists library
         if (!TextUtils.isEmpty(item.getUploader())) {
-            itemUploaderView.setText(Localization.concatenateStrings(item.getUploader(),
+            itemUploaderView.setText(Localization.concatenateStrings(item.getShortedUploaderName(),
                     NewPipe.getNameOfService(item.getServiceId())));
         } else {
             itemUploaderView.setText(NewPipe.getNameOfService(item.getServiceId()));


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- add a new function in PlaylistRemoteEntity 
- use the upper function in RemotePlaylistItemHolder 
- Instead of showing long strings in name that is not necessary we show 35 character of name ending with three dots.

#### Fixes the following issue(s)
- Fixes #4924 

#### APK testing 
- I don't get this part :)

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
