### PR TITLE
Load full stream info when enqueuing a stream

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
@@ -159,11 +159,6 @@ class FeedFragment : BaseStateFragment<FeedState>() {
         }
     }
 
-    // TODO: Move
-    fun redrawContent() {
-        groupAdapter.notifyItemRangeChanged(0, Int.MAX_VALUE)
-    }
-
     fun setupListViewMode() {
         // does everything needed to setup the layouts for grid or list modes
         groupAdapter.spanCount = if (shouldUseGridLayout(context)) getGridSpanCountStreams(context) else 1

--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
@@ -159,6 +159,11 @@ class FeedFragment : BaseStateFragment<FeedState>() {
         }
     }
 
+    // TODO: Move
+    fun redrawContent() {
+        groupAdapter.notifyItemRangeChanged(0, Int.MAX_VALUE)
+    }
+
     fun setupListViewMode() {
         // does everything needed to setup the layouts for grid or list modes
         groupAdapter.spanCount = if (shouldUseGridLayout(context)) getGridSpanCountStreams(context) else 1

--- a/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
+++ b/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
@@ -237,7 +237,6 @@ public enum StreamDialogEntry {
                     item.getUrl(),
                     false
             )
-
                     .subscribeOn(Schedulers.io())
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe(result -> {

--- a/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
+++ b/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
@@ -223,7 +223,7 @@ public enum StreamDialogEntry {
             final InfoCallback callback) {
         if ((item.getStreamType() == StreamType.LIVE_STREAM || item.getStreamType() == StreamType.AUDIO_LIVE_STREAM) && item.getDuration() < 0) {
             // Sparse item: fetched by fast fetch
-            final Disposable currentWorker = ExtractorHelper.getStreamInfo(
+            ExtractorHelper.getStreamInfo(
                     item.getServiceId(),
                     item.getUrl(),
                     false

--- a/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
+++ b/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
@@ -10,6 +10,7 @@ import androidx.fragment.app.Fragment;
 import org.schabi.newpipe.NewPipeDatabase;
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
+import org.schabi.newpipe.extractor.stream.StreamType;
 import org.schabi.newpipe.local.dialog.PlaylistAppendDialog;
 import org.schabi.newpipe.local.dialog.PlaylistCreationDialog;
 import org.schabi.newpipe.local.history.HistoryRecordManager;
@@ -21,7 +22,6 @@ import java.util.Collections;
 import java.util.List;
 
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
-import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 
 import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
@@ -221,7 +221,9 @@ public enum StreamDialogEntry {
     private static void fetchItemInfoIfSparse(final Fragment fragment,
             final StreamInfoItem item,
             final InfoCallback callback) {
-        if ((item.getStreamType() == StreamType.LIVE_STREAM || item.getStreamType() == StreamType.AUDIO_LIVE_STREAM) && item.getDuration() < 0) {
+        if (!(item.getStreamType() == StreamType.LIVE_STREAM
+                || item.getStreamType() == StreamType.AUDIO_LIVE_STREAM)
+                && item.getDuration() < 0) {
             // Sparse item: fetched by fast fetch
             ExtractorHelper.getStreamInfo(
                     item.getServiceId(),

--- a/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
+++ b/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
@@ -62,30 +62,23 @@ public enum StreamDialogEntry {
      * Info: Add this entry within showStreamDialog.
      */
     enqueue(R.string.enqueue_stream, (fragment, item) -> {
-        fetchItemInfoIfSparse(fragment, item,
-                fullItem -> NavigationHelper.enqueueOnPlayer(fragment.getContext(), fullItem)
-        );
+        fetchItemInfoIfSparse(fragment, item, fullItem ->
+                NavigationHelper.enqueueOnPlayer(fragment.getContext(), fullItem));
     }),
 
     enqueue_next(R.string.enqueue_next_stream, (fragment, item) -> {
-        fetchItemInfoIfSparse(fragment, item,
-                fullItem -> NavigationHelper.enqueueNextOnPlayer(fragment.getContext(), fullItem)
-        );
+        fetchItemInfoIfSparse(fragment, item, fullItem ->
+                NavigationHelper.enqueueNextOnPlayer(fragment.getContext(), fullItem));
     }),
 
     start_here_on_background(R.string.start_here_on_background, (fragment, item) -> {
-        fetchItemInfoIfSparse(fragment, item,
-                fullItem -> {
-                    NavigationHelper.playOnBackgroundPlayer(fragment.getContext(),
-                            fullItem, true);
-                });
+        fetchItemInfoIfSparse(fragment, item, fullItem ->
+                NavigationHelper.playOnBackgroundPlayer(fragment.getContext(), fullItem, true));
     }),
 
     start_here_on_popup(R.string.start_here_on_popup, (fragment, item) -> {
-        fetchItemInfoIfSparse(fragment, item, fullItem -> {
-                    NavigationHelper.playOnPopupPlayer(fragment.getContext(),
-                            fullItem, true);
-                });
+        fetchItemInfoIfSparse(fragment, item, fullItem ->
+                NavigationHelper.playOnPopupPlayer(fragment.getContext(), fullItem, true));
     }),
 
     set_as_playlist_thumbnail(R.string.set_as_playlist_thumbnail, (fragment, item) -> {

--- a/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
+++ b/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
@@ -2,6 +2,7 @@ package org.schabi.newpipe.util;
 
 import android.content.Context;
 import android.net.Uri;
+import android.util.Log;
 import android.widget.Toast;
 
 import androidx.fragment.app.Fragment;
@@ -20,6 +21,7 @@ import java.util.Collections;
 import java.util.List;
 
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
+import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 
 import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
@@ -60,11 +62,15 @@ public enum StreamDialogEntry {
      * Info: Add this entry within showStreamDialog.
      */
     enqueue(R.string.enqueue_stream, (fragment, item) -> {
-        NavigationHelper.enqueueOnPlayer(fragment.getContext(), new SinglePlayQueue(item));
+        fetchItemInfoIfSparse(item,
+                fullItem -> NavigationHelper.enqueueOnPlayer(fragment.getContext(), fullItem)
+        );
     }),
 
     enqueue_next(R.string.enqueue_next_stream, (fragment, item) -> {
-        NavigationHelper.enqueueNextOnPlayer(fragment.getContext(), new SinglePlayQueue(item));
+        fetchItemInfoIfSparse(item,
+                fullItem -> NavigationHelper.enqueueNextOnPlayer(fragment.getContext(), fullItem)
+        );
     }),
 
     start_here_on_background(R.string.start_here_on_background, (fragment, item) ->
@@ -202,5 +208,32 @@ public enum StreamDialogEntry {
         NavigationHelper.openChannelFragment(
                 fragment.requireActivity().getSupportFragmentManager(),
                 item.getServiceId(), uploaderUrl, item.getUploaderName());
+    }
+
+    /////////////////////////////////////////////
+    // helper functions                        //
+    /////////////////////////////////////////////
+
+    private interface InfoCallback {
+        void onInfo(SinglePlayQueue item);
+    }
+
+    private static void fetchItemInfoIfSparse(final StreamInfoItem item,
+                                              final InfoCallback callback) {
+        if (item.getDuration() < 0) {
+            // Sparse item: fetched by fast fetch
+            final Disposable currentWorker = ExtractorHelper.getStreamInfo(
+                    item.getServiceId(),
+                    item.getUrl(),
+                    false
+            )
+                    .subscribeOn(Schedulers.io())
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .subscribe(result -> {
+                        callback.onInfo(new SinglePlayQueue(result));
+                    }, throwable -> Log.e("StreamDialogEntry", throwable.toString()));
+        } else {
+            callback.onInfo(new SinglePlayQueue(item));
+        }
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
+++ b/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
@@ -73,13 +73,20 @@ public enum StreamDialogEntry {
         );
     }),
 
-    start_here_on_background(R.string.start_here_on_background, (fragment, item) ->
-            NavigationHelper.playOnBackgroundPlayer(fragment.getContext(),
-                    new SinglePlayQueue(item), true)),
+    start_here_on_background(R.string.start_here_on_background, (fragment, item) -> {
+        fetchItemInfoIfSparse(fragment, item,
+                fullItem -> {
+                    NavigationHelper.playOnBackgroundPlayer(fragment.getContext(),
+                            fullItem, true);
+                });
+    }),
 
-    start_here_on_popup(R.string.start_here_on_popup, (fragment, item) ->
-            NavigationHelper.playOnPopupPlayer(fragment.getContext(),
-                    new SinglePlayQueue(item), true)),
+    start_here_on_popup(R.string.start_here_on_popup, (fragment, item) -> {
+        fetchItemInfoIfSparse(fragment, item, fullItem -> {
+                    NavigationHelper.playOnPopupPlayer(fragment.getContext(),
+                            fullItem, true);
+                });
+    }),
 
     set_as_playlist_thumbnail(R.string.set_as_playlist_thumbnail, (fragment, item) -> {
     }), // has to be set manually

--- a/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
+++ b/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
@@ -221,7 +221,7 @@ public enum StreamDialogEntry {
     private static void fetchItemInfoIfSparse(final Fragment fragment,
             final StreamInfoItem item,
             final InfoCallback callback) {
-        if (item.getDuration() < 0) {
+        if ((item.getStreamType() == StreamType.LIVE_STREAM || item.getStreamType() == StreamType.AUDIO_LIVE_STREAM) && item.getDuration() < 0) {
             // Sparse item: fetched by fast fetch
             final Disposable currentWorker = ExtractorHelper.getStreamInfo(
                     item.getServiceId(),

--- a/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
+++ b/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
@@ -20,6 +20,7 @@ import org.schabi.newpipe.util.external_communication.ShareUtils;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Consumer;
 
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 import io.reactivex.rxjava3.schedulers.Schedulers;
@@ -214,13 +215,9 @@ public enum StreamDialogEntry {
     // helper functions                        //
     /////////////////////////////////////////////
 
-    private interface InfoCallback {
-        void onInfo(SinglePlayQueue item);
-    }
-
     private static void fetchItemInfoIfSparse(final Fragment fragment,
             final StreamInfoItem item,
-            final InfoCallback callback) {
+            final Consumer<SinglePlayQueue> callback) {
         if (!(item.getStreamType() == StreamType.LIVE_STREAM
                 || item.getStreamType() == StreamType.AUDIO_LIVE_STREAM)
                 && item.getDuration() < 0) {
@@ -242,10 +239,10 @@ public enum StreamDialogEntry {
                                         throwable.toString()))
                                 .subscribe();
 
-                        callback.onInfo(new SinglePlayQueue(result));
+                        callback.accept(new SinglePlayQueue(result));
                     }, throwable -> Log.e("StreamDialogEntry", throwable.toString()));
         } else {
-            callback.onInfo(new SinglePlayQueue(item));
+            callback.accept(new SinglePlayQueue(item));
         }
     }
 }


### PR DESCRIPTION
Please feel free to criticize the code here, I am not sure if I am using workers correctly or if there is a better way to do this. I essentially copied the code from https://github.com/TeamNewPipe/NewPipe/blob/faa7a91764cf633e668d9621eb6884b5db58bfa1/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java#L878-L906

I decided loading the information when adding to the queue is better than loading when the video starts playing as it allows the queue progress text to be correct as well. 

<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
This PR calls getStreamInfo causing a full network fetch of stream info (I believe only if required) when adding a stream item to the queue. This should prevent UI issues of missing metadata when queuing videos that have been fast-loaded and are missing metadata.


#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #7035

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
