### PR TITLE
Convert PlayerHolder to Singleton; cleanup in VideoDetailFragment; Player/MainPlayer do not call onDestroy() directly

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -823,7 +823,7 @@ public class MainActivity extends AppCompatActivity {
             return;
         }
 
-        if (PlayerHolder.isPlayerOpen()) {
+        if (PlayerHolder.getInstance().isPlayerOpen()) {
             // if the player is already open, no need for a broadcast receiver
             openMiniPlayerIfMissing();
         } else {

--- a/app/src/main/java/org/schabi/newpipe/RouterActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/RouterActivity.java
@@ -453,7 +453,7 @@ public class RouterActivity extends AppCompatActivity {
                 returnList.add(showInfo);
                 returnList.add(videoPlayer);
             } else {
-                final MainPlayer.PlayerType playerType = PlayerHolder.getType();
+                final MainPlayer.PlayerType playerType = PlayerHolder.getInstance().getType();
                 if (capabilities.contains(VIDEO)
                         && PlayerHelper.isAutoplayAllowedByUser(context)
                         && playerType == null || playerType == MainPlayer.PlayerType.VIDEO) {

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -1059,6 +1059,14 @@ public final class VideoDetailFragment
     // Play Utils
     //////////////////////////////////////////////////////////////////////////*/
 
+    private void toggleFullscreenIfInFullscreenMode() {
+        // If a user watched video inside fullscreen mode and than chose another player
+        // return to non-fullscreen mode
+        if (isPlayerAvailable() && player.isFullscreen()) {
+            player.toggleFullscreen();
+        }
+    }
+
     private void openBackgroundPlayer(final boolean append) {
         final AudioStream audioStream = currentInfo.getAudioStreams()
                 .get(ListHelper.getDefaultAudioFormat(activity, currentInfo.getAudioStreams()));
@@ -1067,11 +1075,7 @@ public final class VideoDetailFragment
                 .getDefaultSharedPreferences(activity)
                 .getBoolean(activity.getString(R.string.use_external_audio_player_key), false);
 
-        //  If a user watched video inside fullscreen mode and than chose another player
-        //  return to non-fullscreen mode
-        if (isPlayerAvailable() && player.isFullscreen()) {
-            player.toggleFullscreen();
-        }
+        toggleFullscreenIfInFullscreenMode();
 
         if (!useExternalAudioPlayer) {
             openNormalBackgroundPlayer(append);
@@ -1091,11 +1095,7 @@ public final class VideoDetailFragment
             PlayerHolder.startService(App.getApp(), false, this);
         }
 
-        //  If a user watched video inside fullscreen mode and than chose another player
-        //  return to non-fullscreen mode
-        if (isPlayerAvailable() && player.isFullscreen()) {
-            player.toggleFullscreen();
-        }
+        toggleFullscreenIfInFullscreenMode();
 
         final PlayQueue queue = setupPlayQueueForIntent(append);
         if (append) {
@@ -1393,9 +1393,8 @@ public final class VideoDetailFragment
             return;
         }
 
-        if (isPlayerAvailable() && player.isFullscreen()) {
-            player.toggleFullscreen();
-        }
+        toggleFullscreenIfInFullscreenMode();
+
         // This will show systemUI and pause the player.
         // User can tap on Play button and video will be in fullscreen mode again
         // Note for tablet: trying to avoid orientation changes since it's not easy
@@ -1812,9 +1811,7 @@ public final class VideoDetailFragment
         if (error.type == ExoPlaybackException.TYPE_SOURCE
                 || error.type == ExoPlaybackException.TYPE_UNEXPECTED) {
             // Properly exit from fullscreen
-            if (isPlayerAndPlayerServiceAvailable() && player.isFullscreen()) {
-                player.toggleFullscreen();
-            }
+            toggleFullscreenIfInFullscreenMode();
             hideMainPlayer();
         }
     }

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -304,7 +304,8 @@ public final class VideoDetailFragment
     @Override
     public View onCreateView(@NonNull final LayoutInflater inflater, final ViewGroup container,
                              final Bundle savedInstanceState) {
-        return inflater.inflate(R.layout.fragment_video_detail, container, false);
+        binding = FragmentVideoDetailBinding.inflate(inflater, container, false);
+        return binding.getRoot();
     }
 
     @Override
@@ -355,7 +356,6 @@ public final class VideoDetailFragment
     @Override
     public void onDestroy() {
         super.onDestroy();
-        binding = null;
 
         // Stop the service when user leaves the app with double back press
         // if video player is selected. Otherwise unbind
@@ -386,6 +386,12 @@ public final class VideoDetailFragment
             currentInfo = null;
             stack = new LinkedList<>();
         }
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        binding = null;
     }
 
     @Override
@@ -586,10 +592,9 @@ public final class VideoDetailFragment
     // Init
     //////////////////////////////////////////////////////////////////////////*/
 
-    @Override
+    @Override // called from onViewCreated in {@link BaseFragment#onViewCreated}
     protected void initViews(final View rootView, final Bundle savedInstanceState) {
         super.initViews(rootView, savedInstanceState);
-        binding = FragmentVideoDetailBinding.bind(rootView);
 
         pageAdapter = new TabAdapter(getChildFragmentManager());
         binding.viewPager.setAdapter(pageAdapter);

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -201,6 +201,7 @@ public final class VideoDetailFragment
     @Nullable
     private MainPlayer playerService;
     private Player player;
+    private PlayerHolder playerHolder = PlayerHolder.getInstance();
 
     /*//////////////////////////////////////////////////////////////////////////
     // Service management
@@ -360,9 +361,9 @@ public final class VideoDetailFragment
         // Stop the service when user leaves the app with double back press
         // if video player is selected. Otherwise unbind
         if (activity.isFinishing() && isPlayerAvailable() && player.videoPlayerSelected()) {
-            PlayerHolder.stopService(App.getApp());
+            playerHolder.stopService();
         } else {
-            PlayerHolder.removeListener();
+            playerHolder.setListener(null);
         }
 
         PreferenceManager.getDefaultSharedPreferences(activity)
@@ -660,10 +661,10 @@ public final class VideoDetailFragment
         });
 
         setupBottomPlayer();
-        if (!PlayerHolder.bound) {
+        if (!playerHolder.bound) {
             setHeightThumbnail();
         } else {
-            PlayerHolder.startService(App.getApp(), false, this);
+            playerHolder.startService(false, this);
         }
     }
 
@@ -1097,7 +1098,7 @@ public final class VideoDetailFragment
 
         // See UI changes while remote playQueue changes
         if (!isPlayerAvailable()) {
-            PlayerHolder.startService(App.getApp(), false, this);
+            playerHolder.startService(false, this);
         }
 
         toggleFullscreenIfInFullscreenMode();
@@ -1123,7 +1124,7 @@ public final class VideoDetailFragment
     private void openNormalBackgroundPlayer(final boolean append) {
         // See UI changes while remote playQueue changes
         if (!isPlayerAvailable()) {
-            PlayerHolder.startService(App.getApp(), false, this);
+            playerHolder.startService(false, this);
         }
 
         final PlayQueue queue = setupPlayQueueForIntent(append);
@@ -1137,7 +1138,7 @@ public final class VideoDetailFragment
 
     private void openMainPlayer() {
         if (!isPlayerServiceAvailable()) {
-            PlayerHolder.startService(App.getApp(), autoPlayEnabled, this);
+            playerHolder.startService(autoPlayEnabled, this);
             return;
         }
         if (currentInfo == null) {
@@ -1155,7 +1156,7 @@ public final class VideoDetailFragment
 
         final Intent playerIntent = NavigationHelper
                 .getPlayerIntent(requireContext(), MainPlayer.class, queue, true, autoPlayEnabled);
-        activity.startService(playerIntent);
+        ContextCompat.startForegroundService(activity, playerIntent);
     }
 
     private void hideMainPlayer() {
@@ -1373,9 +1374,9 @@ public final class VideoDetailFragment
                             bottomSheetBehavior.setState(BottomSheetBehavior.STATE_COLLAPSED);
                         }
                         // Rebound to the service if it was closed via notification or mini player
-                        if (!PlayerHolder.bound) {
-                            PlayerHolder.startService(
-                                    App.getApp(), false, VideoDetailFragment.this);
+                        if (!playerHolder.bound) {
+                            playerHolder.startService(
+                                    false, VideoDetailFragment.this);
                         }
                         break;
                 }
@@ -2119,7 +2120,7 @@ public final class VideoDetailFragment
         if (currentWorker != null) {
             currentWorker.dispose();
         }
-        PlayerHolder.stopService(App.getApp());
+        playerHolder.stopService();
         setInitialData(0, null, "", null);
         currentInfo = null;
         updateOverlayData(null, null, null);

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
@@ -353,7 +353,7 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
 
         final List<StreamDialogEntry> entries = new ArrayList<>();
 
-        if (PlayerHolder.getType() != null) {
+        if (PlayerHolder.getInstance().getType() != null) {
             entries.add(StreamDialogEntry.enqueue);
         }
         if (item.getStreamType() == StreamType.AUDIO_STREAM) {

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
@@ -144,7 +144,7 @@ public class PlaylistFragment extends BaseListInfoFragment<PlaylistInfo> {
 
         final ArrayList<StreamDialogEntry> entries = new ArrayList<>();
 
-        if (PlayerHolder.getType() != null) {
+        if (PlayerHolder.getInstance().getType() != null) {
             entries.add(StreamDialogEntry.enqueue);
         }
         if (item.getStreamType() == StreamType.AUDIO_STREAM) {

--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
@@ -331,7 +331,7 @@ class FeedFragment : BaseStateFragment<FeedState>() {
         if (context == null || context.resources == null || activity == null) return
 
         val entries = ArrayList<StreamDialogEntry>()
-        if (PlayerHolder.getType() != null) {
+        if (PlayerHolder.getInstance().getType() != null) {
             entries.add(StreamDialogEntry.enqueue)
         }
         if (item.streamType == StreamType.AUDIO_STREAM) {

--- a/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
@@ -340,7 +340,7 @@ public class StatisticsPlaylistFragment
 
         final ArrayList<StreamDialogEntry> entries = new ArrayList<>();
 
-        if (PlayerHolder.getType() != null) {
+        if (PlayerHolder.getInstance().getType() != null) {
             entries.add(StreamDialogEntry.enqueue);
         }
         if (infoItem.getStreamType() == StreamType.AUDIO_STREAM) {

--- a/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
@@ -749,7 +749,7 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
 
         final ArrayList<StreamDialogEntry> entries = new ArrayList<>();
 
-        if (PlayerHolder.getType() != null) {
+        if (PlayerHolder.getInstance().getType() != null) {
             entries.add(StreamDialogEntry.enqueue);
         }
         if (infoItem.getStreamType() == StreamType.AUDIO_STREAM) {

--- a/app/src/main/java/org/schabi/newpipe/player/MainPlayer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/MainPlayer.java
@@ -178,7 +178,10 @@ public final class MainPlayer extends Service {
         if (DEBUG) {
             Log.d(TAG, "destroy() called");
         }
+        cleanup();
+    }
 
+    private void cleanup() {
         if (player != null) {
             // Exit from fullscreen when user closes the player via notification
             if (player.isFullscreen()) {
@@ -191,9 +194,14 @@ public final class MainPlayer extends Service {
             player.stopActivityBinding();
             player.removePopupFromView();
             player.destroy();
-        }
 
+            player = null;
+        }
+    }
+
+    public void stopService() {
         NotificationUtil.getInstance().cancelNotificationAndStopForeground(this);
+        cleanup();
         stopSelf();
     }
 

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -857,7 +857,7 @@ public final class Player implements
             Log.d(TAG, "onPlaybackShutdown() called");
         }
         // destroys the service, which in turn will destroy the player
-        service.onDestroy();
+        service.stopService();
     }
 
     public void smoothStopPlayer() {
@@ -1097,7 +1097,7 @@ public final class Player implements
                 pause();
                 break;
             case ACTION_CLOSE:
-                service.onDestroy();
+                service.stopService();
                 break;
             case ACTION_PLAY_PAUSE:
                 playPause();
@@ -1498,7 +1498,7 @@ public final class Player implements
                         Objects.requireNonNull(windowManager)
                                 .removeView(closeOverlayBinding.getRoot());
                         closeOverlayBinding = null;
-                        service.onDestroy();
+                        service.stopService();
                     }
                 }).start();
     }

--- a/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
@@ -349,13 +349,13 @@ public final class NavigationHelper {
                                                final boolean switchingPlayers) {
 
         final boolean autoPlay;
-        @Nullable final MainPlayer.PlayerType playerType = PlayerHolder.getType();
+        @Nullable final MainPlayer.PlayerType playerType = PlayerHolder.getInstance().getType();
         if (playerType == null) {
             // no player open
             autoPlay = PlayerHelper.isAutoplayAllowedByUser(context);
         } else if (switchingPlayers) {
             // switching player to main player
-            autoPlay = PlayerHolder.isPlaying(); // keep play/pause state
+            autoPlay = PlayerHolder.getInstance().isPlaying(); // keep play/pause state
         } else if (playerType == MainPlayer.PlayerType.VIDEO) {
             // opening new stream while already playing in main player
             autoPlay = PlayerHelper.isAutoplayAllowedByUser(context);

--- a/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
+++ b/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
@@ -39,7 +39,7 @@ public enum StreamDialogEntry {
      * Info: Add this entry within showStreamDialog.
      */
     enqueue(R.string.enqueue_stream, (fragment, item) -> {
-        final MainPlayer.PlayerType type = PlayerHolder.getType();
+        final MainPlayer.PlayerType type = PlayerHolder.getInstance().getType();
 
         if (type == AUDIO) {
             NavigationHelper.enqueueOnBackgroundPlayer(fragment.getContext(),


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- PlayerHolder: convert to Singleton, handle context within, prevent ServiceConnection leak
- VideoDetailFragment: use viewBinding correctly
- VideoDetailFragment: remove duplicated code for toggle Fullscreen
- VideoDetailFragment: move null checks for player and playerService to helper methods
- Player/MainPlayer: service.onDestroy() should only be called from the system and not manually

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
