### PR TITLE
Using Eclipse ``temurin`` in GH actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: 8
-          distribution: "adopt"
+          distribution: "temurin"
 
       - name: Cache Gradle dependencies
         uses: actions/cache@v2
@@ -69,7 +69,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: 8
-          distribution: "adopt"
+          distribution: "temurin"
 
       - name: Cache Gradle dependencies
         uses: actions/cache@v2
@@ -97,7 +97,7 @@ jobs:
 #         uses: actions/setup-java@v2
 #         with:
 #           java-version: 11 # Sonar requires JDK 11
-#           distribution: "adopt"
+#           distribution: "temurin"
 
 #       - name: Cache SonarCloud packages
 #         uses: actions/cache@v2


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Using Eclipse ``temurin`` in GH actions as AdoptOpenJDK is getting deprecated.

Eclipse ``temurin`` is a de-facto renamed AdoptOpenJDK.

Ref:
* https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/
* https://github.com/actions/setup-java#supported-distributions

Reasons why using Eclipse Temurin/Adoptium and not Zulu can be found here:
* https://github.com/TeamNewPipe/NewPipe/pull/6360#issue-650785646
* https://github.com/TeamNewPipe/NewPipe/pull/6360#issuecomment-848094559

#### APK testing 
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
