### PR TITLE
Prevent automatic replay after returning from background

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -2031,6 +2031,9 @@ public final class Player implements
         currentItem = null;
         currentMetadata = null;
         simpleExoPlayer.stop();
+        if (currentState == STATE_COMPLETED) {
+            simpleExoPlayer.setPlayWhenReady(false);
+        }
         isPrepared = false;
 
         changeState(STATE_BLOCKED);


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [X] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- If the video has completed, when the app returns from background, prevent the player from staring playback automatically by setting setPlayWhenReady to false

I'm not 100% sure if this is the good way to fix it. If not, please let me know how I can improve it.

Steps to reproduce the bug:
1. Play a video
2. Lock the device while the video is still playing
3. Wait until the video ends
4. Unlock the device
5. The video starts playing again automatically

This is kind of annoying when you listen to some podcast in audio-only mode, and then a few hours later you want to do something else on the phone, so your unlock it, and all of a sudden NewPipe starts playing the video again.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before:

https://user-images.githubusercontent.com/4525736/140655574-733a3749-ea7c-4979-b993-3847ed2a20dc.mp4

- After:

https://user-images.githubusercontent.com/4525736/140655773-6869c510-6657-428e-a97e-d9f86ff7d139.mp4

<!-- #### Fixes the following issue(s) -->
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
<!-- - Fixes # -->

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [X] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
