### PR TITLE
Update AndroidX Fragment to 1.3.4

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -198,6 +198,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     implementation 'androidx.core:core-ktx:1.3.2'
     implementation 'androidx.documentfile:documentfile:1.0.1'
+    implementation 'androidx.fragment:fragment-ktx:1.3.4'
     implementation "androidx.lifecycle:lifecycle-livedata:${androidxLifecycleVersion}"
     implementation "androidx.lifecycle:lifecycle-viewmodel:${androidxLifecycleVersion}"
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'

--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -603,6 +603,7 @@ public class MainActivity extends AppCompatActivity {
     public void onRequestPermissionsResult(final int requestCode,
                                            @NonNull final String[] permissions,
                                            @NonNull final int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
         for (final int i : grantResults) {
             if (i == PackageManager.PERMISSION_DENIED) {
                 return;

--- a/app/src/main/java/org/schabi/newpipe/RouterActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/RouterActivity.java
@@ -590,6 +590,7 @@ public class RouterActivity extends AppCompatActivity {
     public void onRequestPermissionsResult(final int requestCode,
                                            @NonNull final String[] permissions,
                                            @NonNull final int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
         for (final int i : grantResults) {
             if (i == PackageManager.PERMISSION_DENIED) {
                 finish();

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/ImportConfirmationDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/ImportConfirmationDialog.java
@@ -23,13 +23,9 @@ public class ImportConfirmationDialog extends DialogFragment {
 
     public static void show(@NonNull final Fragment fragment,
                             @NonNull final Intent resultServiceIntent) {
-        if (fragment.getFragmentManager() == null) {
-            return;
-        }
-
         final ImportConfirmationDialog confirmationDialog = new ImportConfirmationDialog();
         confirmationDialog.setResultServiceIntent(resultServiceIntent);
-        confirmationDialog.show(fragment.getFragmentManager(), null);
+        confirmationDialog.show(fragment.getParentFragmentManager(), null);
     }
 
     public void setResultServiceIntent(final Intent resultServiceIntent) {

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
@@ -198,7 +198,7 @@ class SubscriptionFragment : BaseStateFragment<SubscriptionState>() {
     }
 
     private fun openReorderDialog() {
-        FeedGroupReorderDialog().show(requireFragmentManager(), null)
+        FeedGroupReorderDialog().show(parentFragmentManager, null)
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
@@ -15,6 +15,8 @@ import android.view.MenuInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.activity.result.ActivityResult
+import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.appcompat.app.AlertDialog
 import androidx.lifecycle.ViewModelProvider
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
@@ -81,6 +83,11 @@ class SubscriptionFragment : BaseStateFragment<SubscriptionState>() {
     private lateinit var importExportItem: FeedImportExportItem
     private lateinit var feedGroupsSortMenuItem: HeaderWithMenuItem
     private val subscriptionsSection = Section()
+
+    private val requestExportLauncher =
+        registerForActivityResult(StartActivityForResult(), this::requestExportResult)
+    private val requestImportLauncher =
+        registerForActivityResult(StartActivityForResult(), this::requestImportResult)
 
     @State
     @JvmField
@@ -184,16 +191,15 @@ class SubscriptionFragment : BaseStateFragment<SubscriptionState>() {
     }
 
     private fun onImportPreviousSelected() {
-        startActivityForResult(StoredFileHelper.getPicker(activity), REQUEST_IMPORT_CODE)
+        requestImportLauncher.launch(StoredFileHelper.getPicker(activity))
     }
 
     private fun onExportSelected() {
         val date = SimpleDateFormat("yyyyMMddHHmm", Locale.ENGLISH).format(Date())
         val exportName = "newpipe_subscriptions_$date.json"
 
-        startActivityForResult(
-            StoredFileHelper.getNewPicker(activity, exportName, "application/json", null),
-            REQUEST_EXPORT_CODE
+        requestExportLauncher.launch(
+            StoredFileHelper.getNewPicker(activity, exportName, "application/json", null)
         )
     }
 
@@ -201,22 +207,23 @@ class SubscriptionFragment : BaseStateFragment<SubscriptionState>() {
         FeedGroupReorderDialog().show(parentFragmentManager, null)
     }
 
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        super.onActivityResult(requestCode, resultCode, data)
-        if (data != null && data.data != null && resultCode == Activity.RESULT_OK) {
-            if (requestCode == REQUEST_EXPORT_CODE) {
-                activity.startService(
-                    Intent(activity, SubscriptionsExportService::class.java)
-                        .putExtra(SubscriptionsExportService.KEY_FILE_PATH, data.data)
-                )
-            } else if (requestCode == REQUEST_IMPORT_CODE) {
-                ImportConfirmationDialog.show(
-                    this,
-                    Intent(activity, SubscriptionsImportService::class.java)
-                        .putExtra(KEY_MODE, PREVIOUS_EXPORT_MODE)
-                        .putExtra(KEY_VALUE, data.data)
-                )
-            }
+    fun requestExportResult(result: ActivityResult) {
+        if (result.data != null && result.resultCode == Activity.RESULT_OK) {
+            activity.startService(
+                Intent(activity, SubscriptionsExportService::class.java)
+                    .putExtra(SubscriptionsExportService.KEY_FILE_PATH, result.data?.data)
+            )
+        }
+    }
+
+    fun requestImportResult(result: ActivityResult) {
+        if (result.data != null && result.resultCode == Activity.RESULT_OK) {
+            ImportConfirmationDialog.show(
+                this,
+                Intent(activity, SubscriptionsImportService::class.java)
+                    .putExtra(KEY_MODE, PREVIOUS_EXPORT_MODE)
+                    .putExtra(KEY_VALUE, result.data?.data)
+            )
         }
     }
 
@@ -435,10 +442,5 @@ class SubscriptionFragment : BaseStateFragment<SubscriptionState>() {
     private fun getGridSpanCount(): Int {
         val minWidth = resources.getDimensionPixelSize(R.dimen.channel_item_grid_min_width)
         return max(1, floor(resources.displayMetrics.widthPixels / minWidth.toDouble()).toInt())
-    }
-
-    companion object {
-        private const val REQUEST_EXPORT_CODE = 666
-        private const val REQUEST_IMPORT_CODE = 667
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/settings/tabs/ChooseTabsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/tabs/ChooseTabsFragment.java
@@ -192,13 +192,13 @@ public class ChooseTabsFragment extends Fragment {
                 final SelectKioskFragment selectKioskFragment = new SelectKioskFragment();
                 selectKioskFragment.setOnSelectedListener((serviceId, kioskId, kioskName) ->
                         addTab(new Tab.KioskTab(serviceId, kioskId)));
-                selectKioskFragment.show(requireFragmentManager(), "select_kiosk");
+                selectKioskFragment.show(getParentFragmentManager(), "select_kiosk");
                 return;
             case CHANNEL:
                 final SelectChannelFragment selectChannelFragment = new SelectChannelFragment();
                 selectChannelFragment.setOnSelectedListener((serviceId, url, name) ->
                         addTab(new Tab.ChannelTab(serviceId, url, name)));
-                selectChannelFragment.show(requireFragmentManager(), "select_channel");
+                selectChannelFragment.show(getParentFragmentManager(), "select_channel");
                 return;
             case PLAYLIST:
                 final SelectPlaylistFragment selectPlaylistFragment = new SelectPlaylistFragment();
@@ -215,7 +215,7 @@ public class ChooseTabsFragment extends Fragment {
                                 addTab(new Tab.PlaylistTab(serviceId, url, name));
                             }
                         });
-                selectPlaylistFragment.show(requireFragmentManager(), "select_playlist");
+                selectPlaylistFragment.show(getParentFragmentManager(), "select_playlist");
                 return;
             default:
                 addTab(type.getTab());

--- a/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
+++ b/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
@@ -66,16 +66,14 @@ public enum StreamDialogEntry {
     }), // has to be set manually
 
     append_playlist(R.string.append_playlist, (fragment, item) -> {
-        if (fragment.getFragmentManager() != null) {
-            final PlaylistAppendDialog d = PlaylistAppendDialog
-                    .fromStreamInfoItems(Collections.singletonList(item));
+        final PlaylistAppendDialog d = PlaylistAppendDialog
+                .fromStreamInfoItems(Collections.singletonList(item));
 
-            PlaylistAppendDialog.onPlaylistFound(fragment.getContext(),
-                () -> d.show(fragment.getFragmentManager(), "StreamDialogEntry@append_playlist"),
-                () -> PlaylistCreationDialog.newInstance(d)
-                        .show(fragment.getFragmentManager(), "StreamDialogEntry@create_playlist")
-            );
-        }
+        PlaylistAppendDialog.onPlaylistFound(fragment.getContext(),
+            () -> d.show(fragment.getParentFragmentManager(), "StreamDialogEntry@append_playlist"),
+            () -> PlaylistCreationDialog.newInstance(d)
+                    .show(fragment.getParentFragmentManager(), "StreamDialogEntry@create_playlist")
+        );
     }),
 
     play_with_kodi(R.string.play_with_kodi_title, (fragment, item) -> {


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
- Updated AndroidX Fragment to 1.3.4 ([changelog](https://developer.android.com/jetpack/androidx/releases/fragment))
- Fix most deprecations from pre-1.3.0 Fragment versions
- Fix some of the onActivityResult deprecations

#### Fixes the following issue(s)
- Comes with whatever bugfixes were made between 1.2.4 and 1.3.4 (which are quite a lot). I highly recommend thoroughly reading the changelog.

#### APK testing 
On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).


## Notes
There are other deprecations that come with this upgrade that will need fixing at some point:
- ViewPager1 is now officially deprecated (YEAH BOIIIIII)

I didn't do other deprecations like onRequestPermissionsResult and the other onActivityResult ones because I'm not too confident and I want to keep this one smaller. I'll do them in other PRs.)