### PR TITLE
Add Tubus (Invidious) and EduVid (PeerTube)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -224,6 +224,7 @@
 
                 <data android:scheme="http" />
                 <data android:scheme="https" />
+                <data android:host="tubus.eduvid.org" />
                 <data android:host="invidio.us" />
                 <data android:host="dev.invidio.us" />
                 <data android:host="www.invidio.us" />
@@ -309,6 +310,7 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
 
+                <data android:host="eduvid.org" />
                 <data android:host="framatube.org" />
                 <data android:host="media.assassinate-you.net" />
                 <data android:host="peertube.co.uk" />


### PR DESCRIPTION
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

This adds the Invidious instance tubus.eduvid.org as well as the PeerTube instance eduvid.org.

Please note, that it's explicitly not wished to include Tubus in a "Choose an invidious instance" list, as it's configured to proxy all trafic and primarily intended for use in education.

Both services are hosted by Teckids e.V. (https://www.teckids.org)

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
(I think testing the APK isn't necessary here ;))