### PR TITLE
Hotfix release 0.21.8

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,8 +17,8 @@ android {
         resValue "string", "app_name", "NewPipe"
         minSdkVersion 19
         targetSdkVersion 29
-        versionCode 973
-        versionName "0.21.7"
+        versionCode 974
+        versionName "0.21.8"
 
         multiDexEnabled true
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -186,7 +186,7 @@ dependencies {
     // name and the commit hash with the commit hash of the (pushed) commit you want to test
     // This works thanks to JitPack: https://jitpack.io/
     implementation 'com.github.TeamNewPipe:nanojson:1d9e1aea9049fc9f85e68b43ba39fe7be1c1f751'
-    implementation 'com.github.TeamNewPipe:NewPipeExtractor:v0.21.6'
+    implementation 'com.github.TeamNewPipe:NewPipeExtractor:v0.21.8'
 
 /** Checkstyle **/
     checkstyle "com.puppycrawl.tools:checkstyle:${checkstyleVersion}"

--- a/fastlane/metadata/android/en-US/changelogs/974.txt
+++ b/fastlane/metadata/android/en-US/changelogs/974.txt
@@ -1,0 +1,5 @@
+Hotfix
+• Fix buffering issues caused by YouTube throttling
+• Fix YouTube comments extraction and crashes with disabled comments
+• Fix YouTube music search
+• Fix PeerTube livestreams


### PR DESCRIPTION
Yet another hotfix release. No NewPipe-side PRs were included; instead all NewPipeExtractor PRs were included since cherry picking 55 commits possibly depending on the parent ones would not have been feasible. The PRs I had to include for this reason, but which were not essential for the hotfix, were anyway small PRs with no possible regression (https://github.com/TeamNewPipe/NewPipeExtractor/pull/661 and https://github.com/TeamNewPipe/NewPipeExtractor/pull/647). The detailed extractor changelog is [here](https://github.com/TeamNewPipe/NewPipeExtractor/releases/tag/v0.21.8). Even though usually NewPipe's changelog do not contain NewPipeExtractor PRs references, I had to include them in this case because otherwise the changelog would have been empty. Anyway the changelog for NewPipe contains less dev-only details than that of NewPipeExtractor:

### Fixed
- [YouTube] Fix buffering and throttling by decoding `n` parameter in stream URLs TeamNewPipe/NewPipeExtractor#683 TeamNewPipe/NewPipeExtractor#696 
- [YouTube] Fix comment extraction and more improvements TeamNewPipe/NewPipeExtractor#604 
- [YouTube] Fix crashes with disabled comments TeamNewPipe/NewPipeExtractor#652 
- [YouTube] Fix music search TeamNewPipe/NewPipeExtractor#699 
- [PeerTube] Fix livestreams TeamNewPipe/NewPipeExtractor#661 