### PR TITLE
Disable media tunneling on RealtekATV

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
@@ -32,6 +32,9 @@ public final class DeviceUtils {
     // Zephir TS43UHD-2
     private static final boolean CVT_MT5886_EU_1G = Build.VERSION.SDK_INT == 24
             && Build.DEVICE.equals("cvt_mt5886_eu_1g");
+    // Hilife TV
+    private static final boolean REALTEKATV = Build.VERSION.SDK_INT == 25
+            && Build.DEVICE.equals("RealtekATV");
 
     private DeviceUtils() {
     }
@@ -128,6 +131,7 @@ public final class DeviceUtils {
     public static boolean shouldSupportMediaTunneling() {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
                 && !HI3798MV200
-                && !CVT_MT5886_EU_1G;
+                && !CVT_MT5886_EU_1G
+                && !REALTEKATV;
     }
 }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [X] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Disables media tunneling on RealtekATV with Android 7.1.1.

Interesting to note: from what we have collected thus far, only devices that are using a Mali GPU with the old Utgard arch are affected (Mali-400, Mali-450, Mali-470).
https://en.wikipedia.org/wiki/Mali_(GPU)#Variants

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #7084

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [X] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
