### PR TITLE
Use constraint layout for play queue item

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
@@ -294,8 +294,10 @@ class SubscriptionFragment : BaseStateFragment<SubscriptionState>() {
     }
 
     private fun showLongTapDialog(selectedItem: ChannelInfoItem) {
-        val commands = arrayOf(getString(R.string.share), getString(R.string.open_in_browser),
-                getString(R.string.unsubscribe))
+        val commands = arrayOf(
+            getString(R.string.share), getString(R.string.open_in_browser),
+            getString(R.string.unsubscribe)
+        )
 
         val actions = DialogInterface.OnClickListener { _, i ->
             when (i) {

--- a/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueueAdapter.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueueAdapter.java
@@ -182,8 +182,10 @@ public class PlayQueueAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
         return ITEM_VIEW_TYPE_ID;
     }
 
+    @NonNull
     @Override
-    public RecyclerView.ViewHolder onCreateViewHolder(final ViewGroup parent, final int type) {
+    public RecyclerView.ViewHolder onCreateViewHolder(@NonNull final ViewGroup parent,
+                                                      final int type) {
         switch (type) {
             case FOOTER_VIEW_TYPE_ID:
                 return new HFHolder(footer);
@@ -197,7 +199,8 @@ public class PlayQueueAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
     }
 
     @Override
-    public void onBindViewHolder(final RecyclerView.ViewHolder holder, final int position) {
+    public void onBindViewHolder(@NonNull final RecyclerView.ViewHolder holder,
+                                 final int position) {
         if (holder instanceof PlayQueueItemHolder) {
             final PlayQueueItemHolder itemHolder = (PlayQueueItemHolder) holder;
 
@@ -207,7 +210,6 @@ public class PlayQueueAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
 
             // Check if the current item should be selected/highlighted
             final boolean isSelected = playQueue.getIndex() == position;
-            itemHolder.itemSelected.setVisibility(isSelected ? View.VISIBLE : View.INVISIBLE);
             itemHolder.itemView.setSelected(isSelected);
         } else if (holder instanceof HFHolder && position == playQueue.getStreams().size()
                 && footer != null && showFooter) {

--- a/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueueItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueueItemHolder.java
@@ -37,7 +37,6 @@ public class PlayQueueItemHolder extends RecyclerView.ViewHolder {
     public final TextView itemDurationView;
     final TextView itemAdditionalDetailsView;
 
-    final ImageView itemSelected;
     public final ImageView itemThumbnailView;
     final ImageView itemHandle;
 
@@ -49,7 +48,6 @@ public class PlayQueueItemHolder extends RecyclerView.ViewHolder {
         itemVideoTitleView = v.findViewById(R.id.itemVideoTitleView);
         itemDurationView = v.findViewById(R.id.itemDurationView);
         itemAdditionalDetailsView = v.findViewById(R.id.itemAdditionalDetails);
-        itemSelected = v.findViewById(R.id.itemSelected);
         itemThumbnailView = v.findViewById(R.id.itemThumbnailView);
         itemHandle = v.findViewById(R.id.itemHandle);
     }

--- a/app/src/main/res/layout/play_queue_item.xml
+++ b/app/src/main/res/layout/play_queue_item.xml
@@ -1,102 +1,99 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/itemRoot"
     android:layout_width="match_parent"
-    android:layout_height="48dp"
+    android:layout_height="wrap_content"
     android:background="?attr/selector"
     android:clickable="true"
     android:focusable="true"
-    android:foreground="?attr/selectableItemBackground"
-    android:paddingTop="6dp"
-    android:paddingBottom="6dp">
-
-    <androidx.appcompat.widget.AppCompatImageView
-        android:id="@+id/itemSelected"
-        android:layout_width="10dp"
-        android:layout_height="10dp"
-        android:layout_alignParentStart="true"
-        android:layout_alignParentLeft="true"
-        android:layout_centerInParent="true"
-        android:layout_marginLeft="2dp"
-        android:layout_marginRight="2dp"
-        android:scaleType="fitXY"
-        app:srcCompat="?attr/ic_selected"
-        tools:ignore="ContentDescription,RtlHardcoded" />
+    android:foreground="?attr/selectableItemBackground">
 
     <ImageView
         android:id="@+id/itemThumbnailView"
         android:layout_width="@dimen/play_queue_thumbnail_width"
         android:layout_height="@dimen/play_queue_thumbnail_height"
-        android:layout_alignParentTop="true"
-        android:layout_marginRight="@dimen/video_item_search_image_right_margin"
-        android:layout_toEndOf="@+id/itemSelected"
-        android:layout_toRightOf="@+id/itemSelected"
+        android:layout_marginStart="@dimen/video_item_search_image_right_margin"
+        android:layout_marginTop="@dimen/video_item_search_image_right_margin"
+        android:layout_marginBottom="@dimen/video_item_search_image_right_margin"
         android:contentDescription="@string/list_thumbnail_view_description"
         android:scaleType="centerCrop"
         android:src="@drawable/dummy_thumbnail"
-        tools:ignore="RtlHardcoded" />
-
-    <androidx.appcompat.widget.AppCompatImageView
-        android:id="@+id/itemHandle"
-        android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:layout_alignParentRight="true"
-        android:layout_gravity="center_vertical"
-        android:padding="@dimen/video_item_search_image_right_margin"
-        android:scaleType="center"
-        app:srcCompat="@drawable/ic_drag_handle"
-        tools:ignore="ContentDescription,RtlHardcoded" />
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
         android:id="@+id/itemDurationView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignRight="@id/itemThumbnailView"
+        android:layout_alignEnd="@id/itemThumbnailView"
         android:layout_alignBottom="@id/itemThumbnailView"
-        android:layout_marginRight="@dimen/video_item_search_duration_margin"
+        android:layout_marginEnd="@dimen/video_item_search_duration_margin"
         android:layout_marginBottom="@dimen/video_item_search_duration_margin"
         android:background="@color/duration_background_color"
-        android:paddingLeft="@dimen/video_item_search_duration_horizontal_padding"
+        android:paddingStart="@dimen/video_item_search_duration_horizontal_padding"
         android:paddingTop="@dimen/video_item_search_duration_vertical_padding"
-        android:paddingRight="@dimen/video_item_search_duration_horizontal_padding"
+        android:paddingEnd="@dimen/video_item_search_duration_horizontal_padding"
         android:paddingBottom="@dimen/video_item_search_duration_vertical_padding"
         android:textAppearance="?android:attr/textAppearanceSmall"
         android:textColor="@color/duration_text_color"
         android:textSize="@dimen/video_item_search_duration_text_size"
-        tools:ignore="RtlHardcoded"
+        app:layout_constraintBottom_toBottomOf="@+id/itemThumbnailView"
+        app:layout_constraintEnd_toEndOf="@+id/itemThumbnailView"
         tools:text="1:09:10" />
 
 
     <TextView
         android:id="@+id/itemVideoTitleView"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_alignParentTop="true"
+        android:layout_marginStart="8dp"
         android:layout_toStartOf="@id/itemHandle"
-        android:layout_toLeftOf="@id/itemHandle"
         android:layout_toEndOf="@id/itemThumbnailView"
-        android:layout_toRightOf="@id/itemThumbnailView"
         android:ellipsize="end"
         android:singleLine="true"
         android:textAppearance="?android:attr/textAppearanceLarge"
         android:textSize="@dimen/video_item_search_title_text_size"
-        tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. " />
+        app:layout_constraintBottom_toTopOf="@+id/itemAdditionalDetails"
+        app:layout_constraintEnd_toStartOf="@+id/itemHandle"
+        app:layout_constraintStart_toEndOf="@+id/itemThumbnailView"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_chainStyle="packed"
+        tools:text="Lorem ipsum dolor sit amet, consectetur adipisci elit. " />
 
     <TextView
         android:id="@+id/itemAdditionalDetails"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
+        android:layout_marginStart="8dp"
         android:layout_toStartOf="@id/itemHandle"
-        android:layout_toLeftOf="@id/itemHandle"
         android:layout_toEndOf="@id/itemThumbnailView"
-        android:layout_toRightOf="@id/itemThumbnailView"
         android:ellipsize="end"
         android:singleLine="true"
         android:textAppearance="?android:attr/textAppearanceSmall"
         android:textSize="@dimen/video_item_search_upload_date_text_size"
-        tools:text="Uploader" />
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/itemHandle"
+        app:layout_constraintStart_toEndOf="@+id/itemThumbnailView"
+        app:layout_constraintTop_toBottomOf="@+id/itemVideoTitleView"
+        tools:text="Uploader uploader uploader uploader uploader · Youtube" />
 
-</RelativeLayout>
+    <androidx.appcompat.widget.AppCompatImageView
+        android:id="@+id/itemHandle"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:layout_alignParentRight="true"
+        android:layout_gravity="center_vertical"
+        android:paddingHorizontal="@dimen/video_item_search_image_right_margin"
+        android:scaleType="center"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/ic_drag_handle"
+        tools:ignore="ContentDescription,RtlHardcoded" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-
-    <attr name="ic_selected" format="reference" />
-
     <attr name="progress_horizontal_drawable" format="reference" />
     <!-- Can't refer to colors directly in drawable's xml-->
     <attr name="toolbar_shadow" format="reference" />

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -114,9 +114,9 @@
     <dimen name="playlist_detail_uploader_image_size">24dp</dimen>
     <dimen name="playlist_detail_uploader_layout_height">28dp</dimen>
 
-    <!-- Play Queue View Dimensions -->
+    <!-- Play queue thumbnail view dimensions (16:9) -->
     <dimen name="play_queue_thumbnail_width">62dp</dimen>
-    <dimen name="play_queue_thumbnail_height">40dp</dimen>
+    <dimen name="play_queue_thumbnail_height">35dp</dimen>
 
     <!-- Kiosk view Dimensions-->
     <dimen name="kiosk_title_text_size">30sp</dimen>


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This PR uses the contraint layout in play queue item to improve how it looks, in particular on small devices (see screenshots below). The item became a little bit bigger, but that's just because the thumbnail now is really `16:9` (its height was squished, before). I also removed the "selected" indicator that was present to the left of the item a few versions ago (added in b0948cf9fc40c4fb8ea7b7445ad8b7bd9e422f3b): its icon did not exist so it was invisible, and anyway I don't think it was any useful, since changing the color of the playing item is already enough to distinguish it from the others.

Before:
![image](https://user-images.githubusercontent.com/36421898/120966202-31248280-c766-11eb-9936-c8eb76aceb7a.png)
After:
![image](https://user-images.githubusercontent.com/36421898/120967274-92992100-c767-11eb-8cb4-3826b5825b9f.png)

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.
I tested both on API 19 and on Android 10 and everything works as expected.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
