### PR TITLE
Allow rename database export file in settings

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
@@ -29,6 +29,7 @@ import org.schabi.newpipe.extractor.localization.ContentCountry;
 import org.schabi.newpipe.extractor.localization.Localization;
 import org.schabi.newpipe.util.FilePickerActivityHelper;
 import org.schabi.newpipe.util.FilePathUtils;
+import org.schabi.newpipe.util.FilenameUtils;
 import org.schabi.newpipe.util.ZipHelper;
 
 import java.io.File;
@@ -211,7 +212,7 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
                 .setNegativeButton(R.string.cancel, null)
                 .setPositiveButton(R.string.export_button, (dialog1, which) -> {
                     final String fileName = fileNameET.getText().toString();
-                    if (fileName.matches("[-_. A-Za-z0-9]+\\.zip")) {
+                    if (FilenameUtils.isValidFileName(fileName, "zip")) {
                         exportDatabase(path + "/" + fileName);
                     } else {
                         Toast.makeText(getContext(), R.string.no_valid_zip_file_name,

--- a/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
@@ -5,7 +5,9 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.text.InputType;
 import android.util.Log;
+import android.widget.EditText;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -180,8 +182,7 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
             setImportExportDataPath(file);
 
             if (requestCode == REQUEST_EXPORT_PATH) {
-                final SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US);
-                exportDatabase(path + "/NewPipeData-" + sdf.format(new Date()) + ".zip");
+                showExportDialog(requireActivity(), path);
             } else {
                 final AlertDialog.Builder builder = new AlertDialog.Builder(requireActivity());
                 builder.setMessage(R.string.override_current_data)
@@ -192,6 +193,33 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
                 builder.create().show();
             }
         }
+    }
+
+    private void showExportDialog(final Context c, final String path) {
+        final EditText fileNameET = new EditText(c);
+
+        final SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US);
+        fileNameET.setText("NewPipeData-" + sdf.format(new Date()) + ".zip");
+
+        fileNameET.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_URI);
+        fileNameET.setHint(R.string.export_data_file_name_hint);
+
+        final AlertDialog dialog = new AlertDialog.Builder(c)
+                .setTitle(R.string.export_data_file_name)
+                .setIcon(R.drawable.ic_import_export)
+                .setNegativeButton(R.string.cancel, null)
+                .setPositiveButton(R.string.export_button, (dialog1, which) -> {
+                    final String fileName = fileNameET.getText().toString();
+                    if (fileName.matches("[-_. A-Za-z0-9]+\\.zip")) {
+                        exportDatabase(path + "/" + fileName);
+                    } else {
+                        Toast.makeText(getContext(), R.string.no_valid_zip_file_name,
+                                Toast.LENGTH_SHORT).show();
+                    }
+                })
+                .create();
+        dialog.setView(fileNameET, 50, 0, 50, 0);
+        dialog.show();
     }
 
     private void exportDatabase(final String path) {

--- a/app/src/main/java/org/schabi/newpipe/util/FilenameUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/FilenameUtils.java
@@ -12,6 +12,7 @@ import java.util.regex.Pattern;
 public final class FilenameUtils {
     private static final String CHARSET_MOST_SPECIAL = "[\\n\\r|?*<\":\\\\>/']+";
     private static final String CHARSET_ONLY_LETTERS_AND_DIGITS = "[^\\w\\d]+";
+    private static final String CHARSET_VALID_IN_FILE_NAMES = "[-_. A-Za-z0-9]+";
 
     private FilenameUtils() { }
 
@@ -65,5 +66,16 @@ public final class FilenameUtils {
     private static String createFilename(final String title, final Pattern invalidCharacters,
                                          final String replacementChar) {
         return title.replaceAll(invalidCharacters.pattern(), replacementChar);
+    }
+
+    /**
+     * Get a file name and extension and check the file name is a valid file name or not.
+     *
+     * @param fileName  name of file to check like "foo.zip"
+     * @param extension extension of file like "zip"
+     * @return is filename valid or not
+     */
+    public static boolean isValidFileName(final String fileName, final String extension) {
+        return fileName.matches(CHARSET_VALID_IN_FILE_NAMES + "\\." + extension);
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -443,7 +443,11 @@
     <string name="select_a_kiosk">Select a kiosk</string>
     <string name="export_complete_toast">Exported</string>
     <string name="import_complete_toast">Imported</string>
+    <string name="export_button">Export</string>
+    <string name="export_data_file_name">Export file name</string>
+    <string name="export_data_file_name_hint">Please enter file name for export.</string>
     <string name="no_valid_zip_file">No valid ZIP file</string>
+    <string name="no_valid_zip_file_name">You entered an invalid name for zip file.</string>
     <string name="could_not_import_all_files">Warning: Could not import all files.</string>
     <string name="override_current_data">This will override your current setup.</string>
     <string name="import_settings">Do you want to also import settings?</string>

--- a/app/src/test/java/org/schabi/newpipe/util/FilenameUtilsTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/FilenameUtilsTest.java
@@ -1,0 +1,59 @@
+package org.schabi.newpipe.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class FilenameUtilsTest {
+    @Test
+    public void testIsValidFileNameOnlyLowerCaseName() {
+        assertTrue(FilenameUtils.isValidFileName("foo.zip", "zip"));
+    }
+
+    @Test
+    public void testIsValidFileNameLowerUpperCaseName() {
+        assertTrue(FilenameUtils.isValidFileName("fooFSDFDWER.zip", "zip"));
+    }
+
+    @Test
+    public void testIsValidFileNameWithNumberName() {
+        assertTrue(FilenameUtils.isValidFileName("foo77.zip", "zip"));
+    }
+
+    @Test
+    public void testIsValidFileNameWithDashName() {
+        assertTrue(FilenameUtils.isValidFileName("foo-77.zip", "zip"));
+    }
+
+    @Test
+    public void testIsValidFileNameWithUnderlineName() {
+        assertTrue(FilenameUtils.isValidFileName("foo_77.zip", "zip"));
+    }
+
+    @Test
+    public void testIsValidFileNameWithMultiDotsName() {
+        assertTrue(FilenameUtils.isValidFileName("foo.export.zip", "zip"));
+    }
+
+    @Test
+    public void testIsValidFileNameAbsolutePath() {
+        assertFalse(FilenameUtils.isValidFileName("/dev/null/file.zip", "zip"));
+    }
+
+    @Test
+    public void testIsValidFileNameRelativePath() {
+        assertFalse(FilenameUtils.isValidFileName("../file.zip", "zip"));
+    }
+
+    @Test
+    public void testIsValidFileNameSpecialChars() {
+        assertFalse(FilenameUtils.isValidFileName("file*.zip", "zip"));
+    }
+
+    @Test
+    public void testIsValidFileNameBadExtension() {
+        assertFalse(FilenameUtils.isValidFileName("file.rar", "zip"));
+    }
+
+}


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
In export database on settings. I show a new dialog and get file name from user. then I save export file with entered name.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #5780 

#### Relies on the following changes
<!-- Delete this if it doesn't apply to you. -->
- #6319 

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
