### PR TITLE
Remove option to immediately commit pref changes on import

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
@@ -199,7 +199,7 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
                 .getDefaultSharedPreferences(requireContext());
             manager.exportDatabase(preferences, file);
 
-            saveLastImportExportDataUri(false); // save export path only on success
+            saveLastImportExportDataUri(); // save export path only on success
             Toast.makeText(getContext(), R.string.export_complete_toast, Toast.LENGTH_SHORT).show();
         } catch (final Exception e) {
             ErrorActivity.reportUiErrorInSnackbar(this, "Exporting database", e);
@@ -252,8 +252,8 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
      * Save import path and restart system.
      */
     private void finishImport() {
-        // save import path only on success; save immediately because app is about to exit
-        saveLastImportExportDataUri(true);
+        // save import path only on success
+        saveLastImportExportDataUri();
         // restart app to properly load db
         NavigationHelper.restartApp(requireActivity());
     }
@@ -263,16 +263,11 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
         return isBlank(path) ? null : Uri.parse(path);
     }
 
-    private void saveLastImportExportDataUri(final boolean immediately) {
+    private void saveLastImportExportDataUri() {
         if (lastImportExportDataUri != null) {
             final SharedPreferences.Editor editor = defaultPreferences.edit()
                     .putString(importExportDataPathKey, lastImportExportDataUri.toString());
-            if (immediately) {
-                // noinspection ApplySharedPref
-                editor.commit(); // app about to be restarted, commit immediately
-            } else {
-                editor.apply();
-            }
+            editor.apply();
         }
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
@@ -33,6 +33,7 @@ import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.ZipHelper;
 
 import java.io.File;
+import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
@@ -43,7 +44,8 @@ import static org.schabi.newpipe.util.Localization.assureCorrectAppLanguage;
 
 public class ContentSettingsFragment extends BasePreferenceFragment {
     private static final String ZIP_MIME_TYPE = "application/zip";
-    private static final SimpleDateFormat EXPORT_DATE_FORMAT
+
+    private final SimpleDateFormat exportDateFormat
             = new SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US);
 
     private ContentSettingsManager manager;
@@ -52,7 +54,8 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
     private String thumbnailLoadToggleKey;
     private String youtubeRestrictedModeEnabledKey;
 
-    @Nullable private Uri lastImportExportDataUri = null;
+    @Nullable
+    private Uri lastImportExportDataUri = null;
     private Localization initialSelectedLocalization;
     private ContentCountry initialSelectedContentCountry;
     private String initialLanguage;
@@ -86,7 +89,7 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
 
             requestExportPathLauncher.launch(
                     StoredFileHelper.getNewPicker(requireContext(),
-                            "NewPipeData-" + EXPORT_DATE_FORMAT.format(new Date()) + ".zip",
+                            "NewPipeData-" + exportDateFormat.format(new Date()) + ".zip",
                             ZIP_MIME_TYPE, getImportExportDataUri()));
             return true;
         });
@@ -216,7 +219,7 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
 
         try {
             if (!manager.ensureDbDirectoryExists()) {
-                throw new Exception("Could not create databases dir");
+                throw new IOException("Could not create databases dir");
             }
 
             if (!manager.extractDb(file)) {


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Codebase improvement (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
Follow up to #6495. See commit messages for detailed descriptions
- Remove option to immediately commit pref changes on import 
- Resolve sonar issues in ContentSettingsFragment 
- Remove variable ContentSettingsFragment.lastImportExportDataUri

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

I tested it manually on API 28 emulator
1. by exporting the settings
2. moving the exported file somewhere else
3. trying to import and verify that the file explorer opens the old correct path
4. navigate to the moved file and import
5. verify that another export now opens to the new file location.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
