### PR TITLE
Use ExoPlayer default values for buffers

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/helper/LoadController.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/LoadController.java
@@ -20,18 +20,16 @@ public class LoadController implements LoadControl {
     //////////////////////////////////////////////////////////////////////////*/
 
     public LoadController() {
-        this(PlayerHelper.getPlaybackStartBufferMs(),
-                PlayerHelper.getPlaybackMinimumBufferMs(),
-                PlayerHelper.getPlaybackOptimalBufferMs());
+        this(PlayerHelper.getPlaybackStartBufferMs());
     }
 
-    private LoadController(final int initialPlaybackBufferMs,
-                           final int minimumPlaybackBufferMs,
-                           final int optimalPlaybackBufferMs) {
+    private LoadController(final int initialPlaybackBufferMs) {
         this.initialPlaybackBufferUs = initialPlaybackBufferMs * 1000;
 
         final DefaultLoadControl.Builder builder = new DefaultLoadControl.Builder();
-        builder.setBufferDurationsMs(minimumPlaybackBufferMs, optimalPlaybackBufferMs,
+        builder.setBufferDurationsMs(
+                DefaultLoadControl.DEFAULT_MIN_BUFFER_MS,
+                DefaultLoadControl.DEFAULT_MAX_BUFFER_MS,
                 initialPlaybackBufferMs,
                 DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS);
         internalLoadControl = builder.build();

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
@@ -307,22 +307,6 @@ public final class PlayerHelper {
         return 500;
     }
 
-    /**
-     * @return the minimum number of milliseconds the player always buffers to
-     * after starting playback.
-     */
-    public static int getPlaybackMinimumBufferMs() {
-        return 25000;
-    }
-
-    /**
-     * @return the maximum/optimal number of milliseconds the player will buffer to once the buffer
-     * hits the point of {@link #getPlaybackMinimumBufferMs()}.
-     */
-    public static int getPlaybackOptimalBufferMs() {
-        return 60000;
-    }
-
     public static TrackSelection.Factory getQualitySelector() {
         return new AdaptiveTrackSelection.Factory(
                 1000,


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [X] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
ExoPlayer 2.12 noted this in the changelog:
_Set the default minimum buffer duration in DefaultLoadControl to 50 seconds (equal to the default maximum buffer), and treat audio and video the same._

Maybe there was a reason they decided to have both minimum and maximum buffer identical since 2.12. NewPipe used years old constants which are now removed in favor of ExoPlayer constants so that future versions will keep up with what changes at ExoPlayer.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
Hopefully fixes some of the buffer issues we have lately like #6510 

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

#### Due diligence
- [X] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
