### PR TITLE
added show watched items toggle preference

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
@@ -128,6 +128,7 @@ class FeedFragment : BaseStateFragment<FeedState>() {
 
         val factory = FeedViewModel.Factory(requireContext(), groupId, showPlayedItems)
         viewModel = ViewModelProvider(this, factory).get(FeedViewModel::class.java)
+        showPlayedItems = viewModel.getSavedPlayedItemsToggle()
         viewModel.stateLiveData.observe(viewLifecycleOwner, { it?.let(::handleResult) })
 
         groupAdapter = GroupieAdapter().apply {
@@ -158,7 +159,7 @@ class FeedFragment : BaseStateFragment<FeedState>() {
         }
     }
 
-    fun setupListViewMode() {
+    private fun setupListViewMode() {
         // does everything needed to setup the layouts for grid or list modes
         groupAdapter.spanCount = if (shouldUseGridLayout(context)) getGridSpanCountStreams(context) else 1
         feedBinding.itemsList.layoutManager = GridLayoutManager(requireContext(), groupAdapter.spanCount).apply {
@@ -213,6 +214,7 @@ class FeedFragment : BaseStateFragment<FeedState>() {
             showPlayedItems = !item.isChecked
             updateTogglePlayedItemsButton(item)
             viewModel.togglePlayedItems(showPlayedItems)
+            viewModel.savePlayedItemsToggle(showPlayedItems)
         }
 
         return super.onOptionsItemSelected(item)

--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
@@ -126,9 +126,9 @@ class FeedFragment : BaseStateFragment<FeedState>() {
         _feedBinding = FragmentFeedBinding.bind(rootView)
         super.onViewCreated(rootView, savedInstanceState)
 
-        val factory = FeedViewModel.Factory(requireContext(), groupId, showPlayedItems)
+        val factory = FeedViewModel.Factory(requireContext(), groupId)
         viewModel = ViewModelProvider(this, factory).get(FeedViewModel::class.java)
-        showPlayedItems = viewModel.getSavedPlayedItemsToggle()
+        showPlayedItems = viewModel.getShowPlayedItemsFromPreferences()
         viewModel.stateLiveData.observe(viewLifecycleOwner, { it?.let(::handleResult) })
 
         groupAdapter = GroupieAdapter().apply {
@@ -214,7 +214,7 @@ class FeedFragment : BaseStateFragment<FeedState>() {
             showPlayedItems = !item.isChecked
             updateTogglePlayedItemsButton(item)
             viewModel.togglePlayedItems(showPlayedItems)
-            viewModel.savePlayedItemsToggle(showPlayedItems)
+            viewModel.saveShowPlayedItemsToPreferences(showPlayedItems)
         }
 
         return super.onOptionsItemSelected(item)

--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedViewModel.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedViewModel.kt
@@ -12,6 +12,7 @@ import io.reactivex.rxjava3.core.Flowable
 import io.reactivex.rxjava3.functions.Function4
 import io.reactivex.rxjava3.processors.BehaviorProcessor
 import io.reactivex.rxjava3.schedulers.Schedulers
+import org.schabi.newpipe.R
 import org.schabi.newpipe.database.feed.model.FeedGroupEntity
 import org.schabi.newpipe.database.stream.StreamWithState
 import org.schabi.newpipe.local.feed.item.StreamItem
@@ -25,15 +26,12 @@ import java.time.OffsetDateTime
 import java.util.concurrent.TimeUnit
 
 class FeedViewModel(
-    applicationContext: Context,
+    val applicationContext: Context,
     groupId: Long = FeedGroupEntity.GROUP_ALL_ID,
     initialShowPlayedItems: Boolean = true
 ) : ViewModel() {
     private var feedDatabaseManager: FeedDatabaseManager = FeedDatabaseManager(applicationContext)
     private var sharedPreferences = PreferenceManager.getDefaultSharedPreferences(applicationContext)
-    companion object {
-        const val SHOW_PLAYED_ITEMS_PREFERENCE = "show_played_items_preference_tag"
-    }
 
     private val toggleShowPlayedItems = BehaviorProcessor.create<Boolean>()
     private val streamItems = toggleShowPlayedItems
@@ -88,11 +86,11 @@ class FeedViewModel(
     }
 
     fun savePlayedItemsToggle(showPlayedItems: Boolean) = sharedPreferences.edit {
-        this.putBoolean(SHOW_PLAYED_ITEMS_PREFERENCE, showPlayedItems)
+        this.putBoolean(applicationContext.getString(R.string.show_played_items_filter_key), showPlayedItems)
         this.apply()
     }
 
-    fun getSavedPlayedItemsToggle() = sharedPreferences.getBoolean(SHOW_PLAYED_ITEMS_PREFERENCE, true)
+    fun getSavedPlayedItemsToggle() = sharedPreferences.getBoolean(applicationContext.getString(R.string.show_played_items_filter_key), true)
 
     class Factory(
         private val context: Context,

--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedViewModel.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedViewModel.kt
@@ -1,10 +1,12 @@
 package org.schabi.newpipe.local.feed
 
 import android.content.Context
+import androidx.core.content.edit
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.preference.PreferenceManager
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.core.Flowable
 import io.reactivex.rxjava3.functions.Function4
@@ -28,6 +30,10 @@ class FeedViewModel(
     initialShowPlayedItems: Boolean = true
 ) : ViewModel() {
     private var feedDatabaseManager: FeedDatabaseManager = FeedDatabaseManager(applicationContext)
+    private var sharedPreferences = PreferenceManager.getDefaultSharedPreferences(applicationContext)
+    companion object {
+        const val SHOW_PLAYED_ITEMS_PREFERENCE = "show_played_items_preference_tag"
+    }
 
     private val toggleShowPlayedItems = BehaviorProcessor.create<Boolean>()
     private val streamItems = toggleShowPlayedItems
@@ -80,6 +86,13 @@ class FeedViewModel(
     fun togglePlayedItems(showPlayedItems: Boolean) {
         toggleShowPlayedItems.onNext(showPlayedItems)
     }
+
+    fun savePlayedItemsToggle(showPlayedItems: Boolean) = sharedPreferences.edit {
+        this.putBoolean(SHOW_PLAYED_ITEMS_PREFERENCE, showPlayedItems)
+        this.apply()
+    }
+
+    fun getSavedPlayedItemsToggle() = sharedPreferences.getBoolean(SHOW_PLAYED_ITEMS_PREFERENCE, true)
 
     class Factory(
         private val context: Context,

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -14,6 +14,7 @@
     <string name="saved_tabs_key" translatable="false">saved_tabs_key</string>
 
     <!-- Key values -->
+    <string name="show_played_items_filter_key" translatable="false">show_played_items_preference_key</string>
     <string name="download_path_video_key" translatable="false">download_path</string>
     <string name="download_path_audio_key" translatable="false">download_path_audio</string>
 

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -14,7 +14,6 @@
     <string name="saved_tabs_key" translatable="false">saved_tabs_key</string>
 
     <!-- Key values -->
-    <string name="feed_show_played_items_key" translatable="false">feed_show_played_items</string>
     <string name="download_path_video_key" translatable="false">download_path</string>
     <string name="download_path_audio_key" translatable="false">download_path_audio</string>
 
@@ -264,6 +263,7 @@
 
     <string name="feed_update_threshold_key" translatable="false">feed_update_threshold_key</string>
     <string name="feed_update_threshold_default_value" translatable="false">300</string>
+    <string name="feed_show_played_items_key" translatable="false">feed_show_played_items</string>
 
     <string name="show_thumbnail_key" translatable="false">show_thumbnail_key</string>
 

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -14,7 +14,7 @@
     <string name="saved_tabs_key" translatable="false">saved_tabs_key</string>
 
     <!-- Key values -->
-    <string name="show_played_items_filter_key" translatable="false">show_played_items_preference_key</string>
+    <string name="feed_show_played_items_key" translatable="false">feed_show_played_items</string>
     <string name="download_path_video_key" translatable="false">download_path</string>
     <string name="download_path_audio_key" translatable="false">download_path_audio</string>
 


### PR DESCRIPTION
default sharedpreference is used to persist and retrieve show watched menu option toggle state

<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- added sharedprefrences in feed ViewModel, wrote two functions to save and retrieve "show watched items" boolean state
- used the same functions in feedfragment onitemoptionselected() function of fragment



#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #7362 


#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
