### PR TITLE
Fix crash when refreshing feed after importing database or subscriptions

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/NewPipeDatabase.java
+++ b/app/src/main/java/org/schabi/newpipe/NewPipeDatabase.java
@@ -51,4 +51,15 @@ public final class NewPipeDatabase {
             throw new RuntimeException("Checkpoint was blocked from completing");
         }
     }
+
+    public static void close() {
+        if (databaseInstance != null) {
+            synchronized (NewPipeDatabase.class) {
+                if (databaseInstance != null) {
+                    databaseInstance.close();
+                    databaseInstance = null;
+                }
+            }
+        }
+    }
 }

--- a/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
@@ -21,6 +21,7 @@ import androidx.fragment.app.FragmentTransaction;
 import com.nostra13.universalimageloader.core.ImageLoader;
 
 import org.schabi.newpipe.MainActivity;
+import org.schabi.newpipe.NewPipeDatabase;
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.RouterActivity;
 import org.schabi.newpipe.about.AboutActivity;
@@ -608,6 +609,7 @@ public final class NavigationHelper {
      * @param activity the activity to finish
      */
     public static void restartApp(final Activity activity) {
+        NewPipeDatabase.getInstance(activity).close();
         activity.finishAffinity();
         final Intent intent = new Intent(activity, MainActivity.class);
         activity.startActivity(intent);

--- a/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
@@ -609,7 +609,7 @@ public final class NavigationHelper {
      * @param activity the activity to finish
      */
     public static void restartApp(final Activity activity) {
-        NewPipeDatabase.getInstance(activity).close();
+        NewPipeDatabase.close();
         activity.finishAffinity();
         final Intent intent = new Intent(activity, MainActivity.class);
         activity.startActivity(intent);


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Close database before restarting the app

#### Fixes the following issue(s)
Fixes crash when refreshing feed after importing database or subscriptions.
## Exception
* __User Action:__ requested feed
* __Request:__ Loading feed
* __Content Country:__ US
* __Content Language:__ en
* __App Language:__ en_GB
* __Service:__ none
* __Version:__ 0.21.6
* __OS:__ Linux Android 10 - 29
<details><summary><b>Crash log </b></summary><p>

```
java.lang.NullPointerException: Attempt to invoke virtual method 'void org.schabi.newpipe.database.subscription.SubscriptionEntity.setName(java.lang.String)' on a null object reference
	at org.schabi.newpipe.local.subscription.SubscriptionManager.updateFromInfo(SubscriptionManager.kt:73)
	at org.schabi.newpipe.local.feed.service.FeedLoadService$databaseConsumer$1$1.run(FeedLoadService.kt:324)
	at androidx.room.RoomDatabase.runInTransaction(RoomDatabase.java:556)
	at org.schabi.newpipe.local.feed.service.FeedLoadService$databaseConsumer$1.accept(FeedLoadService.kt:316)
	at org.schabi.newpipe.local.feed.service.FeedLoadService$databaseConsumer$1.accept(FeedLoadService.kt:65)
	at io.reactivex.rxjava3.internal.operators.flowable.FlowableDoOnEach$DoOnEachSubscriber.onNext(FlowableDoOnEach.java:86)
	at io.reactivex.rxjava3.internal.operators.flowable.FlowableBuffer$PublisherBufferExactSubscriber.onNext(FlowableBuffer.java:124)
	at io.reactivex.rxjava3.internal.operators.flowable.FlowableObserveOn$ObserveOnSubscriber.runAsync(FlowableObserveOn.java:402)
	at io.reactivex.rxjava3.internal.operators.flowable.FlowableObserveOn$BaseObserveOnSubscriber.run(FlowableObserveOn.java:176)
	at io.reactivex.rxjava3.internal.schedulers.ScheduledRunnable.run(ScheduledRunnable.java:65)
	at io.reactivex.rxjava3.internal.schedulers.ScheduledRunnable.call(ScheduledRunnable.java:56)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:301)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
	at java.lang.Thread.run(Thread.java:919)

```
</details>

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
