### PR TITLE
Make SearchHistoryEntry.kt fields nullable to match java version

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/database/history/model/SearchHistoryEntry.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/history/model/SearchHistoryEntry.kt
@@ -12,11 +12,11 @@ import java.time.OffsetDateTime
     indices = [Index(value = [SearchHistoryEntry.SEARCH])]
 )
 data class SearchHistoryEntry(
-    @field:ColumnInfo(name = CREATION_DATE) var creationDate: OffsetDateTime,
+    @field:ColumnInfo(name = CREATION_DATE) var creationDate: OffsetDateTime?,
     @field:ColumnInfo(
         name = SERVICE_ID
     ) var serviceId: Int,
-    @field:ColumnInfo(name = SEARCH) var search: String
+    @field:ColumnInfo(name = SEARCH) var search: String?
 ) {
     @ColumnInfo(name = ID)
     @PrimaryKey(autoGenerate = true)


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
Make SearchHistoryEntry.kt fields nullable to match java version.

I won't and don't want to question whether the nullability makes sense.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- https://github.com/TeamNewPipe/NewPipe/pull/7654#issuecomment-1018125221

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
