### PR TITLE
Fix channel item span count for SubscriptionFragment

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
@@ -73,7 +73,7 @@ import org.schabi.newpipe.player.helper.PlayerHolder
 import org.schabi.newpipe.util.Localization
 import org.schabi.newpipe.util.NavigationHelper
 import org.schabi.newpipe.util.StreamDialogEntry
-import org.schabi.newpipe.util.ThemeHelper.getGridSpanCount
+import org.schabi.newpipe.util.ThemeHelper.getGridSpanCountStreams
 import org.schabi.newpipe.util.ThemeHelper.shouldUseGridLayout
 import java.time.OffsetDateTime
 import java.util.ArrayList
@@ -160,7 +160,7 @@ class FeedFragment : BaseStateFragment<FeedState>() {
 
     fun setupListViewMode() {
         // does everything needed to setup the layouts for grid or list modes
-        groupAdapter.spanCount = if (shouldUseGridLayout(context)) getGridSpanCount(context) else 1
+        groupAdapter.spanCount = if (shouldUseGridLayout(context)) getGridSpanCountStreams(context) else 1
         feedBinding.itemsList.layoutManager = GridLayoutManager(requireContext(), groupAdapter.spanCount).apply {
             spanSizeLookup = groupAdapter.spanSizeLookup
         }

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
@@ -58,7 +58,7 @@ import org.schabi.newpipe.local.subscription.services.SubscriptionsImportService
 import org.schabi.newpipe.streams.io.StoredFileHelper
 import org.schabi.newpipe.util.NavigationHelper
 import org.schabi.newpipe.util.OnClickGesture
-import org.schabi.newpipe.util.ThemeHelper.getGridSpanCount
+import org.schabi.newpipe.util.ThemeHelper.getGridSpanCountChannels
 import org.schabi.newpipe.util.ThemeHelper.shouldUseGridLayout
 import org.schabi.newpipe.util.external_communication.ShareUtils
 import java.text.SimpleDateFormat
@@ -267,7 +267,7 @@ class SubscriptionFragment : BaseStateFragment<SubscriptionState>() {
         super.initViews(rootView, savedInstanceState)
         _binding = FragmentSubscriptionBinding.bind(rootView)
 
-        groupAdapter.spanCount = if (shouldUseGridLayout(context)) getGridSpanCount(context) else 1
+        groupAdapter.spanCount = if (shouldUseGridLayout(context)) getGridSpanCountChannels(context) else 1
         binding.itemsList.layoutManager = GridLayoutManager(requireContext(), groupAdapter.spanCount).apply {
             spanSizeLookup = groupAdapter.spanSizeLookup
         }

--- a/app/src/main/java/org/schabi/newpipe/util/ThemeHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ThemeHelper.java
@@ -324,17 +324,40 @@ public final class ThemeHelper {
     }
 
     /**
-     * Calculates the number of grid items that can fit horizontally on the screen. The width of a
-     * grid item is obtained from the thumbnail width plus the right and left paddings.
+     * Calculates the number of grid channel info items that can fit horizontally on the screen.
      *
      * @param context the context to use
+     * @return the span count of grid channel info items
+     */
+    public static int getGridSpanCountChannels(final Context context) {
+        return getGridSpanCount(context,
+                context.getResources().getDimensionPixelSize(R.dimen.channel_item_grid_min_width));
+    }
+
+    /**
+     * Calculates the number of grid stream info items that can fit horizontally on the screen. The
+     * width of a grid stream info item is obtained from the thumbnail width plus the right and left
+     * paddings.
+     *
+     * @param context the context to use
+     * @return the span count of grid stream info items
+     */
+    public static int getGridSpanCountStreams(final Context context) {
+        final Resources res = context.getResources();
+        return getGridSpanCount(context,
+                res.getDimensionPixelSize(R.dimen.video_item_grid_thumbnail_image_width)
+                        + res.getDimensionPixelSize(R.dimen.video_item_search_padding) * 2);
+    }
+
+    /**
+     * Calculates the number of grid items that can fit horizontally on the screen based on the
+     * minimum width.
+     *
+     * @param context the context to use
+     * @param minWidth the minimum width of items in the grid
      * @return the span count of grid list items
      */
-    public static int getGridSpanCount(final Context context) {
-        final Resources res = context.getResources();
-        final int minWidth
-                = res.getDimensionPixelSize(R.dimen.video_item_grid_thumbnail_image_width)
-                + res.getDimensionPixelSize(R.dimen.video_item_search_padding) * 2;
-        return Math.max(1, res.getDisplayMetrics().widthPixels / minWidth);
+    public static int getGridSpanCount(final Context context, final int minWidth) {
+        return Math.max(1, context.getResources().getDisplayMetrics().widthPixels / minWidth);
     }
 }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
In  #6705 I didn't notice that, when calculating the maximum number of grid list items that could fit horizontally, the `SubscriptionFragment` used a different `minWidth` than the other list fragments. This is because all other list fragments contain `StreamInfoItem`s, while the `SubscriptionFragment` contains `ChannelInfoItem`s. So I've created two methods to calculate the span count: one for streams (doing the same calculation as before) and one for channels.

#### Before/After Screenshots/Screen Record
See the screenshots in #6802. This restores the correct pre-0.21.7 behaviour.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #6802

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
