### PR TITLE
Fix duplicate items in queue causing endless buffering

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -813,7 +813,7 @@ public final class VideoDetailFragment
                                    @NonNull final String newTitle,
                                    @Nullable final PlayQueue newQueue) {
         if (isPlayerAvailable() && newQueue != null && playQueue != null
-                && !Objects.equals(newQueue.getItem(), playQueue.getItem())) {
+                && playQueue.getItem() != null && !playQueue.getItem().getUrl().equals(newUrl)) {
             // Preloading can be disabled since playback is surely being replaced.
             player.disablePreloadingOfCurrentTrack();
         }

--- a/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueueItem.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueueItem.java
@@ -64,20 +64,6 @@ public class PlayQueueItem implements Serializable {
         this.recoveryPosition = RECOVERY_UNSET;
     }
 
-    @Override
-    public boolean equals(final Object o) {
-        if (o instanceof PlayQueueItem) {
-            return url.equals(((PlayQueueItem) o).url);
-        } else {
-            return false;
-        }
-    }
-
-    @Override
-    public int hashCode() {
-        return url.hashCode();
-    }
-
     @NonNull
     public String getTitle() {
         return title;

--- a/app/src/test/java/org/schabi/newpipe/player/playqueue/PlayQueueItemTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/playqueue/PlayQueueItemTest.java
@@ -1,0 +1,19 @@
+package org.schabi.newpipe.player.playqueue;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class PlayQueueItemTest {
+
+    public static final String URL = "MY_URL";
+
+    @Test
+    public void equalsMustNotBeOverloaded() {
+        final PlayQueueItem a = PlayQueueTest.makeItemWithUrl(URL);
+        final PlayQueueItem b = PlayQueueTest.makeItemWithUrl(URL);
+        assertEquals(a, a);
+        assertNotEquals(a, b); // they should compare different even if they have the same data
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/player/playqueue/PlayQueueTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/playqueue/PlayQueueTest.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
@@ -148,6 +149,15 @@ public class PlayQueueTest {
             assertNull(queue.getItem(-1));
             assertNull(queue.getItem(5));
         }
+
+        @Test
+        public void itemsAreNotCloned() {
+            final PlayQueueItem item = makeItemWithUrl("A url");
+            final PlayQueue playQueue = makePlayQueue(0, Collections.singletonList(item));
+
+            // make sure that items are not cloned when added to the queue
+            assertSame(playQueue.getItem(), item);
+        }
     }
 
     public static class EqualsTests {
@@ -159,6 +169,14 @@ public class PlayQueueTest {
             final List<PlayQueueItem> streams = Collections.nCopies(5, item1);
             final PlayQueue queue1 = makePlayQueue(0, streams);
             final PlayQueue queue2 = makePlayQueue(0, streams);
+            assertEquals(queue1, queue2);
+        }
+
+        @Test
+        public void sameStreamsDifferentIndex() {
+            final List<PlayQueueItem> streams = Collections.nCopies(5, item1);
+            final PlayQueue queue1 = makePlayQueue(1, streams);
+            final PlayQueue queue2 = makePlayQueue(4, streams);
             assertEquals(queue1, queue2);
         }
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This is a simple bugfix that allows having play queues with duplicate items. For some reason an `equals()` method was implemented in `PlayQueueItem` that only compared the url, and since duplicate items have the same url they were considered the exact same `PlayQueueItem`s. Using Java's default `equals()` method, that just checks if two objects are the same with `==`, solves the issue, since duplicate items were anyway created one by one and thus are never identical. Removing `equals()` should be completely fine since `PlayQueueItem`s are never `clone()`d, and therefore we never end up with two objects that should be considered the same but down in memory aren't because they were cloned.

#### Fixes the following issue(s)
- Fixes #4940

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.
I am not completely sure that this doesn't introduce regressions, so it needs some testing. @ekiniko12 @RickyM7 @sqtvrnqliq could you check if the endless buffering on duplicate videos in queue is solved?

#### Due diligence
- [ ] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
