### PR TITLE
Only show "mark as watched" when watch history is enabled

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
@@ -349,7 +349,15 @@ class FeedFragment : BaseStateFragment<FeedState>() {
                 )
             )
         }
-        if (item.streamType != StreamType.AUDIO_LIVE_STREAM && item.streamType != StreamType.LIVE_STREAM) {
+
+        // show "mark as watched" only when watch history is enabled
+        val isWatchHistoryEnabled = PreferenceManager
+            .getDefaultSharedPreferences(context)
+            .getBoolean(getString(R.string.enable_watch_history_key), false)
+        if (item.streamType != StreamType.AUDIO_LIVE_STREAM &&
+            item.streamType != StreamType.LIVE_STREAM &&
+            isWatchHistoryEnabled
+        ) {
             entries.add(
                 StreamDialogEntry.mark_as_watched
             )


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Only display the "mark as watched" item in the feed context menu when the watch history is enabled.

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
