### PR TITLE
dismiss choice dialog in onStop() to avoid a leaked window Exception:

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/RouterActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/RouterActivity.java
@@ -107,6 +107,7 @@ public class RouterActivity extends AppCompatActivity {
     protected String currentUrl;
     private StreamingService currentService;
     private boolean selectionIsDownload = false;
+    private AlertDialog alertDialogChoice = null;
 
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
@@ -124,6 +125,15 @@ public class RouterActivity extends AppCompatActivity {
 
         setTheme(ThemeHelper.isLightThemeSelected(this)
                 ? R.style.RouterActivityThemeLight : R.style.RouterActivityThemeDark);
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        // we need to dismiss the dialog before leaving the activity or we get leaks
+        if (alertDialogChoice != null) {
+            alertDialogChoice.dismiss();
+        }
     }
 
     @Override
@@ -333,7 +343,7 @@ public class RouterActivity extends AppCompatActivity {
             }
         };
 
-        final AlertDialog alertDialog = new AlertDialog.Builder(themeWrapperContext)
+        alertDialogChoice = new AlertDialog.Builder(themeWrapperContext)
                 .setTitle(R.string.preferred_open_action_share_menu_title)
                 .setView(radioGroup)
                 .setCancelable(true)
@@ -347,12 +357,12 @@ public class RouterActivity extends AppCompatActivity {
                 .create();
 
         //noinspection CodeBlock2Expr
-        alertDialog.setOnShowListener(dialog -> {
-            setDialogButtonsState(alertDialog, radioGroup.getCheckedRadioButtonId() != -1);
+        alertDialogChoice.setOnShowListener(dialog -> {
+            setDialogButtonsState(alertDialogChoice, radioGroup.getCheckedRadioButtonId() != -1);
         });
 
         radioGroup.setOnCheckedChangeListener((group, checkedId) ->
-                setDialogButtonsState(alertDialog, true));
+                setDialogButtonsState(alertDialogChoice, true));
         final View.OnClickListener radioButtonsClickListener = v -> {
             final int indexOfChild = radioGroup.indexOfChild(v);
             if (indexOfChild == -1) {
@@ -402,10 +412,10 @@ public class RouterActivity extends AppCompatActivity {
         }
         selectedPreviously = selectedRadioPosition;
 
-        alertDialog.show();
+        alertDialogChoice.show();
 
         if (DeviceUtils.isTv(this)) {
-            FocusOverlayView.setupFocusObserver(alertDialog);
+            FocusOverlayView.setupFocusObserver(alertDialogChoice);
         }
     }
 


### PR DESCRIPTION
E/WindowManager: android.view.WindowLeaked: Activity org.schabi.newpipe.RouterActivity has leaked window DecorView@d99fe3b[] that was originally added here
        at android.view.ViewRootImpl.<init>(ViewRootImpl.java:418)

<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- dismiss the dialog correctly so no leaks might occur

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
