### PR TITLE
Add better network message

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
@@ -383,7 +383,8 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
         }
 
         StreamDialogEntry.setEnabledEntries(entries);
-
+        StreamDialogEntry.start_here_on_background.setRequireNetwork(true);
+        StreamDialogEntry.start_here_on_popup.setRequireNetwork(true);
         new InfoItemDialog(activity, item, StreamDialogEntry.getCommands(context),
                 (dialog, which) -> StreamDialogEntry.clickOn(which, this, item)).show();
     }

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
@@ -185,6 +185,8 @@ public class PlaylistFragment extends BaseListInfoFragment<PlaylistInfo> {
         StreamDialogEntry.start_here_on_background.setCustomAction((fragment, infoItem) ->
                 NavigationHelper.playOnBackgroundPlayer(context,
                         getPlayQueueStartingAt(infoItem), true));
+        StreamDialogEntry.start_here_on_popup.setRequireNetwork(true);
+        StreamDialogEntry.start_here_on_background.setRequireNetwork(true);
 
         new InfoItemDialog(activity, item, StreamDialogEntry.getCommands(context),
                 (dialog, which) -> StreamDialogEntry.clickOn(which, this, item)).show();

--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
@@ -369,6 +369,8 @@ class FeedFragment : BaseStateFragment<FeedState>() {
         entries.add(StreamDialogEntry.show_channel_details)
 
         StreamDialogEntry.setEnabledEntries(entries)
+        StreamDialogEntry.start_here_on_popup.setRequireNetwork(true)
+        StreamDialogEntry.start_here_on_background.setRequireNetwork(true)
         InfoItemDialog(activity, item, StreamDialogEntry.getCommands(context)) { _, which ->
             StreamDialogEntry.clickOn(which, this, item)
         }.show()

--- a/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
@@ -375,7 +375,8 @@ public class StatisticsPlaylistFragment
                         .playOnBackgroundPlayer(context, getPlayQueueStartingAt(item), true));
         StreamDialogEntry.delete.setCustomAction((fragment, infoItemDuplicate) ->
                 deleteEntry(Math.max(itemListAdapter.getItemsList().indexOf(item), 0)));
-
+        StreamDialogEntry.start_here_on_popup.setRequireNetwork(true);
+        StreamDialogEntry.start_here_on_background.setRequireNetwork(true);
         new InfoItemDialog(activity, infoItem, StreamDialogEntry.getCommands(context),
                 (dialog, which) -> StreamDialogEntry.clickOn(which, this, infoItem)).show();
     }

--- a/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
@@ -794,6 +794,8 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
                         changeThumbnailUrl(item.getStreamEntity().getThumbnailUrl()));
         StreamDialogEntry.delete.setCustomAction((fragment, infoItemDuplicate) ->
                 deleteItem(item));
+        StreamDialogEntry.start_here_on_popup.setRequireNetwork(true);
+        StreamDialogEntry.start_here_on_background.setRequireNetwork(true);
 
         new InfoItemDialog(activity, infoItem, StreamDialogEntry.getCommands(context),
                 (dialog, which) -> StreamDialogEntry.clickOn(which, this, infoItem)).show();

--- a/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
+++ b/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
@@ -6,7 +6,6 @@ import android.content.Context;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.Uri;
-import android.util.Log;
 import android.widget.Toast;
 
 import androidx.fragment.app.Fragment;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -704,4 +704,6 @@
     <!-- Show Channel Details -->
     <string name="error_show_channel_details">Error at Show Channel Details</string>
     <string name="loading_channel_details">Loading Channel Details…</string>
+    <string name="error_no_network">No Network Available</string>
+    <string name="error_no_network_action">Goto Downloads</string>
 </resources>


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- **What the changes achieve:** for actions that require an Internet connection like, `Play here on background` and `Play here on Popup`, earlier a vague `Toast` message saying `Could not play this stream` would appear but a network connection is a common issue and it would've been helpful to know if that's what was wrong. So, these changes implement a `Snackbar` message for the same with an action to go to the `Downloads` section for offline viewing.
- The changes add a `boolean requireNetwork` parameter to `StreamDialogEntry` that is `false` by default and can be changed via the `setRequireNetwork` method. If `true`, when the option is clicked on, before performing the action, network availability is checked, and if a network is unavailable, an indefinite `Snackbar` is shown.
- I went with this approach since custom actions can be defined for a  `StreamDialogEntry` and maybe more options might be added later that require network connectivity. They will be easier to integrate into these checks.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before: 
<img src="https://user-images.githubusercontent.com/54995644/137577504-8eb9f436-1499-4492-9906-384251fc89c0.jpg" alt="before" width="200" height = "400"/>

- After:
<img src="https://user-images.githubusercontent.com/54995644/137577511-22894e97-dc2a-453f-8c41-02dfce0d6265.jpg" alt="before" width="200" height = "400"/>


#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes ##6381


#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
<!--The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.-->
[debug.apk](https://github.com/TeamNewPipe/NewPipe/suites/4071163970/artifacts/103515630)

Also, apologies for taking so long :( I had exams.
And sorry about the second commit :( I left an unused import in there somehow.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
