### PR TITLE
issue #6217 fixed. replay button doesn't appear twice.

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -375,7 +375,11 @@ public final class Player implements
     @NonNull private final SharedPreferences prefs;
     @NonNull private final HistoryRecordManager recordManager;
 
+     /*//////////////////////////////////////////////////////////////////////////
+    // this field is added to address issue #6217 regarding the replay button appearing twice.
+    //////////////////////////////////////////////////////////////////////////*/
 
+    private boolean isOnreplay = false;
 
     /*//////////////////////////////////////////////////////////////////////////
     // Constructor
@@ -2142,12 +2146,16 @@ public final class Player implements
     }
 
     private void onCompleted() {
+        if (isOnreplay) {
+            return;
+        }
         if (DEBUG) {
             Log.d(TAG, "onCompleted() called");
         }
 
         animate(binding.playPauseButton, false, 0, AnimationType.SCALE_AND_ALPHA, 0,
                 () -> {
+                    isOnreplay = true;
                     binding.playPauseButton.setImageResource(R.drawable.ic_replay);
                     animatePlayButtons(true, DEFAULT_CONTROLS_DURATION);
                 });
@@ -3546,6 +3554,10 @@ public final class Player implements
             seekToDefault();
         } else if (v.getId() == binding.playPauseButton.getId()) {
             playPause();
+            if (isOnreplay) {
+                isOnreplay = false;
+                playPause();
+            }
         } else if (v.getId() == binding.playPreviousButton.getId()) {
             playPrevious();
         } else if (v.getId() == binding.playNextButton.getId()) {


### PR DESCRIPTION
For solving this issue, the following changes where made in Player.java:
1. A boolean field named isOnReplay was added to reflect when the user has pressed the replay button.
2. when the video would reach it's end and the onCompleted method be called, the first time isOnreplay would be set to true. the second time it entered onCompleted (fallacious behavior) it would return since isOnReplay is true.
3.  in the onclick method, when the playpause button was clicked, if it was the replay button which triggered this event, playpause will be called twice (by checking isOnReplay for the second call).


Fixes #6217