### PR TITLE
Increase width of metadata text view

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
@@ -294,8 +294,10 @@ class SubscriptionFragment : BaseStateFragment<SubscriptionState>() {
     }
 
     private fun showLongTapDialog(selectedItem: ChannelInfoItem) {
-        val commands = arrayOf(getString(R.string.share), getString(R.string.open_in_browser),
-                getString(R.string.unsubscribe))
+        val commands = arrayOf(
+            getString(R.string.share), getString(R.string.open_in_browser),
+            getString(R.string.unsubscribe)
+        )
 
         val actions = DialogInterface.OnClickListener { _, i ->
             when (i) {

--- a/app/src/main/res/layout/item_metadata.xml
+++ b/app/src/main/res/layout/item_metadata.xml
@@ -12,7 +12,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.23" />
+        app:layout_constraintGuide_percent="0.30" />
 
     <TextView
         android:id="@+id/metadata_type_view"

--- a/app/src/main/res/layout/item_metadata_tags.xml
+++ b/app/src/main/res/layout/item_metadata_tags.xml
@@ -9,7 +9,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.23" />
+        app:layout_constraintGuide_percent="0.30" />
 
     <TextView
         android:layout_width="0dp"


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Increase width of metadata text view.
Some translations come with longer words causing them to wrap at strange positions

#### Screenshots
| Before | After |
| -------- | -------- |
| ![Screenshot_1623003898](https://user-images.githubusercontent.com/17365767/120935917-4e753480-c705-11eb-8838-b0d8ab698877.png) | ![Screenshot_1623003780](https://user-images.githubusercontent.com/17365767/120935892-2e457580-c705-11eb-9e92-5346c15efc07.png) |



#### APK testing 
On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
