### PR TITLE
Gradle: Replaced deprecated `with` with `using`

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -6,6 +6,6 @@ include ':app'
 
 //includeBuild('../NewPipeExtractor') {
 //    dependencySubstitution {
-//        substitute module('com.github.TeamNewPipe:NewPipeExtractor') with project(':extractor')
+//        substitute module('com.github.TeamNewPipe:NewPipeExtractor') using project(':extractor')
 //    }
 //}


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
- Gradle: Replaced deprecated ``with`` with ``using``

The doc reads as follows:
```java
        /**
         * Specify the target of the substitution.
         *
         * @deprecated Use {@link #using(ComponentSelector)} instead. This method will be removed in Gradle 8.0.
         */
        @Deprecated
        void with(ComponentSelector notation);


        /**
         * Specify the target of the substitution. This is a replacement for the {@link #with(ComponentSelector)}
         * method which supports chaining.
         *
         * @since 6.6
         */
        Substitution using(ComponentSelector notation);
```

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
