### PR TITLE
Add changelog for NewPipe 0.22.0 (983)

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/983.txt
+++ b/fastlane/metadata/android/en-US/changelogs/983.txt
@@ -1,0 +1,9 @@
+New fast forward / rewind behaviour
+Made settings searchable
+Highlight pinned comments as such
+Added FSFE PeerTube instance to URL opener
+Improved error reporting and new error notification
+Fixed first item always played in the play queue when reloading play queue manager
+Wait longer for server to provide livestream parts before failing
+Fixed order of local search results
+Fixed empty fields in play queue by loading full stream info if needed

--- a/fastlane/metadata/android/en-US/changelogs/983.txt
+++ b/fastlane/metadata/android/en-US/changelogs/983.txt
@@ -1,9 +1,9 @@
-New fast forward / rewind behaviour
-Made settings searchable
-Highlight pinned comments as such
-Added FSFE PeerTube instance to URL opener
-Improved error reporting and new error notification
-Fixed first item always played in the play queue when reloading play queue manager
-Wait longer for server to provide livestream parts before failing
-Fixed order of local search results
-Fixed empty fields in play queue by loading full stream info if needed
+New double-tap-to-seek UI and behaviour
+Searchable settings
+Pinned comments
+Open-with-app support for FSFE's PeerTube instance
+Error notifications
+Replay of first queue item on player change fixed
+Longer wait when buffering during livestreams before failing
+Order of local search results fixed
+Empty item fields in play queue fixed

--- a/fastlane/metadata/android/en-US/changelogs/983.txt
+++ b/fastlane/metadata/android/en-US/changelogs/983.txt
@@ -1,9 +1,9 @@
-New double-tap-to-seek UI and behaviour
-Searchable settings
-Pinned comments
-Open-with-app support for FSFE's PeerTube instance
-Error notifications
-Replay of first queue item on player change fixed
-Longer wait when buffering during livestreams before failing
-Order of local search results fixed
-Empty item fields in play queue fixed
+Add new double-tap-to-seek UI and behaviour
+Make settings searchable
+Highlight pinned comments as such
+Add open-with-app support for FSFE's PeerTube instance
+Add error notifications
+Fix replay of first queue item on player change
+Wait longer when buffering during livestreams before failing
+Fix order of local search results
+Fix empty item fields in play queue


### PR DESCRIPTION
Adds the changelog for the upcoming 0.22.0 version.
This enables the translators on Weblate to work on localizations before the new version is published