### PR TITLE
Using integrated cache in ``actions/setup-java``

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,13 +38,7 @@ jobs:
         with:
           java-version: 8
           distribution: "temurin"
-
-      - name: Cache Gradle dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
+          cache: 'gradle'
           
       - name: Build debug APK and run jvm tests
         run: ./gradlew assembleDebug lintDebug testDebugUnitTest --stacktrace -DskipFormatKtlint
@@ -70,13 +64,7 @@ jobs:
         with:
           java-version: 8
           distribution: "temurin"
-
-      - name: Cache Gradle dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
+          cache: 'gradle'
 
       - name: Run android tests
         uses: reactivecircus/android-emulator-runner@v2
@@ -98,6 +86,7 @@ jobs:
 #         with:
 #           java-version: 11 # Sonar requires JDK 11
 #           distribution: "temurin"
+#           cache: 'gradle'
 
 #       - name: Cache SonarCloud packages
 #         uses: actions/cache@v2
@@ -105,13 +94,6 @@ jobs:
 #           path: ~/.sonar/cache
 #           key: ${{ runner.os }}-sonar
 #           restore-keys: ${{ runner.os }}-sonar
-
-#       - name: Cache Gradle packages
-#         uses: actions/cache@v2
-#         with:
-#           path: ~/.gradle/caches
-#           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-#           restore-keys: ${{ runner.os }}-gradle
 
 #       - name: Build and analyze
 #         env:


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Using integrated cache in ``actions/setup-java`` instead of specifying it.
See https://github.com/actions/setup-java#caching-gradle-dependencies for details.

Advantages:
* Results in more compact and easier readable code
* We don't need to specify/manage the cache ourselves as the action does it automatically

A test of the above can be seen in:
* https://github.com/litetex/NewPipe/runs/3450616944?check_suite_focus=true
* https://github.com/litetex/NewPipe/runs/3450662800?check_suite_focus=true

#### APK testing 
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
