### PR TITLE
Fix empty fragment text not centered when text longer than one line

### DIFF
--- a/app/src/main/res/layout/main_bg.xml
+++ b/app/src/main/res/layout/main_bg.xml
@@ -5,6 +5,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
+    android:paddingStart="@dimen/activity_horizontal_margin"
+    android:paddingEnd="@dimen/activity_horizontal_margin"
     tools:context=".fragments.detail.VideoDetailFragment">
 
     <TextView
@@ -13,6 +15,7 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
         android:layout_marginTop="30dp"
+        android:layout_marginBottom="20dp"
         android:fontFamily="sans-serif-condensed"
         android:text="@string/app_name"
         android:textAppearance="?android:attr/textAppearanceLarge"
@@ -20,9 +23,10 @@
 
     <TextView
         android:id="@+id/mainBGSubtitle"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
+        android:gravity="center"
         android:text="@string/main_bg_subtitle"
         android:textAppearance="?android:attr/textAppearanceMedium" />
 


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
When the text on the empty fragment was too long (larger font size or longer translation), the text was not centred anymore.
Fixed that and also added a bit more margin to the "NewPip" title.

#### Fixes the following issue(s)
 |  Before  |  After  |
| ---------- | --------- |
| ![Screenshot_20210528-124155_NewPipe](https://user-images.githubusercontent.com/17365767/119973092-53beda80-bfb3-11eb-913a-d5128c6c2c29.png)  |  ![Screenshot_20210528-124856_NewPipe_Debug](https://user-images.githubusercontent.com/17365767/119973091-53264400-bfb3-11eb-93e8-8a3e19edcbee.png)  |


#### APK testing 
On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
