### PR TITLE
Replace the System.exit calls with getActivity.finishAffinity()

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/ExitActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/ExitActivity.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
 
+import org.schabi.newpipe.util.NavigationHelper;
+
 /*
  * Copyright (C) Hans-Christoph Steiner 2016 <hans@eds.org>
  * ExitActivity.java is part of NewPipe.
@@ -48,6 +50,6 @@ public class ExitActivity extends Activity {
             finish();
         }
 
-        System.exit(0);
+        NavigationHelper.restartApp(this);
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
@@ -27,6 +27,7 @@ import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.localization.ContentCountry;
 import org.schabi.newpipe.extractor.localization.Localization;
 import org.schabi.newpipe.streams.io.StoredFileHelper;
+import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.ZipHelper;
 
 import java.io.File;
@@ -255,7 +256,7 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
         // save import path only on success; save immediately because app is about to exit
         saveLastImportExportDataUri(true);
         // restart app to properly load db
-        System.exit(0);
+        NavigationHelper.restartApp(requireActivity());
     }
 
     private Uri getImportExportDataUri() {

--- a/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
@@ -599,4 +599,16 @@ public final class NavigationHelper {
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         context.startActivity(intent);
     }
+
+    /**
+     * Finish this <code>Activity</code> as well as all <code>Activities</code> running below it
+     * and then start <code>MainActivity</code>.
+     *
+     * @param activity the activity to finish
+     */
+    public static void restartApp(final Activity activity) {
+        activity.finishAffinity();
+        final Intent intent = new Intent(activity, MainActivity.class);
+        activity.startActivity(intent);
+    }
 }


### PR DESCRIPTION
Replaced System.exit call with finishAffinity() and start MainActivity call, tested by changing some settings values, exporting my configuration, reversing the changes, and then reimporting the settings, once the MainActivity was restarted I could then see my chosen settings imported.

Also updated ExitActivity.java to remove System.Exit call and replace with start MainActivity

#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [X] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Replaced System.Exit calls with  getActivity.finishAffinity() in the below 2 files

> NewPipe/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
> src/main/java/org/schabi/newpipe/ExitActivity.java


#### Fixes the following issue(s)

- Fixes #6428 


#### APK testing 
I ran the APK on an emulator and went through the settings flow and ensured that my changes persisted after the importing task had finished and the app was restarted.


#### Due diligence
- [X] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
