### PR TITLE
Fixed Period Transition

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -2448,6 +2448,7 @@ public final class Player implements
         // Refresh the playback if there is a transition to the next video
         final int newWindowIndex = simpleExoPlayer.getCurrentWindowIndex();
         switch (discontinuityReason) {
+            case DISCONTINUITY_REASON_AUTO_TRANSITION:
             case DISCONTINUITY_REASON_REMOVE:
                 // When player is in single repeat mode and a period transition occurs,
                 // we need to register a view count here since no metadata has changed
@@ -2470,7 +2471,6 @@ public final class Player implements
                 }
                 break;
             case DISCONTINUITY_REASON_SKIP:
-            case DISCONTINUITY_REASON_AUTO_TRANSITION:
                 break; // only makes Android Studio linter happy, as there are no ads
         }
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [X] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
I missread the ExoPlayer 2.14.0 changelog
`Report information about the old and the new playback positions to Listener.onPositionDiscontinuity. Add DISCONTINUITY_REASON_SKIP and DISCONTINUITY_REASON_REMOVE as discontinuity reasons, and rename DISCONTINUITY_REASON_PERIOD_TRANSITION to DISCONTINUITY_REASON_AUTO_TRANSITION. Remove DISCONTINUITY_REASON_AD_INSERTION, for which DISCONTINUITY_REASON_AUTO_TRANSITION is used instead`

particularly as REASON_AD_INSERTION was replaced by REASON_AUTO_TRANSITION I replaced this in our code. However as PERIOD-TRANSITION was changed to AUTO_TRANSITION we lost the previous behaviour. Stupid me.
This commit fixes the ExoPlayer 2.14.2 PR #7005

~~I am a bit unsure if DISCONTINUITY_REASON_REMOVE should be at the same position, but according to the javadoc it should be, so I would leave it there unless anyone has objections.~~
I have checked the ExoPlayer Sourcecode, for me it looks like this is okay there.


#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [X] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
