### PR TITLE
Fix crash when long-pressing stream while player is starting

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
@@ -352,7 +352,7 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
         }
         final List<StreamDialogEntry> entries = new ArrayList<>();
 
-        if (PlayerHolder.getInstance().isPlayerOpen()) {
+        if (PlayerHolder.getInstance().isPlayQueueReady()) {
             entries.add(StreamDialogEntry.enqueue);
 
             if (PlayerHolder.getInstance().getQueueSize() > 1) {

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
@@ -149,7 +149,7 @@ public class PlaylistFragment extends BaseListInfoFragment<PlaylistInfo> {
 
         final ArrayList<StreamDialogEntry> entries = new ArrayList<>();
 
-        if (PlayerHolder.getInstance().isPlayerOpen()) {
+        if (PlayerHolder.getInstance().isPlayQueueReady()) {
             entries.add(StreamDialogEntry.enqueue);
 
             if (PlayerHolder.getInstance().getQueueSize() > 1) {

--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
@@ -362,7 +362,7 @@ class FeedFragment : BaseStateFragment<FeedState>() {
         if (context == null || context.resources == null || activity == null) return
 
         val entries = ArrayList<StreamDialogEntry>()
-        if (PlayerHolder.getInstance().isPlayerOpen) {
+        if (PlayerHolder.getInstance().isPlayQueueReady) {
             entries.add(StreamDialogEntry.enqueue)
 
             if (PlayerHolder.getInstance().queueSize > 1) {

--- a/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
@@ -338,7 +338,7 @@ public class StatisticsPlaylistFragment
 
         final ArrayList<StreamDialogEntry> entries = new ArrayList<>();
 
-        if (PlayerHolder.getInstance().isPlayerOpen()) {
+        if (PlayerHolder.getInstance().isPlayQueueReady()) {
             entries.add(StreamDialogEntry.enqueue);
 
             if (PlayerHolder.getInstance().getQueueSize() > 1) {

--- a/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
@@ -753,7 +753,7 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
 
         final ArrayList<StreamDialogEntry> entries = new ArrayList<>();
 
-        if (PlayerHolder.getInstance().isPlayerOpen()) {
+        if (PlayerHolder.getInstance().isPlayQueueReady()) {
             entries.add(StreamDialogEntry.enqueue);
 
             if (PlayerHolder.getInstance().getQueueSize() > 1) {

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -260,7 +260,8 @@ public final class Player implements
     // Playback
     //////////////////////////////////////////////////////////////////////////*/
 
-    private PlayQueue playQueue;
+    // play queue might be null e.g. while player is starting
+    @Nullable private PlayQueue playQueue;
     private PlayQueueAdapter playQueueAdapter;
     private StreamSegmentAdapter segmentAdapter;
 
@@ -4202,6 +4203,7 @@ public final class Player implements
     }
 
 
+    @Nullable
     public PlayQueue getPlayQueue() {
         return playQueue;
     }

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHolder.java
@@ -70,6 +70,15 @@ public final class PlayerHolder {
         return player != null;
     }
 
+    /**
+     * Use this method to only allow the user to manipulate the play queue (e.g. by enqueueing via
+     * the stream long press menu) when there actually is a play queue to manipulate.
+     * @return true only if the player is open and its play queue is ready (i.e. it is not null)
+     */
+    public boolean isPlayQueueReady() {
+        return player != null && player.getPlayQueue() != null;
+    }
+
     public boolean isBound() {
         return bound;
     }

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHolder.java
@@ -38,12 +38,12 @@ public final class PlayerHolder {
     private static final boolean DEBUG = MainActivity.DEBUG;
     private static final String TAG = PlayerHolder.class.getSimpleName();
 
-    private PlayerServiceExtendedEventListener listener;
+    @Nullable private PlayerServiceExtendedEventListener listener;
 
     private final PlayerServiceConnection serviceConnection = new PlayerServiceConnection();
     private boolean bound;
-    private MainPlayer playerService;
-    private Player player;
+    @Nullable private MainPlayer playerService;
+    @Nullable private Player player;
 
     /**
      * Returns the current {@link MainPlayer.PlayerType} of the {@link MainPlayer} service,
@@ -75,7 +75,11 @@ public final class PlayerHolder {
     }
 
     public int getQueueSize() {
-        return isPlayerOpen() ? player.getPlayQueue().size() : 0;
+        if (player == null || player.getPlayQueue() == null) {
+            // player play queue might be null e.g. while player is starting
+            return 0;
+        }
+        return player.getPlayQueue().size();
     }
 
     public void setListener(@Nullable final PlayerServiceExtendedEventListener newListener) {


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This PR fixes a NullPointerException in `PlayerHolder.getQueueSize()` that could happen when the player's queue is `null`, i.e. when the player is starting. It also adds `@Nullable` here and there so that Android Studio's linter reports risks of NPEs.
I think this PR should be merged before the next release as it's just adding an `if (... != null)` but solves a big issue.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #7608
- Fixes #7528 
- Fixes #7305
- And many other duplicates

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
