### PR TITLE
Set workaround for playback position reset when switching to main player with content thumbnail

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -500,6 +500,10 @@ public final class VideoDetailFragment
                 break;
             case R.id.detail_thumbnail_root_layout:
                 autoPlayEnabled = true; // forcefully start playing
+                // FIXME Workaround #7427
+                if (isPlayerAvailable()) {
+                    player.setRecovery();
+                }
                 openVideoPlayerAutoFullscreen();
                 break;
             case R.id.detail_title_root_layout:


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)

#### Description of the changes in your PR
The workaround set with #7668 was not applied when switching to main player with content thumbnail from popup or background player. This PR fixes this by applying the workaround when switching to main player with content thumbnail from popup or background player.

#### Fixes the following issue(s)
- Fixes https://github.com/TeamNewPipe/NewPipe/issues/7427#issuecomment-985465982

#### APK testing 
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).