### PR TITLE
Add the quality selector for livestreams

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -12,7 +12,6 @@ import static com.google.android.exoplayer2.Player.REPEAT_MODE_ALL;
 import static com.google.android.exoplayer2.Player.REPEAT_MODE_OFF;
 import static com.google.android.exoplayer2.Player.REPEAT_MODE_ONE;
 import static com.google.android.exoplayer2.Player.RepeatMode;
-import static com.google.android.exoplayer2.util.MimeTypes.getVideoMediaMimeType;
 import static org.schabi.newpipe.QueueItemMenuUtil.openPopupMenu;
 import static org.schabi.newpipe.extractor.ServiceList.YouTube;
 import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
@@ -3272,7 +3271,7 @@ public final class Player implements
     @Override // own playback listener
     @Nullable
     public MediaSource sourceOf(final PlayQueueItem item, final StreamInfo info) {
-        return (isAudioOnly ? audioResolver : videoResolver).resolve(info);
+        return (isAudioOnly ? audioResolver : videoResolver).resolve(trackSelector, info);
     }
 
     public void disablePreloadingOfCurrentTrack() {
@@ -3444,10 +3443,9 @@ public final class Player implements
                                                   @NonNull final MediaLoadData mediaLoadData) {
                 final Format currentPlayingFormat = mediaLoadData.trackFormat;
                 final String qualityTextViewText = binding.qualityTextView.getText().toString();
-                if (currentPlayingFormat != null
-                        && getVideoMediaMimeType(currentPlayingFormat.codecs) != null
-                        && (qualityTextViewText.isEmpty() || qualityTextViewText.contains(
-                                context.getString(R.string.auto_quality)))) {
+                if (currentPlayingFormat != null && (qualityTextViewText.isEmpty()
+                        || qualityTextViewText.contains(context.getString(
+                                R.string.auto_quality)))) {
 
                     final MappingTrackSelector.MappedTrackInfo currentMappedTrackInfo =
                             trackSelector.getCurrentMappedTrackInfo();

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -3350,7 +3350,7 @@ public final class Player implements
             for (int j = trackGroup.length - 1; j >= 0; j--) {
                 final Format videoFormat = trackGroup.getFormat(j);
                 if ((defaultHeight == -1 || videoFormat.height <= defaultHeight)
-                        && (defaultFrameRate <= -1 || videoFormat.frameRate == defaultFrameRate)) {
+                        && (defaultFrameRate <= -1 || videoFormat.frameRate <= defaultFrameRate)) {
                     final DefaultTrackSelector.SelectionOverride selectionOverride =
                             new DefaultTrackSelector.SelectionOverride(
                                     videoRendererIndex, j);

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -427,26 +427,24 @@ public final class Player implements
             @Override
             public int getDefaultResolutionIndex(final StreamInfo streamInfo,
                     final List<VideoStream> sortedVideos) {
-                if (!StreamTypeUtil.isLiveStream(streamInfo.getStreamType())) {
-                    return videoPlayerSelected()
-                            ? ListHelper.getDefaultResolutionIndex(context, sortedVideos)
-                            : ListHelper.getPopupDefaultResolutionIndex(context, sortedVideos);
-                } else {
+                if (StreamTypeUtil.isLiveStream(streamInfo.getStreamType())) {
                     return -1;
                 }
+                return videoPlayerSelected()
+                        ? ListHelper.getDefaultResolutionIndex(context, sortedVideos)
+                        : ListHelper.getPopupDefaultResolutionIndex(context, sortedVideos);
             }
 
             @Override
             public int getOverrideResolutionIndex(final StreamInfo streamInfo,
                                                   final List<VideoStream> sortedVideos,
                                                   final String playbackQuality) {
-                if (!StreamTypeUtil.isLiveStream(streamInfo.getStreamType())) {
-                    return videoPlayerSelected()
-                            ? getResolutionIndex(context, sortedVideos, playbackQuality)
-                            : getPopupResolutionIndex(context, sortedVideos, playbackQuality);
-                } else {
+                if (StreamTypeUtil.isLiveStream(streamInfo.getStreamType())) {
                     return -1;
                 }
+                return videoPlayerSelected()
+                        ? getResolutionIndex(context, sortedVideos, playbackQuality)
+                        : getPopupResolutionIndex(context, sortedVideos, playbackQuality);
             }
         };
     }

--- a/app/src/main/java/org/schabi/newpipe/player/playback/TrackSelectionListener.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playback/TrackSelectionListener.java
@@ -68,7 +68,6 @@ public class TrackSelectionListener implements PopupMenu.OnMenuItemClickListener
         final int itemId = item.getItemId();
         if (itemId == 0) {
             // 0 is the index of the Auto item of the quality selector
-            trackSelector.setParameters(builder);
 
             // If the quality text view text contains already the auto string, it means the user
             // already selected the auto option and pressed again the auto option from the quality
@@ -113,10 +112,9 @@ public class TrackSelectionListener implements PopupMenu.OnMenuItemClickListener
                 qualityTextView.setText(getResolutionStringFromFormat(context,
                         currentPlayingFormat));
             }
-
-            trackSelector.setParameters(builder);
         }
 
+        trackSelector.setParameters(builder);
         return true;
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/player/playback/TrackSelectionListener.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playback/TrackSelectionListener.java
@@ -1,0 +1,54 @@
+package org.schabi.newpipe.player.playback;
+
+import static com.google.android.exoplayer2.util.Assertions.checkNotNull;
+
+import android.view.MenuItem;
+import android.widget.PopupMenu;
+
+import androidx.annotation.NonNull;
+
+import com.google.android.exoplayer2.source.TrackGroupArray;
+import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
+import com.google.android.exoplayer2.trackselection.MappingTrackSelector;
+
+
+public class TrackSelectionListener implements PopupMenu.OnMenuItemClickListener {
+    private final String autoString;
+    private final CustomTrackSelector trackSelector;
+    private final int rendererIndex;
+    private final TrackGroupArray rendererTrackGroups;
+
+    public TrackSelectionListener(@NonNull final CustomTrackSelector trackSelector,
+                                  @NonNull final String autoString,
+                                  final int rendererIndex) {
+        this.trackSelector = trackSelector;
+        this.autoString = autoString;
+        final MappingTrackSelector.MappedTrackInfo mappedTrackInfo = checkNotNull(trackSelector
+                .getCurrentMappedTrackInfo());
+        this.rendererIndex = rendererIndex;
+
+        rendererTrackGroups = mappedTrackInfo.getTrackGroups(rendererIndex);
+    }
+
+    @Override
+    public boolean onMenuItemClick(@NonNull final MenuItem item) {
+        final DefaultTrackSelector.Parameters selectionParameters =
+                trackSelector.getParameters();
+        final boolean isDisabled = selectionParameters.getRendererDisabled(rendererIndex);
+        final DefaultTrackSelector.ParametersBuilder builder =
+                selectionParameters.buildUpon()
+                        .clearSelectionOverrides(rendererIndex)
+                        .setRendererDisabled(rendererIndex, isDisabled);
+
+        if (!item.getTitle().equals(autoString)) {
+            final DefaultTrackSelector.SelectionOverride selectionOverride =
+                    new DefaultTrackSelector.SelectionOverride(
+                            rendererIndex, item.getItemId() - 1);
+            builder.setSelectionOverride(rendererIndex, rendererTrackGroups,
+                    selectionOverride);
+        }
+
+        trackSelector.setParameters(builder);
+        return true;
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/playback/TrackSelectionListener.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playback/TrackSelectionListener.java
@@ -65,7 +65,20 @@ public class TrackSelectionListener implements PopupMenu.OnMenuItemClickListener
         // The auto string
         final String qualityTextViewText = qualityTextView.getText().toString();
 
-        if (item.getItemId() != 0) {
+        if (item.getItemId() == 0) {
+            // 0 is the index of the Auto item of the quality selector
+            trackSelector.setParameters(builder);
+
+            // If the quality text view text contains already the auto string, it means the user
+            // already selected the auto option and pressed again the auto option from the quality
+            // selector, so no need to update the text of the quality text view (if we update it,
+            // we will get something like Auto (Auto (1080p))).
+            if (!qualityTextViewText.contains(context.getString(R.string.auto_quality))) {
+                qualityTextView.setText(context.getString(R.string.auto_quality_selected,
+                        context.getString(R.string.auto_quality),
+                        qualityTextViewText));
+            }
+        } else {
             // A resolution string
             final TrackGroup videoTrackGroup = rendererTrackGroups.get(0);
 
@@ -87,18 +100,6 @@ public class TrackSelectionListener implements PopupMenu.OnMenuItemClickListener
             }
 
             trackSelector.setParameters(builder);
-        } else {
-            trackSelector.setParameters(builder);
-
-            // If the quality text view text contains already the auto string, it means the user
-            // already selected the auto option and pressed again the auto option from the quality
-            // selector, so no need to update the text of the quality text view (if we update it,
-            // we will get something like Auto (Auto (1080p))).
-            if (!qualityTextViewText.contains(context.getString(R.string.auto_quality))) {
-                qualityTextView.setText(context.getString(R.string.auto_quality_selected,
-                        context.getString(R.string.auto_quality),
-                        qualityTextViewText));
-            }
         }
 
         return true;

--- a/app/src/main/java/org/schabi/newpipe/player/playback/TrackSelectionListener.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playback/TrackSelectionListener.java
@@ -65,7 +65,8 @@ public class TrackSelectionListener implements PopupMenu.OnMenuItemClickListener
         // The auto string
         final String qualityTextViewText = qualityTextView.getText().toString();
 
-        if (item.getItemId() == 0) {
+        final int itemId = item.getItemId();
+        if (itemId == 0) {
             // 0 is the index of the Auto item of the quality selector
             trackSelector.setParameters(builder);
 
@@ -80,9 +81,20 @@ public class TrackSelectionListener implements PopupMenu.OnMenuItemClickListener
             }
         } else {
             // A resolution string
-            final TrackGroup videoTrackGroup = rendererTrackGroups.get(0);
+            TrackGroup videoTrackGroup = null;
+            int lengthOfVideoTrackGroupWhichMatchMenuItem = 0;
+            for (int i = 0; i < rendererTrackGroups.length; i++) {
+                final TrackGroup trackGroup = rendererTrackGroups.get(i);
+                final int rendererTrackGroupLength = trackGroup.length;
+                if (rendererTrackGroupLength >= itemId) {
+                    lengthOfVideoTrackGroupWhichMatchMenuItem = rendererTrackGroupLength;
+                    videoTrackGroup = trackGroup;
+                }
+            }
 
-            final int qualityId = videoTrackGroup.length - item.getItemId();
+            final int qualityId = lengthOfVideoTrackGroupWhichMatchMenuItem > 0
+                    ? lengthOfVideoTrackGroupWhichMatchMenuItem - itemId
+                    : itemId - 1;
             final DefaultTrackSelector.SelectionOverride selectionOverride =
                     new DefaultTrackSelector.SelectionOverride(
                             rendererIndex, qualityId);
@@ -94,7 +106,10 @@ public class TrackSelectionListener implements PopupMenu.OnMenuItemClickListener
             // quality string will be changed in other cases with the analytics listener set in the
             // player)
             if (qualityTextViewText.contains(context.getString(R.string.auto_quality))) {
-                final Format currentPlayingFormat = videoTrackGroup.getFormat(qualityId);
+                final Format currentPlayingFormat = videoTrackGroup != null
+                        ? videoTrackGroup.getFormat(qualityId)
+                        // Fallback to the first track group
+                        : rendererTrackGroups.get(0).getFormat(qualityId);
                 qualityTextView.setText(getResolutionStringFromFormat(context,
                         currentPlayingFormat));
             }

--- a/app/src/main/java/org/schabi/newpipe/player/playback/TrackSelectionListener.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playback/TrackSelectionListener.java
@@ -1,31 +1,40 @@
 package org.schabi.newpipe.player.playback;
 
 import static com.google.android.exoplayer2.util.Assertions.checkNotNull;
+import static org.schabi.newpipe.player.Player.getResolutionStringFromFormat;
 
+import android.content.Context;
 import android.view.MenuItem;
 import android.widget.PopupMenu;
+import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 
+import com.google.android.exoplayer2.Format;
+import com.google.android.exoplayer2.source.TrackGroup;
 import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
 import com.google.android.exoplayer2.trackselection.MappingTrackSelector;
 
+import org.schabi.newpipe.R;
 
 public class TrackSelectionListener implements PopupMenu.OnMenuItemClickListener {
-    private final String autoString;
+    private final Context context;
     private final CustomTrackSelector trackSelector;
     private final int rendererIndex;
+    private final TextView qualityTextView;
     private final TrackGroupArray rendererTrackGroups;
 
-    public TrackSelectionListener(@NonNull final CustomTrackSelector trackSelector,
-                                  @NonNull final String autoString,
-                                  final int rendererIndex) {
+    public TrackSelectionListener(@NonNull final Context context,
+                                  @NonNull final CustomTrackSelector trackSelector,
+                                  final int rendererIndex,
+                                  @NonNull final TextView qualityTextView) {
+        this.context = context;
         this.trackSelector = trackSelector;
-        this.autoString = autoString;
         final MappingTrackSelector.MappedTrackInfo mappedTrackInfo = checkNotNull(trackSelector
                 .getCurrentMappedTrackInfo());
         this.rendererIndex = rendererIndex;
+        this.qualityTextView = qualityTextView;
 
         rendererTrackGroups = mappedTrackInfo.getTrackGroups(rendererIndex);
     }
@@ -40,12 +49,25 @@ public class TrackSelectionListener implements PopupMenu.OnMenuItemClickListener
                         .clearSelectionOverrides(rendererIndex)
                         .setRendererDisabled(rendererIndex, isDisabled);
 
-        if (!item.getTitle().toString().contains(autoString)) {
+        if (item.getItemId() != 0) {
+            final TrackGroup videoTrackGroup = rendererTrackGroups.get(0);
+
+            final int qualityId = videoTrackGroup.length - item.getItemId();
             final DefaultTrackSelector.SelectionOverride selectionOverride =
                     new DefaultTrackSelector.SelectionOverride(
-                            rendererIndex, item.getItemId() - 1);
+                            rendererIndex, qualityId);
             builder.setSelectionOverride(rendererIndex, rendererTrackGroups,
                     selectionOverride);
+
+            final Format currentPlayingFormat = videoTrackGroup.getFormat(qualityId);
+            qualityTextView.setText(getResolutionStringFromFormat(currentPlayingFormat));
+        } else {
+            final String qualityTextViewText = qualityTextView.getText().toString();
+            if (!qualityTextViewText.contains(context.getString(R.string.auto_quality))) {
+                qualityTextView.setText(context.getString(R.string.auto_quality_selected,
+                        context.getString(R.string.auto_quality),
+                        qualityTextViewText));
+            }
         }
 
         trackSelector.setParameters(builder);

--- a/app/src/main/java/org/schabi/newpipe/player/playback/TrackSelectionListener.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playback/TrackSelectionListener.java
@@ -40,7 +40,7 @@ public class TrackSelectionListener implements PopupMenu.OnMenuItemClickListener
                         .clearSelectionOverrides(rendererIndex)
                         .setRendererDisabled(rendererIndex, isDisabled);
 
-        if (!item.getTitle().equals(autoString)) {
+        if (!item.getTitle().toString().contains(autoString)) {
             final DefaultTrackSelector.SelectionOverride selectionOverride =
                     new DefaultTrackSelector.SelectionOverride(
                             rendererIndex, item.getItemId() - 1);

--- a/app/src/main/java/org/schabi/newpipe/player/playback/TrackSelectionListener.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playback/TrackSelectionListener.java
@@ -1,6 +1,7 @@
 package org.schabi.newpipe.player.playback;
 
 import static com.google.android.exoplayer2.util.Assertions.checkNotNull;
+
 import static org.schabi.newpipe.player.Player.getResolutionStringFromFormat;
 
 import android.content.Context;
@@ -61,6 +62,8 @@ public class TrackSelectionListener implements PopupMenu.OnMenuItemClickListener
         final DefaultTrackSelector.ParametersBuilder builder = selectionParameters.buildUpon()
                 .clearSelectionOverrides(rendererIndex)
                 .setRendererDisabled(rendererIndex, isDisabled);
+        // The auto string
+        final String qualityTextViewText = qualityTextView.getText().toString();
 
         if (item.getItemId() != 0) {
             // A resolution string
@@ -73,11 +76,19 @@ public class TrackSelectionListener implements PopupMenu.OnMenuItemClickListener
             builder.setSelectionOverride(rendererIndex, rendererTrackGroups,
                     selectionOverride);
 
-            final Format currentPlayingFormat = videoTrackGroup.getFormat(qualityId);
-            qualityTextView.setText(getResolutionStringFromFormat(context, currentPlayingFormat));
+            // The quality needs only to be set here when a user keeps the quality selected
+            // automatically by ExoPlayer but selects it manually with the quality selector (the
+            // quality string will be changed in other cases with the analytics listener set in the
+            // player)
+            if (qualityTextViewText.contains(context.getString(R.string.auto_quality))) {
+                final Format currentPlayingFormat = videoTrackGroup.getFormat(qualityId);
+                qualityTextView.setText(getResolutionStringFromFormat(context,
+                        currentPlayingFormat));
+            }
+
+            trackSelector.setParameters(builder);
         } else {
-            // The auto string
-            final String qualityTextViewText = qualityTextView.getText().toString();
+            trackSelector.setParameters(builder);
 
             // If the quality text view text contains already the auto string, it means the user
             // already selected the auto option and pressed again the auto option from the quality
@@ -90,7 +101,6 @@ public class TrackSelectionListener implements PopupMenu.OnMenuItemClickListener
             }
         }
 
-        trackSelector.setParameters(builder);
         return true;
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/player/playback/TrackSelectionListener.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playback/TrackSelectionListener.java
@@ -18,6 +18,10 @@ import com.google.android.exoplayer2.trackselection.MappingTrackSelector;
 
 import org.schabi.newpipe.R;
 
+/**
+ * A listener class to allow setting a specified quality for livestreams when clicking an item on
+ * the quality selector popup menu in video players.
+ */
 public class TrackSelectionListener implements PopupMenu.OnMenuItemClickListener {
     private final Context context;
     private final CustomTrackSelector trackSelector;
@@ -25,14 +29,25 @@ public class TrackSelectionListener implements PopupMenu.OnMenuItemClickListener
     private final TextView qualityTextView;
     private final TrackGroupArray rendererTrackGroups;
 
+    /**
+     * Create a {@link TrackSelectionListener}.
+     *
+     * @param context         the player context
+     * @param trackSelector   the {@link CustomTrackSelector} used by the player, which couldn't be
+     *                        null
+     * @param rendererIndex   the index of the video renderer
+     * @param qualityTextView the {@link TextView quality text view} on which the playing quality
+     *                        will be updated after a quality item is clicked
+     * @throws NullPointerException if trackSelector is null
+     */
     public TrackSelectionListener(@NonNull final Context context,
                                   @NonNull final CustomTrackSelector trackSelector,
                                   final int rendererIndex,
                                   @NonNull final TextView qualityTextView) {
         this.context = context;
         this.trackSelector = trackSelector;
-        final MappingTrackSelector.MappedTrackInfo mappedTrackInfo = checkNotNull(trackSelector
-                .getCurrentMappedTrackInfo());
+        final MappingTrackSelector.MappedTrackInfo mappedTrackInfo = checkNotNull(
+                trackSelector.getCurrentMappedTrackInfo());
         this.rendererIndex = rendererIndex;
         this.qualityTextView = qualityTextView;
 
@@ -41,15 +56,14 @@ public class TrackSelectionListener implements PopupMenu.OnMenuItemClickListener
 
     @Override
     public boolean onMenuItemClick(@NonNull final MenuItem item) {
-        final DefaultTrackSelector.Parameters selectionParameters =
-                trackSelector.getParameters();
+        final DefaultTrackSelector.Parameters selectionParameters = trackSelector.getParameters();
         final boolean isDisabled = selectionParameters.getRendererDisabled(rendererIndex);
-        final DefaultTrackSelector.ParametersBuilder builder =
-                selectionParameters.buildUpon()
-                        .clearSelectionOverrides(rendererIndex)
-                        .setRendererDisabled(rendererIndex, isDisabled);
+        final DefaultTrackSelector.ParametersBuilder builder = selectionParameters.buildUpon()
+                .clearSelectionOverrides(rendererIndex)
+                .setRendererDisabled(rendererIndex, isDisabled);
 
         if (item.getItemId() != 0) {
+            // A resolution string
             final TrackGroup videoTrackGroup = rendererTrackGroups.get(0);
 
             final int qualityId = videoTrackGroup.length - item.getItemId();
@@ -60,9 +74,15 @@ public class TrackSelectionListener implements PopupMenu.OnMenuItemClickListener
                     selectionOverride);
 
             final Format currentPlayingFormat = videoTrackGroup.getFormat(qualityId);
-            qualityTextView.setText(getResolutionStringFromFormat(currentPlayingFormat));
+            qualityTextView.setText(getResolutionStringFromFormat(context, currentPlayingFormat));
         } else {
+            // The auto string
             final String qualityTextViewText = qualityTextView.getText().toString();
+
+            // If the quality text view text contains already the auto string, it means the user
+            // already selected the auto option and pressed again the auto option from the quality
+            // selector, so no need to update the text of the quality text view (if we update it,
+            // we will get something like Auto (Auto (1080p))).
             if (!qualityTextViewText.contains(context.getString(R.string.auto_quality))) {
                 qualityTextView.setText(context.getString(R.string.auto_quality_selected,
                         context.getString(R.string.auto_quality),

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/AudioPlaybackResolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/AudioPlaybackResolver.java
@@ -12,6 +12,7 @@ import org.schabi.newpipe.extractor.stream.AudioStream;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.player.helper.PlayerDataSource;
 import org.schabi.newpipe.player.helper.PlayerHelper;
+import org.schabi.newpipe.player.playback.CustomTrackSelector;
 import org.schabi.newpipe.util.ListHelper;
 
 public class AudioPlaybackResolver implements PlaybackResolver {
@@ -28,9 +29,11 @@ public class AudioPlaybackResolver implements PlaybackResolver {
 
     @Override
     @Nullable
-    public MediaSource resolve(@NonNull final StreamInfo info) {
+    public MediaSource resolve(@NonNull final CustomTrackSelector trackSelector,
+                               @NonNull final StreamInfo info) {
         final MediaSource liveSource = maybeBuildLiveMediaSource(dataSource, info);
         if (liveSource != null) {
+            setMaximumVideoSizeIfUsingMobileData(context, trackSelector);
             return liveSource;
         }
 

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/AudioPlaybackResolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/AudioPlaybackResolver.java
@@ -12,7 +12,6 @@ import org.schabi.newpipe.extractor.stream.AudioStream;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.player.helper.PlayerDataSource;
 import org.schabi.newpipe.player.helper.PlayerHelper;
-import org.schabi.newpipe.player.playback.CustomTrackSelector;
 import org.schabi.newpipe.util.ListHelper;
 
 public class AudioPlaybackResolver implements PlaybackResolver {
@@ -20,6 +19,8 @@ public class AudioPlaybackResolver implements PlaybackResolver {
     private final Context context;
     @NonNull
     private final PlayerDataSource dataSource;
+
+    private boolean isLiveSource = false;
 
     public AudioPlaybackResolver(@NonNull final Context context,
                                  @NonNull final PlayerDataSource dataSource) {
@@ -29,11 +30,10 @@ public class AudioPlaybackResolver implements PlaybackResolver {
 
     @Override
     @Nullable
-    public MediaSource resolve(@NonNull final CustomTrackSelector trackSelector,
-                               @NonNull final StreamInfo info) {
+    public MediaSource resolve(@NonNull final StreamInfo info) {
         final MediaSource liveSource = maybeBuildLiveMediaSource(dataSource, info);
         if (liveSource != null) {
-            setMaximumVideoSizeIfUsingMobileData(context, trackSelector);
+            isLiveSource = true;
             return liveSource;
         }
 
@@ -46,5 +46,10 @@ public class AudioPlaybackResolver implements PlaybackResolver {
         final MediaSourceTag tag = new MediaSourceTag(info);
         return buildMediaSource(dataSource, audio.getUrl(), PlayerHelper.cacheKeyOf(info, audio),
                 MediaFormat.getSuffixById(audio.getFormatId()), tag);
+    }
+
+    @Override
+    public boolean isLiveSource() {
+        return isLiveSource;
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/PlaybackResolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/PlaybackResolver.java
@@ -1,9 +1,5 @@
 package org.schabi.newpipe.player.resolver;
 
-import static org.schabi.newpipe.util.ListHelper.getResolutionLimit;
-import static org.schabi.newpipe.util.ListHelper.isMeteredNetwork;
-
-import android.content.Context;
 import android.net.Uri;
 import android.text.TextUtils;
 
@@ -14,13 +10,11 @@ import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.MediaItem;
 import com.google.android.exoplayer2.source.MediaSource;
 import com.google.android.exoplayer2.source.MediaSourceFactory;
-import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
 import com.google.android.exoplayer2.util.Util;
 
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.extractor.stream.StreamType;
 import org.schabi.newpipe.player.helper.PlayerDataSource;
-import org.schabi.newpipe.player.playback.CustomTrackSelector;
 import org.schabi.newpipe.util.StreamTypeUtil;
 
 public interface PlaybackResolver extends Resolver<StreamInfo, MediaSource> {
@@ -107,27 +101,5 @@ public interface PlaybackResolver extends Resolver<StreamInfo, MediaSource> {
                     .setCustomCacheKey(cacheKey)
                     .build()
         );
-    }
-
-    default void setMaximumVideoSizeIfUsingMobileData(
-            @NonNull final Context context,
-            @NonNull final CustomTrackSelector trackSelector) {
-        final String resolutionLimit = getResolutionLimit(context);
-        if (isMeteredNetwork(context) && resolutionLimit != null) {
-            final String[] resolutionLimitArray = resolutionLimit.split("p");
-            final int heightLimit = Integer.parseInt(resolutionLimitArray[0]);
-            final int frameRateLimit = resolutionLimitArray.length == 2
-                    ? Integer.parseInt(resolutionLimitArray[1]) : -1;
-
-            final DefaultTrackSelector.ParametersBuilder parametersBuilder = trackSelector
-                    .buildUponParameters();
-            // We don't know what will be the width of the stream so using Integer.MAX_VALUE allows
-            // ExoPlayer to only take care of the height value (using a negative number for the
-            // width makes ExoPlayer playing always the lowest stream).
-            parametersBuilder.setMaxVideoSize(Integer.MAX_VALUE, heightLimit);
-            parametersBuilder.setMaxVideoFrameRate(frameRateLimit != -1 ? frameRateLimit : 30);
-
-            trackSelector.setParameters(parametersBuilder);
-        }
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/PlaybackResolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/PlaybackResolver.java
@@ -1,5 +1,9 @@
 package org.schabi.newpipe.player.resolver;
 
+import static org.schabi.newpipe.util.ListHelper.getResolutionLimit;
+import static org.schabi.newpipe.util.ListHelper.isMeteredNetwork;
+
+import android.content.Context;
 import android.net.Uri;
 import android.text.TextUtils;
 
@@ -10,11 +14,13 @@ import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.MediaItem;
 import com.google.android.exoplayer2.source.MediaSource;
 import com.google.android.exoplayer2.source.MediaSourceFactory;
+import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
 import com.google.android.exoplayer2.util.Util;
 
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.extractor.stream.StreamType;
 import org.schabi.newpipe.player.helper.PlayerDataSource;
+import org.schabi.newpipe.player.playback.CustomTrackSelector;
 import org.schabi.newpipe.util.StreamTypeUtil;
 
 public interface PlaybackResolver extends Resolver<StreamInfo, MediaSource> {
@@ -101,5 +107,35 @@ public interface PlaybackResolver extends Resolver<StreamInfo, MediaSource> {
                     .setCustomCacheKey(cacheKey)
                     .build()
         );
+    }
+
+    default void setMaximumVideoSizeIfUsingMobileData(
+            @NonNull final Context context,
+            @NonNull final CustomTrackSelector trackSelector) {
+        final String resolutionLimit = getResolutionLimit(context);
+        if (isMeteredNetwork(context) && resolutionLimit != null) {
+            final String[] resolutionLimitArray = resolutionLimit.split("p");
+            final int heightLimit = Integer.parseInt(resolutionLimitArray[0]);
+            final int frameRateLimit;
+            if (resolutionLimitArray.length == 2) {
+                frameRateLimit = Integer.parseInt(resolutionLimitArray[1]);
+            } else {
+                frameRateLimit = -1;
+            }
+
+            final DefaultTrackSelector.ParametersBuilder parametersBuilder = trackSelector
+                    .buildUponParameters();
+            // We don't know what will be the width of the stream so using Integer.MAX_VALUE allows
+            // ExoPlayer to only take care of the height value (using a negative number for the
+            // width makes ExoPlayer playing always the lowest stream).
+            parametersBuilder.setMaxVideoSize(Integer.MAX_VALUE, heightLimit);
+            if (frameRateLimit != -1) {
+                parametersBuilder.setMaxVideoFrameRate(frameRateLimit);
+            } else {
+                parametersBuilder.setMaxVideoFrameRate(30);
+            }
+
+            trackSelector.setParameters(parametersBuilder);
+        }
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/PlaybackResolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/PlaybackResolver.java
@@ -116,12 +116,8 @@ public interface PlaybackResolver extends Resolver<StreamInfo, MediaSource> {
         if (isMeteredNetwork(context) && resolutionLimit != null) {
             final String[] resolutionLimitArray = resolutionLimit.split("p");
             final int heightLimit = Integer.parseInt(resolutionLimitArray[0]);
-            final int frameRateLimit;
-            if (resolutionLimitArray.length == 2) {
-                frameRateLimit = Integer.parseInt(resolutionLimitArray[1]);
-            } else {
-                frameRateLimit = -1;
-            }
+            final int frameRateLimit = resolutionLimitArray.length == 2
+                    ? Integer.parseInt(resolutionLimitArray[1]) : -1;
 
             final DefaultTrackSelector.ParametersBuilder parametersBuilder = trackSelector
                     .buildUponParameters();
@@ -129,11 +125,7 @@ public interface PlaybackResolver extends Resolver<StreamInfo, MediaSource> {
             // ExoPlayer to only take care of the height value (using a negative number for the
             // width makes ExoPlayer playing always the lowest stream).
             parametersBuilder.setMaxVideoSize(Integer.MAX_VALUE, heightLimit);
-            if (frameRateLimit != -1) {
-                parametersBuilder.setMaxVideoFrameRate(frameRateLimit);
-            } else {
-                parametersBuilder.setMaxVideoFrameRate(30);
-            }
+            parametersBuilder.setMaxVideoFrameRate(frameRateLimit != -1 ? frameRateLimit : 30);
 
             trackSelector.setParameters(parametersBuilder);
         }

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/Resolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/Resolver.java
@@ -3,10 +3,9 @@ package org.schabi.newpipe.player.resolver;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import org.schabi.newpipe.player.playback.CustomTrackSelector;
-
 public interface Resolver<Source, Product> {
     @Nullable
-    Product resolve(@NonNull CustomTrackSelector trackSelector,
-                    @NonNull Source source);
+    Product resolve(@NonNull Source source);
+
+    boolean isLiveSource();
 }

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/Resolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/Resolver.java
@@ -3,7 +3,10 @@ package org.schabi.newpipe.player.resolver;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import org.schabi.newpipe.player.playback.CustomTrackSelector;
+
 public interface Resolver<Source, Product> {
     @Nullable
-    Product resolve(@NonNull Source source);
+    Product resolve(@NonNull CustomTrackSelector trackSelector,
+                    @NonNull Source source);
 }

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/VideoPlaybackResolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/VideoPlaybackResolver.java
@@ -1,5 +1,7 @@
 package org.schabi.newpipe.player.resolver;
 
+import static com.google.android.exoplayer2.C.TIME_UNSET;
+
 import android.content.Context;
 import android.net.Uri;
 
@@ -21,8 +23,6 @@ import org.schabi.newpipe.util.ListHelper;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static com.google.android.exoplayer2.C.TIME_UNSET;
 
 public class VideoPlaybackResolver implements PlaybackResolver {
     @NonNull
@@ -60,9 +60,9 @@ public class VideoPlaybackResolver implements PlaybackResolver {
         if (videos.isEmpty()) {
             index = -1;
         } else if (playbackQuality == null) {
-            index = qualityResolver.getDefaultResolutionIndex(videos);
+            index = qualityResolver.getDefaultResolutionIndex(info, videos);
         } else {
-            index = qualityResolver.getOverrideResolutionIndex(videos, getPlaybackQuality());
+            index = qualityResolver.getOverrideResolutionIndex(info, videos, getPlaybackQuality());
         }
         final MediaSourceTag tag = new MediaSourceTag(info, videos, index);
         @Nullable final VideoStream video = tag.getSelectedVideoStream();
@@ -128,8 +128,10 @@ public class VideoPlaybackResolver implements PlaybackResolver {
     }
 
     public interface QualityResolver {
-        int getDefaultResolutionIndex(List<VideoStream> sortedVideos);
+        int getDefaultResolutionIndex(StreamInfo streamInfo, List<VideoStream> sortedVideos);
 
-        int getOverrideResolutionIndex(List<VideoStream> sortedVideos, String playbackQuality);
+        int getOverrideResolutionIndex(StreamInfo streamInfo,
+                                       List<VideoStream> sortedVideos,
+                                       String playbackQuality);
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/VideoPlaybackResolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/VideoPlaybackResolver.java
@@ -63,9 +63,9 @@ public class VideoPlaybackResolver implements PlaybackResolver {
         if (videos.isEmpty()) {
             index = -1;
         } else if (playbackQuality == null) {
-            index = qualityResolver.getDefaultResolutionIndex(info, videos);
+            index = qualityResolver.getDefaultResolutionIndex(videos);
         } else {
-            index = qualityResolver.getOverrideResolutionIndex(info, videos, getPlaybackQuality());
+            index = qualityResolver.getOverrideResolutionIndex(videos, getPlaybackQuality());
         }
         final MediaSourceTag tag = new MediaSourceTag(info, videos, index);
         @Nullable final VideoStream video = tag.getSelectedVideoStream();
@@ -136,10 +136,9 @@ public class VideoPlaybackResolver implements PlaybackResolver {
     }
 
     public interface QualityResolver {
-        int getDefaultResolutionIndex(StreamInfo streamInfo, List<VideoStream> sortedVideos);
+        int getDefaultResolutionIndex(@NonNull List<VideoStream> sortedVideos);
 
-        int getOverrideResolutionIndex(StreamInfo streamInfo,
-                                       List<VideoStream> sortedVideos,
-                                       String playbackQuality);
+        int getOverrideResolutionIndex(@NonNull List<VideoStream> sortedVideos,
+                                       @Nullable String playbackQuality);
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/VideoPlaybackResolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/VideoPlaybackResolver.java
@@ -19,7 +19,6 @@ import org.schabi.newpipe.extractor.stream.SubtitlesStream;
 import org.schabi.newpipe.extractor.stream.VideoStream;
 import org.schabi.newpipe.player.helper.PlayerDataSource;
 import org.schabi.newpipe.player.helper.PlayerHelper;
-import org.schabi.newpipe.player.playback.CustomTrackSelector;
 import org.schabi.newpipe.util.ListHelper;
 
 import java.util.ArrayList;
@@ -32,6 +31,8 @@ public class VideoPlaybackResolver implements PlaybackResolver {
     private final PlayerDataSource dataSource;
     @NonNull
     private final QualityResolver qualityResolver;
+
+    private boolean isLiveSource = false;
 
     @Nullable
     private String playbackQuality;
@@ -46,11 +47,10 @@ public class VideoPlaybackResolver implements PlaybackResolver {
 
     @Override
     @Nullable
-    public MediaSource resolve(@NonNull final CustomTrackSelector trackSelector,
-                               @NonNull final StreamInfo info) {
+    public MediaSource resolve(@NonNull final StreamInfo info) {
         final MediaSource liveSource = maybeBuildLiveMediaSource(dataSource, info);
         if (liveSource != null) {
-            setMaximumVideoSizeIfUsingMobileData(context, trackSelector);
+            isLiveSource = true;
             return liveSource;
         }
 
@@ -119,6 +119,11 @@ public class VideoPlaybackResolver implements PlaybackResolver {
             return new MergingMediaSource(mediaSources.toArray(
                     new MediaSource[0]));
         }
+    }
+
+    @Override
+    public boolean isLiveSource() {
+        return isLiveSource;
     }
 
     @Nullable

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/VideoPlaybackResolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/VideoPlaybackResolver.java
@@ -19,6 +19,7 @@ import org.schabi.newpipe.extractor.stream.SubtitlesStream;
 import org.schabi.newpipe.extractor.stream.VideoStream;
 import org.schabi.newpipe.player.helper.PlayerDataSource;
 import org.schabi.newpipe.player.helper.PlayerHelper;
+import org.schabi.newpipe.player.playback.CustomTrackSelector;
 import org.schabi.newpipe.util.ListHelper;
 
 import java.util.ArrayList;
@@ -45,9 +46,11 @@ public class VideoPlaybackResolver implements PlaybackResolver {
 
     @Override
     @Nullable
-    public MediaSource resolve(@NonNull final StreamInfo info) {
+    public MediaSource resolve(@NonNull final CustomTrackSelector trackSelector,
+                               @NonNull final StreamInfo info) {
         final MediaSource liveSource = maybeBuildLiveMediaSource(dataSource, info);
         if (liveSource != null) {
+            setMaximumVideoSizeIfUsingMobileData(context, trackSelector);
             return liveSource;
         }
 

--- a/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.net.ConnectivityManager;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.core.content.ContextCompat;
@@ -135,8 +136,9 @@ public final class ListHelper {
     // Utils
     //////////////////////////////////////////////////////////////////////////*/
 
-    private static String computeDefaultResolution(final Context context, final int key,
-                                                   final int value) {
+    public static String computeDefaultResolution(@NonNull final Context context,
+                                                  final int key,
+                                                  final int value) {
         final SharedPreferences preferences
                 = PreferenceManager.getDefaultSharedPreferences(context);
 
@@ -519,10 +521,11 @@ public final class ListHelper {
     /**
      * The maximum resolution allowed.
      *
-     * @param context App context
-     * @return maximum resolution allowed or null if there is no maximum
+     * @param context the app context
+     * @return the maximum resolution allowed or null if there is no maximum
      */
-    public static String getResolutionLimit(final Context context) {
+    @Nullable
+    private static String getResolutionLimit(final Context context) {
         String resolutionLimit = null;
         if (isMeteredNetwork(context)) {
             final SharedPreferences preferences

--- a/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
@@ -522,7 +522,7 @@ public final class ListHelper {
      * @param context App context
      * @return maximum resolution allowed or null if there is no maximum
      */
-    private static String getResolutionLimit(final Context context) {
+    public static String getResolutionLimit(final Context context) {
         String resolutionLimit = null;
         if (isMeteredNetwork(context)) {
             final SharedPreferences preferences

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -681,4 +681,5 @@
     <string name="show_crash_the_player_title">Montrer \"Couper le lecteur\"</string>
     <string name="show_crash_the_player_summary">Montrer une option couper lors de l\'utilisation du lecteur</string>
     <string name="auto_quality">Automatique</string>
+    <string name="auto_quality_selected">%1$s (%2$s)</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -680,4 +680,5 @@
     <string name="crash_the_player">Couper le lecteur</string>
     <string name="show_crash_the_player_title">Montrer \"Couper le lecteur\"</string>
     <string name="show_crash_the_player_summary">Montrer une option couper lors de l\'utilisation du lecteur</string>
+    <string name="auto_quality">Automatique</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -682,4 +682,5 @@
     <string name="show_crash_the_player_summary">Montrer une option couper lors de l\'utilisation du lecteur</string>
     <string name="auto_quality">Automatique</string>
     <string name="auto_quality_selected">%1$s (%2$s)</string>
+    <string name="unknown_quality">Qualité inconnue</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -721,4 +721,5 @@
     <!-- Show Channel Details -->
     <string name="error_show_channel_details">Error at Show Channel Details</string>
     <string name="loading_channel_details">Loading Channel Details…</string>
+    <string name="auto_quality">Auto</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -723,4 +723,5 @@
     <string name="loading_channel_details">Loading Channel Details…</string>
     <string name="auto_quality">Auto</string>
     <string name="auto_quality_selected">%1$s (%2$s)</string>
+    <string name="unknown_quality">Unknown quality</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -722,4 +722,5 @@
     <string name="error_show_channel_details">Error at Show Channel Details</string>
     <string name="loading_channel_details">Loading Channel Details…</string>
     <string name="auto_quality">Auto</string>
+    <string name="auto_quality_selected">%1$s (%2$s)</string>
 </resources>

--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -13,7 +13,7 @@
 
   <suppress checks="FinalParameters"
     files="ListHelper.java"
-    lines="280,312"/>
+    lines="282,314"/>
 
   <suppress checks="EmptyBlock"
     files="ContentSettingsFragment.java"


### PR DESCRIPTION
#### What is it?
- [x] Feature (user facing)

#### Description of the changes in your PR
This PR adds the ability to control the quality played for livestreams in NewPipe, both on main and popup players. The livestream quality selector uses the same popup menu as the quality selector for video streams.

The resolution limit on mobile data on livestreams also now works with this PR (even if you need to reload the livestream if you started to play it on Wifi and then you switched to mobile data) with the `Auto` option. You can still choose an higher resolution than the limit you set in `Video and audio` settings, like for videos.

Without setting a limit on mobile data or when playing a livestream on Wifi, the `Auto` option does the same thing as the current behavior (the quality played is managed by ExoPlayer and is, most of times, the highest available).

However, the default video resolution on popup player and main player settings are not working. I don't really know how to do this and I don't really have the time to do it.

#### Before/After Screenshots/Screen Record
- Before:

  <img src="https://user-images.githubusercontent.com/74829229/137585695-0329eb98-55d4-4b3c-a3de-9cc41911002b.jpg" width="500px" alt="Player controls livestreams release">

- After:

  <img src="https://user-images.githubusercontent.com/74829229/137585715-79875664-ac51-445a-9e0a-76c555103015.jpg" width="500px" alt="Player controls livestreams with quality selector">

#### Fixes the following issue(s)
- Fixes #1239

#### APK testing 
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
