### PR TITLE
Specify emulator-build version in CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,35 +44,36 @@ jobs:
           name: app
           path: app/build/outputs/apk/debug/*.apk
 
-# Disabled until emulator works again. see https://github.com/TeamNewPipe/NewPipe/pull/6560
-#  test-android:
-     # macos has hardware acceleration. See android-emulator-runner action
-#    runs-on: macos-latest
-#    strategy:
-#      matrix:
-          # api-level 19 is min sdk, but throws errors related to desugaring
-#        api-level: [21, 29]
-#    steps:
-#      - uses: actions/checkout@v2
-#
-#      - name: set up JDK 8
-#        uses: actions/setup-java@v2
-#        with:
-#          java-version: 8
-#          distribution: "adopt"
-#
-#      - name: Cache Gradle dependencies
-#        uses: actions/cache@v2
-#        with:
-#          path: ~/.gradle/caches
-#          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-#          restore-keys: ${{ runner.os }}-gradle
-#
-#      - name: Run android tests
-#        uses: reactivecircus/android-emulator-runner@v2
-#        with:
-#          api-level: ${{ matrix.api-level }}
-#          script: ./gradlew connectedCheck
+  test-android:
+    # macos has hardware acceleration. See android-emulator-runner action
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        # api-level 19 is min sdk, but throws errors related to desugaring
+        api-level: [ 21, 29 ]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: 8
+          distribution: "adopt"
+
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      - name: Run android tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          # workaround to emulator bug: https://github.com/ReactiveCircus/android-emulator-runner/issues/160
+          emulator-build: 7425822
+          script: ./gradlew connectedCheck
 
 #   sonar:
 #     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- temporary fix from https://github.com/ReactiveCircus/android-emulator-runner/issues/160

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
All actions for instrumented tests fail due to emulator not starting properly
```
/Users/runner/Library/Android/sdk/platform-tools/adb shell getprop sys.boot_completed
adb: no devices/emulators found
The process '/Users/runner/Library/Android/sdk/platform-tools/adb' failed with exit code 1
Error: The operation was canceled.
```

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
