### PR TITLE
Fix reCaptcha being shown on every request

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/error/ReCaptchaActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/error/ReCaptchaActivity.java
@@ -216,17 +216,21 @@ public class ReCaptchaActivity extends AppCompatActivity {
         if (cookies.contains("s_gl=") || cookies.contains("goojf=")
                 || cookies.contains("VISITOR_INFO1_LIVE=")
                 || cookies.contains("GOOGLE_ABUSE_EXEMPTION=")) {
-            // youtube seems to also need the other cookies:
-            addCookie(cookies);
+            // Remove CONSENT cookie; otherwise it will be set twice
+            // YouTube seems to need the other cookies
+            addCookie(cookies
+                    .replaceAll("CONSENT=.*?;\\s", "") // cookie in the middle
+                    .replaceAll(";\\sCONSENT=.*", "")); // cookie at the end
         }
     }
 
-    private void addCookie(final String cookie) {
+    private void addCookie(@NonNull final String cookie) {
         if (foundCookies.contains(cookie)) {
             return;
         }
-
-        if (foundCookies.isEmpty() || foundCookies.endsWith("; ")) {
+        if (cookie.contains(foundCookies)) {
+            foundCookies = cookie;
+        } else if (foundCookies.isEmpty() || foundCookies.endsWith("; ")) {
             foundCookies += cookie;
         } else if (foundCookies.endsWith(";")) {
             foundCookies += " " + cookie;


### PR DESCRIPTION

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This fix is split into two parts:
1) The CONSENT cookie was set twice; once via the extractor and once via the reCaptcha cookie set. This cuased the cookie set to be invalid
2) Two reCaptcha cookies are being passed when submitting. One of them (mostly the second one) was containing the information of the other one and additional info. The more detailed is kept.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #6311 

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
