### PR TITLE
Fix fast seek overlay arc not correctly centered

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -572,14 +572,20 @@ public final class Player implements
         });
 
         // PlaybackControlRoot already consumed window insets but we should pass them to
-        // player_overlays too. Without it they will be off-centered
+        // player_overlays and fast_seek_overlay too. Without it they will be off-centered.
         binding.playbackControlRoot.addOnLayoutChangeListener(
-                (v, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom) ->
-                        binding.playerOverlays.setPadding(
-                                v.getPaddingLeft(),
-                                v.getPaddingTop(),
-                                v.getPaddingRight(),
-                                v.getPaddingBottom()));
+                (v, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom) -> {
+                    binding.playerOverlays.setPadding(
+                            v.getPaddingLeft(),
+                            v.getPaddingTop(),
+                            v.getPaddingRight(),
+                            v.getPaddingBottom());
+                    binding.fastSeekOverlay.setPadding(
+                            v.getPaddingLeft(),
+                            v.getPaddingTop(),
+                            v.getPaddingRight(),
+                            v.getPaddingBottom());
+                });
     }
 
     /**


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] **Regression** bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This PR makes sure that the fast seek overlay arcs share the same paddings as other controls (such as play-pause, brightness, volume, ...). The paddings are being set by the code and are "caused" by the system navigation bar. Play-pause, brightness, volume, ... buttons were correctly centered in the **app** UI (i.e. all of the screen excluding the navigation bar), while the fast seek overlay was centered in the **system** UI (i.e. the whole screen), causing a mismatch between the two that looked ugly, as seen in #7731. My way of fixing it might not be the best, as the arc is now not drawn under the system navigation bar anymore (see *After* screenshot below), but I just wanted to create a PR, I will try to improve it properly later today or tomorrow (though I think the current state is already acceptable).

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/40789489/153716380-9517bf29-b5cb-420c-bc0b-50d4299b74e0.png" height="300px"/> | <img src="https://user-images.githubusercontent.com/36421898/154686412-402f342e-5d1e-4bc3-a9a6-e3d202f91788.png" height="300px"/> |

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #7731

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
