### PR TITLE
Fix NPE when connecting via BT

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -2160,7 +2160,10 @@ public final class Player implements
 
     private void onCompleted() {
         if (DEBUG) {
-            Log.d(TAG, "onCompleted() called");
+            Log.d(TAG, "onCompleted() called" + (playQueue == null ? ". playQueue is null" : ""));
+        }
+        if (playQueue == null) {
+            return;
         }
 
         animate(binding.playPauseButton, false, 0, AnimationType.SCALE_AND_ALPHA, 0,


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [X] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
The last weeks and NewPipe versions I had the issue that as soon as my phone connected via BT with my car NewPipe crashed as for some reason "onCompleted" was called.

`
```
java.lang.NullPointerException: Attempt to invoke virtual method 'int org.schabi.newpipe.player.playqueue.PlayQueue.getIndex()' on a null object reference
org.schabi.newpipe.player.Player.onCompleted
org.schabi.newpipe.player.Player.changeState
org.schabi.newpipe.player.Player.onPlayerStateChanged
```

Maybe I am the only one and this is a specific issue with my current car / car software, but as we have the same null checks in other listener methods, I felt it doesn't hurt to add it here as well.

#### Fixes the following issue(s)
#6233

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
On the website the APK can be found by going to the "Checks" tab below the title and then on "artifacts" on the right.

#### Due diligence
- [X] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
