### PR TITLE
Various fixes related to MediasessionManager

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -140,6 +140,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 import io.reactivex.rxjava3.core.Observable;
@@ -1622,16 +1623,6 @@ public final class Player implements
         if (isQueueVisible) {
             updateQueueTime(currentProgress);
         }
-
-        final boolean showThumbnail = prefs.getBoolean(
-                context.getString(R.string.show_thumbnail_key), true);
-        // setMetadata only updates the metadata when any of the metadata keys are null
-        if (showThumbnail) {
-            mediaSessionManager.setMetadata(getVideoTitle(), getUploaderName(), getThumbnail(),
-                    duration);
-        } else {
-            mediaSessionManager.setMetadata(getVideoTitle(), getUploaderName(), duration);
-        }
     }
 
     private void startProgressLoop() {
@@ -2950,6 +2941,16 @@ public final class Player implements
                 tag.getMetadata().getPreviewFrames());
 
         NotificationUtil.getInstance().createNotificationIfNeededAndUpdate(this, false);
+
+        final boolean showThumbnail = prefs.getBoolean(
+                context.getString(R.string.show_thumbnail_key), true);
+        mediaSessionManager.setMetadata(
+                getVideoTitle(),
+                getUploaderName(),
+                showThumbnail ? Optional.ofNullable(getThumbnail()) : Optional.empty(),
+                tag.getMetadata().getDuration()
+        );
+
         notifyMetadataUpdateToListeners();
 
         if (areSegmentsVisible) {

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -1626,8 +1626,12 @@ public final class Player implements
         final boolean showThumbnail = prefs.getBoolean(
                 context.getString(R.string.show_thumbnail_key), true);
         // setMetadata only updates the metadata when any of the metadata keys are null
-        mediaSessionManager.setMetadata(getVideoTitle(), getUploaderName(),
-                showThumbnail ? getThumbnail() : null, duration);
+        if (showThumbnail) {
+            mediaSessionManager.setMetadata(getVideoTitle(), getUploaderName(), getThumbnail(),
+                    duration);
+        } else {
+            mediaSessionManager.setMetadata(getVideoTitle(), getUploaderName(), duration);
+        }
     }
 
     private void startProgressLoop() {
@@ -3023,9 +3027,11 @@ public final class Player implements
 
     @Nullable
     public Bitmap getThumbnail() {
-        return currentThumbnail == null
-                ? BitmapFactory.decodeResource(context.getResources(), R.drawable.dummy_thumbnail)
-                : currentThumbnail;
+        if (currentThumbnail == null) {
+            currentThumbnail = BitmapFactory.decodeResource(
+                    context.getResources(), R.drawable.dummy_thumbnail);
+        }
+        return currentThumbnail;
     }
     //endregion
 

--- a/app/src/main/java/org/schabi/newpipe/player/helper/MediaSessionManager.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/MediaSessionManager.java
@@ -67,6 +67,39 @@ public class MediaSessionManager {
 
     public void setMetadata(final String title,
                             final String artist,
+                            final long duration) {
+        if (!mediaSession.isActive()) {
+            return;
+        }
+
+        if (DEBUG) {
+            if (getMetadataTitle() == null) {
+                Log.d(TAG, "N_getMetadataTitle: title == null");
+            }
+            if (getMetadataArtist() == null) {
+                Log.d(TAG, "N_getMetadataArtist: artist == null");
+            }
+            if (getMetadataDuration() <= 1) {
+                Log.d(TAG, "N_getMetadataDuration: duration <= 1; " + getMetadataDuration());
+            }
+        }
+
+        if (getMetadataTitle() == null || getMetadataArtist() == null || getMetadataDuration() <= 1
+                || !getMetadataTitle().equals(title)) {
+            if (DEBUG) {
+                Log.d(TAG, "setMetadata: N_Metadata update: t: " + title + " a: " + artist
+                        + " d: " + duration);
+            }
+
+            mediaSession.setMetadata(new MediaMetadataCompat.Builder()
+                    .putString(MediaMetadataCompat.METADATA_KEY_TITLE, title)
+                    .putString(MediaMetadataCompat.METADATA_KEY_ARTIST, artist)
+                    .putLong(MediaMetadataCompat.METADATA_KEY_DURATION, duration).build());
+        }
+    }
+
+    public void setMetadata(final String title,
+                            final String artist,
                             final Bitmap albumArt,
                             final long duration) {
         if (albumArt == null || !mediaSession.isActive()) {

--- a/app/src/main/java/org/schabi/newpipe/player/helper/MediaSessionManager.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/MediaSessionManager.java
@@ -93,36 +93,41 @@ public class MediaSessionManager {
             return;
         }
 
-        if (checkIfMetadataShouldBeSet(title, artist, optAlbumArt, duration)) {
+        if (!checkIfMetadataShouldBeSet(title, artist, optAlbumArt, duration)) {
             if (DEBUG) {
-                Log.d(TAG, "setMetadata: N_Metadata update:"
-                        + " t: " + title
-                        + " a: " + artist
-                        + " thumb: " + (
-                        optAlbumArt.isPresent()
-                                ? optAlbumArt.get().hashCode()
-                                : "<none>")
-                        + " d: " + duration);
+                Log.d(TAG, "setMetadata: No update required");
             }
+            return;
+        }
 
-            final MediaMetadataCompat.Builder builder = new MediaMetadataCompat.Builder()
-                    .putString(MediaMetadataCompat.METADATA_KEY_TITLE, title)
-                    .putString(MediaMetadataCompat.METADATA_KEY_ARTIST, artist)
-                    .putLong(MediaMetadataCompat.METADATA_KEY_DURATION, duration);
+        if (DEBUG) {
+            Log.d(TAG, "setMetadata: N_Metadata update:"
+                    + " t: " + title
+                    + " a: " + artist
+                    + " thumb: " + (
+                    optAlbumArt.isPresent()
+                            ? optAlbumArt.get().hashCode()
+                            : "<none>")
+                    + " d: " + duration);
+        }
 
-            if (optAlbumArt.isPresent()) {
-                builder.putBitmap(MediaMetadataCompat.METADATA_KEY_ALBUM_ART, optAlbumArt.get());
-                builder.putBitmap(MediaMetadataCompat.METADATA_KEY_DISPLAY_ICON, optAlbumArt.get());
-            }
+        final MediaMetadataCompat.Builder builder = new MediaMetadataCompat.Builder()
+                .putString(MediaMetadataCompat.METADATA_KEY_TITLE, title)
+                .putString(MediaMetadataCompat.METADATA_KEY_ARTIST, artist)
+                .putLong(MediaMetadataCompat.METADATA_KEY_DURATION, duration);
 
-            mediaSession.setMetadata(builder.build());
+        if (optAlbumArt.isPresent()) {
+            builder.putBitmap(MediaMetadataCompat.METADATA_KEY_ALBUM_ART, optAlbumArt.get());
+            builder.putBitmap(MediaMetadataCompat.METADATA_KEY_DISPLAY_ICON, optAlbumArt.get());
+        }
 
-            lastTitleHashCode = title.hashCode();
-            lastArtistHashCode = artist.hashCode();
-            lastDuration = duration;
-            if (optAlbumArt.isPresent()) {
-                lastAlbumArtHashCode = optAlbumArt.get().hashCode();
-            }
+        mediaSession.setMetadata(builder.build());
+
+        lastTitleHashCode = title.hashCode();
+        lastArtistHashCode = artist.hashCode();
+        lastDuration = duration;
+        if (optAlbumArt.isPresent()) {
+            lastAlbumArtHashCode = optAlbumArt.get().hashCode();
         }
     }
 
@@ -144,6 +149,7 @@ public class MediaSessionManager {
             }
             return true;
         }
+
         // Check if the current metadata is valid
         if (getMetadataTitle() == null
                 || getMetadataArtist() == null
@@ -163,6 +169,7 @@ public class MediaSessionManager {
             }
             return true;
         }
+
         // If we got an album art check if the current set AlbumArt is null
         if (optAlbumArt.isPresent() && getMetadataAlbumArt() == null) {
             if (DEBUG) {


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
The following things are fixed
 
from #7161 (credits to @Redirion)

> Issue 1 is when the option "Show thumbnail" is turned off. It caused setMetadata to never be called.
`// setMetadata only updates the metadata when any of the metadata keys are null mediaSessionManager.setMetadata(getVideoTitle(), getUploaderName(), showThumbnail ? getThumbnail() : null, duration);`
>
> basically the first line in setMetadata checks, if the provided thumbnail/albumArt is not null.
>
> Issue 2: if no thumbnail could be loaded, the dummy thumbnail resource would be used to be created through a Bitmap factory. Firstly it will be created each time (expensive) and secondly hashCode() will always yield different results. This means that setMetadata was basically executed in its whole every single time (each second since last updates).

I also reworked/de-duplicated the code a bit 😉

Issue 3: #7087 
https://github.com/TeamNewPipe/NewPipe/issues/7087#issuecomment-926934423
> Okay I tested the stuff a bit and found out that the metadata updates - that are done every second - are completely useless.
> They should only be done when the metadata changes e.g. when opening a new video.

Issue 4:
Comparisons e.g. if the current title/artist/duration is also the requested one have been missing. 
Added those by caching the last requested data using hashcodes.
This also avoids resource-intensive ``mediaSession.getController().getMetadata()`` calls.


#### Fixes the following issue(s)
- Fixes #7087 

#### APK testing 
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
