### PR TITLE
Have fast seek overlay arc go under system ui

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -580,11 +580,17 @@ public final class Player implements
                             v.getPaddingTop(),
                             v.getPaddingRight(),
                             v.getPaddingBottom());
-                    binding.fastSeekOverlay.setPadding(
-                            v.getPaddingLeft(),
-                            v.getPaddingTop(),
-                            v.getPaddingRight(),
-                            v.getPaddingBottom());
+
+                    // If we added padding to the fast seek overlay, too, it would not go under the
+                    // system ui. Instead we apply negative margins equal to the window insets of
+                    // the opposite side, so that the view covers all of the player (overflowing on
+                    // some sides) and its center coincides with the center of other controls.
+                    final RelativeLayout.LayoutParams fastSeekParams = (RelativeLayout.LayoutParams)
+                            binding.fastSeekOverlay.getLayoutParams();
+                    fastSeekParams.leftMargin = -v.getPaddingRight();
+                    fastSeekParams.topMargin = -v.getPaddingBottom();
+                    fastSeekParams.rightMargin = -v.getPaddingLeft();
+                    fastSeekParams.bottomMargin = -v.getPaddingTop();
                 });
     }
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
In #7893 I added padding (equal to the window insets) to the fast seek overlay just as it was done with the player overlays (play-pause, brightness, ...). But as you can see in the "Before" screenshot below, that caused the fast-seek arc to not go under the system ui. This PR instead applies to the fast seek overlay negative margins, for each side respectively equal to minus the window inset of the opposite side. This way the view covers all of the player (overflowing on some sides, but that's not important) and its center still coincides with the center of other controls (which is a requirement, since we don't want #7731).

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/36421898/154686412-402f342e-5d1e-4bc3-a9a6-e3d202f91788.png" width="500px"/> <img src="https://user-images.githubusercontent.com/36421898/154796885-9b55988b-d4e4-4616-bb15-120b657f5732.png" width="500px"/> | <img src="https://user-images.githubusercontent.com/36421898/154796736-7d4e95af-12f8-43cb-87b1-ed7de1df9ea0.png" width="500px"/> <img src="https://user-images.githubusercontent.com/36421898/154796284-8049bbd4-3a71-4671-94b0-aba0c4fa0b46.png" width="500px"/> |

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
I tested on API 19 and API 30 and it worked fine.
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
