### PR TITLE
Added loading of items when the view can't be scrolled

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
@@ -328,6 +328,7 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
             public void onScrolledDown(final RecyclerView recyclerView) {
                 onScrollToBottom();
             }
+
             @Override
             public void onScrolled(final RecyclerView recyclerView, final int dx, final int dy) {
                 super.onScrolled(recyclerView, dx, dy);

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
@@ -328,6 +328,16 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
             public void onScrolledDown(final RecyclerView recyclerView) {
                 onScrollToBottom();
             }
+            @Override
+            public void onScrolled(final RecyclerView recyclerView, final int dx, final int dy) {
+                super.onScrolled(recyclerView, dx, dy);
+
+                if (!recyclerView.canScrollVertically(1)
+                        && !recyclerView.canScrollVertically(-1)
+                        && hasMoreItems() && !isLoading.get()) {
+                    loadMoreItems();
+                }
+            }
         });
     }
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Added loading of items when scrolling isn't possible for classes implementing BaseListFragment class.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #1974

#### Relies on the following changes
<!-- Delete this if it doesn't apply to your PR. -->

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->

Comment: 
- I ran into the bug #4475 several times when I was testing the grid view on a tablet emulator. I just wanted to make you aware of that. 

- I didn't know how to test the local list 
#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
