### PR TITLE
Add no-response workflow

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -1,0 +1,20 @@
+name: No Response
+
+# Both `issue_comment` and `scheduled` event types are required for this Action
+# to work properly.
+on:
+  issue_comment:
+    types: [created]
+  schedule:
+    # Schedule for five minutes after the hour, every hour
+    - cron: '5 * * * *'
+
+jobs:
+  noResponse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lee-dohm/no-response@v0.5.0
+        with:
+          token: ${{ github.token }}
+          daysUntilClose: 14
+          responseRequiredLabel: waiting-for-author

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -6,8 +6,8 @@ on:
   issue_comment:
     types: [created]
   schedule:
-    # Schedule for five minutes after the hour, every hour
-    - cron: '5 * * * *'
+    # Run daily at midnight.
+    - cron: '0 0 * * *'
 
 jobs:
   noResponse:


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
Add a workflow to help manage issues where the author hasn't responded to requests for more information. Here's an example:
1. I open an issue, but it doesn't give enough information
2. `@opusforlife` creates a comment asking me for the missing enough and labels the issue as `waiting-for-author`
3. If I reply before 14 days, the label is automatically removed. If I reply after 14 days, the label is automatically removed and the issue is re-opened.

I [opened an issue on the action's repo asking whether this works with PRs](https://github.com/lee-dohm/no-response/issues/171), but there's no reply yet. In any case, usage with PRs right now should be avoided, as 14 days is a far too short span of time. I plan to modify the action so we can have a separate `daysUntilClose` for PRs, but for now, this should be used with issues only.

I [created a repo with an identical workflow to the one added in this PR](https://github.com/mhmdanas/test-no-response-action). If anyone is interested in testing, feel free to ask and I'll send you an invite.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
