### PR TITLE
Fix player controls not hiding if resumed from media button

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -3752,9 +3752,12 @@ public final class Player implements
             default:
                 break;
             case KeyEvent.KEYCODE_SPACE:
-                playPause();
-                if (isPlaying()) {
-                    hideControls(0, 0);
+                if (isFullscreen) {
+                    playPause();
+                    if (isPlaying()) {
+                        hideControls(0, 0);
+                    }
+                    return true;
                 }
                 break;
             case KeyEvent.KEYCODE_BACK:

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -3754,6 +3754,9 @@ public final class Player implements
             case KeyEvent.KEYCODE_SPACE:
                 if (isFullscreen) {
                     playPause();
+                    if (isPlaying()) {
+                        hideControls(0, 0);
+                    }
                 }
                 break;
             case KeyEvent.KEYCODE_BACK:

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -3752,11 +3752,9 @@ public final class Player implements
             default:
                 break;
             case KeyEvent.KEYCODE_SPACE:
-                if (isFullscreen) {
-                    playPause();
-                    if (isPlaying()) {
-                        hideControls(0, 0);
-                    }
+                playPause();
+                if (isPlaying()) {
+                    hideControls(0, 0);
                 }
                 break;
             case KeyEvent.KEYCODE_BACK:

--- a/app/src/main/java/org/schabi/newpipe/player/playback/PlayerMediaSession.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playback/PlayerMediaSession.java
@@ -88,6 +88,7 @@ public class PlayerMediaSession implements MediaSessionCallback {
     @Override
     public void play() {
         player.play();
+        player.hideControls(0, 0);
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/player/playback/PlayerMediaSession.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playback/PlayerMediaSession.java
@@ -88,6 +88,7 @@ public class PlayerMediaSession implements MediaSessionCallback {
     @Override
     public void play() {
         player.play();
+        // hide the player controls even if the play command came from the media session
         player.hideControls(0, 0);
     }
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Added `hideControls(0, 0)` to the Space key pressed and the `PlayerMediaSession` `play` method (only if the player is currently playing)

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
| Before | After |
| -- | -- |
| <video src="https://user-images.githubusercontent.com/71804605/139620899-b62f3eb7-1d07-44d3-959e-104d46e9fbea.mp4"/> | <video src="https://user-images.githubusercontent.com/71804605/139621120-d73b284d-de60-4eb7-af34-eaae7df747d6.mp4"/> |

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- ~~Fixes #7340~~ (I made that issue then only looked at how to fix it)
- Fixes #3403

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
