### PR TITLE
Use AdoptOpenJDK instead of Zulu in GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: 8
-          distribution: "zulu"
+          distribution: "adopt"
 
       - name: Cache Gradle dependencies
         uses: actions/cache@v2
@@ -54,7 +54,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: 8
-          distribution: "zulu"
+          distribution: "adopt"
 
       - name: Cache Gradle dependencies
         uses: actions/cache@v2
@@ -79,7 +79,7 @@ jobs:
 #         uses: actions/setup-java@v2
 #         with:
 #           java-version: 11 # Sonar requires JDK 11
-#           distribution: "zulu"
+#           distribution: "adopt"
 
 #       - name: Cache SonarCloud packages
 #         uses: actions/cache@v2


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
* Follow-up of #6079
* Using adoptopenjdk instead of zulu
  * AdoptOpenJDK is unbranded (Zulu is branded)
  * AdoptOpenJDK is very close related to OpenJDK / less modified than zulu
  * There seem to be no specific commitments regarding the availability of Zulu's free constructions
  * Android studio is shipped with OpenJDK:
  ![demo](https://user-images.githubusercontent.com/40789489/119261407-952c4000-bbd7-11eb-9734-82422117c7e8.png)
  * See also: https://github.com/actions/setup-java/issues/13, https://dzone.com/articles/java-and-the-jdks-which-one-to-use
* See also: https://github.com/TeamNewPipe/NewPipeExtractor/pull/635

#### Relies on the following changes
none

#### APK testing 
On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
