### PR TITLE
Provide mime type to file picker to gray out unselectable files

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
@@ -179,7 +179,7 @@ class SubscriptionFragment : BaseStateFragment<SubscriptionState>() {
     }
 
     private fun onImportPreviousSelected() {
-        requestImportLauncher.launch(StoredFileHelper.getPicker(activity))
+        requestImportLauncher.launch(StoredFileHelper.getPicker(activity, JSON_MIME_TYPE))
     }
 
     private fun onExportSelected() {
@@ -187,7 +187,7 @@ class SubscriptionFragment : BaseStateFragment<SubscriptionState>() {
         val exportName = "newpipe_subscriptions_$date.json"
 
         requestExportLauncher.launch(
-            StoredFileHelper.getNewPicker(activity, exportName, "application/json", null)
+            StoredFileHelper.getNewPicker(activity, exportName, JSON_MIME_TYPE, null)
         )
     }
 
@@ -195,7 +195,7 @@ class SubscriptionFragment : BaseStateFragment<SubscriptionState>() {
         FeedGroupReorderDialog().show(parentFragmentManager, null)
     }
 
-    fun requestExportResult(result: ActivityResult) {
+    private fun requestExportResult(result: ActivityResult) {
         if (result.data != null && result.resultCode == Activity.RESULT_OK) {
             activity.startService(
                 Intent(activity, SubscriptionsExportService::class.java)
@@ -204,7 +204,7 @@ class SubscriptionFragment : BaseStateFragment<SubscriptionState>() {
         }
     }
 
-    fun requestImportResult(result: ActivityResult) {
+    private fun requestImportResult(result: ActivityResult) {
         if (result.data != null && result.resultCode == Activity.RESULT_OK) {
             ImportConfirmationDialog.show(
                 this,
@@ -406,5 +406,9 @@ class SubscriptionFragment : BaseStateFragment<SubscriptionState>() {
     override fun hideLoading() {
         super.hideLoading()
         binding.itemsList.animate(true, 200)
+    }
+
+    companion object {
+        const val JSON_MIME_TYPE = "application/json"
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionsImportFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionsImportFragment.java
@@ -177,7 +177,8 @@ public class SubscriptionsImportFragment extends BaseFragment {
     }
 
     public void onImportFile() {
-        requestImportFileLauncher.launch(StoredFileHelper.getPicker(activity));
+        // leave */* mime type to support all services with different mime types and file extensions
+        requestImportFileLauncher.launch(StoredFileHelper.getPicker(activity, "*/*"));
     }
 
     private void requestImportFileResult(final ActivityResult result) {

--- a/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
@@ -77,7 +77,8 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
         final Preference importDataPreference = requirePreference(R.string.import_data);
         importDataPreference.setOnPreferenceClickListener((Preference p) -> {
             requestImportPathLauncher.launch(
-                    StoredFileHelper.getPicker(requireContext(), getImportExportDataUri()));
+                    StoredFileHelper.getPicker(requireContext(),
+                            ZIP_MIME_TYPE, getImportExportDataUri()));
             return true;
         });
 

--- a/app/src/main/java/org/schabi/newpipe/streams/io/StoredFileHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/streams/io/StoredFileHelper.java
@@ -459,11 +459,12 @@ public class StoredFileHelper implements Serializable {
         return !str1.equals(str2);
     }
 
-    public static Intent getPicker(@NonNull final Context ctx) {
+    public static Intent getPicker(@NonNull final Context ctx,
+                                   @NonNull final String mimeType) {
         if (NewPipeSettings.useStorageAccessFramework(ctx)) {
             return new Intent(Intent.ACTION_OPEN_DOCUMENT)
                     .putExtra("android.content.extra.SHOW_ADVANCED", true)
-                    .setType("*/*")
+                    .setType(mimeType)
                     .addCategory(Intent.CATEGORY_OPENABLE)
                     .addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION
                             | StoredDirectoryHelper.PERMISSION_FLAGS);
@@ -477,8 +478,10 @@ public class StoredFileHelper implements Serializable {
         }
     }
 
-    public static Intent getPicker(@NonNull final Context ctx, @Nullable final Uri initialPath) {
-        return applyInitialPathToPickerIntent(ctx, getPicker(ctx), initialPath, null);
+    public static Intent getPicker(@NonNull final Context ctx,
+                                   @NonNull final String mimeType,
+                                   @Nullable final Uri initialPath) {
+        return applyInitialPathToPickerIntent(ctx, getPicker(ctx, mimeType), initialPath, null);
     }
 
     public static Intent getNewPicker(@NonNull final Context ctx,


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This PR just adds a mime type to all `getPicker` calls. When using SAF now, each time the app will want to open a file (to import the database or subscriptions), all files with the incorrect file format will be grayed out. So the database import picker will only let `.zip` be selected and the subscription import picker will only let `.json` be selected. The service-specific subscription imports, though, still have `*/*` as mime type as the extension of those files could be subject to change and is different between services.

#### Before/After Screenshots/Screen Record
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/36421898/127770001-b0d8a65d-cdfb-4e0c-8e46-8851c1c5f00b.png" height="300px"/></td>
    <td><img src="https://user-images.githubusercontent.com/36421898/127770031-e53579c1-42b1-445c-81ed-a48c3ef9dadb.png" height="300px"/></td>
  </tr>
</table>


#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Partially fixes #1493
- Fixes problems with people mixing up the database zip and the subscriptions json

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. @opusforlife2 

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
