### PR TITLE
Save backup import/export location for future import/exports

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
@@ -26,6 +26,7 @@ import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.localization.ContentCountry;
 import org.schabi.newpipe.extractor.localization.Localization;
 import org.schabi.newpipe.util.FilePickerActivityHelper;
+import org.schabi.newpipe.util.FilePathUtils;
 import org.schabi.newpipe.util.ZipHelper;
 
 import java.io.File;
@@ -67,7 +68,7 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
                     .putExtra(FilePickerActivityHelper.EXTRA_MODE,
                             FilePickerActivityHelper.MODE_FILE);
             final String path = defaultPreferences.getString(importExportDataPathKey, "");
-            if (isValidPath(path)) {
+            if (FilePathUtils.isValidDirectoryPath(path)) {
                 i.putExtra(FilePickerActivityHelper.EXTRA_START_PATH, path);
             }
             startActivityForResult(i, REQUEST_IMPORT_PATH);
@@ -82,7 +83,7 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
                     .putExtra(FilePickerActivityHelper.EXTRA_MODE,
                             FilePickerActivityHelper.MODE_DIR);
             final String path = defaultPreferences.getString(importExportDataPathKey, "");
-            if (isValidPath(path)) {
+            if (FilePathUtils.isValidDirectoryPath(path)) {
                 i.putExtra(FilePickerActivityHelper.EXTRA_START_PATH, path);
             }
             startActivityForResult(i, REQUEST_EXPORT_PATH);
@@ -252,14 +253,6 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
         } catch (final Exception e) {
             ErrorActivity.reportUiErrorInSnackbar(this, "Importing database", e);
         }
-    }
-
-    private boolean isValidPath(final String path) {
-        if (path == null || path.isEmpty()) {
-            return false;
-        }
-        final File file = new File(path);
-        return file.exists() && file.isDirectory();
     }
 
     private void setImportExportDataPath(final File file) {

--- a/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
@@ -257,15 +257,15 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
 
     private void setImportExportDataPath(final File file) {
         final String directoryPath;
-        if (!file.isDirectory()) {
+        if (file.isDirectory()) {
+            directoryPath = file.getAbsolutePath();
+        } else {
             final File parentFile = file.getParentFile();
             if (parentFile != null) {
                 directoryPath = parentFile.getAbsolutePath();
             } else {
                 directoryPath = "";
             }
-        } else {
-            directoryPath = file.getAbsolutePath();
         }
         defaultPreferences.edit().putString(importExportDataPathKey, directoryPath).apply();
     }

--- a/app/src/main/java/org/schabi/newpipe/util/FilePathUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/FilePathUtils.java
@@ -1,0 +1,22 @@
+package org.schabi.newpipe.util;
+
+import java.io.File;
+
+public final class FilePathUtils {
+    private FilePathUtils() { }
+
+
+    /**
+     * Check that the path is a valid directory path and it exists.
+     *
+     * @param path full path of directory,
+     * @return is path valid or not
+     */
+    public static boolean isValidDirectoryPath(final String path) {
+        if (path == null || path.isEmpty()) {
+            return false;
+        }
+        final File file = new File(path);
+        return file.exists() && file.isDirectory();
+    }
+}

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -265,6 +265,7 @@
     </string-array>
     <string name="feed_use_dedicated_fetch_method_key" translatable="false">feed_use_dedicated_fetch_method</string>
 
+    <string name="import_export_data_path" translatable="false">import_export_data_path</string>
     <string name="import_data" translatable="false">import_data</string>
     <string name="export_data" translatable="false">export_data</string>
 

--- a/app/src/test/java/org/schabi/newpipe/util/FilePathHelperTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/FilePathHelperTest.java
@@ -1,5 +1,6 @@
 package org.schabi.newpipe.util;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
@@ -10,28 +11,44 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class FilePathHelperTest {
+
+    private File dir;
+
+    @Before
+    public void setUp() throws IOException {
+        dir = Files.createTempDirectory("dir1").toFile();
+    }
+
     @Test
-    public void testIsValidDirectoryPath() throws IOException {
-        // empty path is not valid
+    public void testIsValidDirectoryPathWithEmptyString() {
         assertFalse(FilePathUtils.isValidDirectoryPath(""));
+    }
 
-        // null path is not valid
+    @Test
+    public void testIsValidDirectoryPathWithNullString() {
         assertFalse(FilePathUtils.isValidDirectoryPath(null));
+    }
 
-        // path that exists
-        final File dir1 = Files.createTempDirectory("dir1").toFile();
-        assertTrue(FilePathUtils.isValidDirectoryPath(dir1.getAbsolutePath()));
+    @Test
+    public void testIsValidDirectoryPathWithValidPath() {
+        assertTrue(FilePathUtils.isValidDirectoryPath(dir.getAbsolutePath()));
+    }
 
-        // a directory in above path that exists
-        final File subDir = Files.createDirectory(dir1.toPath().resolve("subdir")).toFile();
+    @Test
+    public void testIsValidDirectoryPathWithDeepValidDirectory() throws IOException {
+        final File subDir = Files.createDirectory(dir.toPath().resolve("subdir")).toFile();
         assertTrue(FilePathUtils.isValidDirectoryPath(subDir.getAbsolutePath()));
+    }
 
-        // a directory in above path that doesn't exist
-        assertFalse(FilePathUtils.isValidDirectoryPath(dir1.toPath().resolve("not-exists-subdir").
+    @Test
+    public void testIsValidDirectoryPathWithNotExistDirectory() {
+        assertFalse(FilePathUtils.isValidDirectoryPath(dir.toPath().resolve("not-exists-subdir").
                 toFile().getAbsolutePath()));
+    }
 
-        // file is not a valid direcotry path
-        final File tempFile = Files.createFile(dir1.toPath().resolve("simple_file")).toFile();
+    @Test
+    public void testIsValidDirectoryPathWithFile() throws IOException {
+        final File tempFile = Files.createFile(dir.toPath().resolve("simple_file")).toFile();
         assertFalse(FilePathUtils.isValidDirectoryPath(tempFile.getAbsolutePath()));
     }
 

--- a/app/src/test/java/org/schabi/newpipe/util/FilePathHelperTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/FilePathHelperTest.java
@@ -6,17 +6,18 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class FilePathHelperTest {
 
-    private File dir;
+    private Path dir;
 
     @Before
     public void setUp() throws IOException {
-        dir = Files.createTempDirectory("dir1").toFile();
+        dir = Files.createTempDirectory("dir1");
     }
 
     @Test
@@ -31,24 +32,24 @@ public class FilePathHelperTest {
 
     @Test
     public void testIsValidDirectoryPathWithValidPath() {
-        assertTrue(FilePathUtils.isValidDirectoryPath(dir.getAbsolutePath()));
+        assertTrue(FilePathUtils.isValidDirectoryPath(dir.toAbsolutePath().toString()));
     }
 
     @Test
     public void testIsValidDirectoryPathWithDeepValidDirectory() throws IOException {
-        final File subDir = Files.createDirectory(dir.toPath().resolve("subdir")).toFile();
+        final File subDir = Files.createDirectory(dir.resolve("subdir")).toFile();
         assertTrue(FilePathUtils.isValidDirectoryPath(subDir.getAbsolutePath()));
     }
 
     @Test
     public void testIsValidDirectoryPathWithNotExistDirectory() {
-        assertFalse(FilePathUtils.isValidDirectoryPath(dir.toPath().resolve("not-exists-subdir").
-                toFile().getAbsolutePath()));
+        assertFalse(FilePathUtils.isValidDirectoryPath(dir.resolve("not-exists-subdir").
+            toFile().getAbsolutePath()));
     }
 
     @Test
     public void testIsValidDirectoryPathWithFile() throws IOException {
-        final File tempFile = Files.createFile(dir.toPath().resolve("simple_file")).toFile();
+        final File tempFile = Files.createFile(dir.resolve("simple_file")).toFile();
         assertFalse(FilePathUtils.isValidDirectoryPath(tempFile.getAbsolutePath()));
     }
 

--- a/app/src/test/java/org/schabi/newpipe/util/FilePathHelperTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/FilePathHelperTest.java
@@ -12,6 +12,12 @@ import static org.junit.Assert.assertTrue;
 public class FilePathHelperTest {
     @Test
     public void testIsValidDirectoryPath() throws IOException {
+        // empty path is not valid
+        assertFalse(FilePathUtils.isValidDirectoryPath(""));
+
+        // null path is not valid
+        assertFalse(FilePathUtils.isValidDirectoryPath(null));
+
         // path that exists
         final File dir1 = Files.createTempDirectory("dir1").toFile();
         assertTrue(FilePathUtils.isValidDirectoryPath(dir1.getAbsolutePath()));

--- a/app/src/test/java/org/schabi/newpipe/util/FilePathHelperTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/FilePathHelperTest.java
@@ -1,0 +1,32 @@
+package org.schabi.newpipe.util;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class FilePathHelperTest {
+    @Test
+    public void testIsValidDirectoryPath() throws IOException {
+        // path that exists
+        final File dir1 = Files.createTempDirectory("dir1").toFile();
+        assertTrue(FilePathUtils.isValidDirectoryPath(dir1.getAbsolutePath()));
+
+        // a directory in above path that exists
+        final File subDir = Files.createDirectory(dir1.toPath().resolve("subdir")).toFile();
+        assertTrue(FilePathUtils.isValidDirectoryPath(subDir.getAbsolutePath()));
+
+        // a directory in above path that doesn't exist
+        assertFalse(FilePathUtils.isValidDirectoryPath(dir1.toPath().resolve("not-exists-subdir").
+                toFile().getAbsolutePath()));
+
+        // file is not a valid direcotry path
+        final File tempFile = Files.createFile(dir1.toPath().resolve("simple_file")).toFile();
+        assertFalse(FilePathUtils.isValidDirectoryPath(tempFile.getAbsolutePath()));
+    }
+
+}


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
To save location of import/export, I add a new preference key for `import_export_path` and save this preference on result of file chooser activity and send it on intent of file chooser on later tries.

So as a user, If a export data on folder `foo`, when I want to import this data, file chooser show `foo` as start path.


#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #6039 

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
