### PR TITLE
Revert "Ignore paths unrelated to builds in CI (#6789)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,20 +6,10 @@ on:
     branches:
       - dev
       - master
-    paths-ignore:
-      - 'README*.md'
-      - 'fastlane/**'
-      - 'assets/**'
-      - '.github/**/*.md'
   push:
     branches:
       - dev
       - master
-    paths-ignore:
-      - 'README*.md'
-      - 'fastlane/**'
-      - 'assets/**'
-      - '.github/**/*.md'
 
 jobs:
   build-and-test-jvm:


### PR DESCRIPTION
This reverts commit c7f75bf7d19cbc91e04151a964519a8d973aff06.

<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
The repo settings currently require a PR's status checks to complete without failure for it to be merged. However, GitHub currently doesn't take into account that for some PRs the checks will never run, since all the files modified are `paths-ignore`d. You can see an instance of this problem in #7165.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).

@TobiGr @opusforlife2 