### PR TITLE
Fix first item always played in the play queue when reloading play queue manager

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -2048,7 +2048,7 @@ public final class Player implements
         if (currentState == STATE_BLOCKED) {
             changeState(STATE_BUFFERING);
         }
-        simpleExoPlayer.setMediaSource(mediaSource);
+        simpleExoPlayer.setMediaSource(mediaSource, false);
         simpleExoPlayer.prepare();
     }
 


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)

#### Description of the changes in your PR

This PR fixes the playback of the first item in the play queue when a resolution (when switching the quality played in the quality selector) or a player type change occurs (for e.g. switching from background to main player), when playing another item than the first one of the play queue.

The issue was caused by an ExoPlayer change, which when setting a new media source, resets now the current playback position and the current window index to the first item and its default position by default (the position was then set with the first item's recovery position).

It sets now to ExoPlayer to not reset the position when setting a new media source.

#### Fixes the following issue(s)
- Fixes #7531

#### APK testing 
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).