### PR TITLE
Allow manual execution of ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - dev


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [x] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
As mentioned in https://github.com/TeamNewPipe/NewPipe/pull/6709#issuecomment-888559715:

> * Is something speaking against adding [``workflow_dispatch:``](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch) by default to the CI workflow? 
> If I do these kinds of PR, I always have to add it manually and change the default branch of my fork. 
> Shouldn't do any harm in theory.
> If nothing speaks against it I will open a PR.


#### APK testing 
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
