### PR TITLE
Added comments disabled functionallity

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -186,7 +186,7 @@ dependencies {
     // name and the commit hash with the commit hash of the (pushed) commit you want to test
     // This works thanks to JitPack: https://jitpack.io/
     implementation 'com.github.TeamNewPipe:nanojson:1d9e1aea9049fc9f85e68b43ba39fe7be1c1f751'
-    implementation 'com.github.TeamNewPipe:NewPipeExtractor:v0.21.6'
+    implementation 'com.github.TeamNewPipe:NewPipeExtractor:c38a06e8dcd9c206a52b622704b138b78d633274'
 
 /** Checkstyle **/
     checkstyle "com.puppycrawl.tools:checkstyle:${checkstyleVersion}"

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/comments/CommentsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/comments/CommentsFragment.java
@@ -6,6 +6,7 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -24,6 +25,8 @@ import io.reactivex.rxjava3.disposables.CompositeDisposable;
 public class CommentsFragment extends BaseListInfoFragment<CommentsInfo> {
     private final CompositeDisposable disposables = new CompositeDisposable();
 
+    private TextView commentsDisabledView;
+
     public static CommentsFragment getInstance(final int serviceId, final String url,
                                                final String name) {
         final CommentsFragment instance = new CommentsFragment();
@@ -33,6 +36,13 @@ public class CommentsFragment extends BaseListInfoFragment<CommentsInfo> {
 
     public CommentsFragment() {
         super(UserAction.REQUESTED_COMMENTS);
+    }
+
+    @Override
+    protected void initViews(final View rootView, final Bundle savedInstanceState) {
+        super.initViews(rootView, savedInstanceState);
+
+        commentsDisabledView = rootView.findViewById(R.id.comments_disabled);
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -73,6 +83,10 @@ public class CommentsFragment extends BaseListInfoFragment<CommentsInfo> {
     @Override
     public void handleResult(@NonNull final CommentsInfo result) {
         super.handleResult(result);
+
+        commentsDisabledView.setVisibility(
+                result.isCommentsDisabled() ? View.VISIBLE : View.GONE);
+
         ViewUtils.slideUp(requireView(), 120, 150, 0.06f);
         disposables.clear();
     }

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/comments/CommentsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/comments/CommentsFragment.java
@@ -25,7 +25,7 @@ import io.reactivex.rxjava3.disposables.CompositeDisposable;
 public class CommentsFragment extends BaseListInfoFragment<CommentsInfo> {
     private final CompositeDisposable disposables = new CompositeDisposable();
 
-    private TextView commentsDisabledView;
+    private TextView emptyStateDesc;
 
     public static CommentsFragment getInstance(final int serviceId, final String url,
                                                final String name) {
@@ -42,7 +42,7 @@ public class CommentsFragment extends BaseListInfoFragment<CommentsInfo> {
     protected void initViews(final View rootView, final Bundle savedInstanceState) {
         super.initViews(rootView, savedInstanceState);
 
-        commentsDisabledView = rootView.findViewById(R.id.comments_disabled);
+        emptyStateDesc = rootView.findViewById(R.id.empty_state_desc);
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -84,8 +84,10 @@ public class CommentsFragment extends BaseListInfoFragment<CommentsInfo> {
     public void handleResult(@NonNull final CommentsInfo result) {
         super.handleResult(result);
 
-        commentsDisabledView.setVisibility(
-                result.isCommentsDisabled() ? View.VISIBLE : View.GONE);
+        emptyStateDesc.setText(
+                result.isCommentsDisabled()
+                        ? R.string.comments_are_disabled
+                        : R.string.no_comments);
 
         ViewUtils.slideUp(requireView(), 120, 150, 0.06f);
         disposables.clear();

--- a/app/src/main/res/layout/fragment_comments.xml
+++ b/app/src/main/res/layout/fragment_comments.xml
@@ -41,6 +41,7 @@
             tools:ignore="HardcodedText,UnusedAttribute" />
 
         <TextView
+            android:id="@+id/empty_state_desc"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
@@ -48,17 +49,6 @@
             android:textSize="24sp" />
 
     </LinearLayout>
-
-    <TextView
-        android:id="@+id/comments_disabled"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_below="@id/empty_state_view"
-        android:layout_centerHorizontal="true"
-        android:text="@string/comments_are_disabled"
-        android:textSize="20sp"
-        android:visibility="gone"
-        tools:visibility="visible" />
 
     <!--ERROR PANEL-->
     <include

--- a/app/src/main/res/layout/fragment_comments.xml
+++ b/app/src/main/res/layout/fragment_comments.xml
@@ -49,6 +49,17 @@
 
     </LinearLayout>
 
+    <TextView
+        android:id="@+id/comments_disabled"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/empty_state_view"
+        android:layout_centerHorizontal="true"
+        android:text="@string/comments_are_disabled"
+        android:textSize="20sp"
+        android:visibility="gone"
+        tools:visibility="visible" />
+
     <!--ERROR PANEL-->
     <include
         android:id="@+id/error_panel"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -462,6 +462,7 @@
     <string name="show_comments_summary">Ausschalten, um Kommentare auszublenden</string>
     <string name="autoplay_title">Automatische Wiedergabe</string>
     <string name="no_comments">Keine Kommentare</string>
+    <string name="comments_are_disabled">Kommentare sind deaktiviert</string>
     <string name="error_unable_to_load_comments">Kommentare konnten nicht geladen werden</string>
     <string name="close">Schließen</string>
     <string name="enable_playback_resume_title">Wiedergabe fortsetzen</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -336,6 +336,7 @@
         <item quantity="other">%s videos</item>
     </plurals>
     <string name="no_comments">No comments</string>
+    <string name="comments_are_disabled">Comments are disabled</string>
     <!-- Missions -->
     <string name="start">Start</string>
     <string name="pause">Pause</string>


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Currently NewPipe shows an error when the comments are disabled → #5769 / https://github.com/TeamNewPipe/NewPipeExtractor/issues/577

<details><summary>Adds a "Comments are disabled" line under the "No comments" area when the comments are disabled <br/>(click to show demo) </summary>

![grafik](https://user-images.githubusercontent.com/40789489/122643301-54104880-d10f-11eb-88b0-62f773236a5c.png)

</details>

For testing:
SFW Video with disabled comments: https://m.youtube.com/watch?v=MhReKn8STX8

#### Fixes the following issue(s)
- Fixes/Improves #5769 

#### Relies on the following changes
- https://github.com/TeamNewPipe/NewPipeExtractor/pull/652

#### APK testing 
On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
