### PR TITLE
Fix NullPointerException when checking if storage exists

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/streams/io/StoredFileHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/streams/io/StoredFileHelper.java
@@ -8,6 +8,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Environment;
 import android.provider.DocumentsContract;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -15,6 +16,7 @@ import androidx.documentfile.provider.DocumentFile;
 
 import com.nononsenseapps.filepicker.Utils;
 
+import org.schabi.newpipe.MainActivity;
 import org.schabi.newpipe.settings.NewPipeSettings;
 import org.schabi.newpipe.util.FilePickerActivityHelper;
 
@@ -27,6 +29,9 @@ import us.shandian.giga.io.FileStream;
 import us.shandian.giga.io.FileStreamSAF;
 
 public class StoredFileHelper implements Serializable {
+    private static final boolean DEBUG = MainActivity.DEBUG;
+    private static final String TAG = StoredFileHelper.class.getSimpleName();
+
     private static final long serialVersionUID = 0L;
     public static final String DEFAULT_MIME = "application/octet-stream";
 
@@ -286,6 +291,12 @@ public class StoredFileHelper implements Serializable {
 
     public boolean existsAsFile() {
         if (source == null || (docFile == null && ioFile == null)) {
+            if (DEBUG) {
+                Log.d(TAG, "existsAsFile called but something is null: source = ["
+                        + (source == null ? "null => storage is invalid" : source)
+                        + "], docFile = [" + (docFile == null ? "null" : docFile)
+                        + "], ioFile = [" + (ioFile == null ? "null" : ioFile) + "]");
+            }
             return false;
         }
 

--- a/app/src/main/java/org/schabi/newpipe/streams/io/StoredFileHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/streams/io/StoredFileHelper.java
@@ -285,7 +285,7 @@ public class StoredFileHelper implements Serializable {
     }
 
     public boolean existsAsFile() {
-        if (source == null) {
+        if (source == null || (docFile == null && ioFile == null)) {
             return false;
         }
 

--- a/app/src/main/java/us/shandian/giga/get/DownloadMission.java
+++ b/app/src/main/java/us/shandian/giga/get/DownloadMission.java
@@ -664,7 +664,7 @@ public class DownloadMission extends Mission {
      * @return {@code true}, if storage is invalid and cannot be used
      */
     public boolean hasInvalidStorage() {
-        return errCode == ERROR_PROGRESS_LOST || storage == null || storage.isInvalid() || !storage.existsAsFile();
+        return errCode == ERROR_PROGRESS_LOST || storage == null || !storage.existsAsFile();
     }
 
     /**


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
I just added yet another null check ;-)
I removed the ` || storage.isInvalid()` check in `DownloadMission` since that's already taken care of by ` || !storage.existsAsFile()`

#### Fixes the following issue(s)
Fixes https://github.com/TeamNewPipe/NewPipe/issues/6687#issuecomment-885928174

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
