### PR TITLE
Load uploaderUrl when showing Channel Details from Play Queue

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/QueueItemMenuUtil.java
+++ b/app/src/main/java/org/schabi/newpipe/QueueItemMenuUtil.java
@@ -14,6 +14,7 @@ import org.schabi.newpipe.local.dialog.PlaylistDialog;
 import org.schabi.newpipe.player.playqueue.PlayQueue;
 import org.schabi.newpipe.player.playqueue.PlayQueueItem;
 import org.schabi.newpipe.util.NavigationHelper;
+import org.schabi.newpipe.util.SaveUploaderUrlHelper;
 
 import java.util.Collections;
 
@@ -61,11 +62,13 @@ public final class QueueItemMenuUtil {
 
                     return true;
                 case R.id.menu_item_channel_details:
-                    // An intent must be used here.
-                    // Opening with FragmentManager transactions is not working,
-                    // as PlayQueueActivity doesn't use fragments.
-                    NavigationHelper.openChannelFragmentUsingIntent(context, item.getServiceId(),
-                            item.getUploaderUrl(), item.getUploader());
+                    SaveUploaderUrlHelper.saveUploaderUrlIfNeeded(context, item,
+                            // An intent must be used here.
+                            // Opening with FragmentManager transactions is not working,
+                            // as PlayQueueActivity doesn't use fragments.
+                            uploaderUrl -> NavigationHelper.openChannelFragmentUsingIntent(
+                                    context, item.getServiceId(), uploaderUrl, item.getUploader()
+                            ));
                     return true;
                 case R.id.menu_item_share:
                     shareText(context, item.getTitle(), item.getUrl(),

--- a/app/src/main/java/org/schabi/newpipe/util/SaveUploaderUrlHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/SaveUploaderUrlHelper.java
@@ -1,0 +1,94 @@
+package org.schabi.newpipe.util;
+
+import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
+
+import android.content.Context;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
+import org.schabi.newpipe.NewPipeDatabase;
+import org.schabi.newpipe.R;
+import org.schabi.newpipe.error.ErrorInfo;
+import org.schabi.newpipe.error.ErrorUtil;
+import org.schabi.newpipe.error.UserAction;
+import org.schabi.newpipe.extractor.stream.StreamInfoItem;
+import org.schabi.newpipe.player.playqueue.PlayQueueItem;
+
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+
+/**
+ * Utility class for putting the uploader url into the database - when required.
+ */
+public final class SaveUploaderUrlHelper {
+    private SaveUploaderUrlHelper() {
+    }
+
+    // Public functions which call the function that does
+    // the actual work with the correct parameters
+    public static void saveUploaderUrlIfNeeded(@NonNull final Fragment fragment,
+                                               @NonNull final StreamInfoItem infoItem,
+                                               @NonNull final SaveUploaderUrlCallback callback) {
+        saveUploaderUrlIfNeeded(fragment.requireContext(),
+                infoItem.getServiceId(),
+                infoItem.getUrl(),
+                infoItem.getUploaderUrl(),
+                callback);
+    }
+    public static void saveUploaderUrlIfNeeded(@NonNull final Context context,
+                                               @NonNull final PlayQueueItem queueItem,
+                                               @NonNull final SaveUploaderUrlCallback callback) {
+        saveUploaderUrlIfNeeded(context,
+                queueItem.getServiceId(),
+                queueItem.getUrl(),
+                queueItem.getUploaderUrl(),
+                callback);
+    }
+
+    /**
+     * Fetches and saves the uploaderUrl if it is empty (meaning that it does
+     * not exist in the video item). The callback is called with either the
+     * fetched uploaderUrl, or the already saved uploaderUrl, but it is always
+     * called with a valid uploaderUrl that can be used to show channel details.
+     *
+     * @param context       Context
+     * @param serviceId     The serviceId of the item
+     * @param url           The item url
+     * @param uploaderUrl   The uploaderUrl of the item, if null or empty, it
+     *                      will be fetched using the item url.
+     * @param callback      The callback that returns the fetched or existing
+     *                      uploaderUrl
+     */
+    private static void saveUploaderUrlIfNeeded(@NonNull final Context context,
+                                         final int serviceId,
+                                         @NonNull final String url,
+                                         // Only used if not null or empty
+                                         @Nullable final String uploaderUrl,
+                                         @NonNull final SaveUploaderUrlCallback callback) {
+        if (isNullOrEmpty(uploaderUrl)) {
+            Toast.makeText(context, R.string.loading_channel_details,
+                    Toast.LENGTH_SHORT).show();
+            ExtractorHelper.getStreamInfo(serviceId, url, false)
+                    .subscribeOn(Schedulers.io())
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .subscribe(result -> {
+                        NewPipeDatabase.getInstance(context).streamDAO()
+                                .setUploaderUrl(serviceId, url, result.getUploaderUrl())
+                                .subscribeOn(Schedulers.io()).subscribe();
+                        callback.onCallback(result.getUploaderUrl());
+                    }, throwable -> ErrorUtil.createNotification(context,
+                            new ErrorInfo(throwable, UserAction.REQUESTED_CHANNEL,
+                                    "Could not load channel details")
+                    ));
+        } else {
+            callback.onCallback(uploaderUrl);
+        }
+    }
+
+    public interface SaveUploaderUrlCallback {
+        void onCallback(@NonNull String uploaderUrl);
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
+++ b/app/src/main/java/org/schabi/newpipe/util/StreamDialogEntry.java
@@ -3,12 +3,10 @@ package org.schabi.newpipe.util;
 import android.content.Context;
 import android.net.Uri;
 import android.util.Log;
-import android.widget.Toast;
 
 import androidx.fragment.app.Fragment;
 import androidx.preference.PreferenceManager;
 
-import org.schabi.newpipe.NewPipeDatabase;
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.database.stream.model.StreamEntity;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
@@ -27,36 +25,14 @@ import java.util.function.Consumer;
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 
-import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
-
 public enum StreamDialogEntry {
     //////////////////////////////////////
     // enum values with DEFAULT actions //
     //////////////////////////////////////
 
     show_channel_details(R.string.show_channel_details, (fragment, item) -> {
-        if (isNullOrEmpty(item.getUploaderUrl())) {
-            final int serviceId = item.getServiceId();
-            final String url = item.getUrl();
-            Toast.makeText(fragment.getContext(), R.string.loading_channel_details,
-                    Toast.LENGTH_SHORT).show();
-            ExtractorHelper.getStreamInfo(serviceId, url, false)
-                    .subscribeOn(Schedulers.io())
-                    .observeOn(AndroidSchedulers.mainThread())
-                    .subscribe(result -> {
-                        NewPipeDatabase.getInstance(fragment.requireContext()).streamDAO()
-                                .setUploaderUrl(serviceId, url, result.getUploaderUrl())
-                                .subscribeOn(Schedulers.io()).subscribe();
-                        openChannelFragment(fragment, item, result.getUploaderUrl());
-                    }, throwable -> Toast.makeText(
-                            // TODO: Open the Error Activity
-                            fragment.getContext(),
-                            R.string.error_show_channel_details,
-                            Toast.LENGTH_SHORT
-                    ).show());
-        } else {
-            openChannelFragment(fragment, item, item.getUploaderUrl());
-        }
+        SaveUploaderUrlHelper.saveUploaderUrlIfNeeded(fragment, item,
+                uploaderUrl -> openChannelFragment(fragment, item, uploaderUrl));
     }),
 
     /**


### PR DESCRIPTION
This checks if the uploaderUrl is in the database, if not it gets the
uploaderUrl and puts it in the database. This is similar to the fetching
of uploaderUrl when it doesn't exist done in #6919.

<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Move the code that conditionally fetches the `uploaderUrl` and saves it to the database into a helper class + method.
- Use the `saveUploaderUrlIfNeeded` method in `QueueItemMenuUtil` when selecting `Show Channel Details` in order to load the `uploaderUrl` if it isn't available in the database.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
Android Emulator screen recording seems to be broken, I'll do my best to describe the before and after in text.
- Before: When selecting `Show Channel Details` on a video that doesn't have `uploaderUrl` in the database, it will go to the channel fragment, but the `uploaderUrl` will be `null`, so it will cause a network error.
- After: When selecting `Show Channel Details` on a video that doesn't have `uploaderUrl` in the database, it will fetch the `uploaderUrl` and display a loading toast, then open the channel fragment.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
Did not find any issues that will be fixed by this PR.

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
