### PR TITLE
Make progress bars of watched streams filled

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/database/stream/model/StreamStateEntity.java
+++ b/app/src/main/java/org/schabi/newpipe/database/stream/model/StreamStateEntity.java
@@ -65,8 +65,8 @@ public class StreamStateEntity {
 
     public boolean isValid(final int durationInSeconds) {
         final int seconds = (int) TimeUnit.MILLISECONDS.toSeconds(progressTime);
-        return seconds > PLAYBACK_SAVE_THRESHOLD_START_SECONDS
-                && seconds < durationInSeconds - PLAYBACK_SAVE_THRESHOLD_END_SECONDS;
+        return (Math.abs(seconds - durationInSeconds) <= 1) || (seconds > PLAYBACK_SAVE_THRESHOLD_START_SECONDS
+                && seconds < durationInSeconds - PLAYBACK_SAVE_THRESHOLD_END_SECONDS);
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -1921,7 +1921,7 @@ public final class Player implements
             case com.google.android.exoplayer2.Player.STATE_ENDED: // 4
                 changeState(STATE_COMPLETED);
                 if (currentMetadata != null) {
-                    resetStreamProgressState(currentMetadata.getMetadata());
+                    saveStreamProgressState(currentMetadata.getMetadata(), simpleExoPlayer.getDuration());
                 }
                 isPrepared = false;
                 break;
@@ -2812,10 +2812,6 @@ public final class Player implements
                     .subscribe();
             databaseUpdateDisposable.add(stateSaver);
         }
-    }
-
-    private void resetStreamProgressState(final StreamInfo info) {
-        saveStreamProgressState(info, 0);
     }
 
     public void saveStreamProgressState() {


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
When you finish a video and see it in your watch history, the red bar usually shown on the thumbnail is not present. The cause is that the player resets the watch progress of videos when they are done, so that when the video is played again it would start from the beginning. This PR instead saves the actual watch progress and then starts from the beginning in the player (still didn't figure out how to do this part).

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #4480

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
