### PR TITLE
Allow passing in package suffix for release builds through CLI param

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,6 +54,11 @@ android {
         // debug build. This seems to be a Gradle bug, therefore
         // TODO: update Gradle version
         release {
+            if (System.properties.containsKey('packageSuffix')) {
+                applicationIdSuffix System.getProperty('packageSuffix')
+                resValue "string", "app_name", "NewPipe " + System.getProperty('packageSuffix')
+                archivesBaseName = 'NewPipe_' + System.getProperty('packageSuffix')
+            }
             minifyEnabled true
             shrinkResources false // disabled to fix F-Droid's reproducible build
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'

--- a/doc/gradle.md
+++ b/doc/gradle.md
@@ -1,0 +1,14 @@
+# Custom gradle parameters
+
+You can use these parameters by specifying them inside the `gradle.properties` file as 
+`systemProp.<name>=<value>` or passing them through the CLI with `-D<name>=<value>`.
+
+## packageSuffix
+This allows you to specify a suffix, which will be added on release builds to the application id, 
+the `app_name` string and the apk file.  
+No validation is made, so make sure to pass in a valid value.
+
+## skipFormatKtlint
+This allows you to skip the `formatKtLint` task.  
+No value is needed.   
+It is used for CI in order to check for badly formatted files.


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Allow passing in package suffix for release builds through CLI param
- Add documentation for the custom gradle parameters

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #6420

#### Testing Description
- Run `gradle clean assembleRelease -DpackageSuffix=nightly`
- Sign it with `apksigner` https://developer.android.com/studio/command-line/apksigner
- Install the apk and see that it has the `nightly` suffix

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
