### PR TITLE
Remove api level 29 from android ci tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,8 @@ jobs:
     strategy:
       matrix:
         # api-level 19 is min sdk, but throws errors related to desugaring
-        api-level: [ 21, 29 ]
+        # api-level 29 currently not working https://github.com/ReactiveCircus/android-emulator-runner/issues/168 
+        api-level: [ 21 ]
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Codebase improvement (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
api level 29 currently times out, see https://github.com/TeamNewPipe/NewPipe/pull/6673/checks?check_run_id=3080440435.

so remove until it is resolved https://github.com/ReactiveCircus/android-emulator-runner/issues/168

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
