### PR TITLE
Remove/Revert MediaParser support (Android 11+) due to bugs

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerDataSource.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerDataSource.java
@@ -1,18 +1,14 @@
 package org.schabi.newpipe.player.helper;
 
 import android.content.Context;
-import android.os.Build;
 
 import androidx.annotation.NonNull;
 
-import com.google.android.exoplayer2.source.MediaParserExtractorAdapter;
 import com.google.android.exoplayer2.source.ProgressiveMediaSource;
 import com.google.android.exoplayer2.source.SingleSampleMediaSource;
-import com.google.android.exoplayer2.source.chunk.MediaParserChunkExtractor;
 import com.google.android.exoplayer2.source.dash.DashMediaSource;
 import com.google.android.exoplayer2.source.dash.DefaultDashChunkSource;
 import com.google.android.exoplayer2.source.hls.HlsMediaSource;
-import com.google.android.exoplayer2.source.hls.MediaParserHlsMediaChunkExtractor;
 import com.google.android.exoplayer2.source.smoothstreaming.DefaultSsChunkSource;
 import com.google.android.exoplayer2.source.smoothstreaming.SsMediaSource;
 import com.google.android.exoplayer2.upstream.DataSource;
@@ -46,17 +42,10 @@ public class PlayerDataSource {
     }
 
     public HlsMediaSource.Factory getLiveHlsMediaSourceFactory() {
-        final HlsMediaSource.Factory factory =
-                new HlsMediaSource.Factory(cachelessDataSourceFactory)
-                        .setAllowChunklessPreparation(true)
-                        .setLoadErrorHandlingPolicy(
-                                new DefaultLoadErrorHandlingPolicy(MANIFEST_MINIMUM_RETRY));
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            factory.setExtractorFactory(MediaParserHlsMediaChunkExtractor.FACTORY);
-        }
-
-        return factory;
+        return new HlsMediaSource.Factory(cachelessDataSourceFactory)
+                .setAllowChunklessPreparation(true)
+                .setLoadErrorHandlingPolicy(
+                        new DefaultLoadErrorHandlingPolicy(MANIFEST_MINIMUM_RETRY));
     }
 
     public DashMediaSource.Factory getLiveDashMediaSourceFactory() {
@@ -71,26 +60,11 @@ public class PlayerDataSource {
     private DefaultDashChunkSource.Factory getDefaultDashChunkSourceFactory(
             final DataSource.Factory dataSourceFactory
     ) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            return new DefaultDashChunkSource.Factory(
-                    MediaParserChunkExtractor.FACTORY,
-                    dataSourceFactory,
-                    1
-            );
-        }
-
         return new DefaultDashChunkSource.Factory(dataSourceFactory);
     }
 
     public HlsMediaSource.Factory getHlsMediaSourceFactory() {
-        final HlsMediaSource.Factory factory = new HlsMediaSource.Factory(cacheDataSourceFactory);
-
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
-            return factory;
-        }
-
-        // *** >= Android 11 / R / API 30 ***
-        return factory.setExtractorFactory(MediaParserHlsMediaChunkExtractor.FACTORY);
+        return new HlsMediaSource.Factory(cacheDataSourceFactory);
     }
 
     public DashMediaSource.Factory getDashMediaSourceFactory() {
@@ -101,18 +75,9 @@ public class PlayerDataSource {
     }
 
     public ProgressiveMediaSource.Factory getExtractorMediaSourceFactory() {
-        final ProgressiveMediaSource.Factory factory;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            factory = new ProgressiveMediaSource.Factory(
-                    cacheDataSourceFactory,
-                    MediaParserExtractorAdapter.FACTORY
-            );
-        } else {
-            factory = new ProgressiveMediaSource.Factory(cacheDataSourceFactory);
-        }
-
-        return factory.setLoadErrorHandlingPolicy(
-                new DefaultLoadErrorHandlingPolicy(EXTRACTOR_MINIMUM_RETRY));
+        return new ProgressiveMediaSource.Factory(cacheDataSourceFactory)
+                .setLoadErrorHandlingPolicy(
+                        new DefaultLoadErrorHandlingPolicy(EXTRACTOR_MINIMUM_RETRY));
     }
 
     public SingleSampleMediaSource.Factory getSampleMediaSourceFactory() {


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
* Reverts some of the changes done in #7005 as on Android 11+ the playback fails to resume after buffering.
* Removed the use of ``MediaParser``
* Further description is available here:
  * https://github.com/TeamNewPipe/NewPipe/issues/7529#issuecomment-997448814
  * https://github.com/TeamNewPipe/NewPipe/issues/7529#issuecomment-998013182

#### Fixes the following issue(s)
- Fixes #7529

#### APK testing 
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
