### PR TITLE
Fixed search not accepting key input after closing player overlay

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -2208,6 +2208,7 @@ public final class VideoDetailFragment
             ((ViewGroup) requireView()).setDescendantFocusability(blockDescendants);
             // Only focus the mainFragment if the mainFragment (e.g. search-results)
             // or the toolbar (e.g. Textfield for search) don't have focus.
+            // This was done to fix problems with the keyboard input, see also #7490
             if (!mainFragment.hasFocus() && !toolbar.hasFocus()) {
                 mainFragment.requestFocus();
             }

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -2206,12 +2206,19 @@ public final class VideoDetailFragment
             mainFragment.setDescendantFocusability(afterDescendants);
             toolbar.setDescendantFocusability(afterDescendants);
             ((ViewGroup) requireView()).setDescendantFocusability(blockDescendants);
-            mainFragment.requestFocus();
+            // Check if the mainFragment (search-results) or the toolbar (Textfield for search)
+            // have focus. If so then don't focus them again.
+            if (!mainFragment.hasFocus() && !toolbar.hasFocus()) {
+                mainFragment.requestFocus();
+            }
         } else {
             mainFragment.setDescendantFocusability(blockDescendants);
             toolbar.setDescendantFocusability(blockDescendants);
             ((ViewGroup) requireView()).setDescendantFocusability(afterDescendants);
-            binding.detailThumbnailRootLayout.requestFocus();
+            // Check if the player already has focus. If so don't focus again.
+            if (!binding.getRoot().hasFocus()) {
+                binding.detailThumbnailRootLayout.requestFocus();
+            }
         }
     }
 

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -2206,8 +2206,8 @@ public final class VideoDetailFragment
             mainFragment.setDescendantFocusability(afterDescendants);
             toolbar.setDescendantFocusability(afterDescendants);
             ((ViewGroup) requireView()).setDescendantFocusability(blockDescendants);
-            // Check if the mainFragment (search-results) or the toolbar (Textfield for search)
-            // have focus. If so then don't focus them again.
+            // Only focus the mainFragment if the mainFragment (e.g. search-results)
+            // or the toolbar (e.g. Textfield for search) don't have focus.
             if (!mainFragment.hasFocus() && !toolbar.hasFocus()) {
                 mainFragment.requestFocus();
             }
@@ -2215,7 +2215,7 @@ public final class VideoDetailFragment
             mainFragment.setDescendantFocusability(blockDescendants);
             toolbar.setDescendantFocusability(blockDescendants);
             ((ViewGroup) requireView()).setDescendantFocusability(afterDescendants);
-            // Check if the player already has focus. If so don't focus again.
+            // Only focus the player if it not already has focus
             if (!binding.getRoot().hasFocus()) {
                 binding.detailThumbnailRootLayout.requestFocus();
             }


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Supersedes #7592

Fixes the problem by checking if the corresponding views have focus and only focuses them if that's not the case.

If this should still cause problems we can also limit the method call to Android TV devices.

#### Before/After Screenshots/Screen Record
- Before: 
See #7592
- After:

https://user-images.githubusercontent.com/40789489/147854501-00ebefb4-bc99-4ab4-82ee-239e2dd162be.mp4


#### Fixes the following issue(s)
- Fixes #7490

#### APK testing 
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
