### PR TITLE
Fixes view of sub-channel icon when not in use

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -1648,6 +1648,11 @@ public final class VideoDetailFragment
         binding.detailSubChannelTextView.setVisibility(View.VISIBLE);
         binding.detailSubChannelTextView.setSelected(true);
         binding.detailUploaderTextView.setVisibility(View.GONE);
+
+        //No sub-channel name implies no sub-channel icon, but check just to make sure.
+        if(isEmpty(info.getSubChannelAvatarUrl())){
+            binding.detailSubChannelThumbnailView.setVisibility(View.GONE);
+        }
     }
 
     private void displayBothUploaderAndSubChannel(final StreamInfo info) {

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -1521,6 +1521,8 @@ public final class VideoDetailFragment
         animate(binding.detailThumbnailPlayButton, true, 200);
         binding.detailVideoTitleView.setText(title);
 
+        binding.detailSubChannelThumbnailView.setVisibility(View.GONE);
+
         if (!isEmpty(info.getSubChannelName())) {
             displayBothUploaderAndSubChannel(info);
         } else if (!isEmpty(info.getUploaderName())) {
@@ -1648,11 +1650,6 @@ public final class VideoDetailFragment
         binding.detailSubChannelTextView.setVisibility(View.VISIBLE);
         binding.detailSubChannelTextView.setSelected(true);
         binding.detailUploaderTextView.setVisibility(View.GONE);
-
-        //No sub-channel name implies no sub-channel icon, but check just to make sure.
-        if (isEmpty(info.getSubChannelAvatarUrl())) {
-            binding.detailSubChannelThumbnailView.setVisibility(View.GONE);
-        }
     }
 
     private void displayBothUploaderAndSubChannel(final StreamInfo info) {

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -1650,7 +1650,7 @@ public final class VideoDetailFragment
         binding.detailUploaderTextView.setVisibility(View.GONE);
 
         //No sub-channel name implies no sub-channel icon, but check just to make sure.
-        if(isEmpty(info.getSubChannelAvatarUrl())){
+        if (isEmpty(info.getSubChannelAvatarUrl())) {
             binding.detailSubChannelThumbnailView.setVisibility(View.GONE);
         }
     }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
Removes a blank sub-channel icon if you watch a Peertube video and then a non-PeerTube video after.
- Does not remove the icon if you watch a PeerTube video with a channel that does not have a sub-channel icon, to avoid confusion

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->

- Before:
https://peertube.co.uk/videos/watch/8afb877a-9f14-4178-b9fb-a0e0c6bfa215
At the end in the bottom right corner of the YouTube creator icon, the app still tries to show you the sub-channel icon like it would in PeerTube. This is because whey you load up a video it only checks whether it needs to create the icon for a video and never if it needs to be hidden.

- After:
https://peertube.co.uk/videos/watch/e778dfb5-0bbf-4997-a02d-c8ccb241230b 
At the end in the bottom right corner of the YouTube creator icon, the app no longer tries to show you the sub-channel icon.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #7557 

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
