### PR TITLE
Fixed auto transition

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -2448,6 +2448,7 @@ public final class Player implements
         // Refresh the playback if there is a transition to the next video
         final int newWindowIndex = simpleExoPlayer.getCurrentWindowIndex();
         switch (discontinuityReason) {
+            case DISCONTINUITY_REASON_AUTO_TRANSITION:
             case DISCONTINUITY_REASON_REMOVE:
                 // When player is in single repeat mode and a period transition occurs,
                 // we need to register a view count here since no metadata has changed
@@ -2470,7 +2471,6 @@ public final class Player implements
                 }
                 break;
             case DISCONTINUITY_REASON_SKIP:
-            case DISCONTINUITY_REASON_AUTO_TRANSITION:
                 break; // only makes Android Studio linter happy, as there are no ads
         }
 

--- a/app/src/main/java/org/schabi/newpipe/player/helper/LoadController.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/LoadController.java
@@ -1,81 +1,28 @@
 package org.schabi.newpipe.player.helper;
 
 import com.google.android.exoplayer2.DefaultLoadControl;
-import com.google.android.exoplayer2.LoadControl;
-import com.google.android.exoplayer2.Renderer;
-import com.google.android.exoplayer2.source.TrackGroupArray;
-import com.google.android.exoplayer2.trackselection.ExoTrackSelection;
-import com.google.android.exoplayer2.upstream.Allocator;
 
-public class LoadController implements LoadControl {
+public class LoadController extends DefaultLoadControl {
 
     public static final String TAG = "LoadController";
-
-    private final long initialPlaybackBufferUs;
-    private final LoadControl internalLoadControl;
     private boolean preloadingEnabled = true;
-
-    /*//////////////////////////////////////////////////////////////////////////
-    // Default Load Control
-    //////////////////////////////////////////////////////////////////////////*/
-
-    public LoadController() {
-        this(PlayerHelper.getPlaybackStartBufferMs());
-    }
-
-    private LoadController(final int initialPlaybackBufferMs) {
-        this.initialPlaybackBufferUs = initialPlaybackBufferMs * 1000;
-
-        final DefaultLoadControl.Builder builder = new DefaultLoadControl.Builder();
-        builder.setBufferDurationsMs(
-                DefaultLoadControl.DEFAULT_MIN_BUFFER_MS,
-                DefaultLoadControl.DEFAULT_MAX_BUFFER_MS,
-                initialPlaybackBufferMs,
-                DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS);
-        internalLoadControl = builder.build();
-    }
-
-    /*//////////////////////////////////////////////////////////////////////////
-    // Custom behaviours
-    //////////////////////////////////////////////////////////////////////////*/
 
     @Override
     public void onPrepared() {
         preloadingEnabled = true;
-        internalLoadControl.onPrepared();
-    }
-
-    @Override
-    public void onTracksSelected(final Renderer[] renderers, final TrackGroupArray trackGroups,
-                                 final ExoTrackSelection[] trackSelections) {
-        internalLoadControl.onTracksSelected(renderers, trackGroups, trackSelections);
+        super.onPrepared();
     }
 
     @Override
     public void onStopped() {
         preloadingEnabled = true;
-        internalLoadControl.onStopped();
+        super.onStopped();
     }
 
     @Override
     public void onReleased() {
         preloadingEnabled = true;
-        internalLoadControl.onReleased();
-    }
-
-    @Override
-    public Allocator getAllocator() {
-        return internalLoadControl.getAllocator();
-    }
-
-    @Override
-    public long getBackBufferDurationUs() {
-        return internalLoadControl.getBackBufferDurationUs();
-    }
-
-    @Override
-    public boolean retainBackBufferFromKeyframe() {
-        return internalLoadControl.retainBackBufferFromKeyframe();
+        super.onReleased();
     }
 
     @Override
@@ -85,19 +32,8 @@ public class LoadController implements LoadControl {
         if (!preloadingEnabled) {
             return false;
         }
-        return internalLoadControl.shouldContinueLoading(
+        return super.shouldContinueLoading(
                 playbackPositionUs, bufferedDurationUs, playbackSpeed);
-    }
-
-    @Override
-    public boolean shouldStartPlayback(final long bufferedDurationUs, final float playbackSpeed,
-                                       final boolean rebuffering, final long targetLiveOffsetUs) {
-        final boolean isInitialPlaybackBufferFilled
-                = bufferedDurationUs >= this.initialPlaybackBufferUs * playbackSpeed;
-        final boolean isInternalStartingPlayback = internalLoadControl
-                .shouldStartPlayback(bufferedDurationUs, playbackSpeed, rebuffering,
-                        targetLiveOffsetUs);
-        return isInitialPlaybackBufferFilled || isInternalStartingPlayback;
     }
 
     public void disablePreloadingOfCurrentTrack() {

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
@@ -305,13 +305,6 @@ public final class PlayerHelper {
         return 2 * 1024 * 1024L; // ExoPlayer CacheDataSink.MIN_RECOMMENDED_FRAGMENT_SIZE
     }
 
-    /**
-     * @return the number of milliseconds the player buffers for before starting playback
-     */
-    public static int getPlaybackStartBufferMs() {
-        return 500;
-    }
-
     public static ExoTrackSelection.Factory getQualitySelector() {
         return new AdaptiveTrackSelection.Factory(
                 1000,


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [X] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- record videos
- create clones
- take over the world

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
I missread the [ExoPlayer 2.14.0 changelog](https://github.com/google/ExoPlayer/blob/release-v2/RELEASENOTES.md#2140-2021-05-13)
`Report information about the old and the new playback positions to Listener.onPositionDiscontinuity. Add DISCONTINUITY_REASON_SKIP and DISCONTINUITY_REASON_REMOVE as discontinuity reasons, and rename DISCONTINUITY_REASON_PERIOD_TRANSITION to DISCONTINUITY_REASON_AUTO_TRANSITION. Remove DISCONTINUITY_REASON_AD_INSERTION, for which DISCONTINUITY_REASON_AUTO_TRANSITION is used instead`

particularly as REASON_AD_INSERTION was replaced by REASON_AUTO_TRANSITION I replaced this in our code. However as PERIOD-TRANSITION was changed to AUTO_TRANSITION we lost the previous behaviour. Stupid me. 
This commit fixes the ExoPlayer 2.14.2 PR #7005

I am a bit unsure if DISCONTINUITY_REASON_REMOVE should be at the same position, but according to the javadoc it should be, so I would leave it there unless anyone has objections.

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [X] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
