### PR TITLE
Option for download is redundant and thus removed when linkType is CH…

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/RouterActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/RouterActivity.java
@@ -466,6 +466,11 @@ public class RouterActivity extends AppCompatActivity {
             if (capabilities.contains(AUDIO)) {
                 returnList.add(backgroundPlayer);
             }
+            // download is redundant for linkType CHANNEL AND PLAYLIST (till playlist downloading is
+            // not supported )
+            returnList.add(new AdapterChoiceItem(getString(R.string.download_key),
+                    getString(R.string.download),
+                    R.drawable.ic_file_download));
 
         } else {
             returnList.add(showInfo);
@@ -477,10 +482,6 @@ public class RouterActivity extends AppCompatActivity {
                 returnList.add(backgroundPlayer);
             }
         }
-
-        returnList.add(new AdapterChoiceItem(getString(R.string.download_key),
-                getString(R.string.download),
-                R.drawable.ic_file_download));
 
         return returnList;
     }


### PR DESCRIPTION
…ANNEL or PLAYLIST

<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- The Download button should not be included in option action choices when linkType is CHANNEL or PLAYLIST (as it will just give unsupported url ) , thus done the needed changes

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #6371 

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
