### PR TITLE
Player seekbar thumbnail preview

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -186,7 +186,7 @@ dependencies {
     // name and the commit hash with the commit hash of the (pushed) commit you want to test
     // This works thanks to JitPack: https://jitpack.io/
     implementation 'com.github.TeamNewPipe:nanojson:1d9e1aea9049fc9f85e68b43ba39fe7be1c1f751'
-    implementation 'com.github.TeamNewPipe:NewPipeExtractor:c38a06e8dcd9c206a52b622704b138b78d633274'
+    implementation 'com.github.litetex:NewPipeExtractor:playerSeekbarPreview-SNAPSHOT'
 
 /** Checkstyle **/
     checkstyle "com.puppycrawl.tools:checkstyle:${checkstyleVersion}"

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -27,6 +27,8 @@ import android.util.DisplayMetrics;
 import android.util.Log;
 import android.util.TypedValue;
 import android.view.ContextThemeWrapper;
+import android.view.GestureDetector;
+import android.view.Gravity;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -123,6 +125,8 @@ import org.schabi.newpipe.player.playqueue.PlayQueueItemTouchCallback;
 import org.schabi.newpipe.player.resolver.AudioPlaybackResolver;
 import org.schabi.newpipe.player.resolver.MediaSourceTag;
 import org.schabi.newpipe.player.resolver.VideoPlaybackResolver;
+import org.schabi.newpipe.player.seekbarpreview.SeekbarPreviewThumbnailHelper;
+import org.schabi.newpipe.player.seekbarpreview.SeekbarPreviewThumbnailHolder;
 import org.schabi.newpipe.util.DeviceUtils;
 import org.schabi.newpipe.util.ImageDisplayConstants;
 import org.schabi.newpipe.util.ListHelper;
@@ -379,6 +383,8 @@ public final class Player implements
     @NonNull private final SharedPreferences prefs;
     @NonNull private final HistoryRecordManager recordManager;
 
+    @NonNull private final SeekbarPreviewThumbnailHolder seekbarPreviewThumbnailHolder =
+            new SeekbarPreviewThumbnailHolder();
 
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -1676,12 +1682,67 @@ public final class Player implements
     @Override // seekbar listener
     public void onProgressChanged(final SeekBar seekBar, final int progress,
                                   final boolean fromUser) {
-        if (DEBUG && fromUser) {
+        // Currently we don't need method execution when fromUser is false
+        if (!fromUser) {
+            return;
+        }
+        if (DEBUG) {
             Log.d(TAG, "onProgressChanged() called with: "
                     + "seekBar = [" + seekBar + "], progress = [" + progress + "]");
         }
-        if (fromUser) {
-            binding.currentDisplaySeek.setText(getTimeString(progress));
+
+        binding.currentDisplaySeek.setText(getTimeString(progress));
+
+        // Seekbar Preview Thumbnail
+        SeekbarPreviewThumbnailHelper
+                .tryResizeAndSetSeekbarPreviewThumbnail(
+                        getContext(),
+                        seekbarPreviewThumbnailHolder.getBitmapAt(progress),
+                        binding.currentSeekbarPreviewThumbnail,
+                        binding.subtitleView::getWidth);
+
+        adjustSeekbarPreviewContainer();
+    }
+
+    private void adjustSeekbarPreviewContainer() {
+        try {
+            // Should only be required when an error occurred before
+            // and the layout was positioned in the center
+            binding.bottomSeekbarPreviewLayout.setGravity(Gravity.NO_GRAVITY);
+
+            // Calculate the current left position of seekbar progress in px
+            // More info: https://stackoverflow.com/q/20493577
+            final int currentSeekbarLeft =
+                    binding.playbackSeekBar.getLeft()
+                            + binding.playbackSeekBar.getPaddingLeft()
+                            + binding.playbackSeekBar.getThumb().getBounds().left;
+
+            // Calculate the (unchecked) left position of the container
+            final int uncheckedContainerLeft =
+                    currentSeekbarLeft - (binding.seekbarPreviewContainer.getWidth() / 2);
+
+            // Fix the position so it's within the boundaries
+            final int checkedContainerLeft =
+                    Math.max(
+                            Math.min(
+                                    uncheckedContainerLeft,
+                                    // Max left
+                                    binding.playbackWindowRoot.getWidth()
+                                            - binding.seekbarPreviewContainer.getWidth()
+                            ),
+                            0 // Min left
+                    );
+
+            // See also: https://stackoverflow.com/a/23249734
+            final LinearLayout.LayoutParams params =
+                    new LinearLayout.LayoutParams(
+                            binding.seekbarPreviewContainer.getLayoutParams());
+            params.setMarginStart(checkedContainerLeft);
+            binding.seekbarPreviewContainer.setLayoutParams(params);
+        } catch (final Exception ex) {
+            Log.e(TAG, "Failed to adjust seekbarPreviewContainer", ex);
+            // Fallback - position in the middle
+            binding.bottomSeekbarPreviewLayout.setGravity(Gravity.CENTER);
         }
     }
 
@@ -1702,6 +1763,8 @@ public final class Player implements
         showControls(0);
         animate(binding.currentDisplaySeek, true, DEFAULT_CONTROLS_DURATION,
                 AnimationType.SCALE_AND_ALPHA);
+        animate(binding.currentSeekbarPreviewThumbnail, true, DEFAULT_CONTROLS_DURATION,
+                AnimationType.SCALE_AND_ALPHA);
     }
 
     @Override // seekbar listener
@@ -1717,6 +1780,7 @@ public final class Player implements
 
         binding.playbackCurrentTime.setText(getTimeString(seekBar.getProgress()));
         animate(binding.currentDisplaySeek, false, 200, AnimationType.SCALE_AND_ALPHA);
+        animate(binding.currentSeekbarPreviewThumbnail, false, 200, AnimationType.SCALE_AND_ALPHA);
 
         if (currentState == STATE_PAUSED_SEEK) {
             changeState(STATE_BUFFERING);
@@ -2865,6 +2929,10 @@ public final class Player implements
 
         binding.titleTextView.setText(tag.getMetadata().getName());
         binding.channelTextView.setText(tag.getMetadata().getUploaderName());
+
+        this.seekbarPreviewThumbnailHolder.resetFrom(
+                this.getContext(),
+                tag.getMetadata().getPreviewFrames());
 
         NotificationUtil.getInstance().createNotificationIfNeededAndUpdate(this, false);
         notifyMetadataUpdateToListeners();

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -27,7 +27,6 @@ import android.util.DisplayMetrics;
 import android.util.Log;
 import android.util.TypedValue;
 import android.view.ContextThemeWrapper;
-import android.view.GestureDetector;
 import android.view.Gravity;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;

--- a/app/src/main/java/org/schabi/newpipe/player/seekbarpreview/SeekbarPreviewThumbnailHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/player/seekbarpreview/SeekbarPreviewThumbnailHelper.java
@@ -1,0 +1,108 @@
+package org.schabi.newpipe.player.seekbarpreview;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.util.Log;
+import android.view.View;
+import android.widget.ImageView;
+
+import androidx.annotation.IntDef;
+import androidx.annotation.NonNull;
+import androidx.preference.PreferenceManager;
+
+import org.schabi.newpipe.R;
+import org.schabi.newpipe.util.DeviceUtils;
+
+import java.lang.annotation.Retention;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.IntSupplier;
+
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+import static org.schabi.newpipe.player.seekbarpreview.SeekbarPreviewThumbnailHelper.SeekbarPreviewThumbnailType.HIGH_QUALITY;
+import static org.schabi.newpipe.player.seekbarpreview.SeekbarPreviewThumbnailHelper.SeekbarPreviewThumbnailType.LOW_QUALITY;
+import static org.schabi.newpipe.player.seekbarpreview.SeekbarPreviewThumbnailHelper.SeekbarPreviewThumbnailType.NONE;
+
+/**
+ * Helper for the seekbar preview.
+ */
+public final class SeekbarPreviewThumbnailHelper {
+
+    // This has to be <= 23 chars on devices running Android 7 or lower (API <= 25)
+    // or it fails with an IllegalArgumentException
+    // https://stackoverflow.com/a/54744028
+    public static final String TAG = "SeekbarPrevThumbHelper";
+
+    private SeekbarPreviewThumbnailHelper() {
+        // No impl pls
+    }
+
+    @Retention(SOURCE)
+    @IntDef({HIGH_QUALITY, LOW_QUALITY,
+            NONE})
+    public @interface SeekbarPreviewThumbnailType {
+        int HIGH_QUALITY = 0;
+        int LOW_QUALITY = 1;
+        int NONE = 2;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Settings Resolution
+    ///////////////////////////////////////////////////////////////////////////
+
+    @SeekbarPreviewThumbnailType
+    public static int getSeekbarPreviewThumbnailType(@NonNull final Context context) {
+        final String type = PreferenceManager.getDefaultSharedPreferences(context).getString(
+                context.getString(R.string.seekbar_preview_thumbnail_key), "");
+        if (type.equals(context.getString(R.string.seekbar_preview_thumbnail_none))) {
+            return NONE;
+        } else if (type.equals(context.getString(R.string.seekbar_preview_thumbnail_low_quality))) {
+            return LOW_QUALITY;
+        } else {
+            return HIGH_QUALITY; // default
+        }
+    }
+
+    public static void tryResizeAndSetSeekbarPreviewThumbnail(
+            @NonNull final Context context,
+            @NonNull final Optional<Bitmap> optPreviewThumbnail,
+            @NonNull final ImageView currentSeekbarPreviewThumbnail,
+            @NonNull final IntSupplier baseViewWidthSupplier) {
+
+        if (!optPreviewThumbnail.isPresent()) {
+            currentSeekbarPreviewThumbnail.setVisibility(View.GONE);
+            return;
+        }
+
+        currentSeekbarPreviewThumbnail.setVisibility(View.VISIBLE);
+        final Bitmap srcBitmap = optPreviewThumbnail.get();
+
+        // Resize original bitmap
+        try {
+            Objects.requireNonNull(srcBitmap);
+
+            final int srcWidth = srcBitmap.getWidth() > 0 ? srcBitmap.getWidth() : 1;
+            final int newWidth = Math.max(
+                    Math.min(
+                            // Use 1/4 of the width for the preview
+                            Math.round(baseViewWidthSupplier.getAsInt() / 4f),
+                            // Scaling more than that factor looks really pixelated -> max
+                            Math.round(srcWidth * 2.5f)
+                    ),
+                    // Min width = 80dp
+                    DeviceUtils.dpToPx(80, context)
+            );
+
+            final float scaleFactor = (float) newWidth / srcWidth;
+            final int newHeight = (int) (srcBitmap.getHeight() * scaleFactor);
+
+            currentSeekbarPreviewThumbnail.setImageBitmap(
+                    Bitmap.createScaledBitmap(srcBitmap, newWidth, newHeight, true));
+        } catch (final Exception ex) {
+            Log.e(TAG, "Failed to resize and set seekbar preview thumbnail", ex);
+            currentSeekbarPreviewThumbnail.setVisibility(View.GONE);
+        } finally {
+            srcBitmap.recycle();
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/seekbarpreview/SeekbarPreviewThumbnailHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/player/seekbarpreview/SeekbarPreviewThumbnailHelper.java
@@ -89,8 +89,8 @@ public final class SeekbarPreviewThumbnailHelper {
                             // Scaling more than that factor looks really pixelated -> max
                             Math.round(srcWidth * 2.5f)
                     ),
-                    // Min width = 80dp
-                    DeviceUtils.dpToPx(80, context)
+                    // Min width = 10dp
+                    DeviceUtils.dpToPx(10, context)
             );
 
             final float scaleFactor = (float) newWidth / srcWidth;

--- a/app/src/main/java/org/schabi/newpipe/player/seekbarpreview/SeekbarPreviewThumbnailHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/player/seekbarpreview/SeekbarPreviewThumbnailHolder.java
@@ -1,0 +1,252 @@
+package org.schabi.newpipe.player.seekbarpreview;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+
+import com.google.common.base.Stopwatch;
+import com.nostra13.universalimageloader.core.ImageLoader;
+
+import org.schabi.newpipe.extractor.stream.Frameset;
+import org.schabi.newpipe.util.ImageDisplayConstants;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import static org.schabi.newpipe.player.seekbarpreview.SeekbarPreviewThumbnailHelper.SeekbarPreviewThumbnailType;
+
+public class SeekbarPreviewThumbnailHolder {
+
+    // This has to be <= 23 chars on devices running Android 7 or lower (API <= 25)
+    // or it fails with an IllegalArgumentException
+    // https://stackoverflow.com/a/54744028
+    public static final String TAG = "SeekbarPrevThumbHolder";
+
+    // Key = Position of the picture in milliseconds
+    // Supplier = Supplies the bitmap for that position
+    private final Map<Integer, Supplier<Bitmap>> seekbarPreviewData = new ConcurrentHashMap<>();
+
+    // This ensures that if the reset is still undergoing
+    // and another reset starts, only the last reset is processed
+    private UUID currentUpdateRequestIdentifier = UUID.randomUUID();
+
+    public synchronized void resetFrom(
+            @NonNull final Context context,
+            final List<Frameset> framesets) {
+
+        final int seekbarPreviewType =
+                SeekbarPreviewThumbnailHelper.getSeekbarPreviewThumbnailType(context);
+
+        final UUID updateRequestIdentifier = UUID.randomUUID();
+        this.currentUpdateRequestIdentifier = updateRequestIdentifier;
+
+        final ExecutorService executorService = Executors.newSingleThreadExecutor();
+        executorService.submit(() -> {
+            try {
+                resetFromAsync(seekbarPreviewType, framesets, updateRequestIdentifier);
+            } catch (final Exception ex) {
+                Log.e(TAG, "Failed to execute async", ex);
+            }
+        });
+        // ensure that the executorService stops/destroys it's threads
+        // after the task is finished
+        executorService.shutdown();
+    }
+
+    private void resetFromAsync(
+            final int seekbarPreviewType,
+            final List<Frameset> framesets,
+            final UUID updateRequestIdentifier) {
+
+        Log.d(TAG, "Clearing seekbarPreviewData");
+        seekbarPreviewData.clear();
+
+        if (seekbarPreviewType == SeekbarPreviewThumbnailType.NONE) {
+            Log.d(TAG, "Not processing seekbarPreviewData due to settings");
+            return;
+        }
+
+        final Frameset frameset = getFrameSetForType(framesets, seekbarPreviewType);
+        if (frameset == null) {
+            Log.d(TAG, "No frameset was found to fill seekbarPreviewData");
+            return;
+        }
+
+        Log.d(TAG, "Frameset quality info: "
+                + "[width=" + frameset.getFrameWidth()
+                + ", heigh=" + frameset.getFrameHeight() + "]");
+
+        // Abort method execution if we are not the latest request
+        if (!isRequestIdentifierCurrent(updateRequestIdentifier)) {
+            return;
+        }
+
+        generateDataFrom(frameset, updateRequestIdentifier);
+    }
+
+    private Frameset getFrameSetForType(
+            final List<Frameset> framesets,
+            final int seekbarPreviewType) {
+
+        if (seekbarPreviewType == SeekbarPreviewThumbnailType.HIGH_QUALITY) {
+            Log.d(TAG, "Strategy for seekbarPreviewData: high quality");
+            return framesets.stream()
+                    .max(Comparator.comparingInt(fs -> fs.getFrameHeight() * fs.getFrameWidth()))
+                    .orElse(null);
+        } else {
+            Log.d(TAG, "Strategy for seekbarPreviewData: low quality");
+            return framesets.stream()
+                    .min(Comparator.comparingInt(fs -> fs.getFrameHeight() * fs.getFrameWidth()))
+                    .orElse(null);
+        }
+    }
+
+    private void generateDataFrom(
+            final Frameset frameset,
+            final UUID updateRequestIdentifier) {
+
+        Log.d(TAG, "Starting generation of seekbarPreviewData");
+        final Stopwatch sw = Log.isLoggable(TAG, Log.DEBUG) ? Stopwatch.createStarted() : null;
+
+        int currentPosMs = 0;
+        int pos = 1;
+
+        final int frameCountPerUrl = frameset.getFramesPerPageX() * frameset.getFramesPerPageY();
+
+        // Process each url in the frameset
+        for (final String url : frameset.getUrls()) {
+            // get the bitmap
+            final Bitmap srcBitMap = getBitMapFrom(url);
+
+            // The data is not added directly to "seekbarPreviewData" due to
+            // concurrency and checks for "updateRequestIdentifier"
+            final Map<Integer, Supplier<Bitmap>> generatedDataForUrl = new HashMap<>();
+
+            // The bitmap consists of several images, which we process here
+            // foreach frame in the returned bitmap
+            for (int i = 0; i < frameCountPerUrl; i++) {
+                // Frames outside the video length are skipped
+                if (pos > frameset.getTotalCount()) {
+                    break;
+                }
+
+                // Get the bounds where the frame is found
+                final int[] bounds = frameset.getFrameBoundsAt(currentPosMs);
+                generatedDataForUrl.put(currentPosMs, () -> {
+                    // It can happen, that the original bitmap could not be downloaded
+                    // In such a case - we don't want a NullPointer - simply return null
+                    if (srcBitMap == null) {
+                        return null;
+                    }
+
+                    // Cut out the corresponding bitmap form the "srcBitMap"
+                    return Bitmap.createBitmap(srcBitMap, bounds[1], bounds[2],
+                            frameset.getFrameWidth(), frameset.getFrameHeight());
+                });
+
+                currentPosMs += frameset.getDurationPerFrame();
+                pos++;
+            }
+
+            // Check if we are still the latest request
+            // If not abort method execution
+            if (isRequestIdentifierCurrent(updateRequestIdentifier)) {
+                seekbarPreviewData.putAll(generatedDataForUrl);
+            } else {
+                Log.d(TAG, "Aborted of generation of seekbarPreviewData");
+                break;
+            }
+        }
+
+        if (sw != null) {
+            Log.d(TAG, "Generation of seekbarPreviewData took " + sw.stop().toString());
+        }
+    }
+
+    private Bitmap getBitMapFrom(final String url) {
+        if (url == null) {
+            Log.w(TAG, "url is null; This should never happen");
+            return null;
+        }
+
+        final Stopwatch sw = Log.isLoggable(TAG, Log.DEBUG) ? Stopwatch.createStarted() : null;
+        try {
+            final SyncImageLoadingListener syncImageLoadingListener =
+                    new SyncImageLoadingListener();
+
+            Log.d(TAG, "Downloading bitmap for seekbarPreview from '" + url + "'");
+
+            // Ensure that everything is running
+            ImageLoader.getInstance().resume();
+            // Load the image
+            // Impl-Note:
+            // Ensure that your are not running on the main-Thread this will otherwise hang
+            ImageLoader.getInstance().loadImage(
+                    url,
+                    ImageDisplayConstants.DISPLAY_SEEKBAR_PREVIEW_OPTIONS,
+                    syncImageLoadingListener);
+
+            // Get the bitmap within the timeout
+            final Bitmap bitmap =
+                    syncImageLoadingListener.waitForBitmapOrThrow(30, TimeUnit.SECONDS);
+
+            if (sw != null) {
+                Log.d(TAG,
+                        "Download of bitmap for seekbarPreview from '" + url
+                                + "' took " + sw.stop().toString());
+            }
+
+            return bitmap;
+        } catch (final Exception ex) {
+            Log.w(TAG,
+                    "Failed to get bitmap for seekbarPreview from url='" + url
+                            + "' in time",
+                    ex);
+            return null;
+        }
+    }
+
+    private boolean isRequestIdentifierCurrent(final UUID requestIdentifier) {
+        return this.currentUpdateRequestIdentifier.equals(requestIdentifier);
+    }
+
+
+    public Optional<Bitmap> getBitmapAt(final int positionInMs) {
+        // Check if the BitmapData is empty
+        if (seekbarPreviewData.isEmpty()) {
+            return Optional.empty();
+        }
+
+        // Get the closest frame to the requested position
+        final int closestIndexPosition =
+                seekbarPreviewData.keySet().stream()
+                        .min(Comparator.comparingInt(i -> Math.abs(i - positionInMs)))
+                        .orElse(-1);
+
+        // this should never happen, because
+        // it indicates that "seekbarPreviewData" is empty which was already checked
+        if (closestIndexPosition == -1) {
+            return Optional.empty();
+        }
+
+        try {
+            // Get the bitmap for the position (executes the supplier)
+            return Optional.ofNullable(seekbarPreviewData.get(closestIndexPosition).get());
+        } catch (final Exception ex) {
+            // If there is an error, log it and return Optional.empty
+            Log.w(TAG, "Unable to get seekbar preview", ex);
+            return Optional.empty();
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/seekbarpreview/SyncImageLoadingListener.java
+++ b/app/src/main/java/org/schabi/newpipe/player/seekbarpreview/SyncImageLoadingListener.java
@@ -1,0 +1,87 @@
+package org.schabi.newpipe.player.seekbarpreview;
+
+import android.graphics.Bitmap;
+import android.view.View;
+
+import com.nostra13.universalimageloader.core.assist.FailReason;
+import com.nostra13.universalimageloader.core.listener.SimpleImageLoadingListener;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Listener for synchronously downloading of an image/bitmap.
+ */
+public class SyncImageLoadingListener extends SimpleImageLoadingListener {
+
+    private final CountDownLatch countDownLatch = new CountDownLatch(1);
+
+    private Bitmap bitmap;
+    private boolean cancelled = false;
+    private FailReason failReason = null;
+
+    @SuppressWarnings("checkstyle:HiddenField")
+    @Override
+    public void onLoadingFailed(
+            final String imageUri,
+            final View view,
+            final FailReason failReason) {
+
+        this.failReason = failReason;
+        countDownLatch.countDown();
+    }
+
+    @Override
+    public void onLoadingComplete(
+            final String imageUri,
+            final View view,
+            final Bitmap loadedImage) {
+
+        bitmap = loadedImage;
+        countDownLatch.countDown();
+    }
+
+    @Override
+    public void onLoadingCancelled(final String imageUri, final View view) {
+        cancelled = true;
+        countDownLatch.countDown();
+    }
+
+    public Bitmap waitForBitmapOrThrow(final long timeout, final TimeUnit timeUnit)
+            throws InterruptedException, TimeoutException {
+
+        // Wait for the download to finish
+        if (!countDownLatch.await(timeout, timeUnit)) {
+            throw new TimeoutException("Couldn't get the image in time");
+        }
+
+        if (isCancelled()) {
+            throw new CancellationException("Download of image was cancelled");
+        }
+
+        if (getFailReason() != null) {
+            throw new RuntimeException("Failed to download image" + getFailReason().getType(),
+                    getFailReason().getCause());
+        }
+
+        if (getBitmap() == null) {
+            throw new NullPointerException("Bitmap is null");
+        }
+
+        return getBitmap();
+    }
+
+    public Bitmap getBitmap() {
+        return bitmap;
+    }
+
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    public FailReason getFailReason() {
+        return failReason;
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/util/ImageDisplayConstants.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ImageDisplayConstants.java
@@ -56,5 +56,10 @@ public final class ImageDisplayConstants {
                     .showImageOnFail(R.drawable.dummy_thumbnail_playlist)
                     .build();
 
+    public static final DisplayImageOptions DISPLAY_SEEKBAR_PREVIEW_OPTIONS =
+            new DisplayImageOptions.Builder()
+                    .cloneFrom(BASE_DISPLAY_IMAGE_OPTIONS)
+                    .build();
+
     private ImageDisplayConstants() { }
 }

--- a/app/src/main/res/layout-large-land/player.xml
+++ b/app/src/main/res/layout-large-land/player.xml
@@ -367,7 +367,7 @@
                     android:layout_height="wrap_content"
                     android:gravity="center"
                     android:orientation="vertical"
-                    android:paddingBottom="8dp">
+                    android:paddingBottom="12dp">
 
                     <TextView
                         android:id="@+id/currentDisplaySeek"

--- a/app/src/main/res/layout-large-land/player.xml
+++ b/app/src/main/res/layout-large-land/player.xml
@@ -369,15 +369,6 @@
                     android:orientation="vertical"
                     android:paddingBottom="8dp">
 
-                    <ImageView
-                        android:id="@+id/currentSeekbarPreviewThumbnail"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:paddingBottom="2dp"
-                        android:visibility="gone"
-                        app:srcCompat="@drawable/dummy_thumbnail"
-                        tools:visibility="visible" />
-
                     <TextView
                         android:id="@+id/currentDisplaySeek"
                         android:layout_width="wrap_content"
@@ -392,6 +383,15 @@
                         android:visibility="gone"
                         tools:ignore="RtlHardcoded"
                         tools:text="1:06:29"
+                        tools:visibility="visible" />
+
+                    <ImageView
+                        android:id="@+id/currentSeekbarPreviewThumbnail"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:paddingTop="2dp"
+                        android:visibility="gone"
+                        app:srcCompat="@drawable/dummy_thumbnail"
                         tools:visibility="visible" />
 
                 </LinearLayout>

--- a/app/src/main/res/layout-large-land/player.xml
+++ b/app/src/main/res/layout-large-land/player.xml
@@ -103,8 +103,8 @@
                         android:padding="@dimen/player_main_buttons_padding"
                         android:scaleType="fitXY"
                         android:visibility="gone"
-                        app:tint="@color/white"
                         app:srcCompat="@drawable/ic_close"
+                        app:tint="@color/white"
                         tools:ignore="ContentDescription,RtlHardcoded" />
 
                     <LinearLayout
@@ -189,8 +189,8 @@
                         android:paddingBottom="3dp"
                         android:scaleType="fitCenter"
                         android:visibility="gone"
-                        app:tint="@color/white"
                         app:srcCompat="@drawable/ic_list"
+                        app:tint="@color/white"
                         tools:ignore="ContentDescription,RtlHardcoded"
                         tools:visibility="visible" />
 
@@ -208,8 +208,8 @@
                         android:paddingBottom="3dp"
                         android:scaleType="fitCenter"
                         android:visibility="gone"
-                        app:tint="@color/white"
                         app:srcCompat="@drawable/ic_format_list_numbered"
+                        app:tint="@color/white"
                         tools:ignore="ContentDescription,RtlHardcoded"
                         tools:visibility="visible" />
 
@@ -222,8 +222,8 @@
                         android:focusable="true"
                         android:padding="@dimen/player_main_buttons_padding"
                         android:scaleType="fitXY"
-                        app:tint="@color/white"
                         app:srcCompat="@drawable/ic_expand_more"
+                        app:tint="@color/white"
                         tools:ignore="ContentDescription,RtlHardcoded" />
 
                 </LinearLayout>
@@ -287,8 +287,8 @@
                         android:focusable="true"
                         android:padding="@dimen/player_main_buttons_padding"
                         android:scaleType="fitXY"
-                        app:tint="@color/white"
                         app:srcCompat="@drawable/ic_cast"
+                        app:tint="@color/white"
                         tools:ignore="RtlHardcoded" />
 
                     <androidx.appcompat.widget.AppCompatImageButton
@@ -302,8 +302,8 @@
                         android:focusable="true"
                         android:padding="@dimen/player_main_buttons_padding"
                         android:scaleType="fitXY"
-                        app:tint="@color/white"
                         app:srcCompat="@drawable/ic_language"
+                        app:tint="@color/white"
                         tools:ignore="RtlHardcoded" />
 
                     <androidx.appcompat.widget.AppCompatImageButton
@@ -317,8 +317,8 @@
                         android:focusable="true"
                         android:padding="@dimen/player_main_buttons_padding"
                         android:scaleType="fitXY"
-                        app:tint="@color/white"
                         app:srcCompat="@drawable/ic_share"
+                        app:tint="@color/white"
                         tools:ignore="RtlHardcoded" />
 
                     <androidx.appcompat.widget.AppCompatImageButton
@@ -331,8 +331,8 @@
                         android:focusable="true"
                         android:padding="@dimen/player_main_buttons_padding"
                         android:scaleType="fitXY"
-                        app:tint="@color/white"
                         app:srcCompat="@drawable/ic_volume_off"
+                        app:tint="@color/white"
                         tools:ignore="RtlHardcoded" />
 
                     <androidx.appcompat.widget.AppCompatImageButton
@@ -345,9 +345,52 @@
                         android:padding="@dimen/player_main_buttons_padding"
                         android:scaleType="fitCenter"
                         android:visibility="gone"
-                        app:tint="@color/white"
                         app:srcCompat="@drawable/ic_fullscreen"
+                        app:tint="@color/white"
                         tools:ignore="ContentDescription,RtlHardcoded"
+                        tools:visibility="visible" />
+
+                </LinearLayout>
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/bottomSeekbarPreviewLayout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_above="@id/bottomControls"
+                android:orientation="horizontal">
+
+                <LinearLayout
+                    android:id="@+id/seekbarPreviewContainer"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:orientation="vertical">
+
+                    <ImageView
+                        android:id="@+id/currentSeekbarPreviewThumbnail"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:paddingBottom="3dp"
+                        android:visibility="gone"
+                        app:srcCompat="@drawable/dummy_thumbnail"
+                        tools:visibility="visible" />
+
+                    <TextView
+                        android:id="@+id/currentDisplaySeek"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:background="#60000000"
+                        android:paddingLeft="5dp"
+                        android:paddingRight="5dp"
+                        android:paddingBottom="2dp"
+                        android:textColor="@android:color/white"
+                        android:textSize="14sp"
+                        android:textStyle="bold"
+                        android:visibility="gone"
+                        tools:ignore="RtlHardcoded"
+                        tools:text="1:06:29"
                         tools:visibility="visible" />
 
                 </LinearLayout>
@@ -685,24 +728,6 @@
                     tools:src="@drawable/ic_brightness_high" />
             </RelativeLayout>
 
-            <TextView
-                android:id="@+id/currentDisplaySeek"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_centerInParent="true"
-                android:layout_marginBottom="58dp"
-                android:background="#64000000"
-                android:paddingLeft="30dp"
-                android:paddingTop="10dp"
-                android:paddingRight="30dp"
-                android:paddingBottom="10dp"
-                android:textColor="@android:color/white"
-                android:textSize="26sp"
-                android:textStyle="bold"
-                android:visibility="gone"
-                tools:ignore="RtlHardcoded"
-                tools:text="1:06:29"
-                tools:visibility="visible" />
         </RelativeLayout>
 
     </RelativeLayout>

--- a/app/src/main/res/layout-large-land/player.xml
+++ b/app/src/main/res/layout-large-land/player.xml
@@ -366,13 +366,14 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:gravity="center"
-                    android:orientation="vertical">
+                    android:orientation="vertical"
+                    android:paddingBottom="8dp">
 
                     <ImageView
                         android:id="@+id/currentSeekbarPreviewThumbnail"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:paddingBottom="3dp"
+                        android:paddingBottom="2dp"
                         android:visibility="gone"
                         app:srcCompat="@drawable/dummy_thumbnail"
                         tools:visibility="visible" />

--- a/app/src/main/res/layout-large-land/player.xml
+++ b/app/src/main/res/layout-large-land/player.xml
@@ -386,7 +386,7 @@
                         android:paddingRight="5dp"
                         android:paddingBottom="2dp"
                         android:textColor="@android:color/white"
-                        android:textSize="14sp"
+                        android:textSize="18sp"
                         android:textStyle="bold"
                         android:visibility="gone"
                         tools:ignore="RtlHardcoded"

--- a/app/src/main/res/layout/player.xml
+++ b/app/src/main/res/layout/player.xml
@@ -365,13 +365,14 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:gravity="center"
-                    android:orientation="vertical">
+                    android:orientation="vertical"
+                    android:paddingBottom="8dp">
 
                     <ImageView
                         android:id="@+id/currentSeekbarPreviewThumbnail"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:paddingBottom="3dp"
+                        android:paddingBottom="2dp"
                         android:visibility="gone"
                         app:srcCompat="@drawable/dummy_thumbnail"
                         tools:visibility="visible" />

--- a/app/src/main/res/layout/player.xml
+++ b/app/src/main/res/layout/player.xml
@@ -385,7 +385,7 @@
                         android:paddingRight="5dp"
                         android:paddingBottom="2dp"
                         android:textColor="@android:color/white"
-                        android:textSize="14sp"
+                        android:textSize="18sp"
                         android:textStyle="bold"
                         android:visibility="gone"
                         tools:ignore="RtlHardcoded"

--- a/app/src/main/res/layout/player.xml
+++ b/app/src/main/res/layout/player.xml
@@ -101,8 +101,8 @@
                         android:padding="@dimen/player_main_buttons_padding"
                         android:scaleType="fitXY"
                         android:visibility="gone"
-                        app:tint="@color/white"
                         app:srcCompat="@drawable/ic_close"
+                        app:tint="@color/white"
                         tools:ignore="ContentDescription,RtlHardcoded" />
 
                     <LinearLayout
@@ -191,8 +191,8 @@
                         android:paddingBottom="3dp"
                         android:scaleType="fitCenter"
                         android:visibility="gone"
-                        app:tint="@color/white"
                         app:srcCompat="@drawable/ic_list"
+                        app:tint="@color/white"
                         tools:ignore="ContentDescription,RtlHardcoded" />
 
                     <androidx.appcompat.widget.AppCompatImageButton
@@ -209,8 +209,8 @@
                         android:paddingBottom="3dp"
                         android:scaleType="fitCenter"
                         android:visibility="gone"
-                        app:tint="@color/white"
                         app:srcCompat="@drawable/ic_format_list_numbered"
+                        app:tint="@color/white"
                         tools:ignore="ContentDescription,RtlHardcoded" />
 
                     <androidx.appcompat.widget.AppCompatImageButton
@@ -222,8 +222,8 @@
                         android:focusable="true"
                         android:padding="@dimen/player_main_buttons_padding"
                         android:scaleType="fitXY"
-                        app:tint="@color/white"
                         app:srcCompat="@drawable/ic_expand_more"
+                        app:tint="@color/white"
                         tools:ignore="ContentDescription,RtlHardcoded" />
 
                 </LinearLayout>
@@ -286,8 +286,8 @@
                         android:focusable="true"
                         android:padding="@dimen/player_main_buttons_padding"
                         android:scaleType="fitXY"
-                        app:tint="@color/white"
                         app:srcCompat="@drawable/ic_cast"
+                        app:tint="@color/white"
                         tools:ignore="RtlHardcoded" />
 
                     <androidx.appcompat.widget.AppCompatImageButton
@@ -301,8 +301,8 @@
                         android:focusable="true"
                         android:padding="@dimen/player_main_buttons_padding"
                         android:scaleType="fitXY"
-                        app:tint="@color/white"
                         app:srcCompat="@drawable/ic_language"
+                        app:tint="@color/white"
                         tools:ignore="RtlHardcoded" />
 
                     <androidx.appcompat.widget.AppCompatImageButton
@@ -316,8 +316,8 @@
                         android:focusable="true"
                         android:padding="@dimen/player_main_buttons_padding"
                         android:scaleType="fitXY"
-                        app:tint="@color/white"
                         app:srcCompat="@drawable/ic_share"
+                        app:tint="@color/white"
                         tools:ignore="RtlHardcoded" />
 
                     <androidx.appcompat.widget.AppCompatImageButton
@@ -330,8 +330,8 @@
                         android:focusable="true"
                         android:padding="@dimen/player_main_buttons_padding"
                         android:scaleType="fitXY"
-                        app:tint="@color/white"
                         app:srcCompat="@drawable/ic_volume_off"
+                        app:tint="@color/white"
                         tools:ignore="RtlHardcoded" />
 
                     <androidx.appcompat.widget.AppCompatImageButton
@@ -344,9 +344,52 @@
                         android:padding="@dimen/player_main_buttons_padding"
                         android:scaleType="fitCenter"
                         android:visibility="gone"
-                        app:tint="@color/white"
                         app:srcCompat="@drawable/ic_fullscreen"
+                        app:tint="@color/white"
                         tools:ignore="ContentDescription,RtlHardcoded"
+                        tools:visibility="visible" />
+
+                </LinearLayout>
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/bottomSeekbarPreviewLayout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_above="@id/bottomControls"
+                android:orientation="horizontal">
+
+                <LinearLayout
+                    android:id="@+id/seekbarPreviewContainer"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:orientation="vertical">
+
+                    <ImageView
+                        android:id="@+id/currentSeekbarPreviewThumbnail"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:paddingBottom="3dp"
+                        android:visibility="gone"
+                        app:srcCompat="@drawable/dummy_thumbnail"
+                        tools:visibility="visible" />
+
+                    <TextView
+                        android:id="@+id/currentDisplaySeek"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:background="#60000000"
+                        android:paddingLeft="5dp"
+                        android:paddingRight="5dp"
+                        android:paddingBottom="2dp"
+                        android:textColor="@android:color/white"
+                        android:textSize="14sp"
+                        android:textStyle="bold"
+                        android:visibility="gone"
+                        tools:ignore="RtlHardcoded"
+                        tools:text="1:06:29"
                         tools:visibility="visible" />
 
                 </LinearLayout>
@@ -681,24 +724,6 @@
                     tools:src="@drawable/ic_brightness" />
             </RelativeLayout>
 
-            <TextView
-                android:id="@+id/currentDisplaySeek"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_centerInParent="true"
-                android:layout_marginBottom="58dp"
-                android:background="#64000000"
-                android:paddingLeft="30dp"
-                android:paddingTop="10dp"
-                android:paddingRight="30dp"
-                android:paddingBottom="10dp"
-                android:textColor="@android:color/white"
-                android:textSize="26sp"
-                android:textStyle="bold"
-                android:visibility="gone"
-                tools:ignore="RtlHardcoded"
-                tools:text="1:06:29"
-                tools:visibility="visible" />
         </RelativeLayout>
 
     </RelativeLayout>

--- a/app/src/main/res/layout/player.xml
+++ b/app/src/main/res/layout/player.xml
@@ -366,7 +366,7 @@
                     android:layout_height="wrap_content"
                     android:gravity="center"
                     android:orientation="vertical"
-                    android:paddingBottom="8dp">
+                    android:paddingBottom="12dp">
 
                     <TextView
                         android:id="@+id/currentDisplaySeek"

--- a/app/src/main/res/layout/player.xml
+++ b/app/src/main/res/layout/player.xml
@@ -368,15 +368,6 @@
                     android:orientation="vertical"
                     android:paddingBottom="8dp">
 
-                    <ImageView
-                        android:id="@+id/currentSeekbarPreviewThumbnail"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:paddingBottom="2dp"
-                        android:visibility="gone"
-                        app:srcCompat="@drawable/dummy_thumbnail"
-                        tools:visibility="visible" />
-
                     <TextView
                         android:id="@+id/currentDisplaySeek"
                         android:layout_width="wrap_content"
@@ -391,6 +382,15 @@
                         android:visibility="gone"
                         tools:ignore="RtlHardcoded"
                         tools:text="1:06:29"
+                        tools:visibility="visible" />
+
+                    <ImageView
+                        android:id="@+id/currentSeekbarPreviewThumbnail"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:paddingTop="2dp"
+                        android:visibility="gone"
+                        app:srcCompat="@drawable/dummy_thumbnail"
                         tools:visibility="visible" />
 
                 </LinearLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -422,6 +422,10 @@
     <string name="grid">Raster</string>
     <string name="auto">Automatisch</string>
     <string name="switch_view">Ansicht wechseln</string>
+    <string name="seekbar_preview_thumbnail_title">Vorschaubild der Suchleiste</string>
+    <string name="high_quality_larger">Hohe Qualität (größer)</string>
+    <string name="low_quality_smaller">Niedrige Qualität (kleiner)</string>
+    <string name="dont_show">Nicht anzeigen</string>
     <string name="app_update_notification_content_title">Eine NewPipe-Aktualisierung ist verfügbar!</string>
     <string name="app_update_notification_content_text">Zum Herunterladen antippen</string>
     <string name="missions_header_finished">Fertig</string>

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -89,6 +89,21 @@
         <item>@string/never</item>
     </string-array>
 
+    <string name="seekbar_preview_thumbnail_key" translatable="false">seekbar_preview_thumbnail_key</string>
+    <string name="seekbar_preview_thumbnail_high_quality" translatable="false">seekbar_preview_thumbnail_high_quality</string>
+    <string name="seekbar_preview_thumbnail_low_quality" translatable="false">seekbar_preview_thumbnail_low_quality</string>
+    <string name="seekbar_preview_thumbnail_none" translatable="false">seekbar_preview_thumbnail_none</string>
+    <string-array name="seekbar_preview_thumbnail_type_key" translatable="false">
+        <item>@string/seekbar_preview_thumbnail_high_quality</item>
+        <item>@string/seekbar_preview_thumbnail_low_quality</item>
+        <item>@string/seekbar_preview_thumbnail_none</item>
+    </string-array>
+    <string-array name="seekbar_preview_thumbnail_type_description" translatable="false">
+        <item>@string/high_quality_larger</item>
+        <item>@string/low_quality_smaller</item>
+        <item>@string/dont_show</item>
+    </string-array>
+
     <string name="default_resolution_key" translatable="false">default_resolution</string>
     <string name="default_resolution_value" translatable="false">720p60</string>
     <string name="show_higher_resolutions_key" translatable="false">show_higher_resolutions</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -587,6 +587,11 @@
     <string name="grid">Grid</string>
     <string name="auto">Auto</string>
     <string name="switch_view">Switch View</string>
+    <!-- Seekbar Preview Thumbnail-->
+    <string name="seekbar_preview_thumbnail_title">Seekbar thumbnail preview</string>
+    <string name="high_quality_larger">High quality (larger)</string>
+    <string name="low_quality_smaller">Low quality (smaller)</string>
+    <string name="dont_show">Don\'t show</string>
     <!-- App update notification -->
     <string name="app_update_notification_content_title">NewPipe update is available!</string>
     <string name="app_update_notification_content_text">Tap to download</string>

--- a/app/src/main/res/xml/video_audio_settings.xml
+++ b/app/src/main/res/xml/video_audio_settings.xml
@@ -79,6 +79,16 @@
             android:summary="@string/show_play_with_kodi_summary"
             android:title="@string/show_play_with_kodi_title"
             app:iconSpaceReserved="false" />
+        <ListPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="seekbar_preview_thumbnail_high_quality"
+            android:entries="@array/seekbar_preview_thumbnail_type_description"
+            android:entryValues="@array/seekbar_preview_thumbnail_type_key"
+            android:key="@string/seekbar_preview_thumbnail_key"
+            android:summary="%s"
+            android:title="@string/seekbar_preview_thumbnail_title"
+            app:iconSpaceReserved="false" />
 
     </PreferenceCategory>
 


### PR DESCRIPTION
### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

### Description of the changes in your PR

<details><summary><b>Click here to show the demo (screenshots + video) data</b><br/> (it's a lot so it's collapsed by default)</summary>
<p>

- Full demo video:

https://user-images.githubusercontent.com/40789489/120905951-e3205980-c655-11eb-8087-59f7e81c2cd6.mp4

- Screenshots:
  - Settings:
![settings1](https://user-images.githubusercontent.com/40789489/120905981-1c58c980-c656-11eb-82d3-50ce8cdb4074.png) ![settings2](https://user-images.githubusercontent.com/40789489/120905994-34304d80-c656-11eb-9a61-5802d543a758.png)
  - Video seekbar thumbnail preview (high quality):
![vid_stp_hq1](https://user-images.githubusercontent.com/40789489/120906026-748fcb80-c656-11eb-9b4d-5ea2994eff8c.png)
![vid_stp_hq2_full](https://user-images.githubusercontent.com/40789489/120906070-b02a9580-c656-11eb-9d1b-6631ab2bb080.png)
  - Video seekbar thumbnail preview (low quality):
![vid_stp_lq1](https://user-images.githubusercontent.com/40789489/120906113-16afb380-c657-11eb-8a55-22925aac9241.png)
![vid_stp_lq1_full](https://user-images.githubusercontent.com/40789489/120906141-478fe880-c657-11eb-8a3f-f3e5d319bac2.png)
  - Video seekbar thumbnail preview (off):
![grafik](https://user-images.githubusercontent.com/40789489/120906267-2f6c9900-c658-11eb-81de-c619a20acd8c.png)

</p>
</details>

<br/>

<details><summary><b>Implementation details (click to open)</b></summary>
<p>
These are the major parts of this implementation:

**(Meta)-Data**
The metadata of a video contains a new field (the extractor had to be modified for this → https://github.com/TeamNewPipe/NewPipeExtractor/pull/647 )
  * This field consists of a list of framesets (yt currently returns 2)
  * The framesets have different preview thumbnail sizes (that's why there exists the option low and high quality in the settings)
  * A frameset has urls to the preview thumbnails; a url returns an ("base") image with multiple preview thumbnails, e.g.
  ![prev_thumb](https://user-images.githubusercontent.com/40789489/120906651-7f992a80-c65b-11eb-9fc5-1fddc9e661a4.png)

**How it get's into the seekbar**
1. Preparing the data

The metadata is changed in the player, when a new video is played/started.

When this happens the urls get asynchronously fetched and processed, which happens mostly in ``SeekbarPreviewThumbnailHolder``

2. Seekbar positioning

Note: The images from the url are not "pre-processed". The extraction of the corresponding preview thumbnail and resizing happens when the seekbar is changed.

When the seekbar is moved the closest image to the current position (in ms) is searched and returned.
If none is found or an error occurs the thumbnail will simply be hidden.

After thumbnail was extracted from/cut out of the "base" image (from the url of the frameset) it will also be resized:
The size of the final thumbnail is calculated as follows:
* absolute min-width: 100dp
* (preferred) width: player-width / 4
* absolute max-width: 2.5 times the original width (else it becomes too pixelated)

**Settings**
New option"seekbar thumbnail preview" (under Settings>Video and audio>Player)
Can contain the following values:
* "High quality (larger)" - default
* "Low quality (smaller)"
* "Don't show" (a thumbnail)

The settings will be applied when the next video is started / opened or more specific when the metadata of the player is changed

</p>
</details>


### Fixes the following issue(s)
- Fixes #3207 

### Relies on the following changes
- https://github.com/TeamNewPipe/NewPipeExtractor/pull/647

### APK testing 
On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.


<details><summary>You may also build/test it with this manual (click to open)</summary>
<p>

* Prepare a new folder
* Checkout https://github.com/litetex/NewPipe/tree/playerSeekbarPreview
* Checkout https://github.com/litetex/NewPipeExtractor/tree/playerSeekbarPreview
* Make sure both of these projects have the same parent folder
* Uncomment 
  ```
  includeBuild('../NewPipeExtractor') {
      dependencySubstitution {
          substitute module('com.github.TeamNewPipe:NewPipeExtractor') with project(':extractor')
      }
  }
  ```
  in [``settings.gradle``](https://github.com/TeamNewPipe/NewPipe/blob/dev/settings.gradle)
* Launch the app using Android Studio or build the apk

</p>
</details>

### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).

### Things that should be checked 👁️‍🗨️ 
#### Technical
I implemented these changes as good as i could think of.
However there the following topics/parts of the code should be checked carefully by the reviewers, because if it fails it may cause excessive problems:
* thread management (a relatively simple ExecutorService is currently used, maybe there are better ways)
* handling of the bitmaps (check for memory leaks)
* Check the thumbnail showing logic / calculation where the seekbar preview container (thumbnail + currentTime) should be 

#### Other behaviors and implementations that should be looked upon
* The resizing of the thumbnail logic - I tested that on "normal" devices (Google Pixel 3a emulated), maybe some devices like tablets or TVs respond differently and the thumbnail is too small or large
