### PR TITLE
Prevent automatic replay after returning from background

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -859,14 +859,8 @@ public final class Player implements
         final long windowPos = simpleExoPlayer.getCurrentPosition();
         final long duration = simpleExoPlayer.getDuration();
 
-        if (windowPos > 0
-                // Sometimes (e.g. when the playback ended) the windowPos is a few milliseconds
-                // higher than the duration. Due to this a little buffer (100ms) was introduced.
-                // See also https://github.com/TeamNewPipe/NewPipe/pull/7195#issuecomment-962624380
-                && windowPos <= duration + 100
-        ) {
-            setRecovery(queuePos, Math.min(windowPos, duration));
-        }
+        // No checks due to https://github.com/TeamNewPipe/NewPipe/pull/7195#issuecomment-962624380
+        setRecovery(queuePos, Math.max(0, Math.min(windowPos, duration)));
     }
 
     private void setRecovery(final int queuePos, final long windowPos) {

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -857,9 +857,15 @@ public final class Player implements
 
         final int queuePos = playQueue.getIndex();
         final long windowPos = simpleExoPlayer.getCurrentPosition();
+        final long duration = simpleExoPlayer.getDuration();
 
-        if (windowPos > 0 && windowPos <= simpleExoPlayer.getDuration()) {
-            setRecovery(queuePos, windowPos);
+        if (windowPos > 0
+                // Sometimes (e.g. when the playback ended) the windowPos is a few milliseconds
+                // higher than the duration. Due to this a little buffer (100ms) was introduced.
+                // See also https://github.com/TeamNewPipe/NewPipe/pull/7195#issuecomment-962624380
+                && windowPos <= duration + 100
+        ) {
+            setRecovery(queuePos, Math.min(windowPos, duration));
         }
     }
 


### PR DESCRIPTION
See also https://github.com/TeamNewPipe/NewPipe/pull/7195#issuecomment-962624380

<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Successor to #7195

* If the video has completed, when the app returns from background, prevent the player from staring playback automatically 

Analysis of the problem: https://github.com/TeamNewPipe/NewPipe/pull/7195#issuecomment-962624380

Steps to reproduce the bug:
1. Play a video
2. Lock the device while the video is still playing
3. Wait until the video ends
4. Unlock the device
5. The video starts playing again automatically


#### Before/After Screenshots/Screen Record
- Before:

https://user-images.githubusercontent.com/4525736/140655574-733a3749-ea7c-4979-b993-3847ed2a20dc.mp4

- After:

https://user-images.githubusercontent.com/4525736/140655671-53f10945-2987-4843-a71a-95b09d5e1216.mp4


#### APK testing 
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
