### PR TITLE
Update Matrix link of NewPipe IRC from Freenode to Libera.chat

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: ircs://irc.libera.chat:6697/newpipe
     about: Chat with us via IRC for quick Q/A
   - name: 💬 Matrix
-    url: https://matrix.to/#/#freenode_#newpipe:matrix.org
+    url: https://matrix.to/#/#newpipe:libera.chat
     about: Chat with us via Matrix for quick Q/A


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [x] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Change the IRC link for Matrix users from Freenode to [Libera](https://libera.chat).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
