### PR TITLE
Added itemsListHeaderDuration to large-hand player

### DIFF
--- a/app/src/main/res/layout-large-land/player.xml
+++ b/app/src/main/res/layout-large-land/player.xml
@@ -563,6 +563,17 @@
                 android:tint="?attr/colorAccent"
                 app:srcCompat="@drawable/ic_shuffle"
                 tools:ignore="ContentDescription,RtlHardcoded" />
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/itemsListHeaderDuration"
+                style="@style/TextAppearance.AppCompat.Medium"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerVertical="true"
+                android:layout_toLeftOf="@id/itemsListClose"
+                android:layout_toRightOf="@id/shuffleButton"
+                android:gravity="center"
+                android:textColor="@android:color/white" />
         </RelativeLayout>
 
         <androidx.recyclerview.widget.RecyclerView


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
- The ``temsListHeaderDuration`` element was missing in the ``large-hand`` player which caused crashes on larger devices like TVs or tablets to crash

Problem was caused by #6441 / https://github.com/TeamNewPipe/NewPipe/commit/d921e2e61b3577469b26e361bd05483343f7b864

#### Fixes the following issue(s)
- Fixes #6467

#### APK testing 
On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
