### PR TITLE
Fix handling exception in `playOnPopup` and toggle description tab

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/BaseFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/BaseFragment.java
@@ -16,7 +16,7 @@ import leakcanary.AppWatcher;
 
 public abstract class BaseFragment extends Fragment {
     protected final String TAG = getClass().getSimpleName() + "@" + Integer.toHexString(hashCode());
-    protected final boolean DEBUG = MainActivity.DEBUG;
+    protected static final boolean DEBUG = MainActivity.DEBUG;
     protected AppCompatActivity activity;
     //These values are used for controlling fragments when they are part of the frontpage
     @State

--- a/app/src/main/java/org/schabi/newpipe/error/ErrorPanelHelper.kt
+++ b/app/src/main/java/org/schabi/newpipe/error/ErrorPanelHelper.kt
@@ -121,27 +121,14 @@ class ErrorPanelHelper(
                 ErrorActivity.reportError(context, errorInfo)
             }
 
-            errorTextView.setText(
-                when (errorInfo.throwable) {
-                    is AgeRestrictedContentException -> R.string.restricted_video_no_stream
-                    is GeographicRestrictionException -> R.string.georestricted_content
-                    is PaidContentException -> R.string.paid_content
-                    is PrivateContentException -> R.string.private_content
-                    is SoundCloudGoPlusContentException -> R.string.soundcloud_go_plus_content
-                    is YoutubeMusicPremiumContentException -> R.string.youtube_music_premium_content
-                    is ContentNotAvailableException -> R.string.content_not_available
-                    is ContentNotSupportedException -> R.string.content_not_supported
-                    else -> {
-                        // show retry button only for content which is not unavailable or unsupported
-                        errorRetryButton.isVisible = true
-                        if (errorInfo.throwable != null && errorInfo.throwable!!.isNetworkRelated) {
-                            R.string.network_error
-                        } else {
-                            R.string.error_snackbar_message
-                        }
-                    }
-                }
-            )
+            errorTextView.setText(getExceptionDescription(errorInfo.throwable))
+
+            if (errorInfo.throwable !is ContentNotAvailableException &&
+                errorInfo.throwable !is ContentNotSupportedException
+            ) {
+                // show retry button only for content which is not unavailable or unsupported
+                errorRetryButton.isVisible = true
+            }
         }
 
         setRootVisible()
@@ -189,5 +176,27 @@ class ErrorPanelHelper(
     companion object {
         val TAG: String = ErrorPanelHelper::class.simpleName!!
         val DEBUG: Boolean = MainActivity.DEBUG
+
+        @StringRes
+        public fun getExceptionDescription(throwable: Throwable?): Int {
+            return when (throwable) {
+                is AgeRestrictedContentException -> R.string.restricted_video_no_stream
+                is GeographicRestrictionException -> R.string.georestricted_content
+                is PaidContentException -> R.string.paid_content
+                is PrivateContentException -> R.string.private_content
+                is SoundCloudGoPlusContentException -> R.string.soundcloud_go_plus_content
+                is YoutubeMusicPremiumContentException -> R.string.youtube_music_premium_content
+                is ContentNotAvailableException -> R.string.content_not_available
+                is ContentNotSupportedException -> R.string.content_not_supported
+                else -> {
+                    // show retry button only for content which is not unavailable or unsupported
+                    if (throwable != null && throwable.isNetworkRelated) {
+                        R.string.network_error
+                    } else {
+                        R.string.error_snackbar_message
+                    }
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/error/ReCaptchaActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/error/ReCaptchaActivity.java
@@ -1,5 +1,6 @@
 package org.schabi.newpipe.error;
 
+import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Build;
@@ -66,6 +67,7 @@ public class ReCaptchaActivity extends AppCompatActivity {
     private ActivityRecaptchaBinding recaptchaBinding;
     private String foundCookies = "";
 
+    @SuppressLint("SetJavaScriptEnabled")
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
         ThemeHelper.setTheme(this);

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -423,7 +423,7 @@ public final class VideoDetailFragment
             showRelatedItems = sharedPreferences.getBoolean(key, true);
             tabSettingsChanged = true;
         } else if (key.equals(getString(R.string.show_description_key))) {
-            showComments = sharedPreferences.getBoolean(key, true);
+            showDescription = sharedPreferences.getBoolean(key, true);
             tabSettingsChanged = true;
         }
     }

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/search/SearchFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/search/SearchFragment.java
@@ -215,6 +215,7 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
 
     @Override
     public void onViewCreated(@NonNull final View rootView, final Bundle savedInstanceState) {
+        searchBinding = FragmentSearchBinding.bind(rootView);
         super.onViewCreated(rootView, savedInstanceState);
         showSearchOnStart();
         initSearchListeners();
@@ -341,7 +342,6 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
     @Override
     protected void initViews(final View rootView, final Bundle savedInstanceState) {
         super.initViews(rootView, savedInstanceState);
-        searchBinding = FragmentSearchBinding.bind(rootView);
 
         searchBinding.suggestionsList.setAdapter(suggestionListAdapter);
         new ItemTouchHelper(new ItemTouchHelper.Callback() {
@@ -807,18 +807,21 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
                 })
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(listNotification -> {
-                    if (listNotification.isOnNext()) {
-                        if (listNotification.getValue() != null) {
-                            handleSuggestions(listNotification.getValue());
-                        }
-                    } else if (listNotification.isOnError()
-                            && listNotification.getError() != null
-                            && !ExceptionUtils.isInterruptedCaused(listNotification.getError())) {
-                        showSnackBarError(new ErrorInfo(listNotification.getError(),
-                                UserAction.GET_SUGGESTIONS, searchString, serviceId));
-                    }
-                });
+                .subscribe(
+                        listNotification -> {
+                            if (listNotification.isOnNext()) {
+                                if (listNotification.getValue() != null) {
+                                    handleSuggestions(listNotification.getValue());
+                                }
+                            } else if (listNotification.isOnError()
+                                    && listNotification.getError() != null
+                                    && !ExceptionUtils.isInterruptedCaused(
+                                            listNotification.getError())) {
+                                showSnackBarError(new ErrorInfo(listNotification.getError(),
+                                        UserAction.GET_SUGGESTIONS, searchString, serviceId));
+                            }
+                        }, throwable -> showSnackBarError(new ErrorInfo(
+                            throwable, UserAction.GET_SUGGESTIONS, searchString, serviceId)));
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -614,7 +614,7 @@ public final class Player implements
             playQueue.append(newQueue.getStreams());
 
             if ((intent.getBooleanExtra(SELECT_ON_APPEND, false)
-                    || currentState == STATE_COMPLETED) && newQueue.getStreams().size() > 0) {
+                    || currentState == STATE_COMPLETED) && !newQueue.getStreams().isEmpty()) {
                 playQueue.setIndex(sizeBeforeAppend);
             }
 
@@ -2326,7 +2326,7 @@ public final class Player implements
             Log.d(TAG, "ExoPlayer - onRepeatModeChanged() called with: "
                     + "repeatMode = [" + repeatMode + "]");
         }
-        setRepeatModeButton(((AppCompatImageButton) binding.repeatButton), repeatMode);
+        setRepeatModeButton(binding.repeatButton, repeatMode);
         onShuffleOrRepeatModeChanged();
     }
 
@@ -3189,7 +3189,7 @@ public final class Player implements
     private StreamSegmentAdapter.StreamSegmentListener getStreamSegmentListener() {
         return (item, seconds) -> {
             segmentAdapter.selectSegment(item);
-            seekTo(seconds * 1000);
+            seekTo(seconds * 1000L);
             triggerProgressUpdate();
         };
     }
@@ -3199,7 +3199,7 @@ public final class Player implements
         final List<StreamSegment> segments = currentMetadata.getMetadata().getStreamSegments();
 
         for (int i = 0; i < segments.size(); i++) {
-            if (segments.get(i).getStartTimeSeconds() * 1000 > playbackPosition) {
+            if (segments.get(i).getStartTimeSeconds() * 1000L > playbackPosition) {
                 break;
             }
             nearestPosition++;

--- a/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
@@ -360,7 +360,7 @@ public final class NavigationHelper {
             autoPlay = false;
         }
 
-        final RunnableWithVideoDetailFragment onVideoDetailFragmentReady = (detailFragment) -> {
+        final RunnableWithVideoDetailFragment onVideoDetailFragmentReady = detailFragment -> {
             expandMainPlayer(detailFragment.requireActivity());
             detailFragment.setAutoPlay(autoPlay);
             if (switchingPlayers) {

--- a/app/src/main/java/org/schabi/newpipe/util/PermissionHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/PermissionHelper.java
@@ -119,7 +119,7 @@ public final class PermissionHelper {
 
     public static boolean isPopupEnabled(final Context context) {
         return Build.VERSION.SDK_INT < Build.VERSION_CODES.M
-                || PermissionHelper.checkSystemAlertWindowPermission(context);
+                || checkSystemAlertWindowPermission(context);
     }
 
     public static void showPopupEnablementToast(final Context context) {

--- a/app/src/main/java/org/schabi/newpipe/util/external_communication/InternalUrlsHandler.java
+++ b/app/src/main/java/org/schabi/newpipe/util/external_communication/InternalUrlsHandler.java
@@ -101,7 +101,12 @@ public final class InternalUrlsHandler {
             return false;
         }
         final String matchedUrl = matcher.group(1);
-        final int seconds = Integer.parseInt(matcher.group(2));
+        final int seconds;
+        if (matcher.group(2) == null) {
+            seconds = -1;
+        } else {
+            seconds = Integer.parseInt(matcher.group(2));
+        }
 
         final StreamingService service;
         final StreamingService.LinkType linkType;
@@ -154,7 +159,7 @@ public final class InternalUrlsHandler {
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(info -> {
                     final PlayQueue playQueue
-                            = new SinglePlayQueue(info, seconds * 1000);
+                            = new SinglePlayQueue(info, seconds * 1000L);
                     NavigationHelper.playOnPopupPlayer(context, playQueue, false);
                 }, throwable -> {
                     if (DEBUG) {

--- a/app/src/main/java/org/schabi/newpipe/util/external_communication/InternalUrlsHandler.java
+++ b/app/src/main/java/org/schabi/newpipe/util/external_communication/InternalUrlsHandler.java
@@ -1,9 +1,14 @@
 package org.schabi.newpipe.util.external_communication;
 
 import android.content.Context;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
 
+import org.schabi.newpipe.MainActivity;
+import org.schabi.newpipe.R;
+import org.schabi.newpipe.error.ErrorPanelHelper;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
@@ -24,6 +29,9 @@ import io.reactivex.rxjava3.disposables.CompositeDisposable;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 
 public final class InternalUrlsHandler {
+    private static final String TAG = InternalUrlsHandler.class.getSimpleName();
+    private static final boolean DEBUG = MainActivity.DEBUG;
+
     private static final Pattern AMPERSAND_TIMESTAMP_PATTERN = Pattern.compile("(.*)&t=(\\d+)");
     private static final Pattern HASHTAG_TIMESTAMP_PATTERN =
             Pattern.compile("(.*)#timestamp=(\\d+)");
@@ -148,6 +156,16 @@ public final class InternalUrlsHandler {
                     final PlayQueue playQueue
                             = new SinglePlayQueue(info, seconds * 1000);
                     NavigationHelper.playOnPopupPlayer(context, playQueue, false);
+                }, throwable -> {
+                    if (DEBUG) {
+                        Log.e(TAG, "Could not play on popup: " + url, throwable);
+                    }
+                    new AlertDialog.Builder(context)
+                            .setTitle(R.string.player_stream_failure)
+                            .setMessage(
+                                    ErrorPanelHelper.Companion.getExceptionDescription(throwable))
+                            .setPositiveButton(R.string.ok, (v, b) -> { })
+                            .show();
                 }));
         return true;
     }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
- Fixed updating the wrong tabs when changing settings while running the minimized player in VideoDetailFragment. The comments tab was updated although the settings for the description tab were changed.
- Fixed `OnErrorNotImplementedException` in `InternalUrlsHandler.playOnPopup` by implementing error handling. A popup is shown with a little info on the error:
  <img src="https://user-images.githubusercontent.com/17365767/132091683-3a9e7ef3-9d22-4db5-95fc-7bbd633ce90c.png" width="300" />
- Fixed  `OnErrorNotImplementedException` in `SearchFragment.initSuggestionObserver()`. Errors are reported in the snackbar now. Not sure if I also managed to fix the cause of the original error. This needs to be investigated.
- Fixed a few warnings by SonarLint

### Fixes issues
- Fixes #6873
- Fixes #6979
- Fixes #6976

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
