### PR TITLE
Add download option to long-press menu

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -65,6 +65,7 @@ import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.services.peertube.PeertubeInstance;
+import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.fragments.BackPressable;
 import org.schabi.newpipe.fragments.MainFragment;
 import org.schabi.newpipe.fragments.detail.VideoDetailFragment;
@@ -617,7 +618,11 @@ public class MainActivity extends AppCompatActivity {
                 final Fragment fragment = getSupportFragmentManager()
                         .findFragmentById(R.id.fragment_player_holder);
                 if (fragment instanceof VideoDetailFragment) {
-                    ((VideoDetailFragment) fragment).openDownloadDialog();
+                    final StreamInfo currentInfo =
+                            ((VideoDetailFragment) fragment).getCurrentStreamInfo();
+                    if (currentInfo != null) {
+                        NavigationHelper.openDownloadDialog(this, currentInfo);
+                    }
                 }
                 break;
         }

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -449,7 +449,7 @@ public final class VideoDetailFragment
             case R.id.detail_controls_download:
                 if (PermissionHelper.checkStoragePermissions(activity,
                         PermissionHelper.DOWNLOAD_DIALOG_REQUEST_CODE)) {
-                    this.openDownloadDialog();
+                    NavigationHelper.openDownloadDialog(activity, currentInfo);
                 }
                 break;
             case R.id.detail_controls_share:
@@ -1603,6 +1603,10 @@ public final class VideoDetailFragment
         } else {
             binding.detailUploaderTextView.setVisibility(View.GONE);
         }
+    }
+
+    public StreamInfo getCurrentStreamInfo() {
+        return currentInfo;
     }
 
     public void openDownloadDialog() {

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
@@ -371,6 +371,7 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
             ));
         }
         entries.add(StreamDialogEntry.open_in_browser);
+        entries.add(StreamDialogEntry.download);
         if (KoreUtils.shouldShowPlayWithKodi(context, item.getServiceId())) {
             entries.add(StreamDialogEntry.play_with_kodi);
         }

--- a/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
@@ -26,6 +26,10 @@ import org.schabi.newpipe.RouterActivity;
 import org.schabi.newpipe.about.AboutActivity;
 import org.schabi.newpipe.database.feed.model.FeedGroupEntity;
 import org.schabi.newpipe.download.DownloadActivity;
+import org.schabi.newpipe.download.DownloadDialog;
+import org.schabi.newpipe.error.ErrorActivity;
+import org.schabi.newpipe.error.ErrorInfo;
+import org.schabi.newpipe.error.UserAction;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
@@ -540,6 +544,43 @@ public final class NavigationHelper {
             intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         }
         return intent;
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+    // Downloading a video without starting a player
+    //////////////////////////////////////////////////////////////////////////*/
+
+    public static void openDownloadDialogWithoutStartingPlayer(
+            final AppCompatActivity activity, final StreamInfo currentInfo) {
+        if (currentInfo == null) {
+            return;
+        }
+
+        try {
+            // Get the sortedVideoStreams and selectedVideoStreamIndex using ListHelper
+            final ArrayList<VideoStream> sortedVideoStreams = new ArrayList<>(
+                    ListHelper.getSortedStreamVideosList(
+                            activity.getApplicationContext(),
+                            currentInfo.getVideoStreams(),
+                            currentInfo.getVideoOnlyStreams(),
+                            false
+                    )
+            );
+            final int selectedVideoStreamIndex = ListHelper.getDefaultResolutionIndex(
+                    activity.getApplicationContext(), sortedVideoStreams);
+
+            final DownloadDialog downloadDialog = DownloadDialog.newInstance(currentInfo);
+            downloadDialog.setVideoStreams(sortedVideoStreams);
+            downloadDialog.setAudioStreams(currentInfo.getAudioStreams());
+            downloadDialog.setSelectedVideoStream(selectedVideoStreamIndex);
+            downloadDialog.setSubtitleStreams(currentInfo.getSubtitles());
+
+            downloadDialog.show(activity.getSupportFragmentManager(), "downloadDialog");
+        } catch (final Exception e) {
+            ErrorActivity.reportErrorInSnackbar(activity,
+                    new ErrorInfo(e, UserAction.DOWNLOAD_OPEN_DIALOG, "Showing download dialog",
+                            currentInfo));
+        }
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
@@ -550,7 +550,7 @@ public final class NavigationHelper {
     // Downloading a video without starting a player
     //////////////////////////////////////////////////////////////////////////*/
 
-    public static void openDownloadDialogWithoutStartingPlayer(
+    public static void openDownloadDialog (
             final AppCompatActivity activity, final StreamInfo currentInfo) {
         if (currentInfo == null) {
             return;

--- a/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
@@ -546,10 +546,6 @@ public final class NavigationHelper {
         return intent;
     }
 
-    /*//////////////////////////////////////////////////////////////////////////
-    // Downloading a video without starting a player
-    //////////////////////////////////////////////////////////////////////////*/
-
     public static void openDownloadDialog (
             final AppCompatActivity activity, final StreamInfo currentInfo) {
         if (currentInfo == null) {

--- a/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
@@ -60,6 +60,7 @@ import org.schabi.newpipe.settings.SettingsActivity;
 import org.schabi.newpipe.util.external_communication.ShareUtils;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import static org.schabi.newpipe.util.external_communication.ShareUtils.installApp;
 
@@ -554,7 +555,7 @@ public final class NavigationHelper {
 
         try {
             // Get the sortedVideoStreams and selectedVideoStreamIndex using ListHelper
-            final ArrayList<VideoStream> sortedVideoStreams = new ArrayList<>(
+            final List<VideoStream> sortedVideoStreams = new ArrayList<>(
                     ListHelper.getSortedStreamVideosList(
                             activity.getApplicationContext(),
                             currentInfo.getVideoStreams(),

--- a/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
@@ -547,7 +547,7 @@ public final class NavigationHelper {
         return intent;
     }
 
-    public static void openDownloadDialog (
+    public static void openDownloadDialog(
             final AppCompatActivity activity, final StreamInfo currentInfo) {
         if (currentInfo == null) {
             return;

--- a/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
+++ b/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
@@ -47,7 +47,7 @@ public enum StreamDialogEntry {
                 .subscribe(result -> {
                     if (PermissionHelper.checkStoragePermissions(fragment.getActivity(),
                             PermissionHelper.DOWNLOAD_DIALOG_REQUEST_CODE)) {
-                        NavigationHelper.openDownloadDialogWithoutStartingPlayer(
+                        NavigationHelper.openDownloadDialog(
                                 (AppCompatActivity) fragment.getActivity(), result);
                     }
                 });

--- a/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
+++ b/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
@@ -7,6 +7,9 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
 
 import org.schabi.newpipe.R;
+import org.schabi.newpipe.error.ErrorActivity;
+import org.schabi.newpipe.error.ErrorInfo;
+import org.schabi.newpipe.error.UserAction;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.local.dialog.PlaylistAppendDialog;
 import org.schabi.newpipe.local.dialog.PlaylistCreationDialog;
@@ -50,7 +53,10 @@ public enum StreamDialogEntry {
                         NavigationHelper.openDownloadDialog(
                                 (AppCompatActivity) fragment.getActivity(), result);
                     }
-                });
+                }, throwable -> ErrorActivity.reportErrorInSnackbar(fragment.getActivity(),
+                        new ErrorInfo(throwable, UserAction.DOWNLOAD_OPEN_DIALOG,
+                                "Fetching Stream Info",
+                                serviceId)));
     }),
     /**
      * Enqueues the stream automatically to the current PlayerType.<br>

--- a/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
+++ b/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
@@ -33,6 +33,12 @@ public enum StreamDialogEntry {
                 item.getServiceId(), item.getUploaderUrl(), item.getUploaderName())
     ),
 
+    download(R.string.download, (fragment, item) -> {
+        if (PermissionHelper.checkStoragePermissions(fragment.getActivity(),
+                PermissionHelper.DOWNLOAD_DIALOG_REQUEST_CODE)) {
+            // Open download dialog
+        }
+    }),
     /**
      * Enqueues the stream automatically to the current PlayerType.<br>
      * <br>

--- a/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
+++ b/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
@@ -3,6 +3,7 @@ package org.schabi.newpipe.util;
 import android.content.Context;
 import android.net.Uri;
 
+import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
 
 import org.schabi.newpipe.R;
@@ -17,6 +18,9 @@ import org.schabi.newpipe.util.external_communication.ShareUtils;
 
 import java.util.Collections;
 import java.util.List;
+
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 import static org.schabi.newpipe.player.MainPlayer.PlayerType.AUDIO;
 import static org.schabi.newpipe.player.MainPlayer.PlayerType.POPUP;
@@ -34,10 +38,19 @@ public enum StreamDialogEntry {
     ),
 
     download(R.string.download, (fragment, item) -> {
-        if (PermissionHelper.checkStoragePermissions(fragment.getActivity(),
-                PermissionHelper.DOWNLOAD_DIALOG_REQUEST_CODE)) {
-            // Open download dialog
-        }
+        final int serviceId = item.getServiceId();
+        final String url = item.getUrl();
+
+        ExtractorHelper.getStreamInfo(serviceId, url, true)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(result -> {
+                    if (PermissionHelper.checkStoragePermissions(fragment.getActivity(),
+                            PermissionHelper.DOWNLOAD_DIALOG_REQUEST_CODE)) {
+                        NavigationHelper.openDownloadDialogWithoutStartingPlayer(
+                                (AppCompatActivity) fragment.getActivity(), result);
+                    }
+                });
     }),
     /**
      * Enqueues the stream automatically to the current PlayerType.<br>


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Feature (user facing)

#### Description of the changes in your PR
Add option to download the video when long-pressing items.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #2171 

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
