### PR TITLE
Use the correct app language when searching in the settings

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/settings/SettingsActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/SettingsActivity.java
@@ -2,6 +2,7 @@ package org.schabi.newpipe.settings;
 
 import static org.schabi.newpipe.util.Localization.assureCorrectAppLanguage;
 
+import android.content.Context;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Log;
@@ -228,7 +229,9 @@ public class SettingsActivity extends AppCompatActivity implements
 
 
         // Build search items
-        final PreferenceParser parser = new PreferenceParser(getApplicationContext(), config);
+        final Context searchContext = getApplicationContext();
+        assureCorrectAppLanguage(searchContext);
+        final PreferenceParser parser = new PreferenceParser(searchContext, config);
         final PreferenceSearcher searcher = new PreferenceSearcher(config);
 
         // Find all searchable SettingsResourceRegistry fragments


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
* When you currently search inside the settings (introduced #7586) you end up with results that are displayed in the phone's language. This PR fixes this bug by using the app language.

#### Before/After Screenshots/Screen Record
* Device language is ``en`` - English
* App language is ``de`` - German

| Before | After |
| --- | --- |
| ![grafik](https://user-images.githubusercontent.com/40789489/153661994-3bd21e23-8350-4215-93cf-d758c922ed66.png) | ![grafik](https://user-images.githubusercontent.com/40789489/153661552-9f96ca9c-92e5-428e-a16e-1e92cfce315d.png) |


#### APK testing 
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
