### PR TITLE
Fix two issues with setMetadata

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -1606,8 +1606,12 @@ public final class Player implements
         final boolean showThumbnail = prefs.getBoolean(
                 context.getString(R.string.show_thumbnail_key), true);
         // setMetadata only updates the metadata when any of the metadata keys are null
-        mediaSessionManager.setMetadata(getVideoTitle(), getUploaderName(),
-                showThumbnail ? getThumbnail() : null, duration);
+        if (showThumbnail) {
+            mediaSessionManager.setMetadata(getVideoTitle(), getUploaderName(), getThumbnail(),
+                    duration);
+        } else {
+            mediaSessionManager.setMetadata(getVideoTitle(), getUploaderName(), duration);
+        }
     }
 
     private void startProgressLoop() {
@@ -2987,9 +2991,11 @@ public final class Player implements
 
     @Nullable
     public Bitmap getThumbnail() {
-        return currentThumbnail == null
-                ? BitmapFactory.decodeResource(context.getResources(), R.drawable.dummy_thumbnail)
-                : currentThumbnail;
+        if (currentThumbnail == null) {
+            currentThumbnail = BitmapFactory.decodeResource(
+                    context.getResources(), R.drawable.dummy_thumbnail);
+        }
+        return currentThumbnail;
     }
     //endregion
 

--- a/app/src/main/java/org/schabi/newpipe/player/helper/MediaSessionManager.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/MediaSessionManager.java
@@ -67,6 +67,39 @@ public class MediaSessionManager {
 
     public void setMetadata(final String title,
                             final String artist,
+                            final long duration) {
+        if (!mediaSession.isActive()) {
+            return;
+        }
+
+        if (DEBUG) {
+            if (getMetadataTitle() == null) {
+                Log.d(TAG, "N_getMetadataTitle: title == null");
+            }
+            if (getMetadataArtist() == null) {
+                Log.d(TAG, "N_getMetadataArtist: artist == null");
+            }
+            if (getMetadataDuration() <= 1) {
+                Log.d(TAG, "N_getMetadataDuration: duration <= 1; " + getMetadataDuration());
+            }
+        }
+
+        if (getMetadataTitle() == null || getMetadataArtist() == null || getMetadataDuration() <= 1
+                || !getMetadataTitle().equals(title)) {
+            if (DEBUG) {
+                Log.d(TAG, "setMetadata: N_Metadata update: t: " + title + " a: " + artist
+                        + " d: " + duration);
+            }
+
+            mediaSession.setMetadata(new MediaMetadataCompat.Builder()
+                    .putString(MediaMetadataCompat.METADATA_KEY_TITLE, title)
+                    .putString(MediaMetadataCompat.METADATA_KEY_ARTIST, artist)
+                    .putLong(MediaMetadataCompat.METADATA_KEY_DURATION, duration).build());
+        }
+    }
+
+    public void setMetadata(final String title,
+                            final String artist,
                             final Bitmap albumArt,
                             final long duration) {
         if (albumArt == null || !mediaSession.isActive()) {


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [X] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Issue 1 is when the option "Show thumbnail" is turned off. It caused setMetadata to never be called.
`// setMetadata only updates the metadata when any of the metadata keys are null mediaSessionManager.setMetadata(getVideoTitle(), getUploaderName(), showThumbnail ? getThumbnail() : null, duration);`

basically the first line in setMetadata checks, if the provided thumbnail/albumArt is not null.

Issue 2: if no thumbnail could be loaded, the dummy thumbnail resource would be used to be created through a Bitmap factory. Firstly it will be created each time (expensive) and secondly hashCode() will always yield different results. This means that setMetadata was basically executed in its whole every single time (each second since last updates).

#### Fixes the following issue(s)
Don't know if there is an issue that would be closed by this. I found it while looking at issue #7087


#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [X] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
