### PR TITLE
Never use ``android.R.string``s; remove unused ``add`` string

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/about/LicenseFragmentHelper.kt
+++ b/app/src/main/java/org/schabi/newpipe/about/LicenseFragmentHelper.kt
@@ -108,7 +108,7 @@ object LicenseFragmentHelper {
                     alert.setView(webView)
                     Localization.assureCorrectAppLanguage(context)
                     alert.setNegativeButton(
-                        context.getString(R.string.finish)
+                        context.getString(R.string.ok)
                     ) { dialog, _ -> dialog.dismiss() }
                     alert.show()
                 }

--- a/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
@@ -681,7 +681,7 @@ public class DownloadDialog extends DialogFragment
         new AlertDialog.Builder(context)
                 .setTitle(R.string.general_error)
                 .setMessage(msg)
-                .setNegativeButton(getString(R.string.finish), null)
+                .setNegativeButton(getString(R.string.ok), null)
                 .create()
                 .show();
     }

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -2071,7 +2071,7 @@ public final class VideoDetailFragment
         new AlertDialog.Builder(activity)
                 .setTitle(R.string.clear_queue_confirmation_description)
                 .setNegativeButton(R.string.cancel, null)
-                .setPositiveButton(android.R.string.yes, (dialog, which) -> {
+                .setPositiveButton(R.string.ok, (dialog, which) -> {
                     onAllow.run();
                     dialog.dismiss();
                 }).show();

--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
@@ -206,7 +206,7 @@ class FeedFragment : BaseStateFragment<FeedState>() {
                         putBoolean(getString(R.string.feed_use_dedicated_fetch_method_key), !usingDedicatedMethod)
                     }
                 }
-                .setPositiveButton(resources.getString(R.string.finish), null)
+                .setPositiveButton(resources.getString(R.string.ok), null)
                 .create()
                 .show()
             return true

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/ImportConfirmationDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/ImportConfirmationDialog.java
@@ -40,7 +40,7 @@ public class ImportConfirmationDialog extends DialogFragment {
                 .setMessage(R.string.import_network_expensive_warning)
                 .setCancelable(true)
                 .setNegativeButton(R.string.cancel, null)
-                .setPositiveButton(R.string.finish, (dialogInterface, i) -> {
+                .setPositiveButton(R.string.ok, (dialogInterface, i) -> {
                     if (resultServiceIntent != null && getContext() != null) {
                         getContext().startService(resultServiceIntent);
                     }

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/dialog/FeedGroupDialog.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/dialog/FeedGroupDialog.kt
@@ -143,21 +143,15 @@ class FeedGroupDialog : DialogFragment(), BackPressable {
         ).get(FeedGroupDialogViewModel::class.java)
 
         viewModel.groupLiveData.observe(viewLifecycleOwner, Observer(::handleGroup))
-        viewModel.subscriptionsLiveData.observe(
-            viewLifecycleOwner,
-            Observer {
-                setupSubscriptionPicker(it.first, it.second)
+        viewModel.subscriptionsLiveData.observe(viewLifecycleOwner) {
+            setupSubscriptionPicker(it.first, it.second)
+        }
+        viewModel.dialogEventLiveData.observe(viewLifecycleOwner) {
+            when (it) {
+                ProcessingEvent -> disableInput()
+                SuccessEvent -> dismiss()
             }
-        )
-        viewModel.dialogEventLiveData.observe(
-            viewLifecycleOwner,
-            Observer {
-                when (it) {
-                    ProcessingEvent -> disableInput()
-                    SuccessEvent -> dismiss()
-                }
-            }
-        )
+        }
 
         subscriptionGroupAdapter = GroupAdapter<GroupieViewHolder>().apply {
             add(subscriptionMainSection)
@@ -437,7 +431,7 @@ class FeedGroupDialog : DialogFragment(), BackPressable {
         feedGroupCreateBinding.confirmButton.setText(
             when {
                 currentScreen == InitialScreen && groupId == NO_GROUP_SELECTED -> R.string.create
-                else -> android.R.string.ok
+                else -> R.string.ok
             }
         )
 

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlaybackParameterDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlaybackParameterDialog.java
@@ -164,7 +164,7 @@ public class PlaybackParameterDialog extends DialogFragment {
                         setPlaybackParameters(initialTempo, initialPitch, initialSkipSilence))
                 .setNeutralButton(R.string.playback_reset, (dialogInterface, i) ->
                         setPlaybackParameters(DEFAULT_TEMPO, DEFAULT_PITCH, DEFAULT_SKIP_SILENCE))
-                .setPositiveButton(R.string.finish, (dialogInterface, i) ->
+                .setPositiveButton(R.string.ok, (dialogInterface, i) ->
                         setCurrentPlaybackParameters());
 
         return dialogBuilder.create();

--- a/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
@@ -184,7 +184,7 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
 
             new AlertDialog.Builder(requireActivity())
                     .setMessage(R.string.override_current_data)
-                    .setPositiveButton(R.string.finish, (d, id) ->
+                    .setPositiveButton(R.string.ok, (d, id) ->
                             importDatabase(file, lastImportDataUri))
                     .setNegativeButton(R.string.cancel, (d, id) ->
                             d.cancel())
@@ -236,7 +236,7 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
                     dialog.dismiss();
                     finishImport(importDataUri);
                 });
-                alert.setPositiveButton(getString(R.string.finish), (dialog, which) -> {
+                alert.setPositiveButton(getString(R.string.ok), (dialog, which) -> {
                     dialog.dismiss();
                     manager.loadSharedPreferences(PreferenceManager
                             .getDefaultSharedPreferences(requireContext()));

--- a/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
@@ -232,11 +232,11 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
                 final AlertDialog.Builder alert = new AlertDialog.Builder(requireContext());
                 alert.setTitle(R.string.import_settings);
 
-                alert.setNegativeButton(android.R.string.no, (dialog, which) -> {
+                alert.setNegativeButton(R.string.cancel, (dialog, which) -> {
                     dialog.dismiss();
                     finishImport(importDataUri);
                 });
-                alert.setPositiveButton(getString(R.string.ok), (dialog, which) -> {
+                alert.setPositiveButton(R.string.ok, (dialog, which) -> {
                     dialog.dismiss();
                     manager.loadSharedPreferences(PreferenceManager
                             .getDefaultSharedPreferences(requireContext()));

--- a/app/src/main/java/org/schabi/newpipe/settings/DownloadSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/DownloadSettingsFragment.java
@@ -179,7 +179,7 @@ public class DownloadSettingsFragment extends BasePreferenceFragment {
         final AlertDialog.Builder msg = new AlertDialog.Builder(ctx);
         msg.setTitle(title);
         msg.setMessage(message);
-        msg.setPositiveButton(getString(R.string.finish), null);
+        msg.setPositiveButton(getString(R.string.ok), null);
         msg.show();
     }
 

--- a/app/src/main/java/org/schabi/newpipe/settings/PeertubeInstanceListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/PeertubeInstanceListFragment.java
@@ -218,7 +218,7 @@ public class PeertubeInstanceListFragment extends Fragment {
                 .setIcon(R.drawable.place_holder_peertube)
                 .setView(dialogBinding.getRoot())
                 .setNegativeButton(R.string.cancel, null)
-                .setPositiveButton(R.string.finish, (dialog1, which) -> {
+                .setPositiveButton(R.string.ok, (dialog1, which) -> {
                     final String url = dialogBinding.dialogEditText.getText().toString();
                     addInstance(url);
                 })

--- a/app/src/main/java/us/shandian/giga/ui/adapter/MissionAdapter.java
+++ b/app/src/main/java/us/shandian/giga/ui/adapter/MissionAdapter.java
@@ -555,7 +555,7 @@ public class MissionAdapter extends Adapter<ViewHolder> implements Handler.Callb
             );
         }
 
-        builder.setNegativeButton(R.string.finish, (dialog, which) -> dialog.cancel())
+        builder.setNegativeButton(R.string.ok, (dialog, which) -> dialog.cancel())
                 .setTitle(mission.storage.getName())
                 .create()
                 .show();

--- a/app/src/main/res/layout/dialog_feed_group_reorder.xml
+++ b/app/src/main/res/layout/dialog_feed_group_reorder.xml
@@ -27,5 +27,5 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="end"
-        android:text="@string/finish" />
+        android:text="@string/ok" />
 </LinearLayout>

--- a/app/src/main/res/menu/dialog_url.xml
+++ b/app/src/main/res/menu/dialog_url.xml
@@ -3,7 +3,7 @@
 
     <item
         android:id="@+id/okay"
-        android:title="@string/finish"
+        android:title="@string/ok"
         app:showAsAction="always" />
 
 </menu>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -168,7 +168,6 @@
     <string name="view">شغل</string>
     <string name="delete">حذف</string>
     <string name="checksum">التوقيع</string>
-    <string name="add">مهمة جديدة</string>
     <string name="ok">حسناً</string>
     <string name="msg_name">اسم الملف</string>
     <string name="msg_threads">التقسيم</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -169,7 +169,7 @@
     <string name="delete">حذف</string>
     <string name="checksum">التوقيع</string>
     <string name="add">مهمة جديدة</string>
-    <string name="finish">حسناً</string>
+    <string name="ok">حسناً</string>
     <string name="msg_name">اسم الملف</string>
     <string name="msg_threads">التقسيم</string>
     <string name="msg_error">الخطأ</string>

--- a/app/src/main/res/values-b+ast/strings.xml
+++ b/app/src/main/res/values-b+ast/strings.xml
@@ -41,7 +41,6 @@
     <string name="audio">Audiu</string>
     <string name="delete">Desaniciar</string>
     <string name="checksum">Suma de comprobación</string>
-    <string name="add">Misión nueva</string>
     <string name="ok">Aceutar</string>
     <string name="msg_threads">Filos</string>
     <string name="msg_error">Fallu</string>

--- a/app/src/main/res/values-b+ast/strings.xml
+++ b/app/src/main/res/values-b+ast/strings.xml
@@ -42,7 +42,7 @@
     <string name="delete">Desaniciar</string>
     <string name="checksum">Suma de comprobación</string>
     <string name="add">Misión nueva</string>
-    <string name="finish">Aceutar</string>
+    <string name="ok">Aceutar</string>
     <string name="msg_threads">Filos</string>
     <string name="msg_error">Fallu</string>
     <string name="msg_wait">Espera…</string>

--- a/app/src/main/res/values-b+uz+Latn/strings.xml
+++ b/app/src/main/res/values-b+uz+Latn/strings.xml
@@ -280,7 +280,6 @@
     <string name="msg_threads">Iplar</string>
     <string name="msg_name">Faylnomi</string>
     <string name="ok">Ok</string>
-    <string name="add">Yangi missiya</string>
     <string name="rename">Nomni o\'zgartirish</string>
     <string name="dismiss">Tarqatish</string>
     <string name="checksum">Sumnazorat</string>

--- a/app/src/main/res/values-b+uz+Latn/strings.xml
+++ b/app/src/main/res/values-b+uz+Latn/strings.xml
@@ -279,7 +279,7 @@
     <string name="msg_error">Xato</string>
     <string name="msg_threads">Iplar</string>
     <string name="msg_name">Faylnomi</string>
-    <string name="finish">Ok</string>
+    <string name="ok">Ok</string>
     <string name="add">Yangi missiya</string>
     <string name="rename">Nomni o\'zgartirish</string>
     <string name="dismiss">Tarqatish</string>

--- a/app/src/main/res/values-b+zh+HANS+CN/strings.xml
+++ b/app/src/main/res/values-b+zh+HANS+CN/strings.xml
@@ -98,7 +98,7 @@
     <string name="delete">删除</string>
     <string name="checksum">校验</string>
     <string name="add">新任务</string>
-    <string name="finish">确定</string>
+    <string name="ok">确定</string>
     <string name="msg_name">文件名</string>
     <string name="msg_threads">线程数</string>
     <string name="msg_error">错误</string>

--- a/app/src/main/res/values-b+zh+HANS+CN/strings.xml
+++ b/app/src/main/res/values-b+zh+HANS+CN/strings.xml
@@ -97,7 +97,6 @@
     <string name="view">播放</string>
     <string name="delete">删除</string>
     <string name="checksum">校验</string>
-    <string name="add">新任务</string>
     <string name="ok">确定</string>
     <string name="msg_name">文件名</string>
     <string name="msg_threads">线程数</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -228,7 +228,7 @@
     <string name="dismiss">Адхіліць</string>
     <string name="rename">Перайменаваць</string>
     <string name="add">Новая мэта</string>
-    <string name="finish">ОК</string>
+    <string name="ok">ОК</string>
     <string name="msg_name">Імя файла</string>
     <string name="msg_threads">Патокі</string>
     <string name="msg_error">Памылка</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -227,7 +227,6 @@
     <string name="checksum">Кантрольная сума</string>
     <string name="dismiss">Адхіліць</string>
     <string name="rename">Перайменаваць</string>
-    <string name="add">Новая мэта</string>
     <string name="ok">ОК</string>
     <string name="msg_name">Імя файла</string>
     <string name="msg_threads">Патокі</string>

--- a/app/src/main/res/values-ber/strings.xml
+++ b/app/src/main/res/values-ber/strings.xml
@@ -40,7 +40,7 @@
     <string name="msg_wait">ⵕⴰⵊⴰ…</string>
     <string name="msg_error">ⵜⴰⵣⴳⵍⵜ</string>
     <string name="msg_name">ⵉⵙⵎ ⵓⴼⴰⵢⵍⵓ</string>
-    <string name="finish">ⵡⴰⵅⵅⴰ</string>
+    <string name="ok">ⵡⴰⵅⵅⴰ</string>
     <string name="rename">ⵙⵙⵏⴼⵍ ⵉⵙⵎ</string>
     <string name="dismiss">ⵙⵙⵔ</string>
     <string name="delete_all">ⴽⴽⵙ ⵎⴰⵕⵕⴰ</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -260,7 +260,6 @@
     <string name="start">Начало</string>
     <string name="delete_one">Изтрий един</string>
     <string name="rename">Преименувай</string>
-    <string name="add">Нова цел</string>
     <string name="no_available_dir">Моля, изберете достъпна папка за изтегляния</string>
     <string name="msg_popup_permission">Това разрешение се изисква за
 \nвъзпроизвеждане в отделен прозорец</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -156,7 +156,7 @@
     <string name="view">Начало</string>
     <string name="delete">Изтрий</string>
     <string name="checksum">Контролна сума</string>
-    <string name="finish">ОК</string>
+    <string name="ok">ОК</string>
     <string name="msg_name">Име на файла</string>
     <string name="msg_threads">Нишки</string>
     <string name="msg_error">Грешка</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -118,7 +118,6 @@
     <string name="delete">ডিলেট</string>
     <string name="checksum">চেকসাম</string>
     <!-- Fragment -->
-    <string name="add">নতুন মিশন</string>
     <string name="ok">ঠিক আছে</string>
     <!-- Msg -->
     <string name="msg_name">ফাইলের নাম</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -119,7 +119,7 @@
     <string name="checksum">চেকসাম</string>
     <!-- Fragment -->
     <string name="add">নতুন মিশন</string>
-    <string name="finish">ঠিক আছে</string>
+    <string name="ok">ঠিক আছে</string>
     <!-- Msg -->
     <string name="msg_name">ফাইলের নাম</string>
     <string name="msg_threads">থ্রেড</string>

--- a/app/src/main/res/values-bn-rIN/strings.xml
+++ b/app/src/main/res/values-bn-rIN/strings.xml
@@ -23,7 +23,7 @@
     <string name="msg_error">ত্রুটি</string>
     <string name="msg_threads">থ্রেড</string>
     <string name="msg_name">ফাইলের নাম</string>
-    <string name="finish">ঠিক আছে</string>
+    <string name="ok">ঠিক আছে</string>
     <string name="add">নতুন মিশন</string>
     <string name="rename">নাম পরিবর্তন করুন</string>
     <string name="checksum">চেকসাম</string>

--- a/app/src/main/res/values-bn-rIN/strings.xml
+++ b/app/src/main/res/values-bn-rIN/strings.xml
@@ -24,7 +24,6 @@
     <string name="msg_threads">থ্রেড</string>
     <string name="msg_name">ফাইলের নাম</string>
     <string name="ok">ঠিক আছে</string>
-    <string name="add">নতুন মিশন</string>
     <string name="rename">নাম পরিবর্তন করুন</string>
     <string name="checksum">চেকসাম</string>
     <string name="delete">ডিলেট</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -110,7 +110,7 @@
     <string name="msg_error">ত্রুটি</string>
     <string name="msg_threads">থ্রেড</string>
     <string name="msg_name">ফাইলের নাম</string>
-    <string name="finish">ঠিক আছে</string>
+    <string name="ok">ঠিক আছে</string>
     <string name="add">নতুন মিশন</string>
     <string name="rename">নাম পরিবর্তন করুন</string>
     <string name="dismiss">সরাও</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -111,7 +111,6 @@
     <string name="msg_threads">থ্রেড</string>
     <string name="msg_name">ফাইলের নাম</string>
     <string name="ok">ঠিক আছে</string>
-    <string name="add">নতুন মিশন</string>
     <string name="rename">নাম পরিবর্তন করুন</string>
     <string name="dismiss">সরাও</string>
     <string name="checksum">চেকসাম</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -63,7 +63,7 @@
         <item quantity="one">%s subscriptor</item>
         <item quantity="other">%s subscriptors</item>
     </plurals>
-    <string name="finish">D\'acord</string>
+    <string name="ok">D\'acord</string>
     <string name="msg_name">Nom de fitxer</string>
     <string name="msg_error">Error</string>
     <string name="settings_category_downloads_title">Baixades</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -292,7 +292,6 @@
     <string name="short_million">milions</string>
     <string name="short_billion">mil milions</string>
     <string name="start">Inicia</string>
-    <string name="add">Nova missió</string>
     <string name="msg_url_malform">L\'URL té un format no vàlid o no hi ha connexió a Internet</string>
     <string name="msg_running_detail">Feu un toc aquí per a més detalls</string>
     <string name="no_available_dir">Defineix una carpeta de baixades més endavant als paràmetres</string>

--- a/app/src/main/res/values-ckb/strings.xml
+++ b/app/src/main/res/values-ckb/strings.xml
@@ -299,7 +299,7 @@
     </plurals>
     <string name="rename_playlist">ناولێنانه‌وه‌</string>
     <string name="download">دابه‌زاندن</string>
-    <string name="finish">باشە</string>
+    <string name="ok">باشە</string>
     <string name="metadata_cache_wipe_title">سڕینه‌وه‌ی پاشماوەی مێتاداتا</string>
     <string name="error_download_resource_gone">ناتوانرێت ئەمه‌ داببه‌زێنرێته‌وه‌</string>
     <string name="unsubscribe">بەژدارنەبوون</string>

--- a/app/src/main/res/values-ckb/strings.xml
+++ b/app/src/main/res/values-ckb/strings.xml
@@ -70,7 +70,6 @@
     </plurals>
     <string name="delete_one">سڕینەوەی یەک</string>
     <string name="show_higher_resolutions_title">پیشاندانی قه‌باره‌ی به‌رزتر</string>
-    <string name="add">ئەرکی نوێ</string>
     <string name="queued">نۆبه‌تكراو</string>
     <string name="generate_unique_name">دانانی ناوی نوێ</string>
     <string name="import_data_summary">ده‌چه‌سپێت لەسەر مێژووی ئێستات، بەژدارییه‌كانت، خشته‌لێدانه‌كانت و ڕێكخستنه‌كانت</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -97,7 +97,6 @@
     <string name="your_comment">Vaše poznámky (anglicky):</string>
     <string name="storage_permission_denied">Nejdříve udělit oprávnění přístupu k úložišti</string>
     <string name="view">Přehrát</string>
-    <string name="add">Nová mise</string>
     <string name="ok">OK</string>
     <string name="title_activity_recaptcha">Výzva reCAPTCHA</string>
     <string name="recaptcha_request_toast">Požadována výzva reCAPTCHA</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -98,7 +98,7 @@
     <string name="storage_permission_denied">Nejdříve udělit oprávnění přístupu k úložišti</string>
     <string name="view">Přehrát</string>
     <string name="add">Nová mise</string>
-    <string name="finish">OK</string>
+    <string name="ok">OK</string>
     <string name="title_activity_recaptcha">Výzva reCAPTCHA</string>
     <string name="recaptcha_request_toast">Požadována výzva reCAPTCHA</string>
     <string name="black_theme_title">Černé</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -230,7 +230,6 @@
     <string name="checksum">Kontrolsum</string>
     <string name="dismiss">Afvis</string>
     <string name="rename">Omdøb</string>
-    <string name="add">Ny mission</string>
     <string name="ok">OK</string>
     <string name="msg_name">Filnavn</string>
     <string name="msg_threads">Tråde</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -231,7 +231,7 @@
     <string name="dismiss">Afvis</string>
     <string name="rename">Omdøb</string>
     <string name="add">Ny mission</string>
-    <string name="finish">OK</string>
+    <string name="ok">OK</string>
     <string name="msg_name">Filnavn</string>
     <string name="msg_threads">Tråde</string>
     <string name="msg_error">Fejl</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -99,7 +99,6 @@
     <string name="start">Starten</string>
     <string name="pause">Pause</string>
     <string name="view">Abspielen</string>
-    <string name="add">Neue Mission</string>
     <string name="ok">OK</string>
     <string name="msg_server_unsupported">Nicht unterstützter Server</string>
     <string name="could_not_load_image">Konnte Bild nicht laden</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -100,7 +100,7 @@
     <string name="pause">Pause</string>
     <string name="view">Abspielen</string>
     <string name="add">Neue Mission</string>
-    <string name="finish">OK</string>
+    <string name="ok">OK</string>
     <string name="msg_server_unsupported">Nicht unterstützter Server</string>
     <string name="could_not_load_image">Konnte Bild nicht laden</string>
     <string name="app_ui_crash">App/UI abgestürzt</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -234,7 +234,6 @@
     <string name="checksum">Άθροισμα ελέγχου</string>
     <string name="dismiss">Αγνόηση</string>
     <string name="rename">Μετονομασία</string>
-    <string name="add">Νέα αποστολή</string>
     <string name="ok">Εντάξει</string>
     <string name="msg_name">Όνομα αρχείου</string>
     <string name="msg_threads">Νήματα</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -235,7 +235,7 @@
     <string name="dismiss">Αγνόηση</string>
     <string name="rename">Μετονομασία</string>
     <string name="add">Νέα αποστολή</string>
-    <string name="finish">Εντάξει</string>
+    <string name="ok">Εντάξει</string>
     <string name="msg_name">Όνομα αρχείου</string>
     <string name="msg_threads">Νήματα</string>
     <string name="msg_server_unsupported">Ο εξυπηρετητής δεν υποστηρίζεται</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -297,7 +297,7 @@
     <string name="delete">Forviŝi</string>
     <string name="checksum">Kontrolsumo</string>
     <string name="add">Nova misio</string>
-    <string name="finish">Bone</string>
+    <string name="ok">Bone</string>
     <string name="msg_name">Dosiernomo</string>
     <string name="msg_threads">Fadenoj</string>
     <string name="msg_error">Eraro</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -296,7 +296,6 @@
     <string name="view">Ludi</string>
     <string name="delete">Forviŝi</string>
     <string name="checksum">Kontrolsumo</string>
-    <string name="add">Nova misio</string>
     <string name="ok">Bone</string>
     <string name="msg_name">Dosiernomo</string>
     <string name="msg_threads">Fadenoj</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -88,7 +88,6 @@
     <string name="view">Reproducir</string>
     <string name="delete">Borrar</string>
     <string name="checksum">Suma de comprobación</string>
-    <string name="add">Misión nueva</string>
     <string name="ok">Aceptar</string>
     <string name="msg_name">Nombre del archivo</string>
     <string name="msg_threads">Subprocesos</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -89,7 +89,7 @@
     <string name="delete">Borrar</string>
     <string name="checksum">Suma de comprobación</string>
     <string name="add">Misión nueva</string>
-    <string name="finish">Aceptar</string>
+    <string name="ok">Aceptar</string>
     <string name="msg_name">Nombre del archivo</string>
     <string name="msg_threads">Subprocesos</string>
     <string name="msg_error">Error</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -218,7 +218,6 @@
     <string name="checksum">Kontrollsumma</string>
     <string name="dismiss">Loobu</string>
     <string name="rename">Nimeta ümber</string>
-    <string name="add">Uus ülesanne</string>
     <string name="ok">OK</string>
     <string name="msg_name">Faili nimi</string>
     <string name="msg_threads">Lõimed</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -219,7 +219,7 @@
     <string name="dismiss">Loobu</string>
     <string name="rename">Nimeta ümber</string>
     <string name="add">Uus ülesanne</string>
-    <string name="finish">OK</string>
+    <string name="ok">OK</string>
     <string name="msg_name">Faili nimi</string>
     <string name="msg_threads">Lõimed</string>
     <string name="msg_error">Viga</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -121,7 +121,7 @@
     <string name="delete">Ezabatu</string>
     <string name="checksum">Egiaztaketa-batura</string>
     <string name="add">Misio berria</string>
-    <string name="finish">Ados</string>
+    <string name="ok">Ados</string>
     <string name="msg_name">Fitxategi-izena</string>
     <string name="msg_threads">Hariak</string>
     <string name="msg_error">Errorea</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -120,7 +120,6 @@
     <string name="view">Jo</string>
     <string name="delete">Ezabatu</string>
     <string name="checksum">Egiaztaketa-batura</string>
-    <string name="add">Misio berria</string>
     <string name="ok">Ados</string>
     <string name="msg_name">Fitxategi-izena</string>
     <string name="msg_threads">Hariak</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -88,7 +88,7 @@
     <string name="delete">حذف</string>
     <string name="checksum">مجموع مقابله‌ای</string>
     <string name="add">مآموریت جدید</string>
-    <string name="finish">قبول</string>
+    <string name="ok">قبول</string>
     <string name="msg_name">نام پرونده</string>
     <string name="msg_threads">رشته‌ها</string>
     <string name="msg_error">خطا</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -87,7 +87,6 @@
     <string name="view">پخش</string>
     <string name="delete">حذف</string>
     <string name="checksum">مجموع مقابله‌ای</string>
-    <string name="add">مآموریت جدید</string>
     <string name="ok">قبول</string>
     <string name="msg_name">نام پرونده</string>
     <string name="msg_threads">رشته‌ها</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -155,7 +155,6 @@
     <string name="view">Toista</string>
     <string name="delete">Poista</string>
     <string name="checksum">Tarkistussumma</string>
-    <string name="add">Uusi tehtävä</string>
     <string name="ok">OK</string>
     <string name="msg_name">Tiedostonimi</string>
     <string name="msg_threads">Säikeet</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -156,7 +156,7 @@
     <string name="delete">Poista</string>
     <string name="checksum">Tarkistussumma</string>
     <string name="add">Uusi tehtävä</string>
-    <string name="finish">OK</string>
+    <string name="ok">OK</string>
     <string name="msg_name">Tiedostonimi</string>
     <string name="msg_threads">Säikeet</string>
     <string name="msg_error">Virhe</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -89,7 +89,6 @@
     <string name="view">Lire</string>
     <string name="delete">Supprimer</string>
     <string name="checksum">Somme de contrôle</string>
-    <string name="add">Nouvelle mission</string>
     <string name="ok">OK</string>
     <string name="msg_name">Nom du fichier</string>
     <string name="msg_threads">Nombre de connexions simultanées</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -90,7 +90,7 @@
     <string name="delete">Supprimer</string>
     <string name="checksum">Somme de contrôle</string>
     <string name="add">Nouvelle mission</string>
-    <string name="finish">OK</string>
+    <string name="ok">OK</string>
     <string name="msg_name">Nom du fichier</string>
     <string name="msg_threads">Nombre de connexions simultanées</string>
     <string name="msg_error">Erreur</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -223,7 +223,6 @@
     <string name="checksum">Suma de comprobación</string>
     <string name="dismiss">Descartar</string>
     <string name="rename">Renomear</string>
-    <string name="add">Nova misión</string>
     <string name="ok">OK</string>
     <string name="msg_name">Nome do ficheiro</string>
     <string name="msg_threads">Fios</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -224,7 +224,7 @@
     <string name="dismiss">Descartar</string>
     <string name="rename">Renomear</string>
     <string name="add">Nova misión</string>
-    <string name="finish">OK</string>
+    <string name="ok">OK</string>
     <string name="msg_name">Nome do ficheiro</string>
     <string name="msg_threads">Fios</string>
     <string name="msg_error">Erro</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -173,7 +173,6 @@
     <string name="view">נגינה</string>
     <string name="delete">מחיקה</string>
     <string name="checksum">גיבוב לאימות</string>
-    <string name="add">משימה חדשה</string>
     <string name="ok">אישור</string>
     <string name="msg_name">שם קובץ</string>
     <string name="msg_threads">תת־דיונים</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -174,7 +174,7 @@
     <string name="delete">מחיקה</string>
     <string name="checksum">גיבוב לאימות</string>
     <string name="add">משימה חדשה</string>
-    <string name="finish">אישור</string>
+    <string name="ok">אישור</string>
     <string name="msg_name">שם קובץ</string>
     <string name="msg_threads">תת־דיונים</string>
     <string name="msg_error">שגיאה</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -189,7 +189,7 @@
     <string name="delete">मिटाएँ</string>
     <string name="checksum">checksum</string>
     <string name="add">नया मिशन</string>
-    <string name="finish">ठीक है</string>
+    <string name="ok">ठीक है</string>
     <string name="msg_name">फाइल का नाम</string>
     <string name="msg_threads">मेसेज के thread</string>
     <string name="msg_error">त्रुटी</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -188,7 +188,6 @@
     <string name="view">चलाये</string>
     <string name="delete">मिटाएँ</string>
     <string name="checksum">checksum</string>
-    <string name="add">नया मिशन</string>
     <string name="ok">ठीक है</string>
     <string name="msg_name">फाइल का नाम</string>
     <string name="msg_threads">मेसेज के thread</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -135,7 +135,7 @@
     <string name="delete">Izbriši</string>
     <string name="checksum">Kontrolna suma</string>
     <string name="add">Novi zadatak</string>
-    <string name="finish">U redu</string>
+    <string name="ok">U redu</string>
     <string name="msg_name">Naziv datoteke</string>
     <string name="msg_threads">Niti</string>
     <string name="msg_error">Greška</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -134,7 +134,6 @@
     <string name="view">Reproduciraj</string>
     <string name="delete">Izbriši</string>
     <string name="checksum">Kontrolna suma</string>
-    <string name="add">Novi zadatak</string>
     <string name="ok">U redu</string>
     <string name="msg_name">Naziv datoteke</string>
     <string name="msg_threads">Niti</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -87,7 +87,7 @@
     <string name="view">Lejátszás</string>
     <string name="delete">Törlés</string>
     <string name="checksum">Ellenőrző összeg</string>
-    <string name="finish">Rendben</string>
+    <string name="ok">Rendben</string>
     <string name="msg_name">Fájlnév</string>
     <string name="msg_threads">Threadek</string>
     <string name="msg_error">Hiba</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -99,7 +99,6 @@
     <string name="msg_copied">Vágólapra másolva</string>
     <string name="no_available_dir">Kérlek adj meg egy letöltés könyvtárat a beállításokban</string>
     <string name="msg_server_unsupported">Nem támogatott szerver</string>
-    <string name="add">Új küldetés</string>
     <string name="channel_unsubscribed">Csatornáról leiratkozva</string>
     <string name="subscription_change_failed">Nem sikerült megváltoztatni a feliratkozást</string>
     <string name="subscription_update_failed">Nem sikerült frissíteni a feliratkozást</string>

--- a/app/src/main/res/values-hy/strings.xml
+++ b/app/src/main/res/values-hy/strings.xml
@@ -14,7 +14,7 @@
     <string name="msg_exists">Ֆայլ արդեն կա</string>
     <string name="msg_error">Սխալ</string>
     <string name="msg_name">ֆայլի անուն</string>
-    <string name="finish">Լավ</string>
+    <string name="ok">Լավ</string>
     <string name="delete">Ջնջել</string>
     <string name="start">Սկսել</string>
     <string name="detail_likes_img_view_description">Հավանում եմ</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -84,7 +84,7 @@
     <string name="pause">Jeda</string>
     <string name="checksum">Ceksum</string>
     <string name="add">Misi baru</string>
-    <string name="finish">OK</string>
+    <string name="ok">OK</string>
     <string name="msg_name">Nama berkas</string>
     <string name="msg_error">Galat</string>
     <string name="msg_server_unsupported">Server tidak didukung</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -83,7 +83,6 @@
     <string name="start">Mulai</string>
     <string name="pause">Jeda</string>
     <string name="checksum">Ceksum</string>
-    <string name="add">Misi baru</string>
     <string name="ok">OK</string>
     <string name="msg_name">Nama berkas</string>
     <string name="msg_error">Galat</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -87,7 +87,6 @@
     <string name="view">Riproduci</string>
     <string name="delete">Elimina</string>
     <string name="checksum">Checksum</string>
-    <string name="add">Nuovo obiettivo</string>
     <string name="ok">OK</string>
     <string name="msg_name">Nome del file</string>
     <string name="msg_threads">Thread</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -88,7 +88,7 @@
     <string name="delete">Elimina</string>
     <string name="checksum">Checksum</string>
     <string name="add">Nuovo obiettivo</string>
-    <string name="finish">OK</string>
+    <string name="ok">OK</string>
     <string name="msg_name">Nome del file</string>
     <string name="msg_threads">Thread</string>
     <string name="msg_error">Errore</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -84,7 +84,6 @@
     <string name="view">再生</string>
     <string name="delete">削除</string>
     <string name="checksum">チェックサム</string>
-    <string name="add">新しいミッション</string>
     <string name="ok">OK</string>
     <string name="msg_name">ファイル名</string>
     <string name="msg_threads">同時接続数</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -85,7 +85,7 @@
     <string name="delete">削除</string>
     <string name="checksum">チェックサム</string>
     <string name="add">新しいミッション</string>
-    <string name="finish">OK</string>
+    <string name="ok">OK</string>
     <string name="msg_name">ファイル名</string>
     <string name="msg_threads">同時接続数</string>
     <string name="msg_error">エラー</string>

--- a/app/src/main/res/values-kab/strings.xml
+++ b/app/src/main/res/values-kab/strings.xml
@@ -32,7 +32,6 @@
     <string name="start">Bdu</string>
     <string name="pause">Seṛǧu</string>
     <string name="view">ɣer</string>
-    <string name="add">Tuɣdaṭ tamaynut</string>
     <string name="more_than_100_videos">100+Tividyutin</string>
     <string name="subscribe_button_title">Jerred</string>
     <string name="export_to">Sifeḍ ɣer</string>

--- a/app/src/main/res/values-kab/strings.xml
+++ b/app/src/main/res/values-kab/strings.xml
@@ -101,7 +101,7 @@
     <string name="dismiss">Ttu</string>
     <string name="short_million">A</string>
     <string name="import_title">Kter</string>
-    <string name="finish">Ih</string>
+    <string name="ok">Ih</string>
     <string name="delete_all">Kkes akk</string>
     <string name="action_history">Amazray</string>
     <string name="list">Liste</string>

--- a/app/src/main/res/values-kmr/strings.xml
+++ b/app/src/main/res/values-kmr/strings.xml
@@ -15,7 +15,6 @@
     <string name="msg_threads">Mijar</string>
     <string name="msg_name">Navê pelê</string>
     <string name="ok">Baş e</string>
-    <string name="add">Mîsyona nû</string>
     <string name="rename">Navlêkirin</string>
     <string name="dismiss">Berdan</string>
     <string name="checksum">Peyda kirin</string>

--- a/app/src/main/res/values-kmr/strings.xml
+++ b/app/src/main/res/values-kmr/strings.xml
@@ -14,7 +14,7 @@
     <string name="msg_error">Şaşî</string>
     <string name="msg_threads">Mijar</string>
     <string name="msg_name">Navê pelê</string>
-    <string name="finish">Baş e</string>
+    <string name="ok">Baş e</string>
     <string name="add">Mîsyona nû</string>
     <string name="rename">Navlêkirin</string>
     <string name="dismiss">Berdan</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -161,7 +161,6 @@
     </plurals>
     <string name="no_videos">비디오 없음</string>
     <string name="view">재생</string>
-    <string name="add">새로운 미션</string>
     <string name="ok">OK</string>
     <string name="msg_name">파일명</string>
     <string name="msg_threads">쓰레드</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -162,7 +162,7 @@
     <string name="no_videos">비디오 없음</string>
     <string name="view">재생</string>
     <string name="add">새로운 미션</string>
-    <string name="finish">OK</string>
+    <string name="ok">OK</string>
     <string name="msg_name">파일명</string>
     <string name="msg_threads">쓰레드</string>
     <string name="msg_error">오류</string>

--- a/app/src/main/res/values-ku/strings.xml
+++ b/app/src/main/res/values-ku/strings.xml
@@ -198,7 +198,7 @@
     <string name="dismiss">فەرامۆشی</string>
     <string name="rename">ناو لێنانەوە</string>
     <string name="add">ئەرکی نوێ</string>
-    <string name="finish">باشە</string>
+    <string name="ok">باشە</string>
     <string name="msg_name">ناوی فایل</string>
     <string name="msg_threads">دابەشکراوەکان</string>
     <string name="msg_error">کێشە ڕوویدا</string>

--- a/app/src/main/res/values-ku/strings.xml
+++ b/app/src/main/res/values-ku/strings.xml
@@ -197,7 +197,6 @@
     <string name="checksum">تاقیکردنەوەی هێڵێک</string>
     <string name="dismiss">فەرامۆشی</string>
     <string name="rename">ناو لێنانەوە</string>
-    <string name="add">ئەرکی نوێ</string>
     <string name="ok">باشە</string>
     <string name="msg_name">ناوی فایل</string>
     <string name="msg_threads">دابەشکراوەکان</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -126,7 +126,7 @@
     <string name="delete">Ištrinti</string>
     <string name="checksum">Kontrolinė suma</string>
     <string name="add">Nauja užduotis</string>
-    <string name="finish">Gerai</string>
+    <string name="ok">Gerai</string>
     <string name="msg_name">Failo pavadinimas</string>
     <string name="msg_threads">Gijos</string>
     <string name="msg_error">Klaida</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -125,7 +125,6 @@
     <string name="pause">Pauzė</string>
     <string name="delete">Ištrinti</string>
     <string name="checksum">Kontrolinė suma</string>
-    <string name="add">Nauja užduotis</string>
     <string name="ok">Gerai</string>
     <string name="msg_name">Failo pavadinimas</string>
     <string name="msg_threads">Gijos</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -118,7 +118,6 @@
     <string name="msg_threads">Procesi</string>
     <string name="msg_name">Faila nosaukums</string>
     <string name="ok">OK</string>
-    <string name="add">Jauna misija</string>
     <string name="rename">Pārsaukt</string>
     <string name="dismiss">Atcelt</string>
     <string name="checksum">Kontrolsumma</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -117,7 +117,7 @@
     <string name="msg_error">Kļūda</string>
     <string name="msg_threads">Procesi</string>
     <string name="msg_name">Faila nosaukums</string>
-    <string name="finish">OK</string>
+    <string name="ok">OK</string>
     <string name="add">Jauna misija</string>
     <string name="rename">Pārsaukt</string>
     <string name="dismiss">Atcelt</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -211,7 +211,6 @@
     <string name="checksum">Чексума</string>
     <string name="dismiss">Отфрли</string>
     <string name="rename">Прекрсти</string>
-    <string name="add">Нова мисија</string>
     <string name="ok">Готово</string>
     <string name="msg_name">Име на датотека</string>
     <string name="msg_threads">Нишки</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -212,7 +212,7 @@
     <string name="dismiss">Отфрли</string>
     <string name="rename">Прекрсти</string>
     <string name="add">Нова мисија</string>
-    <string name="finish">Готово</string>
+    <string name="ok">Готово</string>
     <string name="msg_name">Име на датотека</string>
     <string name="msg_threads">Нишки</string>
     <string name="msg_error">Грешка</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -173,7 +173,6 @@
     <string name="msg_threads">ത്രെഡുകൾ</string>
     <string name="msg_name">ഫയൽനാമം</string>
     <string name="ok">ഓകെ</string>
-    <string name="add">പുതിയ ദൗത്യം</string>
     <string name="rename">പേരുമാറ്റുക</string>
     <string name="dismiss">പുറത്തള്ളുക</string>
     <string name="checksum">ചെക്ക്സം</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -172,7 +172,7 @@
     <string name="msg_error">പിശക്</string>
     <string name="msg_threads">ത്രെഡുകൾ</string>
     <string name="msg_name">ഫയൽനാമം</string>
-    <string name="finish">ഓകെ</string>
+    <string name="ok">ഓകെ</string>
     <string name="add">പുതിയ ദൗത്യം</string>
     <string name="rename">പേരുമാറ്റുക</string>
     <string name="dismiss">പുറത്തള്ളുക</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -237,7 +237,7 @@
     <string name="dismiss">Buangkan</string>
     <string name="rename">Namakan semula</string>
     <string name="add">Misi baru</string>
-    <string name="finish">OK</string>
+    <string name="ok">OK</string>
     <string name="msg_name">Nama fail</string>
     <string name="msg_threads">Thread</string>
     <string name="msg_error">Ralat</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -236,7 +236,6 @@
     <string name="checksum">Ceksum</string>
     <string name="dismiss">Buangkan</string>
     <string name="rename">Namakan semula</string>
-    <string name="add">Misi baru</string>
     <string name="ok">OK</string>
     <string name="msg_name">Nama fail</string>
     <string name="msg_threads">Thread</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -100,7 +100,6 @@
     <string name="msg_copied">Kopiert til utklippstavle</string>
     <string name="info_labels">Hva:\\nForespørsel:\\nInnholdsspråk:\\nInnholdsland:\\nProgramspråk:\\nTjeneste:\\nGMT-tid:\\nPakke:\\nVersjon:\\nOS-versjon:</string>
     <string name="start">Start</string>
-    <string name="add">Nytt mål</string>
     <string name="msg_url_malform">Feilaktig nettadresse eller manglende internettilknytning</string>
     <string name="no_available_dir">Definer en nedlastingsmappe senere i innstillingene</string>
     <string name="title_activity_recaptcha">reCAPTCHA-oppgave</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -88,7 +88,7 @@
     <string name="view">Spill</string>
     <string name="delete">Slett</string>
     <string name="checksum">Sjekksum</string>
-    <string name="finish">OK</string>
+    <string name="ok">OK</string>
     <string name="msg_name">Filnavn</string>
     <string name="msg_threads">Tråder</string>
     <string name="msg_error">Feil</string>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -244,7 +244,6 @@
     <string name="checksum">चेकसम</string>
     <string name="dismiss">खारेज</string>
     <string name="rename">पुनः नामकरण</string>
-    <string name="add">खण्ड</string>
     <string name="ok">ठिक छ</string>
     <string name="msg_name">msg</string>
     <string name="msg_threads">सूत्रहरू</string>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -245,7 +245,7 @@
     <string name="dismiss">खारेज</string>
     <string name="rename">पुनः नामकरण</string>
     <string name="add">खण्ड</string>
-    <string name="finish">ठिक छ</string>
+    <string name="ok">ठिक छ</string>
     <string name="msg_name">msg</string>
     <string name="msg_threads">सूत्रहरू</string>
     <string name="msg_error">त्रुटि</string>

--- a/app/src/main/res/values-nl-rBE/strings.xml
+++ b/app/src/main/res/values-nl-rBE/strings.xml
@@ -213,7 +213,7 @@
     <string name="dismiss">Sluiten</string>
     <string name="rename">Hernoemen</string>
     <string name="add">Nieuwe missie</string>
-    <string name="finish">Oké</string>
+    <string name="ok">Oké</string>
     <string name="msg_name">Bestandsnaam</string>
     <string name="msg_threads">Threads</string>
     <string name="msg_error">Fout</string>

--- a/app/src/main/res/values-nl-rBE/strings.xml
+++ b/app/src/main/res/values-nl-rBE/strings.xml
@@ -212,7 +212,6 @@
     <string name="checksum">Controlesom</string>
     <string name="dismiss">Sluiten</string>
     <string name="rename">Hernoemen</string>
-    <string name="add">Nieuwe missie</string>
     <string name="ok">Oké</string>
     <string name="msg_name">Bestandsnaam</string>
     <string name="msg_threads">Threads</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -90,7 +90,6 @@
     <string name="view">Afspelen</string>
     <string name="delete">Verwijderen</string>
     <string name="checksum">Controlesom</string>
-    <string name="add">Nieuwe missie</string>
     <string name="ok">Oké</string>
     <string name="msg_name">Bestandsnaam</string>
     <string name="msg_threads">Threads</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -91,7 +91,7 @@
     <string name="delete">Verwijderen</string>
     <string name="checksum">Controlesom</string>
     <string name="add">Nieuwe missie</string>
-    <string name="finish">Oké</string>
+    <string name="ok">Oké</string>
     <string name="msg_name">Bestandsnaam</string>
     <string name="msg_threads">Threads</string>
     <string name="msg_error">Fout</string>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -219,7 +219,7 @@
     <string name="dismiss">ਬਰਖਾਸਤ ਕਰੋ</string>
     <string name="rename">ਨਾਮ ਬਦਲੋ</string>
     <string name="add">ਨਵਾਂ ਮਿਸ਼ਨ</string>
-    <string name="finish">ਠੀਕ ਹੈ</string>
+    <string name="ok">ਠੀਕ ਹੈ</string>
     <string name="msg_name">ਫਾਈਲ ਦਾ ਨਾਮ</string>
     <string name="msg_threads">threads</string>
     <string name="msg_error">ERROR</string>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -218,7 +218,6 @@
     <string name="checksum">ਚੈੱਕ-ਸਮ</string>
     <string name="dismiss">ਬਰਖਾਸਤ ਕਰੋ</string>
     <string name="rename">ਨਾਮ ਬਦਲੋ</string>
-    <string name="add">ਨਵਾਂ ਮਿਸ਼ਨ</string>
     <string name="ok">ਠੀਕ ਹੈ</string>
     <string name="msg_name">ਫਾਈਲ ਦਾ ਨਾਮ</string>
     <string name="msg_threads">threads</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -86,7 +86,6 @@
     <string name="view">Odtwórz</string>
     <string name="delete">Usuń</string>
     <string name="checksum">Suma kontrolna</string>
-    <string name="add">Nowa misja</string>
     <string name="ok">OK</string>
     <string name="msg_name">Nazwa pliku</string>
     <string name="msg_threads">Wątki</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -87,7 +87,7 @@
     <string name="delete">Usuń</string>
     <string name="checksum">Suma kontrolna</string>
     <string name="add">Nowa misja</string>
-    <string name="finish">OK</string>
+    <string name="ok">OK</string>
     <string name="msg_name">Nazwa pliku</string>
     <string name="msg_threads">Wątki</string>
     <string name="msg_error">Błąd</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -33,7 +33,7 @@
     <string name="error_report_title">Relatório de erro</string>
     <string name="error_snackbar_action">Relatório</string>
     <string name="error_snackbar_message">Desculpe, algo deu errado.</string>
-    <string name="finish">OK</string>
+    <string name="ok">OK</string>
     <string name="general_error">Erro</string>
     <string name="info_dir_created">Pasta de download criada \'%1$s\'</string>
     <string name="install">Instalar</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -72,7 +72,6 @@
     <string name="downloads">Downloads</string>
     <string name="downloads_title">Downloads</string>
     <string name="did_you_mean">Você quis dizer \"%1$s\"\?</string>
-    <string name="add">Nova missão</string>
     <string name="app_ui_crash">App/IU parou</string>
     <string name="background_player_playing_toast">Reproduzindo em segundo plano</string>
     <string name="could_not_setup_download_menu">O menu de download não pôde ser configurado</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -274,7 +274,6 @@
     <string name="download_path_audio_dialog_title">Escolha a pasta para colocar os ficheiros de áudio</string>
     <string name="app_update_notification_content_title">Atualização NewPipe disponível!</string>
     <string name="events">Eventos</string>
-    <string name="add">Nova missão</string>
     <string name="privacy_policy_title">Política de privacidade do NewPipe</string>
     <string name="could_not_load_thumbnails">Não foi possível carregar todas as miniaturas</string>
     <string name="audio">Áudio</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -253,7 +253,7 @@
     <string name="settings_category_other_title">Outros</string>
     <string name="duration_live">Em direto</string>
     <string name="feed_update_threshold_title">Limite de atualização da fonte</string>
-    <string name="finish">OK</string>
+    <string name="ok">OK</string>
     <string name="could_not_get_stream">Não foi possível obter a emissão</string>
     <string name="subscription_update_failed">Não foi possível atualizar a subscrição</string>
     <string name="toast_no_player">Não existe uma aplicação para reproduzir este ficheiro</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -87,7 +87,6 @@
     <string name="view">Reproduzir</string>
     <string name="delete">Eliminar</string>
     <string name="checksum">Checksum</string>
-    <string name="add">Nova missão</string>
     <string name="msg_name">Nome do ficheiro</string>
     <string name="msg_error">Erro</string>
     <string name="msg_server_unsupported">Servidor não suportado</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -97,7 +97,7 @@
     <string name="msg_wait">Por favor aguarde…</string>
     <string name="msg_copied">Copiado para a área de transferência</string>
     <string name="no_available_dir">Tem que definir, nas definições, uma pasta para as descargas</string>
-    <string name="finish">OK</string>
+    <string name="ok">OK</string>
     <string name="msg_threads">Processos</string>
     <string name="msg_running">Descarga NewPipe</string>
     <string name="could_not_load_image">Não foi possível carregar a imagem</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -87,7 +87,6 @@
     <string name="view">Redă</string>
     <string name="delete">Șterge</string>
     <string name="checksum">Suma de control</string>
-    <string name="add">Misiune nouă</string>
     <string name="ok">OK</string>
     <string name="msg_name">Numele fișierului</string>
     <string name="msg_threads">Thread-uri</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -88,7 +88,7 @@
     <string name="delete">Șterge</string>
     <string name="checksum">Suma de control</string>
     <string name="add">Misiune nouă</string>
-    <string name="finish">OK</string>
+    <string name="ok">OK</string>
     <string name="msg_name">Numele fișierului</string>
     <string name="msg_threads">Thread-uri</string>
     <string name="msg_error">Eroare</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -51,7 +51,7 @@
     <string name="msg_wait">Подождите…</string>
     <string name="msg_exists">Файл уже существует</string>
     <string name="msg_threads">Потоки</string>
-    <string name="finish">ОК</string>
+    <string name="ok">ОК</string>
     <string name="start">Начать</string>
     <string name="pause">Пауза</string>
     <string name="delete">Удалить</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -117,7 +117,6 @@
     <string name="player_gesture_controls_title">Управление жестами</string>
     <string name="all">Всё</string>
     <string name="filter">Фильтр</string>
-    <string name="add">Новая цель</string>
     <string name="info_labels">Что:\\nЗапрос:\\nЯзык контента:\\nСтрана контента:\\nЯзык приложения:\\nСервис:\\nВремя по Гринвичу:\\nПакет:\\nВерсия пакета:\\nВерсия ОС:</string>
     <string name="msg_popup_permission">Это разрешение нужно для
 \nвоспроизведения в окне</string>

--- a/app/src/main/res/values-sc/strings.xml
+++ b/app/src/main/res/values-sc/strings.xml
@@ -154,7 +154,6 @@
     <string name="msg_threads">Connessiones simultàneas</string>
     <string name="msg_name">Nùmene de su documentu</string>
     <string name="ok">AB</string>
-    <string name="add">Missione noa</string>
     <string name="rename">Càmbia de nùmene</string>
     <string name="dismiss">Ignora</string>
     <string name="checksum">Summa de verìfica</string>

--- a/app/src/main/res/values-sc/strings.xml
+++ b/app/src/main/res/values-sc/strings.xml
@@ -153,7 +153,7 @@
     <string name="msg_error">Errore</string>
     <string name="msg_threads">Connessiones simultàneas</string>
     <string name="msg_name">Nùmene de su documentu</string>
-    <string name="finish">AB</string>
+    <string name="ok">AB</string>
     <string name="add">Missione noa</string>
     <string name="rename">Càmbia de nùmene</string>
     <string name="dismiss">Ignora</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -84,7 +84,6 @@
     <string name="view">Prehrať</string>
     <string name="delete">Zmazať</string>
     <string name="checksum">Kontrolný súčet</string>
-    <string name="add">Nová misia</string>
     <string name="ok">OK</string>
     <string name="msg_name">Názov súboru</string>
     <string name="msg_threads">Vlákna</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -85,7 +85,7 @@
     <string name="delete">Zmazať</string>
     <string name="checksum">Kontrolný súčet</string>
     <string name="add">Nová misia</string>
-    <string name="finish">OK</string>
+    <string name="ok">OK</string>
     <string name="msg_name">Názov súboru</string>
     <string name="msg_threads">Vlákna</string>
     <string name="msg_error">Chyba</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -96,7 +96,7 @@
     <string name="msg_copied">Kopirano v odložišče.</string>
     <string name="no_available_dir">Izberite mapo za prejem</string>
     <string name="add">Nova naloga</string>
-    <string name="finish">V redu</string>
+    <string name="ok">V redu</string>
     <string name="downloads">Prejemi</string>
     <string name="downloads_title">Prejemi</string>
     <string name="error_report_title">Poročilo o napaki</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -95,7 +95,6 @@
     <string name="msg_wait">Počakajte …</string>
     <string name="msg_copied">Kopirano v odložišče.</string>
     <string name="no_available_dir">Izberite mapo za prejem</string>
-    <string name="add">Nova naloga</string>
     <string name="ok">V redu</string>
     <string name="downloads">Prejemi</string>
     <string name="downloads_title">Prejemi</string>

--- a/app/src/main/res/values-so/strings.xml
+++ b/app/src/main/res/values-so/strings.xml
@@ -240,7 +240,6 @@
     <string name="msg_threads">Qaybaha</string>
     <string name="msg_name">Magaca shayga</string>
     <string name="ok">Hagaag</string>
-    <string name="add">Hawl cusub</string>
     <string name="rename">Magaca ka baddal</string>
     <string name="dismiss">Iska dhaaf</string>
     <string name="checksum">Xaqiijiyaha</string>

--- a/app/src/main/res/values-so/strings.xml
+++ b/app/src/main/res/values-so/strings.xml
@@ -239,7 +239,7 @@
     <string name="msg_error">Khalad</string>
     <string name="msg_threads">Qaybaha</string>
     <string name="msg_name">Magaca shayga</string>
-    <string name="finish">Hagaag</string>
+    <string name="ok">Hagaag</string>
     <string name="add">Hawl cusub</string>
     <string name="rename">Magaca ka baddal</string>
     <string name="dismiss">Iska dhaaf</string>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -310,7 +310,7 @@
     <string name="msg_error">Gabim</string>
     <string name="msg_threads">Veprimet paralele</string>
     <string name="msg_name">Emri i skedarit</string>
-    <string name="finish">OK</string>
+    <string name="ok">OK</string>
     <string name="add">Mision i ri</string>
     <string name="rename">Riemërto</string>
     <string name="dismiss">Hiqe</string>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -311,7 +311,6 @@
     <string name="msg_threads">Veprimet paralele</string>
     <string name="msg_name">Emri i skedarit</string>
     <string name="ok">OK</string>
-    <string name="add">Mision i ri</string>
     <string name="rename">Riemërto</string>
     <string name="dismiss">Hiqe</string>
     <string name="checksum">Kodi verifikues</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -85,7 +85,7 @@
     <string name="delete">Обриши</string>
     <string name="checksum">Контролна сума</string>
     <string name="add">Нова мисија</string>
-    <string name="finish">У реду</string>
+    <string name="ok">У реду</string>
     <string name="msg_name">Назив фајла</string>
     <string name="msg_threads">Нити</string>
     <string name="msg_error">Грешка</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -84,7 +84,6 @@
     <string name="view">Пусти</string>
     <string name="delete">Обриши</string>
     <string name="checksum">Контролна сума</string>
-    <string name="add">Нова мисија</string>
     <string name="ok">У реду</string>
     <string name="msg_name">Назив фајла</string>
     <string name="msg_threads">Нити</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -168,7 +168,7 @@
     <string name="delete">Ta bort</string>
     <string name="checksum">Kontrollsumma</string>
     <string name="add">Nytt uppdrag</string>
-    <string name="finish">Okej</string>
+    <string name="ok">Okej</string>
     <string name="msg_name">Filnamn</string>
     <string name="msg_threads">Trådar</string>
     <string name="msg_error">Fel</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -167,7 +167,6 @@
     <string name="view">Spela</string>
     <string name="delete">Ta bort</string>
     <string name="checksum">Kontrollsumma</string>
-    <string name="add">Nytt uppdrag</string>
     <string name="ok">Okej</string>
     <string name="msg_name">Filnamn</string>
     <string name="msg_threads">Trådar</string>

--- a/app/src/main/res/values-te/strings.xml
+++ b/app/src/main/res/values-te/strings.xml
@@ -122,7 +122,7 @@
     <string name="view">ప్లే</string>
     <string name="delete">తొలగించు</string>
     <string name="add">కొత్త మిషన్</string>
-    <string name="finish">అలాగే</string>
+    <string name="ok">అలాగే</string>
     <string name="msg_name">ఫైలుపేరు</string>
     <string name="msg_threads">థ్రెడ్లు</string>
     <string name="msg_error">లోపం</string>

--- a/app/src/main/res/values-te/strings.xml
+++ b/app/src/main/res/values-te/strings.xml
@@ -121,7 +121,6 @@
     <string name="pause">ఆపు</string>
     <string name="view">ప్లే</string>
     <string name="delete">తొలగించు</string>
-    <string name="add">కొత్త మిషన్</string>
     <string name="ok">అలాగే</string>
     <string name="msg_name">ఫైలుపేరు</string>
     <string name="msg_threads">థ్రెడ్లు</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -229,7 +229,6 @@
     <string name="delete_all">ลบทั้งหมด</string>
     <string name="dismiss">ไม่สนใจ</string>
     <string name="rename">เปลี่ยนชื่อ</string>
-    <string name="add">ภารกิจใหม่</string>
     <string name="msg_name">ชื่อไฟล์</string>
     <string name="msg_server_unsupported">เซิร์ฟเวอร์ที่ไม่รองรับ</string>
     <string name="msg_exists">ไฟล์มีอยู่แล้ว</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -86,7 +86,6 @@
     <string name="view">Oynat</string>
     <string name="delete">Sil</string>
     <string name="checksum">Doğrulama</string>
-    <string name="add">Yeni görev</string>
     <string name="ok">Tamam</string>
     <string name="msg_name">Dosya adı</string>
     <string name="msg_threads">İş parçacığı</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -87,7 +87,7 @@
     <string name="delete">Sil</string>
     <string name="checksum">Doğrulama</string>
     <string name="add">Yeni görev</string>
-    <string name="finish">Tamam</string>
+    <string name="ok">Tamam</string>
     <string name="msg_name">Dosya adı</string>
     <string name="msg_threads">İş parçacığı</string>
     <string name="msg_error">Hata</string>

--- a/app/src/main/res/values-tzm/strings.xml
+++ b/app/src/main/res/values-tzm/strings.xml
@@ -122,7 +122,7 @@
     <string name="action_settings">Tisɣal</string>
     <string name="settings_category_downloads_title">Agam</string>
     <string name="msg_name">Isem n ufaylu</string>
-    <string name="finish">WAXXA</string>
+    <string name="ok">WAXXA</string>
     <string name="delete">Kkes</string>
     <string name="create">Senulfu</string>
     <string name="view">Γer</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -94,7 +94,7 @@
     <string name="view">Відтворити</string>
     <string name="delete">Видалити</string>
     <string name="checksum">Контрольна сума</string>
-    <string name="finish">Гаразд</string>
+    <string name="ok">Гаразд</string>
     <string name="msg_name">Назва файлу</string>
     <string name="msg_threads">Потоки</string>
     <string name="msg_error">Помилка</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -250,7 +250,6 @@
         <item quantity="few">%s перегляди</item>
         <item quantity="many">%s переглядів</item>
     </plurals>
-    <string name="add">Нове завдання</string>
     <string name="title_activity_recaptcha">Перевірка reCAPTCHA</string>
     <string name="recaptcha_request_toast">Запит перевірки reCAPTCHA</string>
     <string name="copyright" formatted="true">© %1$s, %2$s під %3$s</string>

--- a/app/src/main/res/values-ur/strings.xml
+++ b/app/src/main/res/values-ur/strings.xml
@@ -211,7 +211,6 @@
     <string name="checksum">تشخیص کریں</string>
     <string name="dismiss">برخاست کریں</string>
     <string name="rename">نام تبدیل کریں</string>
-    <string name="add">نیا مشن</string>
     <string name="ok">ٹھيک ہے</string>
     <string name="msg_name">فائل کا نام</string>
     <string name="msg_threads">موضوعات</string>

--- a/app/src/main/res/values-ur/strings.xml
+++ b/app/src/main/res/values-ur/strings.xml
@@ -212,7 +212,7 @@
     <string name="dismiss">برخاست کریں</string>
     <string name="rename">نام تبدیل کریں</string>
     <string name="add">نیا مشن</string>
-    <string name="finish">ٹھيک ہے</string>
+    <string name="ok">ٹھيک ہے</string>
     <string name="msg_name">فائل کا نام</string>
     <string name="msg_threads">موضوعات</string>
     <string name="msg_error">خرابی</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -116,7 +116,6 @@
     <string name="view">Chơi</string>
     <string name="delete">Xóa</string>
     <string name="checksum">Mã tổng kiểm (checksum)</string>
-    <string name="add">Nhiệm vụ mới</string>
     <string name="ok">OK</string>
     <string name="msg_name">Tên file</string>
     <string name="msg_threads">Chủ đề</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -117,7 +117,7 @@
     <string name="delete">Xóa</string>
     <string name="checksum">Mã tổng kiểm (checksum)</string>
     <string name="add">Nhiệm vụ mới</string>
-    <string name="finish">OK</string>
+    <string name="ok">OK</string>
     <string name="msg_name">Tên file</string>
     <string name="msg_threads">Chủ đề</string>
     <string name="msg_error">Lỗi</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -97,7 +97,6 @@
     <string name="view">播放</string>
     <string name="delete">删除</string>
     <string name="checksum">校验</string>
-    <string name="add">新任务</string>
     <string name="ok">OK</string>
     <string name="msg_name">文件名</string>
     <string name="msg_threads">线程数</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -98,7 +98,7 @@
     <string name="delete">删除</string>
     <string name="checksum">校验</string>
     <string name="add">新任务</string>
-    <string name="finish">OK</string>
+    <string name="ok">OK</string>
     <string name="msg_name">文件名</string>
     <string name="msg_threads">线程数</string>
     <string name="msg_error">错误</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -88,7 +88,7 @@
     <string name="delete">刪除</string>
     <string name="checksum">校驗和</string>
     <string name="add">新任務</string>
-    <string name="finish">好</string>
+    <string name="ok">好</string>
     <string name="msg_name">檔案名稱</string>
     <string name="msg_threads">線程</string>
     <string name="msg_error">錯誤</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -87,7 +87,6 @@
     <string name="view">觀看</string>
     <string name="delete">刪除</string>
     <string name="checksum">校驗和</string>
-    <string name="add">新任務</string>
     <string name="ok">好</string>
     <string name="msg_name">檔案名稱</string>
     <string name="msg_threads">線程</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -118,7 +118,6 @@
     <string name="view">播放</string>
     <string name="delete">刪除</string>
     <string name="checksum">檢查碼</string>
-    <string name="add">新任務</string>
     <string name="ok">確定</string>
     <string name="msg_name">檔案名稱</string>
     <string name="msg_threads">執行緒數目</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -119,7 +119,7 @@
     <string name="delete">刪除</string>
     <string name="checksum">檢查碼</string>
     <string name="add">新任務</string>
-    <string name="finish">確定</string>
+    <string name="ok">確定</string>
     <string name="msg_name">檔案名稱</string>
     <string name="msg_threads">執行緒數目</string>
     <string name="msg_error">錯誤</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="no_player_found_toast">No stream player found (you can install VLC to play it).</string>
     <string name="install">Install</string>
     <string name="cancel">Cancel</string>
+    <string name="ok">OK</string>
     <string name="fdroid_vlc_url" translatable="false">https://f-droid.org/repository/browse/?fdfilter=vlc&amp;fdid=org.videolan.vlc</string>
     <string name="open_in_browser">Open in browser</string>
     <string name="mark_as_watched">Mark as watched</string>
@@ -352,9 +353,6 @@
     <string name="checksum">Checksum</string>
     <string name="dismiss">Dismiss</string>
     <string name="rename">Rename</string>
-    <!-- Fragment -->
-    <string name="add">New mission</string>
-    <string name="ok">OK</string>
     <!-- Msg -->
     <string name="msg_name">Filename</string>
     <string name="msg_threads">Threads</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -354,7 +354,7 @@
     <string name="rename">Rename</string>
     <!-- Fragment -->
     <string name="add">New mission</string>
-    <string name="finish">OK</string>
+    <string name="ok">OK</string>
     <!-- Msg -->
     <string name="msg_name">Filename</string>
     <string name="msg_threads">Threads</string>


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
- Rename string `finish`, whose content was "OK", to `ok`
- Replace `android.R.string.yes` and `android.R.string.ok` with `R.string.ok`
- Replace `android.R.string.no` and `android.R.string.cancel` with `R.string.cancel`
- Remove unused string `add` (legacy left behind from the downloader)
- Reformat some lines of code in `FeedGroupDialog`, solving Android Studio warnings

#### Fixes the following issue(s)
Fixes https://github.com/TeamNewPipe/NewPipe/pull/6848#issuecomment-907623835

#### APK testing 
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.
@nadiration could you check if this works well?

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
