### PR TITLE
Update some AndroidX libraries

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -101,7 +101,7 @@ android {
 ext {
     checkstyleVersion = '8.38'
 
-    androidxLifecycleVersion = '2.2.0'
+    androidxLifecycleVersion = '2.3.1'
     androidxRoomVersion = '2.3.0'
 
     icepickVersion = '3.2.0'
@@ -196,12 +196,12 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlin_version}"
 
 /** AndroidX **/
-    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
-    implementation 'androidx.core:core-ktx:1.3.2'
+    implementation 'androidx.core:core-ktx:1.6.0'
     implementation 'androidx.documentfile:documentfile:1.0.1'
-    implementation 'androidx.fragment:fragment-ktx:1.3.5'
+    implementation 'androidx.fragment:fragment-ktx:1.3.6'
     implementation "androidx.lifecycle:lifecycle-livedata:${androidxLifecycleVersion}"
     implementation "androidx.lifecycle:lifecycle-viewmodel:${androidxLifecycleVersion}"
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'

--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -402,7 +402,7 @@ public class MainActivity extends AppCompatActivity {
                 new Handler(Looper.getMainLooper()).postDelayed(() -> {
                     getSupportFragmentManager().popBackStack(null,
                             FragmentManager.POP_BACK_STACK_INCLUSIVE);
-                    recreate();
+                    ActivityCompat.recreate(MainActivity.this);
                 }, 300);
             }
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This PR is meant as a follow up to https://github.com/TeamNewPipe/NewPipe/pull/6702.

- https://github.com/TeamNewPipe/NewPipe/pull/6633#issuecomment-882505567
- Update AndroidX AppCompat 1.3.0 -> 1.3.1 ([changelog](https://developer.android.com/jetpack/androidx/releases/appcompat#version_131_3))
- Update AndroidX Core 1.3.2 -> 1.6.0 ([changelog](https://developer.android.com/jetpack/androidx/releases/core#core_and_core-ktx_version_160_2))
- Update AndroidX Fragment 1.3.5 -> 1.3.6 ([changelog](https://developer.android.com/jetpack/androidx/releases/fragment#version_136_3))
- Update AndroidX Lifecycle 2.2.0 -> 2.3.1 ([changelog](https://developer.android.com/jetpack/androidx/releases/lifecycle#version_231_2))
- Users are basically already using these versions internally because of AppCompat's upgrade to 1.3.0 (other than Core 1.6.0, because AppCompat 1.3.0 uses Core 1.5.0 internally)


#### APK testing 
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
