### PR TITLE
Enable tls related protocols for picasso on <=KitKat devices

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/DownloaderImpl.java
+++ b/app/src/main/java/org/schabi/newpipe/DownloaderImpl.java
@@ -1,11 +1,6 @@
 package org.schabi.newpipe;
 
 import android.content.Context;
-import android.os.Build;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.preference.PreferenceManager;
 
 import org.schabi.newpipe.error.ReCaptchaActivity;
 import org.schabi.newpipe.extractor.downloader.Downloader;
@@ -14,32 +9,21 @@ import org.schabi.newpipe.extractor.downloader.Response;
 import org.schabi.newpipe.extractor.exceptions.ReCaptchaException;
 import org.schabi.newpipe.util.CookieUtils;
 import org.schabi.newpipe.util.InfoCache;
-import org.schabi.newpipe.util.TLSSocketFactoryCompat;
+import org.schabi.newpipe.util.OkHttpTlsHelper;
 
 import java.io.IOException;
-import java.security.KeyManagementException;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.TrustManagerFactory;
-import javax.net.ssl.X509TrustManager;
-
-import okhttp3.CipherSuite;
-import okhttp3.ConnectionSpec;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.preference.PreferenceManager;
 import okhttp3.OkHttpClient;
 import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
-
-import static org.schabi.newpipe.MainActivity.DEBUG;
 
 public final class DownloaderImpl extends Downloader {
     public static final String USER_AGENT
@@ -54,9 +38,7 @@ public final class DownloaderImpl extends Downloader {
     private final OkHttpClient client;
 
     private DownloaderImpl(final OkHttpClient.Builder builder) {
-        if (Build.VERSION.SDK_INT == Build.VERSION_CODES.KITKAT) {
-            enableModernTLS(builder);
-        }
+        OkHttpTlsHelper.enableModernTLS(builder);
         this.client = builder
                 .readTimeout(30, TimeUnit.SECONDS)
 //                .cache(new Cache(new File(context.getExternalCacheDir(), "okhttp"),
@@ -79,55 +61,6 @@ public final class DownloaderImpl extends Downloader {
 
     public static DownloaderImpl getInstance() {
         return instance;
-    }
-
-    /**
-     * Enable TLS 1.2 and 1.1 on Android Kitkat. This function is mostly taken
-     * from the documentation of OkHttpClient.Builder.sslSocketFactory(_,_).
-     * <p>
-     * If there is an error, the function will safely fall back to doing nothing
-     * and printing the error to the console.
-     * </p>
-     *
-     * @param builder The HTTPClient Builder on which TLS is enabled on (will be modified in-place)
-     */
-    private static void enableModernTLS(final OkHttpClient.Builder builder) {
-        try {
-            // get the default TrustManager
-            final TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(
-                    TrustManagerFactory.getDefaultAlgorithm());
-            trustManagerFactory.init((KeyStore) null);
-            final TrustManager[] trustManagers = trustManagerFactory.getTrustManagers();
-            if (trustManagers.length != 1 || !(trustManagers[0] instanceof X509TrustManager)) {
-                throw new IllegalStateException("Unexpected default trust managers:"
-                        + Arrays.toString(trustManagers));
-            }
-            final X509TrustManager trustManager = (X509TrustManager) trustManagers[0];
-
-            // insert our own TLSSocketFactory
-            final SSLSocketFactory sslSocketFactory = TLSSocketFactoryCompat.getInstance();
-
-            builder.sslSocketFactory(sslSocketFactory, trustManager);
-
-            // This will try to enable all modern CipherSuites(+2 more)
-            // that are supported on the device.
-            // Necessary because some servers (e.g. Framatube.org)
-            // don't support the old cipher suites.
-            // https://github.com/square/okhttp/issues/4053#issuecomment-402579554
-            final List<CipherSuite> cipherSuites =
-                    new ArrayList<>(ConnectionSpec.MODERN_TLS.cipherSuites());
-            cipherSuites.add(CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA);
-            cipherSuites.add(CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA);
-            final ConnectionSpec legacyTLS = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
-                    .cipherSuites(cipherSuites.toArray(new CipherSuite[0]))
-                    .build();
-
-            builder.connectionSpecs(Arrays.asList(legacyTLS, ConnectionSpec.CLEARTEXT));
-        } catch (final KeyManagementException | NoSuchAlgorithmException | KeyStoreException e) {
-            if (DEBUG) {
-                e.printStackTrace();
-            }
-        }
     }
 
     public String getCookies(final String url) {

--- a/app/src/main/java/org/schabi/newpipe/util/OkHttpTlsHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/OkHttpTlsHelper.java
@@ -1,0 +1,81 @@
+package org.schabi.newpipe.util;
+
+import android.os.Build;
+
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+
+import okhttp3.CipherSuite;
+import okhttp3.ConnectionSpec;
+import okhttp3.OkHttpClient;
+
+import static org.schabi.newpipe.MainActivity.DEBUG;
+
+public final class OkHttpTlsHelper {
+
+    private OkHttpTlsHelper() {
+    }
+
+    /**
+     * Enable TLS 1.2 and 1.1 on Android Kitkat. This function is mostly taken
+     * from the documentation of OkHttpClient.Builder.sslSocketFactory(_,_).
+     * <p>
+     * If there is an error, the function will safely fall back to doing nothing
+     * and printing the error to the console.
+     * </p>
+     *
+     * @param builder The HTTPClient Builder on which TLS is enabled on (will be modified in-place)
+     */
+    public static void enableModernTLS(final OkHttpClient.Builder builder) {
+        if (Build.VERSION.SDK_INT == Build.VERSION_CODES.KITKAT) {
+            try {
+                // get the default TrustManager
+                final TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(
+                        TrustManagerFactory.getDefaultAlgorithm());
+                trustManagerFactory.init((KeyStore) null);
+                final TrustManager[] trustManagers = trustManagerFactory.getTrustManagers();
+                if (trustManagers.length != 1 || !(trustManagers[0] instanceof X509TrustManager)) {
+                    throw new IllegalStateException("Unexpected default trust managers:"
+                            + Arrays.toString(trustManagers));
+                }
+                final X509TrustManager trustManager = (X509TrustManager) trustManagers[0];
+
+                // insert our own TLSSocketFactory
+                final SSLSocketFactory sslSocketFactory = TLSSocketFactoryCompat.getInstance();
+
+                builder.sslSocketFactory(sslSocketFactory, trustManager);
+
+                // This will try to enable all modern CipherSuites(+2 more)
+                // that are supported on the device.
+                // Necessary because some servers (e.g. Framatube.org)
+                // don't support the old cipher suites.
+                // https://github.com/square/okhttp/issues/4053#issuecomment-402579554
+                final List<CipherSuite> cipherSuites =
+                        new ArrayList<>(ConnectionSpec.MODERN_TLS.cipherSuites());
+                cipherSuites.add(CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA);
+                cipherSuites.add(CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA);
+                final ConnectionSpec legacyTLS =
+                        new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+                                .cipherSuites(cipherSuites.toArray(new CipherSuite[0]))
+                                .build();
+
+                builder.connectionSpecs(Arrays.asList(legacyTLS, ConnectionSpec.CLEARTEXT));
+            } catch (final KeyManagementException | NoSuchAlgorithmException
+                    | KeyStoreException e) {
+                if (DEBUG) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/util/OkHttpTlsHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/OkHttpTlsHelper.java
@@ -35,8 +35,9 @@ public final class OkHttpTlsHelper {
      * </p>
      *
      * @param builder The HTTPClient Builder on which TLS is enabled on (will be modified in-place)
+     * @return the same builder that was supplied. So the method can be chained.
      */
-    public static void enableModernTLS(final OkHttpClient.Builder builder) {
+    public static OkHttpClient.Builder enableModernTLS(final OkHttpClient.Builder builder) {
         if (Build.VERSION.SDK_INT == Build.VERSION_CODES.KITKAT) {
             try {
                 // get the default TrustManager
@@ -77,5 +78,7 @@ public final class OkHttpTlsHelper {
                 }
             }
         }
+
+        return builder;
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/util/PicassoHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/PicassoHelper.java
@@ -40,7 +40,7 @@ public final class PicassoHelper {
 
     public static void init(final Context context) {
         picassoCache = new LruCache(10 * 1024 * 1024);
-        picassoDownloaderClient = new OkHttpClient.Builder()
+        picassoDownloaderClient = OkHttpTlsHelper.enableModernTLS(new OkHttpClient.Builder())
                 .cache(new okhttp3.Cache(new File(context.getExternalCacheDir(), "picasso"),
                         50 * 1024 * 1024))
                 // this should already be the default timeout in OkHttp3, but just to be sure...


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
 Could not load images with Picasso. This problem only surfaced as I maintain a fork of NewPipe that supports the video platform Rumble and the thumbnails stopped to load. The reason is that NewPipe moved from UniversalImageLoader to Picasso. This PR fixes that. It might fix other platforms on those devices too.
  - enable TLSv1.1/1.2 for OkHttpClient.Builder for Picasso on <=KitKat devices that support those protocols but have not been enabled.
#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
