### PR TITLE
Fixed shuffle button opacity UI bug

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -635,7 +635,6 @@ public final class Player implements
         final int repeatMode = intent.getIntExtra(REPEAT_MODE, getRepeatMode());
         final boolean playWhenReady = intent.getBooleanExtra(PLAY_WHEN_READY, true);
         final boolean isMuted = intent.getBooleanExtra(IS_MUTED, isMuted());
-        final boolean shuffleMode = false; //Set the default shuffle mode to disabled
 
         /*
          * There are 3 situations when playback shouldn't be started from scratch (zero timestamp):
@@ -692,7 +691,7 @@ public final class Player implements
                                             state.getProgressMillis());
                                 }
                                 initPlayback(newQueue, repeatMode, playbackSpeed, playbackPitch,
-                                        playbackSkipSilence, playWhenReady, isMuted, shuffleMode);
+                                        playbackSkipSilence, playWhenReady, isMuted);
                             },
                             error -> {
                                 if (DEBUG) {
@@ -700,19 +699,19 @@ public final class Player implements
                                 }
                                 // In case any error we can start playback without history
                                 initPlayback(newQueue, repeatMode, playbackSpeed, playbackPitch,
-                                        playbackSkipSilence, playWhenReady, isMuted, shuffleMode);
+                                        playbackSkipSilence, playWhenReady, isMuted);
                             },
                             () -> {
                                 // Completed but not found in history
                                 initPlayback(newQueue, repeatMode, playbackSpeed, playbackPitch,
-                                        playbackSkipSilence, playWhenReady, isMuted, shuffleMode);
+                                        playbackSkipSilence, playWhenReady, isMuted);
                             }
                     ));
         } else {
             // Good to go...
             // In a case of equal PlayQueues we can re-init old one but only when it is disposed
             initPlayback(samePlayQueue ? playQueue : newQueue, repeatMode, playbackSpeed,
-                    playbackPitch, playbackSkipSilence, playWhenReady, isMuted, shuffleMode);
+                    playbackPitch, playbackSkipSilence, playWhenReady, isMuted);
         }
 
         if (oldPlayerType != playerType && playQueue != null) {
@@ -771,12 +770,11 @@ public final class Player implements
                               final float playbackPitch,
                               final boolean playbackSkipSilence,
                               final boolean playOnReady,
-                              final boolean isMuted,
-                              final boolean shuffleEnabled) {
+                              final boolean isMuted) {
         destroyPlayer();
         initPlayer(playOnReady);
         setRepeatMode(repeatMode);
-        onShuffleModeEnabledChanged(shuffleEnabled);
+        onShuffleModeEnabledChanged(false);
         setPlaybackParameters(playbackSpeed, playbackPitch, playbackSkipSilence);
 
         playQueue = queue;

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -774,7 +774,8 @@ public final class Player implements
         destroyPlayer();
         initPlayer(playOnReady);
         setRepeatMode(repeatMode);
-        onShuffleModeEnabledChanged(false);
+        // #6825 - Ensure that the shuffle-button is in the correct state on the UI
+        setShuffleButton(binding.shuffleButton, simpleExoPlayer.getShuffleModeEnabled());
         setPlaybackParameters(playbackSpeed, playbackPitch, playbackSkipSilence);
 
         playQueue = queue;

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -635,6 +635,7 @@ public final class Player implements
         final int repeatMode = intent.getIntExtra(REPEAT_MODE, getRepeatMode());
         final boolean playWhenReady = intent.getBooleanExtra(PLAY_WHEN_READY, true);
         final boolean isMuted = intent.getBooleanExtra(IS_MUTED, isMuted());
+        final boolean shuffleMode = false; //Set the default shuffle mode to disabled
 
         /*
          * There are 3 situations when playback shouldn't be started from scratch (zero timestamp):
@@ -691,7 +692,7 @@ public final class Player implements
                                             state.getProgressMillis());
                                 }
                                 initPlayback(newQueue, repeatMode, playbackSpeed, playbackPitch,
-                                        playbackSkipSilence, playWhenReady, isMuted);
+                                        playbackSkipSilence, playWhenReady, isMuted, shuffleMode);
                             },
                             error -> {
                                 if (DEBUG) {
@@ -699,19 +700,19 @@ public final class Player implements
                                 }
                                 // In case any error we can start playback without history
                                 initPlayback(newQueue, repeatMode, playbackSpeed, playbackPitch,
-                                        playbackSkipSilence, playWhenReady, isMuted);
+                                        playbackSkipSilence, playWhenReady, isMuted, shuffleMode);
                             },
                             () -> {
                                 // Completed but not found in history
                                 initPlayback(newQueue, repeatMode, playbackSpeed, playbackPitch,
-                                        playbackSkipSilence, playWhenReady, isMuted);
+                                        playbackSkipSilence, playWhenReady, isMuted, shuffleMode);
                             }
                     ));
         } else {
             // Good to go...
             // In a case of equal PlayQueues we can re-init old one but only when it is disposed
             initPlayback(samePlayQueue ? playQueue : newQueue, repeatMode, playbackSpeed,
-                    playbackPitch, playbackSkipSilence, playWhenReady, isMuted);
+                    playbackPitch, playbackSkipSilence, playWhenReady, isMuted, shuffleMode);
         }
 
         if (oldPlayerType != playerType && playQueue != null) {
@@ -770,10 +771,12 @@ public final class Player implements
                               final float playbackPitch,
                               final boolean playbackSkipSilence,
                               final boolean playOnReady,
-                              final boolean isMuted) {
+                              final boolean isMuted,
+                              final boolean shuffleEnabled) {
         destroyPlayer();
         initPlayer(playOnReady);
         setRepeatMode(repeatMode);
+        onShuffleModeEnabledChanged(shuffleEnabled);
         setPlaybackParameters(playbackSpeed, playbackPitch, playbackSkipSilence);
 
         playQueue = queue;

--- a/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueue.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueue.java
@@ -442,7 +442,7 @@ public abstract class PlayQueue implements Serializable {
         if (backup == null) {
             backup = new ArrayList<>(streams);
         }
-        // Can't shuffle an list that's empty or only has one element
+        // Can't shuffle a list that's empty or only has one element
         if (size() <= 2) {
             return;
         }

--- a/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueue.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueue.java
@@ -436,13 +436,15 @@ public abstract class PlayQueue implements Serializable {
      * top, so shuffling a size-2 list does nothing)
      */
     public synchronized void shuffle() {
+        // Create a backup if it doesn't already exist
+        // Note: The backup-list has to be created at all cost (even when size <= 2).
+        // Otherwise it's not possible to enter shuffle-mode!
+        if (backup == null) {
+            backup = new ArrayList<>(streams);
+        }
         // Can't shuffle an list that's empty or only has one element
         if (size() <= 2) {
             return;
-        }
-        // Create a backup if it doesn't already exist
-        if (backup == null) {
-            backup = new ArrayList<>(streams);
         }
 
         final int originalIndex = getIndex();


### PR DESCRIPTION
Parameterised shuffle state into initPlayback for potentially passing the shuffle state into the player in the future

<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Fixes the shuffle mode button UI bug and parameterizes the shuffle mode in `initPlayback` (to potentially allow passing the saved shuffle state into the player in the future)

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes https://github.com/TeamNewPipe/NewPipe/issues/6825

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
