### PR TITLE
Readd api level 29 to android CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,8 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        # api-level 19 is min sdk, but throws errors related to desugaring
-        # api-level 29 currently not working https://github.com/ReactiveCircus/android-emulator-runner/issues/168 
-        api-level: [ 21 ]
+        # api-level 19 is min sdk, but throws errors related to desugaring 
+        api-level: [ 21, 29 ]
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Codebase improvement (dev facing)


#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- The action got fixed and released https://github.com/ReactiveCircus/android-emulator-runner/releases/tag/v2.19.1


#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
