### PR TITLE
Dismiss download dialog correctly

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/RouterActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/RouterActivity.java
@@ -589,9 +589,9 @@ public class RouterActivity extends AppCompatActivity {
                     downloadDialog.setVideoStreams(sortedVideoStreams);
                     downloadDialog.setAudioStreams(result.getAudioStreams());
                     downloadDialog.setSelectedVideoStream(selectedVideoStreamIndex);
+                    downloadDialog.setOnDismissListener(dialog -> finish());
                     downloadDialog.show(fm, "downloadDialog");
                     fm.executePendingTransactions();
-                    downloadDialog.requireDialog().setOnDismissListener(dialog -> finish());
                 }, throwable ->
                         showUnsupportedUrlDialog(currentUrl)));
     }

--- a/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
@@ -3,6 +3,8 @@ package org.schabi.newpipe.download;
 import android.app.Activity;
 import android.content.ComponentName;
 import android.content.Context;
+import android.content.DialogInterface;
+import android.content.DialogInterface.OnDismissListener;
 import android.content.Intent;
 import android.content.ServiceConnection;
 import android.content.SharedPreferences;
@@ -38,7 +40,6 @@ import com.nononsenseapps.filepicker.Utils;
 
 import org.schabi.newpipe.MainActivity;
 import org.schabi.newpipe.R;
-import org.schabi.newpipe.RouterActivity;
 import org.schabi.newpipe.databinding.DownloadDialogBinding;
 import org.schabi.newpipe.error.ErrorActivity;
 import org.schabi.newpipe.error.ErrorInfo;
@@ -100,6 +101,9 @@ public class DownloadDialog extends DialogFragment
     int selectedAudioIndex = 0;
     @State
     int selectedSubtitleIndex = 0;
+
+    @Nullable
+    private OnDismissListener onDismissListener = null;
 
     private StoredDirectoryHelper mainStorageAudio = null;
     private StoredDirectoryHelper mainStorageVideo = null;
@@ -204,6 +208,9 @@ public class DownloadDialog extends DialogFragment
         this.selectedSubtitleIndex = ssi;
     }
 
+    public void setOnDismissListener(@Nullable final OnDismissListener onDismissListener) {
+        this.onDismissListener = onDismissListener;
+    }
 
     /*//////////////////////////////////////////////////////////////////////////
     // Android lifecycle
@@ -219,7 +226,7 @@ public class DownloadDialog extends DialogFragment
 
         if (!PermissionHelper.checkStoragePermissions(getActivity(),
                 PermissionHelper.DOWNLOAD_DIALOG_REQUEST_CODE)) {
-            getDialog().dismiss();
+            dismiss();
             return;
         }
 
@@ -341,7 +348,7 @@ public class DownloadDialog extends DialogFragment
         toolbar.setTitle(R.string.download_dialog_title);
         toolbar.setNavigationIcon(R.drawable.ic_arrow_back);
         toolbar.inflateMenu(R.menu.dialog_url);
-        toolbar.setNavigationOnClickListener(v -> requireDialog().dismiss());
+        toolbar.setNavigationOnClickListener(v -> dismiss());
         toolbar.setNavigationContentDescription(R.string.cancel);
 
         okButton = toolbar.findViewById(R.id.okay);
@@ -350,13 +357,18 @@ public class DownloadDialog extends DialogFragment
         toolbar.setOnMenuItemClickListener(item -> {
             if (item.getItemId() == R.id.okay) {
                 prepareSelectedDownload();
-                if (getActivity() instanceof RouterActivity) {
-                    getActivity().finish();
-                }
                 return true;
             }
             return false;
         });
+    }
+
+    @Override
+    public void onDismiss(@NonNull final DialogInterface dialog) {
+        super.onDismiss(dialog);
+        if (onDismissListener != null) {
+            onDismissListener.onDismiss(dialog);
+        }
     }
 
     @Override
@@ -622,7 +634,7 @@ public class DownloadDialog extends DialogFragment
         } else {
             Toast.makeText(getContext(), R.string.no_streams_available_download,
                     Toast.LENGTH_SHORT).show();
-            getDialog().dismiss();
+            dismiss();
         }
     }
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
The first commit just reorders some methods in the `DownloadDialog` class and adds some comment section separators. 
The second commit fixes the `DownloadDialog` (which is a `DialogFragment`) dismissing according to [this thread](https://stackoverflow.com/questions/11201022/how-to-correctly-dismiss-a-dialogfragment): every reference to `getDialog().dismiss()` is replaced with just `dismiss()`. I also removed references to `getDialog().setOnDismissListener()` and replaced them with a new `onDismissListener` in `DownloadDialog`, required by `RouterActivity` to be able to `finish()` itself when the dialog dismisses. Then I removed the part of code that used to `finish()` the `RouterActivity` inside the `DownloadDialog` (it was in the wrong place), as that's now done correctly by the listener.

#### Fixes the following issue(s)
Fixes #6667
Fixes #6256

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.
@Pass1Vlax @khumarahn @skyGtm @TacoTheDank could you tell me if this works for you?

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
