### PR TITLE
Better player error handling

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/error/EnsureExceptionSerializable.java
+++ b/app/src/main/java/org/schabi/newpipe/error/EnsureExceptionSerializable.java
@@ -1,0 +1,103 @@
+package org.schabi.newpipe.error;
+
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Ensures that a Exception is serializable.
+ * This is
+ */
+public final class EnsureExceptionSerializable {
+    private static final String TAG = "EnsureExSerializable";
+
+    private EnsureExceptionSerializable() {
+        // No instance
+    }
+
+    /**
+     * Ensures that an exception is serializable.
+     * <br/>
+     * If that is not the case a {@link WorkaroundNotSerializableException} is created.
+     *
+     * @param exception
+     * @return if an exception is not serializable a new {@link WorkaroundNotSerializableException}
+     * otherwise the exception from the parameter
+     */
+    public static Exception ensureSerializable(@NonNull final Exception exception) {
+        return checkIfSerializable(exception)
+                ? exception
+                : WorkaroundNotSerializableException.create(exception);
+    }
+
+    public static boolean checkIfSerializable(@NonNull final Exception exception) {
+        try {
+            // Check by creating a new ObjectOutputStream which does the serialization
+            try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                 ObjectOutputStream oos = new ObjectOutputStream(bos)
+            ) {
+                oos.writeObject(exception);
+                oos.flush();
+
+                bos.toByteArray();
+            }
+
+            return true;
+        } catch (final IOException ex) {
+            Log.d(TAG, "Exception is not serializable", ex);
+            return false;
+        }
+    }
+
+    public static class WorkaroundNotSerializableException extends Exception {
+        protected WorkaroundNotSerializableException(
+                final Throwable notSerializableException,
+                final Throwable cause) {
+            super(notSerializableException.toString(), cause);
+            setStackTrace(notSerializableException.getStackTrace());
+        }
+
+        protected WorkaroundNotSerializableException(final Throwable notSerializableException) {
+            super(notSerializableException.toString());
+            setStackTrace(notSerializableException.getStackTrace());
+        }
+
+        public static WorkaroundNotSerializableException create(
+                @NonNull final Exception notSerializableException
+        ) {
+            // Build a list of the exception + all causes
+            final List<Throwable> throwableList = new ArrayList<>();
+
+            int pos = 0;
+            Throwable throwableToProcess = notSerializableException;
+
+            while (throwableToProcess != null) {
+                throwableList.add(throwableToProcess);
+
+                pos++;
+                throwableToProcess = throwableToProcess.getCause();
+            }
+
+            // Reverse list so that it starts with the last one
+            Collections.reverse(throwableList);
+
+            // Build exception stack
+            WorkaroundNotSerializableException cause = null;
+            for (final Throwable t : throwableList) {
+                cause = cause == null
+                        ? new WorkaroundNotSerializableException(t)
+                        : new WorkaroundNotSerializableException(t, cause);
+            }
+
+            return cause;
+        }
+
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/error/ErrorActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/error/ErrorActivity.java
@@ -77,6 +77,16 @@ public class ErrorActivity extends AppCompatActivity {
 
     private ActivityErrorBinding activityErrorBinding;
 
+    /**
+     * Reports a new error by starting a new activity.
+     * <br/>
+     * Ensure that the data within errorInfo is serializable otherwise
+     * an exception will be thrown!<br/>
+     * {@link EnsureExceptionSerializable} might help.
+     *
+     * @param context
+     * @param errorInfo
+     */
     public static void reportError(final Context context, final ErrorInfo errorInfo) {
         final Intent intent = new Intent(context, ErrorActivity.class);
         intent.putExtra(ERROR_INFO, errorInfo);

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -657,7 +657,10 @@ public final class VideoDetailFragment
         binding.detailControlsPlayWithKodi.setOnClickListener(this);
         if (DEBUG) {
             binding.detailControlsCrashThePlayer.setOnClickListener(
-                    v -> VideoDetailPlayerCrasher.onCrashThePlayer(this.player, getLayoutInflater())
+                    v -> VideoDetailPlayerCrasher.onCrashThePlayer(
+                            this.getContext(),
+                            this.player,
+                            getLayoutInflater())
             );
         }
 

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -205,9 +205,6 @@ public final class VideoDetailFragment
     private Player player;
     private final PlayerHolder playerHolder = PlayerHolder.getInstance();
 
-    @Nullable
-    private VideoDetailPlayerCrasher videoDetailPlayerCrasher = null;
-
     /*//////////////////////////////////////////////////////////////////////////
     // Service management
     //////////////////////////////////////////////////////////////////////////*/
@@ -600,13 +597,6 @@ public final class VideoDetailFragment
     @Override
     public void onViewCreated(@NonNull final View rootView, final Bundle savedInstanceState) {
         super.onViewCreated(rootView, savedInstanceState);
-
-        if (DEBUG) {
-            this.videoDetailPlayerCrasher = new VideoDetailPlayerCrasher(
-                    () -> this.getContext(),
-                    () -> this.getLayoutInflater()
-            );
-        }
     }
 
     @Override // called from onViewCreated in {@link BaseFragment#onViewCreated}
@@ -667,7 +657,8 @@ public final class VideoDetailFragment
         binding.detailControlsPlayWithKodi.setOnClickListener(this);
         if (DEBUG) {
             binding.detailControlsCrashThePlayer.setOnClickListener(
-                    v -> videoDetailPlayerCrasher.onCrashThePlayer(this.player));
+                    v -> VideoDetailPlayerCrasher.onCrashThePlayer(this.player, getLayoutInflater())
+            );
         }
 
         binding.overlayThumbnail.setOnClickListener(this);

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailPlayerCrasher.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailPlayerCrasher.java
@@ -12,8 +12,8 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 
+import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.ExoPlaybackException;
-import com.google.android.exoplayer2.RendererCapabilities;
 
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.databinding.ListRadioIconItemBinding;
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 
 /**
@@ -61,7 +60,7 @@ public final class VideoDetailPlayerCrasher {
                         "Dummy renderer",
                         0,
                         null,
-                        RendererCapabilities.FORMAT_HANDLED
+                        C.FORMAT_HANDLED
                 )
         );
         exceptionTypes.put(
@@ -73,13 +72,6 @@ public final class VideoDetailPlayerCrasher {
         exceptionTypes.put(
                 "Remote",
                 () -> ExoPlaybackException.createForRemote(defaultMsg)
-        );
-        exceptionTypes.put(
-                "Timeout",
-                () -> ExoPlaybackException.createForTimeout(
-                        new TimeoutException(defaultMsg),
-                        ExoPlaybackException.TIMEOUT_OPERATION_UNDEFINED
-                )
         );
 
         return Collections.unmodifiableMap(exceptionTypes);

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailPlayerCrasher.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailPlayerCrasher.java
@@ -10,6 +10,7 @@ import android.widget.RadioGroup;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 
 import com.google.android.exoplayer2.C;
@@ -85,9 +86,12 @@ public final class VideoDetailPlayerCrasher {
                         : R.style.DarkTheme);
     }
 
-    public static void onCrashThePlayer(final Player player, final LayoutInflater layoutInflater) {
-        final Context context = player.getContext();
-        if (!isPlayerAvailable(player)) {
+    public static void onCrashThePlayer(
+            @NonNull final Context context,
+            @Nullable final Player player,
+            @NonNull final LayoutInflater layoutInflater
+    ) {
+        if (player == null) {
             Log.d(TAG, "Player is not available");
             Toast.makeText(context, "Player is not available", Toast.LENGTH_SHORT)
                     .show();
@@ -151,9 +155,5 @@ public final class VideoDetailPlayerCrasher {
                     "Run into an exception while crashing the player:",
                     exPlayer);
         }
-    }
-
-    private static boolean isPlayerAvailable(final Player player) {
-        return player != null;
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailPlayerCrasher.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailPlayerCrasher.java
@@ -1,0 +1,165 @@
+package org.schabi.newpipe.fragments.detail;
+
+import android.content.Context;
+import android.util.Log;
+import android.view.ContextThemeWrapper;
+import android.view.LayoutInflater;
+import android.view.ViewGroup;
+import android.widget.RadioButton;
+import android.widget.RadioGroup;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
+
+import com.google.android.exoplayer2.ExoPlaybackException;
+import com.google.android.exoplayer2.RendererCapabilities;
+
+import org.schabi.newpipe.R;
+import org.schabi.newpipe.databinding.ListRadioIconItemBinding;
+import org.schabi.newpipe.databinding.SingleChoiceDialogViewBinding;
+import org.schabi.newpipe.player.Player;
+import org.schabi.newpipe.util.ThemeHelper;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+
+public class VideoDetailPlayerCrasher {
+
+    private static final String TAG = "VideoDetPlayerCrasher";
+
+    @NonNull
+    private final Supplier<Context> contextSupplier;
+    @NonNull
+    private final Supplier<LayoutInflater> layoutInflaterSupplier;
+
+    public VideoDetailPlayerCrasher(
+            @NonNull final Supplier<Context> contextSupplier,
+            @NonNull final Supplier<LayoutInflater> layoutInflaterSupplier
+    ) {
+        this.contextSupplier = contextSupplier;
+        this.layoutInflaterSupplier = layoutInflaterSupplier;
+    }
+
+    private static Map<String, Supplier<ExoPlaybackException>> getExceptionTypes() {
+        final String defaultMsg = "Dummy";
+        final Map<String, Supplier<ExoPlaybackException>> exceptionTypes = new LinkedHashMap<>();
+        exceptionTypes.put(
+                "Source",
+                () -> ExoPlaybackException.createForSource(
+                        new IOException(defaultMsg)
+                )
+        );
+        exceptionTypes.put(
+                "Renderer",
+                () -> ExoPlaybackException.createForRenderer(
+                        new Exception(defaultMsg),
+                        "Dummy renderer",
+                        0,
+                        null,
+                        RendererCapabilities.FORMAT_HANDLED
+                )
+        );
+        exceptionTypes.put(
+                "Unexpected",
+                () -> ExoPlaybackException.createForUnexpected(
+                        new RuntimeException(defaultMsg)
+                )
+        );
+        exceptionTypes.put(
+                "Remote",
+                () -> ExoPlaybackException.createForRemote(defaultMsg)
+        );
+        exceptionTypes.put(
+                "Timeout",
+                () -> ExoPlaybackException.createForTimeout(
+                        new TimeoutException(defaultMsg),
+                        ExoPlaybackException.TIMEOUT_OPERATION_UNDEFINED
+                )
+        );
+
+        return exceptionTypes;
+    }
+
+    private Context getContext() {
+        return this.contextSupplier.get();
+    }
+
+    private LayoutInflater getLayoutInflater() {
+        return this.layoutInflaterSupplier.get();
+    }
+
+    private Context getThemeWrapperContext() {
+        return new ContextThemeWrapper(
+                getContext(),
+                ThemeHelper.isLightThemeSelected(getContext())
+                        ? R.style.LightTheme
+                        : R.style.DarkTheme);
+    }
+
+    public void onCrashThePlayer(final Player player) {
+        if (!isPlayerAvailable(player)) {
+            Log.d(TAG, "Player is not available");
+            Toast.makeText(getContext(), "Player is not available", Toast.LENGTH_SHORT)
+                    .show();
+
+            return;
+        }
+
+        final Context themeWrapperContext = getThemeWrapperContext();
+
+        final LayoutInflater inflater = LayoutInflater.from(themeWrapperContext);
+        final RadioGroup radioGroup = SingleChoiceDialogViewBinding.inflate(getLayoutInflater())
+                .list;
+
+        final AlertDialog alertDialog = new AlertDialog.Builder(getThemeWrapperContext())
+                .setTitle("Choose an exception")
+                .setView(radioGroup)
+                .setCancelable(true)
+                .setNegativeButton(R.string.cancel, null)
+                .create();
+
+        for (final Map.Entry<String, Supplier<ExoPlaybackException>> entry
+                : getExceptionTypes().entrySet()) {
+            final RadioButton radioButton = ListRadioIconItemBinding.inflate(inflater).getRoot();
+            radioButton.setText(entry.getKey());
+            radioButton.setChecked(false);
+            radioButton.setLayoutParams(
+                    new RadioGroup.LayoutParams(
+                            ViewGroup.LayoutParams.MATCH_PARENT,
+                            ViewGroup.LayoutParams.WRAP_CONTENT
+                    )
+            );
+            radioButton.setOnClickListener(v -> {
+                tryCrashPlayerWith(player, entry.getValue().get());
+                if (alertDialog != null) {
+                    alertDialog.cancel();
+                }
+            });
+            radioGroup.addView(radioButton);
+        }
+
+        alertDialog.show();
+    }
+
+    private void tryCrashPlayerWith(
+            @NonNull final Player player,
+            @NonNull final ExoPlaybackException exception
+    ) {
+        Log.d(TAG, "Crashing the player using player.onPlayerError(ex)");
+        try {
+            player.onPlayerError(exception);
+        } catch (final Exception exPlayer) {
+            Log.e(TAG,
+                    "Run into an exception while crashing the player:",
+                    exPlayer);
+        }
+    }
+
+    private boolean isPlayerAvailable(final Player player) {
+        return player != null;
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailPlayerCrasher.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailPlayerCrasher.java
@@ -27,8 +27,14 @@ import java.util.Map;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 
+/**
+ * Outsourced logic for crashing the player in the {@link VideoDetailFragment}.
+ */
 public class VideoDetailPlayerCrasher {
 
+    // This has to be <= 23 chars on devices running Android 7 or lower (API <= 25)
+    // or it fails with an IllegalArgumentException
+    // https://stackoverflow.com/a/54744028
     private static final String TAG = "VideoDetPlayerCrasher";
 
     @NonNull
@@ -108,6 +114,8 @@ public class VideoDetailPlayerCrasher {
 
             return;
         }
+
+        // -- Build the dialog/UI --
 
         final Context themeWrapperContext = getThemeWrapperContext();
 

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailPlayerCrasher.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailPlayerCrasher.java
@@ -145,6 +145,12 @@ public class VideoDetailPlayerCrasher {
         alertDialog.show();
     }
 
+    /**
+     * Note that this method does not crash the underlying exoplayer directly (it's not possible).
+     * It simply supplies a Exception to {@link Player#onPlayerError(ExoPlaybackException)}.
+     * @param player
+     * @param exception
+     */
     private void tryCrashPlayerWith(
             @NonNull final Player player,
             @NonNull final ExoPlaybackException exception

--- a/app/src/main/java/org/schabi/newpipe/player/playererror/PlayerErrorHandler.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playererror/PlayerErrorHandler.java
@@ -1,0 +1,86 @@
+package org.schabi.newpipe.player.playererror;
+
+import android.content.Context;
+import android.util.Log;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
+import androidx.preference.PreferenceManager;
+
+import com.google.android.exoplayer2.ExoPlaybackException;
+
+import org.schabi.newpipe.R;
+import org.schabi.newpipe.error.ErrorActivity;
+import org.schabi.newpipe.error.ErrorInfo;
+import org.schabi.newpipe.error.UserAction;
+import org.schabi.newpipe.extractor.Info;
+
+/**
+ * Handles (exoplayer)errors that occur in the player.
+ */
+public class PlayerErrorHandler {
+    // This has to be <= 23 chars on devices running Android 7 or lower (API <= 25)
+    // or it fails with an IllegalArgumentException
+    // https://stackoverflow.com/a/54744028
+    private static final String TAG = "PlayerErrorHandler";
+
+    @Nullable
+    private Toast errorToast;
+
+    @NonNull
+    private final Context context;
+
+    public PlayerErrorHandler(@NonNull final Context context) {
+        this.context = context;
+    }
+
+    public void showPlayerError(
+            @NonNull final ExoPlaybackException exception,
+            @NonNull final Info info,
+            @StringRes final int textResId) {
+        // Hide existing toast message
+        if (errorToast != null) {
+            Log.d(TAG, "Trying to cancel previous player error error toast");
+            errorToast.cancel();
+            errorToast = null;
+        }
+
+        if (shouldReportError()) {
+            try {
+                reportError(exception, info);
+                // When a report pops up we need no toast
+                return;
+            } catch (final Exception ex) {
+                Log.w(TAG, "Unable to report error:", ex);
+            }
+        }
+
+        Log.d(TAG, "Showing player error toast");
+        errorToast = Toast.makeText(context, textResId, Toast.LENGTH_SHORT);
+        errorToast.show();
+    }
+
+    private void reportError(@NonNull final ExoPlaybackException exception,
+                             @NonNull final Info info) {
+        ErrorActivity.reportError(
+                context,
+                new ErrorInfo(
+                        exception,
+                        UserAction.PLAY_STREAM,
+                        "Player error[type=" + exception.type + "] occurred while playing: "
+                                + info.getUrl(),
+                        info
+                )
+        );
+    }
+
+    private boolean shouldReportError() {
+        return PreferenceManager
+                .getDefaultSharedPreferences(context)
+                .getBoolean(
+                        context.getString(R.string.report_player_errors_key),
+                        false);
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/playererror/PlayerErrorHandler.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playererror/PlayerErrorHandler.java
@@ -39,7 +39,8 @@ public class PlayerErrorHandler {
     public void showPlayerError(
             @NonNull final ExoPlaybackException exception,
             @NonNull final Info info,
-            @StringRes final int textResId) {
+            @StringRes final int textResId
+    ) {
         // Hide existing toast message
         if (errorToast != null) {
             Log.d(TAG, "Trying to cancel previous player error error toast");
@@ -54,6 +55,7 @@ public class PlayerErrorHandler {
                 return;
             } catch (final Exception ex) {
                 Log.w(TAG, "Unable to report error:", ex);
+                // This will show the toast as fallback
             }
         }
 

--- a/app/src/main/java/org/schabi/newpipe/player/playererror/PlayerErrorHandler.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playererror/PlayerErrorHandler.java
@@ -12,6 +12,7 @@ import androidx.preference.PreferenceManager;
 import com.google.android.exoplayer2.ExoPlaybackException;
 
 import org.schabi.newpipe.R;
+import org.schabi.newpipe.error.EnsureExceptionSerializable;
 import org.schabi.newpipe.error.ErrorActivity;
 import org.schabi.newpipe.error.ErrorInfo;
 import org.schabi.newpipe.error.UserAction;
@@ -69,7 +70,7 @@ public class PlayerErrorHandler {
         ErrorActivity.reportError(
                 context,
                 new ErrorInfo(
-                        exception,
+                        EnsureExceptionSerializable.ensureSerializable(exception),
                         UserAction.PLAY_STREAM,
                         "Player error[type=" + exception.type + "] occurred while playing: "
                                 + info.getUrl(),

--- a/app/src/main/res/layout-large-land/fragment_video_detail.xml
+++ b/app/src/main/res/layout-large-land/fragment_video_detail.xml
@@ -225,7 +225,7 @@
                         android:layout_below="@id/detail_title_root_layout"
                         android:layout_marginTop="@dimen/video_item_detail_error_panel_margin"
                         android:visibility="gone"
-                        tools:visibility="visible" />
+                        tools:visibility="gone" />
 
                     <!--HIDING ROOT-->
                     <LinearLayout
@@ -562,6 +562,22 @@
                                 android:text="@string/play_with_kodi_title"
                                 android:textSize="@dimen/detail_control_text_size"
                                 app:drawableTopCompat="@drawable/ic_cast" />
+
+                            <TextView
+                                android:id="@+id/detail_controls_crash_the_player"
+                                android:layout_width="@dimen/detail_control_width"
+                                android:layout_height="@dimen/detail_control_height"
+                                android:layout_gravity="center_vertical"
+                                android:layout_weight="1"
+                                android:background="?attr/selectableItemBackgroundBorderless"
+                                android:clickable="true"
+                                android:contentDescription="@string/crash_the_player"
+                                android:focusable="true"
+                                android:gravity="center"
+                                android:paddingVertical="@dimen/detail_control_padding"
+                                android:text="@string/crash_the_player"
+                                android:textSize="@dimen/detail_control_text_size"
+                                app:drawableTopCompat="@drawable/ic_bug_report" />
 
                         </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_video_detail.xml
+++ b/app/src/main/res/layout/fragment_video_detail.xml
@@ -213,7 +213,7 @@
                     android:layout_below="@id/detail_title_root_layout"
                     android:layout_marginTop="@dimen/video_item_detail_error_panel_margin"
                     android:visibility="gone"
-                    tools:visibility="visible" />
+                    tools:visibility="gone" />
 
                 <!--HIDING ROOT-->
                 <LinearLayout
@@ -546,6 +546,22 @@
                             android:text="@string/play_with_kodi_title"
                             android:textSize="@dimen/detail_control_text_size"
                             app:drawableTopCompat="@drawable/ic_cast" />
+
+                        <TextView
+                            android:id="@+id/detail_controls_crash_the_player"
+                            android:layout_width="@dimen/detail_control_width"
+                            android:layout_height="@dimen/detail_control_height"
+                            android:layout_gravity="center_vertical"
+                            android:layout_weight="1"
+                            android:background="?attr/selectableItemBackgroundBorderless"
+                            android:clickable="true"
+                            android:contentDescription="@string/crash_the_player"
+                            android:focusable="true"
+                            android:gravity="center"
+                            android:paddingVertical="@dimen/detail_control_padding"
+                            android:text="@string/crash_the_player"
+                            android:textSize="@dimen/detail_control_text_size"
+                            app:drawableTopCompat="@drawable/ic_bug_report" />
 
                     </LinearLayout>
 

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -190,6 +190,7 @@
     <string name="disable_media_tunneling_key" translatable="false">disable_media_tunneling_key</string>
     <string name="crash_the_app_key" translatable="false">crash_the_app_key</string>
     <string name="show_image_indicators_key" translatable="false">show_image_indicators_key</string>
+    <string name="show_crash_the_player_key" translatable="false">show_crash_the_player_key</string>
 
     <!-- THEMES -->
     <string name="theme_key" translatable="false">theme</string>

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -89,6 +89,8 @@
         <item>@string/never</item>
     </string-array>
 
+    <string name="report_player_errors_key" translatable="false">report_player_errors_key</string>
+
     <string name="seekbar_preview_thumbnail_key" translatable="false">seekbar_preview_thumbnail_key</string>
     <string name="seekbar_preview_thumbnail_high_quality" translatable="false">seekbar_preview_thumbnail_high_quality</string>
     <string name="seekbar_preview_thumbnail_low_quality" translatable="false">seekbar_preview_thumbnail_low_quality</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,6 +52,7 @@
     <string name="kore_package" translatable="false">org.xbmc.kore</string>
     <string name="show_play_with_kodi_title">Show \"Play with Kodi\" option</string>
     <string name="show_play_with_kodi_summary">Display an option to play a video via Kodi media center</string>
+    <string name="crash_the_player">Crash the player</string>
     <string name="report_player_errors_title">Report player errors</string>
     <string name="report_player_errors_summary">Reports player errors in full detail instead of showing a short-lived toast message (useful for diagnosing problems)</string>
     <string name="notification_scale_to_square_image_title">Scale thumbnail to 1:1 aspect ratio</string>
@@ -475,6 +476,8 @@
     <string name="show_image_indicators_title">Show image indicators</string>
     <string name="show_image_indicators_summary">Show Picasso colored ribbons on top of images indicating their source: red for network, blue for disk and green for memory</string>
     <string name="crash_the_app">Crash the app</string>
+    <string name="show_crash_the_player_title">Show \"crash the player\"</string>
+    <string name="show_crash_the_player_summary">Shows a crash option when using the player</string>
     <!-- Subscriptions import/export -->
     <string name="import_title">Import</string>
     <string name="import_from">Import from</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,6 +52,8 @@
     <string name="kore_package" translatable="false">org.xbmc.kore</string>
     <string name="show_play_with_kodi_title">Show \"Play with Kodi\" option</string>
     <string name="show_play_with_kodi_summary">Display an option to play a video via Kodi media center</string>
+    <string name="report_player_errors_title">Report player errors</string>
+    <string name="report_player_errors_summary">Reports player errors in full detail instead of showing a short-lived toast message (useful for diagnosing problems)</string>
     <string name="notification_scale_to_square_image_title">Scale thumbnail to 1:1 aspect ratio</string>
     <string name="notification_scale_to_square_image_summary">Scale the video thumbnail shown in the notification from 16:9 to 1:1 aspect ratio (may introduce distortions)</string>
     <string name="notification_action_0_title">First action button</string>

--- a/app/src/main/res/xml/debug_settings.xml
+++ b/app/src/main/res/xml/debug_settings.xml
@@ -49,6 +49,14 @@
         android:title="@string/show_image_indicators_title"
         app:iconSpaceReserved="false" />
 
+    <SwitchPreferenceCompat
+        android:defaultValue="false"
+        android:key="@string/report_player_errors_key"
+        android:summary="@string/report_player_errors_summary"
+        android:title="@string/report_player_errors_title"
+        app:singleLineTitle="false"
+        app:iconSpaceReserved="false" />
+
     <Preference
         android:key="@string/crash_the_app_key"
         android:title="@string/crash_the_app"

--- a/app/src/main/res/xml/debug_settings.xml
+++ b/app/src/main/res/xml/debug_settings.xml
@@ -54,4 +54,13 @@
         android:title="@string/crash_the_app"
         app:singleLineTitle="false"
         app:iconSpaceReserved="false" />
+
+    <SwitchPreferenceCompat
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:defaultValue="false"
+        android:key="@string/show_crash_the_player_key"
+        android:summary="@string/show_crash_the_player_summary"
+        android:title="@string/show_crash_the_player_title"
+        app:iconSpaceReserved="false" />
 </PreferenceScreen>

--- a/app/src/main/res/xml/video_audio_settings.xml
+++ b/app/src/main/res/xml/video_audio_settings.xml
@@ -102,14 +102,6 @@
             app:singleLineTitle="false"
             app:iconSpaceReserved="false" />
 
-        <SwitchPreferenceCompat
-            android:defaultValue="false"
-            android:key="@string/report_player_errors_key"
-            android:summary="@string/report_player_errors_summary"
-            android:title="@string/report_player_errors_title"
-            app:singleLineTitle="false"
-            app:iconSpaceReserved="false" />
-
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/app/src/main/res/xml/video_audio_settings.xml
+++ b/app/src/main/res/xml/video_audio_settings.xml
@@ -89,6 +89,7 @@
             android:title="@string/show_play_with_kodi_title"
             app:singleLineTitle="false"
             app:iconSpaceReserved="false" />
+
         <ListPreference
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -98,6 +99,14 @@
             android:key="@string/seekbar_preview_thumbnail_key"
             android:summary="%s"
             android:title="@string/seekbar_preview_thumbnail_title"
+            app:singleLineTitle="false"
+            app:iconSpaceReserved="false" />
+
+        <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="@string/report_player_errors_key"
+            android:summary="@string/report_player_errors_summary"
+            android:title="@string/report_player_errors_title"
             app:singleLineTitle="false"
             app:iconSpaceReserved="false" />
 


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This PR massively improves the handling of player errors. It consist of 2 parts:

#### 1. Improving the player error handling
Up to this PR player errors are always just reported as ![grafik](https://user-images.githubusercontent.com/40789489/134232359-8848b4f0-b488-424d-beeb-1b2ab4feeb04.png) (or similar)
This PR introduces an option (default=off) to report the Error directly (via acra):
<img src="https://user-images.githubusercontent.com/40789489/134232058-6828b0fc-09a5-4eb1-bb1a-afa3020a7e53.png" width=250>


https://user-images.githubusercontent.com/40789489/134233077-f92c9680-4800-47f3-a23a-65f3748c40f6.mp4



#### 2. Added an option to simulate player errors
To simulate errors a debug option was introduced to crash the player.

<img src="https://user-images.githubusercontent.com/40789489/134234206-605087c9-f8ed-4b4a-848f-e5a026b839fd.png" width=250> <img src="https://user-images.githubusercontent.com/40789489/134234291-5c4b2413-c999-496e-ba32-01bff9771431.png" width=250> <img src="https://user-images.githubusercontent.com/40789489/134234315-94b55c57-a257-4427-b45e-7e6bdfa7adfe.png" width=250>


Notes:
* This option is only available when using a Debug version of the app (the same as the ``DebugSettingsFragment``)
* To make this work in all player variants (main, mini, background, popup) it was added to``VideoDetailFragment`` - otherwise at least sometimes there is no UI where the error can be triggered from.
* This is not a true Exoplayer error as it's not possible to crash the player internally (we would have to mess up the streaming data or something similar) therefore ``Player#onPlayerError`` is simply called with an exception
* When no player is available (because e.g. it was crashed) a toast shows up <br/> ![grafik](https://user-images.githubusercontent.com/40789489/134235788-a2de5f38-1807-4d35-9ab1-da4df6856804.png)


#### Fixes the following issue(s)
- Fixes #7008


#### APK testing 
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
