### PR TITLE
Add gradle parameter to skip formatKtLint and use in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,8 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
           
-      - name: Check if kotlin files are formatted correctly
-        run: ./gradlew runKtlint
-
       - name: Build debug APK and run jvm tests
-        run: ./gradlew assembleDebug lintDebug testDebugUnitTest --stacktrace
+        run: ./gradlew assembleDebug lintDebug testDebugUnitTest --stacktrace -DskipFormatKtlint
 
       - name: Upload APK
         uses: actions/upload-artifact@v2

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -165,7 +165,10 @@ task formatKtlint(type: JavaExec) {
 }
 
 afterEvaluate {
-    preDebugBuild.dependsOn formatKtlint, runCheckstyle, runKtlint
+    if (!System.properties.containsKey('skipFormatKtlint')) {
+        preDebugBuild.dependsOn formatKtlint
+    }
+    preDebugBuild.dependsOn runCheckstyle, runKtlint
 }
 
 sonarqube {


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Codebase improvement (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Add gradle parameter to skip formatKtLint and use in CI

#### Screenshots
<details>
<summary>with parameter</summary>

![image](https://user-images.githubusercontent.com/41164160/128540644-615f566c-ab0a-45a7-aab0-debbe30621cd.png)

</details>

<details>
<summary>without parameter it starts with formatKtLint</summary>

![image](https://user-images.githubusercontent.com/41164160/128540732-b202e237-a547-4a3f-9aba-919697bb5057.png)

</details>

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- This way `runKtlint` is not executed twice during CI


#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
