### PR TITLE
Fixed scrolling on refresh in the feed

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
@@ -41,6 +41,7 @@ import androidx.core.view.isVisible
 import androidx.lifecycle.ViewModelProvider
 import androidx.preference.PreferenceManager
 import androidx.recyclerview.widget.GridLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.GroupieViewHolder
 import com.xwray.groupie.Item
@@ -135,6 +136,19 @@ class FeedFragment : BaseStateFragment<FeedState>() {
             setOnItemClickListener(listenerStreamItem)
             setOnItemLongClickListener(listenerStreamItem)
         }
+
+        // Scrolls to the top when a new item is inserted e.g. when refreshing
+        // Using a workaround from
+        // https://dev.to/aldok/how-to-scroll-recyclerview-to-a-certain-position-5ck4
+        // here - the underlying dataset must be ready for scrolling or else scrollToPosition fails
+        groupAdapter.registerAdapterDataObserver(object : RecyclerView.AdapterDataObserver() {
+            override fun onItemRangeInserted(
+                positionStart: Int,
+                itemCount: Int
+            ) {
+                feedBinding.itemsList.scrollToPosition(0)
+            }
+        })
 
         feedBinding.itemsList.adapter = groupAdapter
         setupListViewMode()


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
- When the feed is refreshed, the grid will now always scroll to the top
- The problem only seems to occur when more items are added than removed

#### Before/After Screenshots/Screen Record
<details><summary>Click to open</summary>

Before:

https://user-images.githubusercontent.com/40789489/125986894-f4e7c510-f11a-4a08-bfce-a1153db2ebc6.mp4

After:

https://user-images.githubusercontent.com/40789489/125986902-fb4759f1-2188-47ef-a58d-e9c4d87f6173.mp4

</details>

#### Fixes the following issue(s)
- Fixes #6650

#### APK testing 
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).

#### How to test
* Install the apk / Checkout the branch
* Set your phone / emulator system time to 2021-07-15 at 23:55 (you might need to reset it as the clock counts)
* Import this: [NewPipeData-20210716_190308.zip](https://github.com/TeamNewPipe/NewPipe/files/6832340/NewPipeData-20210716_190308.zip)
* Go to Feed/"What's New" and refresh it

→ It should now scroll to the top 🥳 

