### PR TITLE
Hotfix release 0.21.5

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,8 +17,8 @@ android {
         resValue "string", "app_name", "NewPipe"
         minSdkVersion 19
         targetSdkVersion 29
-        versionCode 970
-        versionName "0.21.4"
+        versionCode 971
+        versionName "0.21.5"
 
         multiDexEnabled true
 

--- a/app/src/main/java/org/schabi/newpipe/player/helper/LoadController.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/LoadController.java
@@ -32,7 +32,8 @@ public class LoadController implements LoadControl {
 
         final DefaultLoadControl.Builder builder = new DefaultLoadControl.Builder();
         builder.setBufferDurationsMs(minimumPlaybackBufferMs, optimalPlaybackBufferMs,
-                initialPlaybackBufferMs, initialPlaybackBufferMs);
+                initialPlaybackBufferMs,
+                DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS);
         internalLoadControl = builder.build();
     }
 

--- a/app/src/main/res/layout-large-land/player.xml
+++ b/app/src/main/res/layout-large-land/player.xml
@@ -563,6 +563,17 @@
                 android:tint="?attr/colorAccent"
                 app:srcCompat="@drawable/ic_shuffle"
                 tools:ignore="ContentDescription,RtlHardcoded" />
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/itemsListHeaderDuration"
+                style="@style/TextAppearance.AppCompat.Medium"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerVertical="true"
+                android:layout_toLeftOf="@id/itemsListClose"
+                android:layout_toRightOf="@id/shuffleButton"
+                android:gravity="center"
+                android:textColor="@android:color/white" />
         </RelativeLayout>
 
         <androidx.recyclerview.widget.RecyclerView

--- a/fastlane/metadata/android/en-US/changelogs/971.txt
+++ b/fastlane/metadata/android/en-US/changelogs/971.txt
@@ -1,0 +1,3 @@
+Hotfix
+• Increase buffer for playback after rebuffer
+• Fixed crash on tablets and TVs when clicking on the play-queue icon in the player


### PR DESCRIPTION
# Changelog
## App
### Hotfix

- Increase buffer for playback after rebuffer #6444 
- Fixed crash on tablets and TVs when clicking on the play-queue icon in the player #6480 
- disable desugaring
- 
# APK for testing

[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/6658963/app-debug.zip)

Please report new bugs in #6494