### PR TITLE
Workaround: Set recovery before switching player

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -1098,6 +1098,11 @@ public final class VideoDetailFragment
 
         toggleFullscreenIfInFullscreenMode();
 
+        if (isPlayerAvailable()) {
+            // FIXME Workaround #7427
+            player.setRecovery();
+        }
+
         if (!useExternalAudioPlayer) {
             openNormalBackgroundPlayer(append);
         } else {
@@ -1114,6 +1119,9 @@ public final class VideoDetailFragment
         // See UI changes while remote playQueue changes
         if (!isPlayerAvailable()) {
             playerHolder.startService(false, this);
+        } else {
+            // FIXME Workaround #7427
+            player.setRecovery();
         }
 
         toggleFullscreenIfInFullscreenMode();

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -635,6 +635,7 @@ public final class Player implements
         final boolean isMuted = intent.getBooleanExtra(IS_MUTED, isMuted());
 
         /*
+         * TODO As seen in #7427 this does not work:
          * There are 3 situations when playback shouldn't be started from scratch (zero timestamp):
          * 1. User pressed on a timestamp link and the same video should be rewound to the timestamp
          * 2. User changed a player from, for example. main to popup, or from audio to main, etc


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Quick and dirty fix for #7427:
Calls ``setRecovery`` before switching the player.

See also https://github.com/TeamNewPipe/NewPipe/issues/7427#issuecomment-1014852363

#### Fixes the following issue(s)
- Fixes #7427 
⚠️ Please reopen the issue when merging as this is only a workaround or notify @litetex that he creates a followup issue

#### APK testing 
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
