### PR TITLE
Improve Bandcamp intent filters

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -332,7 +332,6 @@
                 <data android:scheme="https"/>
                 <data android:host="bandcamp.com"/>
                 <data android:host="*.bandcamp.com"/>
-                <data android:pathPrefix="/"/>
             </intent-filter>
         </activity>
         <service

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -319,7 +319,7 @@
                 <data android:pathPrefix="/video-channels/" />
             </intent-filter>
 
-            <!-- Bandcamp filter -->
+            <!-- Bandcamp filter for tracks, albums and playlists -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>
                 <action android:name="android.media.action.MEDIA_PLAY_FROM_SEARCH"/>
@@ -330,9 +330,23 @@
 
                 <data android:scheme="http"/>
                 <data android:scheme="https"/>
-                <data android:host="bandcamp.com"/>
                 <data android:host="*.bandcamp.com"/>
             </intent-filter>
+
+            <!-- Bandcamp filter for radio -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <action android:name="android.media.action.MEDIA_PLAY_FROM_SEARCH"/>
+                <action android:name="android.nfc.action.NDEF_DISCOVERED"/>
+
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+
+                <data android:scheme="http"/>
+                <data android:scheme="https"/>
+                <data android:sspPattern="bandcamp.com/?show=*"/>
+            </intent-filter>
+
         </activity>
         <service
             android:name=".RouterActivity$FetcherService"


### PR DESCRIPTION


#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR

Removes requirement for Bandcamp links to end with a `/` (see linked issue).

Additionally, I split the intent filter up into two filters into one for each of these two:

* `*.bandcamp.com`
* `bandcamp.com/?show=*`

This means that links like `https://bandcamp.com/`, `https://bandcamp.com/redeem`, …, are no longer falsely accepted.

#### Fixes the following issue(s)

- Fixes #6335
- Includes fix from @yashpalgoyal1304 in https://github.com/TeamNewPipe/NewPipe/issues/6335#issuecomment-845302865, which is working ;)


#### APK testing 
- [app-debug.apk.zip](https://github.com/TeamNewPipe/NewPipe/files/6544495/app-debug.apk.zip)


#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
