### PR TITLE
implement ability to ignore back-queue for main view

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -157,6 +157,9 @@ public final class VideoDetailFragment
     private boolean showComments;
     private boolean showRelatedItems;
     private boolean showDescription;
+
+    private boolean ignoreQueue;
+
     private String selectedTabTag;
     @AttrRes @NonNull final List<Integer> tabIcons = new ArrayList<>();
     @StringRes @NonNull final List<Integer> tabContentDescriptions = new ArrayList<>();
@@ -285,6 +288,7 @@ public final class VideoDetailFragment
         showComments = prefs.getBoolean(getString(R.string.show_comments_key), true);
         showRelatedItems = prefs.getBoolean(getString(R.string.show_next_video_key), true);
         showDescription = prefs.getBoolean(getString(R.string.show_description_key), true);
+        ignoreQueue = prefs.getBoolean(getString(R.string.enable_ignore_main_queue_key), false);
         selectedTabTag = prefs.getString(
                 getString(R.string.stream_info_selected_tab_key), COMMENTS_TAB_TAG);
         prefs.registerOnSharedPreferenceChangeListener(this);
@@ -726,6 +730,11 @@ public final class VideoDetailFragment
     public boolean onBackPressed() {
         if (DEBUG) {
             Log.d(TAG, "onBackPressed() called");
+        }
+
+        // when queue should be ignored, directly skip checks and let MainActivity handle everything
+        if (ignoreQueue) {
+            return false;
         }
 
         // If we are in fullscreen mode just exit from it via first back press

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -704,4 +704,6 @@
     <!-- Show Channel Details -->
     <string name="error_show_channel_details">Error at Show Channel Details</string>
     <string name="loading_channel_details">Loading Channel Details…</string>
+    <string name="enable_ignore_main_queue_key">Ignore Main Queue</string>
+    <string name="enable_ignore_main_queue_title">Main Queue</string>
 </resources>

--- a/app/src/main/res/xml/history_settings.xml
+++ b/app/src/main/res/xml/history_settings.xml
@@ -37,6 +37,15 @@
         app:singleLineTitle="false"
         app:iconSpaceReserved="false" />
 
+    <SwitchPreferenceCompat
+        android:defaultValue="false"
+        android:key="@string/enable_ignore_main_queue_key"
+        android:summary="@string/enable_ignore_main_queue_key"
+        android:title="@string/enable_ignore_main_queue_title"
+        app:singleLineTitle="false"
+        app:iconSpaceReserved="false" />
+
+
     <PreferenceCategory
         android:layout="@layout/settings_category_header_layout"
         android:title="@string/settings_category_clear_data_title"


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Add Setting (under history) to allow the main view to ignore the backstack of videos. Instead of going back to the last video, the player minimizes. This is NOT the default behavior, when no changes are made, the queue is still used.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #4479


#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
