### PR TITLE
Fix some build warnings

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
@@ -167,14 +167,6 @@ class FeedFragment : BaseStateFragment<FeedState>() {
         }
     }
 
-    override fun setUserVisibleHint(isVisibleToUser: Boolean) {
-        super.setUserVisibleHint(isVisibleToUser)
-
-        if (!isVisibleToUser && view != null) {
-            updateRelativeTimeViews()
-        }
-    }
-
     override fun initListeners() {
         super.initListeners()
         feedBinding.refreshRootView.setOnClickListener { reloadContent() }

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
@@ -112,13 +112,6 @@ class SubscriptionFragment : BaseStateFragment<SubscriptionState>() {
         setupInitialLayout()
     }
 
-    override fun setUserVisibleHint(isVisibleToUser: Boolean) {
-        super.setUserVisibleHint(isVisibleToUser)
-        if (activity != null && isVisibleToUser) {
-            setTitle(activity.getString(R.string.tab_subscriptions))
-        }
-    }
-
     override fun onAttach(context: Context) {
         super.onAttach(context)
         subscriptionManager = SubscriptionManager(requireContext())
@@ -156,11 +149,8 @@ class SubscriptionFragment : BaseStateFragment<SubscriptionState>() {
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         super.onCreateOptionsMenu(menu, inflater)
 
-        val supportActionBar = activity.supportActionBar
-        if (supportActionBar != null) {
-            supportActionBar.setDisplayShowTitleEnabled(true)
-            setTitle(getString(R.string.tab_subscriptions))
-        }
+        activity.supportActionBar?.setDisplayShowTitleEnabled(true)
+        activity.supportActionBar?.setTitle(R.string.tab_subscriptions)
     }
 
     private fun setupBroadcastReceiver() {


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This issue fixes 2 build warnings/deprecations:
![grafik](https://user-images.githubusercontent.com/40789489/126041981-126b4553-06d3-4f5e-8ad8-e20a105672fb.png)

The code on these parts was relatively old (>2 years).

Description of the fixes:
* ``FeedFragment``: Removed updateRelativeTimeViews when the activity is paused
We don't need to call ``updateRelativeTimeViews`` when the activity is paused, because the user likely won't notice it (because it is paused).
Despite that ``onResume`` already calls ``updateRelativeTimeViews`` so there is no need to do that twice.
* ``SubscriptionFragment``: Simplified code and adjusted the style so that it's similar to FeedFragment
The title there got set twice (no idea why). Simply copied use the same code (2 lines) from FeedFragment

#### Before/After Screenshots/Screen Record
not applicable

#### Fixes the following issue(s)
not applicable

#### APK testing 
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
