### PR TITLE
Revert part of #6872 and fix playback resuming

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -1181,7 +1181,7 @@ public final class VideoDetailFragment
         addVideoPlayerView();
 
         final Intent playerIntent = NavigationHelper.getPlayerIntent(requireContext(),
-                MainPlayer.class, queue, autoPlayEnabled);
+                MainPlayer.class, queue, true, autoPlayEnabled);
         ContextCompat.startForegroundService(activity, playerIntent);
     }
 

--- a/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
@@ -77,7 +77,8 @@ public final class NavigationHelper {
     @NonNull
     public static <T> Intent getPlayerIntent(@NonNull final Context context,
                                              @NonNull final Class<T> targetClazz,
-                                             @Nullable final PlayQueue playQueue) {
+                                             @Nullable final PlayQueue playQueue,
+                                             final boolean resumePlayback) {
         final Intent intent = new Intent(context, targetClazz);
 
         if (playQueue != null) {
@@ -87,7 +88,7 @@ public final class NavigationHelper {
             }
         }
         intent.putExtra(Player.PLAYER_TYPE, MainPlayer.PlayerType.VIDEO.ordinal());
-        intent.putExtra(Player.RESUME_PLAYBACK, true);
+        intent.putExtra(Player.RESUME_PLAYBACK, resumePlayback);
 
         return intent;
     }
@@ -96,8 +97,9 @@ public final class NavigationHelper {
     public static <T> Intent getPlayerIntent(@NonNull final Context context,
                                              @NonNull final Class<T> targetClazz,
                                              @Nullable final PlayQueue playQueue,
+                                             final boolean resumePlayback,
                                              final boolean playWhenReady) {
-        return getPlayerIntent(context, targetClazz, playQueue)
+        return getPlayerIntent(context, targetClazz, playQueue, resumePlayback)
                 .putExtra(Player.PLAY_WHEN_READY, playWhenReady);
     }
 
@@ -105,7 +107,14 @@ public final class NavigationHelper {
     public static <T> Intent getPlayerEnqueueIntent(@NonNull final Context context,
                                                     @NonNull final Class<T> targetClazz,
                                                     @Nullable final PlayQueue playQueue) {
-        return getPlayerIntent(context, targetClazz, playQueue)
+        // when enqueueing `resumePlayback` is always `false` since:
+        // - if there is a video already playing, the value of `resumePlayback` just doesn't make
+        //   any difference.
+        // - if there is nothing already playing, it is useful for the enqueue action to have a
+        //   slightly different behaviour than the normal play action: the latter resumes playback,
+        //   the former doesn't. (note that enqueue can be triggered when nothing is playing only
+        //   by long pressing the video detail fragment, playlist or channel controls
+        return getPlayerIntent(context, targetClazz, playQueue, false)
                 .putExtra(Player.ENQUEUE, true);
     }
 
@@ -113,7 +122,8 @@ public final class NavigationHelper {
     public static <T> Intent getPlayerEnqueueNextIntent(@NonNull final Context context,
                                                         @NonNull final Class<T> targetClazz,
                                                         @Nullable final PlayQueue playQueue) {
-        return getPlayerIntent(context, targetClazz, playQueue)
+        // see comment in `getPlayerEnqueueIntent` as to why `resumePlayback` is false
+        return getPlayerIntent(context, targetClazz, playQueue, false)
                 .putExtra(Player.ENQUEUE_NEXT, true);
     }
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This PR fixes playback resuming by readding the related parameter in the `getPlayerIntent` function. I checked all places where `getPlayerIntent` was used and the behaviour should now be the same as pre-#6872, except for a small part: when enqueueing `resumePlayback` is always `false`. @TobiGr @Redirion

In https://github.com/TeamNewPipe/NewPipe/pull/6872#pullrequestreview-784135030 I said that `resumePlayback` should be set to `true` when the play buttons are pressed in the channel and playlist fragments; this shall not be done here as this is a hotfix PR. 

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #7236

#### APK testing 
I tested and everything seems to be back to normal. The CI for some reason didn't run for this PR, so here is a manually built apk: [app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/7384112/app-debug.zip)

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).

<sub>Fun fact: this PR's digits, i.e. 7286, are a permutation of the broken PR's, i.e. 6872</sub>
