### PR TITLE
Don't enable SAF on Fire TV

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/settings/NewPipeSettings.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/NewPipeSettings.java
@@ -111,6 +111,8 @@ public final class NewPipeSettings {
     }
 
     public static boolean useStorageAccessFramework(final Context context) {
+        // There's a FireOS bug which prevents SAF open/close dialogs from being confirmed with a
+        // remote (see #6455).
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP || DeviceUtils.isFireTv()) {
             return false;
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {

--- a/app/src/main/java/org/schabi/newpipe/settings/NewPipeSettings.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/NewPipeSettings.java
@@ -111,7 +111,9 @@ public final class NewPipeSettings {
     }
 
     public static boolean useStorageAccessFramework(final Context context) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && !DeviceUtils.isFireTv()) {
+        if (DeviceUtils.isFireTv()) {
+            return false;
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             return true;
         } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
             return false;

--- a/app/src/main/java/org/schabi/newpipe/settings/NewPipeSettings.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/NewPipeSettings.java
@@ -111,12 +111,10 @@ public final class NewPipeSettings {
     }
 
     public static boolean useStorageAccessFramework(final Context context) {
-        if (DeviceUtils.isFireTv()) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP || DeviceUtils.isFireTv()) {
             return false;
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             return true;
-        } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-            return false;
         }
 
         final String key = context.getString(R.string.storage_use_saf);

--- a/app/src/main/java/org/schabi/newpipe/settings/NewPipeSettings.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/NewPipeSettings.java
@@ -9,6 +9,7 @@ import androidx.annotation.NonNull;
 import androidx.preference.PreferenceManager;
 
 import org.schabi.newpipe.R;
+import org.schabi.newpipe.util.DeviceUtils;
 
 import java.io.File;
 import java.util.Set;
@@ -110,7 +111,7 @@ public final class NewPipeSettings {
     }
 
     public static boolean useStorageAccessFramework(final Context context) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && !DeviceUtils.isFireTv()) {
             return true;
         } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
             return false;

--- a/app/src/main/java/org/schabi/newpipe/settings/SettingMigrations.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/SettingMigrations.java
@@ -11,6 +11,7 @@ import org.schabi.newpipe.R;
 import org.schabi.newpipe.error.ErrorActivity;
 import org.schabi.newpipe.error.ErrorInfo;
 import org.schabi.newpipe.error.UserAction;
+import org.schabi.newpipe.util.DeviceUtils;
 
 import static org.schabi.newpipe.MainActivity.DEBUG;
 
@@ -65,7 +66,8 @@ public final class SettingMigrations {
             // NoNonsenseFilePicker. SAF does not work on KitKat and below, though, so the setting
             // is set to false in that case.
             sp.edit().putBoolean(context.getString(R.string.storage_use_saf),
-                    Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP).apply();
+                    Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
+                            && !DeviceUtils.isFireTv()).apply();
         }
     };
 

--- a/app/src/main/java/org/schabi/newpipe/settings/SettingMigrations.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/SettingMigrations.java
@@ -64,7 +64,8 @@ public final class SettingMigrations {
             // We reset the setting to its default value, i.e. "use SAF", since now there are no
             // more issues with SAF and users should use that one instead of the old
             // NoNonsenseFilePicker. SAF does not work on KitKat and below, though, so the setting
-            // is set to false in that case.
+            // is set to false in that case. Also, there's a bug on FireOS in which SAF open/close
+            // dialogs cannot be confirmed with a remote (see #6455).
             sp.edit().putBoolean(context.getString(R.string.storage_use_saf),
                     Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
                             && !DeviceUtils.isFireTv()).apply();

--- a/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
@@ -41,11 +41,9 @@ public final class DeviceUtils {
             return isFireTV;
         }
 
-        final boolean isFireTv =
+        isFireTV =
                 App.getApp().getPackageManager().hasSystemFeature(AMAZON_FEATURE_FIRE_TV);
-
-        DeviceUtils.isFireTV = isFireTv;
-        return isFireTv;
+        return isFireTV;
     }
 
     public static boolean isTv(final Context context) {

--- a/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
@@ -21,6 +21,7 @@ public final class DeviceUtils {
 
     private static final String AMAZON_FEATURE_FIRE_TV = "amazon.hardware.fire_tv";
     private static Boolean isTV = null;
+    private static Boolean isFireTV = null;
 
     /*
      * Devices that do not support media tunneling
@@ -35,6 +36,18 @@ public final class DeviceUtils {
     private DeviceUtils() {
     }
 
+    public static boolean isFireTv() {
+        if (isFireTV != null) {
+            return isFireTV;
+        }
+
+        final boolean isFireTv =
+                App.getApp().getPackageManager().hasSystemFeature(AMAZON_FEATURE_FIRE_TV);
+
+        DeviceUtils.isFireTV = isFireTv;
+        return isFireTv;
+    }
+
     public static boolean isTv(final Context context) {
         if (isTV != null) {
             return isTV;
@@ -45,7 +58,7 @@ public final class DeviceUtils {
         // from doc: https://developer.android.com/training/tv/start/hardware.html#runtime-check
         boolean isTv = ContextCompat.getSystemService(context, UiModeManager.class)
                 .getCurrentModeType() == Configuration.UI_MODE_TYPE_TELEVISION
-                || pm.hasSystemFeature(AMAZON_FEATURE_FIRE_TV)
+                || isFireTv()
                 || pm.hasSystemFeature(PackageManager.FEATURE_TELEVISION);
 
         // from https://stackoverflow.com/a/58932366


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)

#### Description of the changes in your PR
Don't enable SAF when on Fire TV.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #6455

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
