### PR TITLE
Solve Java warning "Raw use of parameterized class"

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
@@ -272,7 +272,7 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
             }
         });
 
-        infoListAdapter.setOnChannelSelectedListener(new OnClickGesture<ChannelInfoItem>() {
+        infoListAdapter.setOnChannelSelectedListener(new OnClickGesture<>() {
             @Override
             public void selected(final ChannelInfoItem selectedItem) {
                 try {
@@ -288,7 +288,7 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
             }
         });
 
-        infoListAdapter.setOnPlaylistSelectedListener(new OnClickGesture<PlaylistInfoItem>() {
+        infoListAdapter.setOnPlaylistSelectedListener(new OnClickGesture<>() {
             @Override
             public void selected(final PlaylistInfoItem selectedItem) {
                 try {

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListInfoFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListInfoFragment.java
@@ -9,6 +9,7 @@ import androidx.annotation.NonNull;
 
 import org.schabi.newpipe.error.ErrorInfo;
 import org.schabi.newpipe.error.UserAction;
+import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.ListExtractor;
 import org.schabi.newpipe.extractor.ListInfo;
 import org.schabi.newpipe.extractor.Page;
@@ -27,8 +28,8 @@ import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 
-public abstract class BaseListInfoFragment<I extends ListInfo>
-        extends BaseListFragment<I, ListExtractor.InfoItemsPage> {
+public abstract class BaseListInfoFragment<I extends InfoItem, L extends ListInfo<I>>
+        extends BaseListFragment<L, ListExtractor.InfoItemsPage<I>> {
     @State
     protected int serviceId = Constants.NO_SERVICE_ID;
     @State
@@ -37,7 +38,7 @@ public abstract class BaseListInfoFragment<I extends ListInfo>
     protected String url;
 
     private final UserAction errorUserAction;
-    protected I currentInfo;
+    protected L currentInfo;
     protected Page currentNextPage;
     protected Disposable currentWorker;
 
@@ -97,7 +98,7 @@ public abstract class BaseListInfoFragment<I extends ListInfo>
     @SuppressWarnings("unchecked")
     public void readFrom(@NonNull final Queue<Object> savedObjects) throws Exception {
         super.readFrom(savedObjects);
-        currentInfo = (I) savedObjects.poll();
+        currentInfo = (L) savedObjects.poll();
         currentNextPage = (Page) savedObjects.poll();
     }
 
@@ -124,7 +125,7 @@ public abstract class BaseListInfoFragment<I extends ListInfo>
      * @param forceLoad allow or disallow the result to come from the cache
      * @return Rx {@link Single} containing the {@link ListInfo}
      */
-    protected abstract Single<I> loadResult(boolean forceLoad);
+    protected abstract Single<L> loadResult(boolean forceLoad);
 
     @Override
     public void startLoading(final boolean forceLoad) {
@@ -140,7 +141,7 @@ public abstract class BaseListInfoFragment<I extends ListInfo>
         currentWorker = loadResult(forceLoad)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe((@NonNull I result) -> {
+                .subscribe((@NonNull L result) -> {
                     isLoading.set(false);
                     currentInfo = result;
                     currentNextPage = result.getNextPage();
@@ -157,7 +158,7 @@ public abstract class BaseListInfoFragment<I extends ListInfo>
      *
      * @return Rx {@link Single} containing the {@link ListExtractor.InfoItemsPage}
      */
-    protected abstract Single<ListExtractor.InfoItemsPage> loadMoreItemsLogic();
+    protected abstract Single<ListExtractor.InfoItemsPage<I>> loadMoreItemsLogic();
 
     @Override
     protected void loadMoreItems() {
@@ -194,7 +195,7 @@ public abstract class BaseListInfoFragment<I extends ListInfo>
     }
 
     @Override
-    public void handleNextItems(final ListExtractor.InfoItemsPage result) {
+    public void handleNextItems(final ListExtractor.InfoItemsPage<I> result) {
         super.handleNextItems(result);
 
         currentNextPage = result.getNextPage();
@@ -218,7 +219,7 @@ public abstract class BaseListInfoFragment<I extends ListInfo>
     //////////////////////////////////////////////////////////////////////////*/
 
     @Override
-    public void handleResult(@NonNull final I result) {
+    public void handleResult(@NonNull final L result) {
         super.handleResult(result);
 
         name = result.getName();

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
@@ -64,7 +64,7 @@ import io.reactivex.rxjava3.functions.Consumer;
 import io.reactivex.rxjava3.functions.Function;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 
-public class ChannelFragment extends BaseListInfoFragment<ChannelInfo>
+public class ChannelFragment extends BaseListInfoFragment<StreamInfoItem, ChannelInfo>
         implements View.OnClickListener {
 
     private static final int BUTTON_DEBOUNCE_INTERVAL = 100;
@@ -374,7 +374,7 @@ public class ChannelFragment extends BaseListInfoFragment<ChannelInfo>
     //////////////////////////////////////////////////////////////////////////*/
 
     @Override
-    protected Single<ListExtractor.InfoItemsPage> loadMoreItemsLogic() {
+    protected Single<ListExtractor.InfoItemsPage<StreamInfoItem>> loadMoreItemsLogic() {
         return ExtractorHelper.getMoreChannelItems(serviceId, url, currentNextPage);
     }
 

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/comments/CommentsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/comments/CommentsFragment.java
@@ -15,6 +15,7 @@ import org.schabi.newpipe.R;
 import org.schabi.newpipe.error.UserAction;
 import org.schabi.newpipe.extractor.ListExtractor;
 import org.schabi.newpipe.extractor.comments.CommentsInfo;
+import org.schabi.newpipe.extractor.comments.CommentsInfoItem;
 import org.schabi.newpipe.fragments.list.BaseListInfoFragment;
 import org.schabi.newpipe.ktx.ViewUtils;
 import org.schabi.newpipe.util.ExtractorHelper;
@@ -22,7 +23,7 @@ import org.schabi.newpipe.util.ExtractorHelper;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.disposables.CompositeDisposable;
 
-public class CommentsFragment extends BaseListInfoFragment<CommentsInfo> {
+public class CommentsFragment extends BaseListInfoFragment<CommentsInfoItem, CommentsInfo> {
     private final CompositeDisposable disposables = new CompositeDisposable();
 
     private TextView emptyStateDesc;
@@ -67,7 +68,7 @@ public class CommentsFragment extends BaseListInfoFragment<CommentsInfo> {
     //////////////////////////////////////////////////////////////////////////*/
 
     @Override
-    protected Single<ListExtractor.InfoItemsPage> loadMoreItemsLogic() {
+    protected Single<ListExtractor.InfoItemsPage<CommentsInfoItem>> loadMoreItemsLogic() {
         return ExtractorHelper.getMoreCommentItems(serviceId, currentInfo, currentNextPage);
     }
 

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/kiosk/KioskFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/kiosk/KioskFragment.java
@@ -21,6 +21,7 @@ import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.kiosk.KioskInfo;
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandlerFactory;
 import org.schabi.newpipe.extractor.localization.ContentCountry;
+import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.fragments.list.BaseListInfoFragment;
 import org.schabi.newpipe.util.ExtractorHelper;
 import org.schabi.newpipe.util.KioskTranslator;
@@ -53,7 +54,7 @@ import io.reactivex.rxjava3.core.Single;
  * </p>
  */
 
-public class KioskFragment extends BaseListInfoFragment<KioskInfo> {
+public class KioskFragment extends BaseListInfoFragment<StreamInfoItem, KioskInfo> {
     @State
     String kioskId = "";
     String kioskTranslatedName;
@@ -145,7 +146,7 @@ public class KioskFragment extends BaseListInfoFragment<KioskInfo> {
     }
 
     @Override
-    public Single<ListExtractor.InfoItemsPage> loadMoreItemsLogic() {
+    public Single<ListExtractor.InfoItemsPage<StreamInfoItem>> loadMoreItemsLogic() {
         return ExtractorHelper.getMoreKioskItems(serviceId, url, currentNextPage);
     }
 

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
@@ -64,7 +64,7 @@ import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.disposables.CompositeDisposable;
 import io.reactivex.rxjava3.disposables.Disposable;
 
-public class PlaylistFragment extends BaseListInfoFragment<PlaylistInfo> {
+public class PlaylistFragment extends BaseListInfoFragment<StreamInfoItem, PlaylistInfo> {
 
     private static final String PICASSO_PLAYLIST_TAG = "PICASSO_PLAYLIST_TAG";
 
@@ -249,7 +249,7 @@ public class PlaylistFragment extends BaseListInfoFragment<PlaylistInfo> {
     //////////////////////////////////////////////////////////////////////////*/
 
     @Override
-    protected Single<ListExtractor.InfoItemsPage> loadMoreItemsLogic() {
+    protected Single<ListExtractor.InfoItemsPage<StreamInfoItem>> loadMoreItemsLogic() {
         return ExtractorHelper.getMorePlaylistItems(serviceId, url, currentNextPage);
     }
 

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/videos/RelatedItemsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/videos/RelatedItemsFragment.java
@@ -15,6 +15,7 @@ import androidx.preference.PreferenceManager;
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.databinding.RelatedItemsHeaderBinding;
 import org.schabi.newpipe.error.UserAction;
+import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.ListExtractor;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.fragments.list.BaseListInfoFragment;
@@ -26,7 +27,7 @@ import java.util.function.Supplier;
 
 import io.reactivex.rxjava3.core.Single;
 
-public class RelatedItemsFragment extends BaseListInfoFragment<RelatedItemInfo>
+public class RelatedItemsFragment extends BaseListInfoFragment<InfoItem, RelatedItemInfo>
         implements SharedPreferences.OnSharedPreferenceChangeListener {
     private static final String INFO_KEY = "related_info_key";
 
@@ -86,7 +87,7 @@ public class RelatedItemsFragment extends BaseListInfoFragment<RelatedItemInfo>
     }
 
     @Override
-    protected Single<ListExtractor.InfoItemsPage> loadMoreItemsLogic() {
+    protected Single<ListExtractor.InfoItemsPage<InfoItem>> loadMoreItemsLogic() {
         return Single.fromCallable(ListExtractor.InfoItemsPage::emptyPage);
     }
 

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/services/ImportExportJsonHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/services/ImportExportJsonHelper.java
@@ -25,7 +25,6 @@ import com.grack.nanojson.JsonAppendableWriter;
 import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
 import com.grack.nanojson.JsonParser;
-import com.grack.nanojson.JsonSink;
 import com.grack.nanojson.JsonWriter;
 
 import org.schabi.newpipe.BuildConfig;
@@ -125,10 +124,11 @@ public final class ImportExportJsonHelper {
     /**
      * @see #writeTo(List, OutputStream, ImportExportEventListener)
      * @param items         the list of subscriptions items
-     * @param writer        the output {@link JsonSink}
+     * @param writer        the output {@link JsonAppendableWriter}
      * @param eventListener listener for the events generated
      */
-    public static void writeTo(final List<SubscriptionItem> items, final JsonSink writer,
+    public static void writeTo(final List<SubscriptionItem> items,
+                               final JsonAppendableWriter writer,
                                @Nullable final ImportExportEventListener eventListener) {
         if (eventListener != null) {
             eventListener.onSizeReceived(items.size());

--- a/app/src/main/java/org/schabi/newpipe/player/playqueue/AbstractInfoPlayQueue.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playqueue/AbstractInfoPlayQueue.java
@@ -17,7 +17,8 @@ import java.util.List;
 import io.reactivex.rxjava3.core.SingleObserver;
 import io.reactivex.rxjava3.disposables.Disposable;
 
-abstract class AbstractInfoPlayQueue<T extends ListInfo, U extends InfoItem> extends PlayQueue {
+abstract class AbstractInfoPlayQueue<T extends ListInfo<StreamInfoItem>, U extends InfoItem>
+        extends PlayQueue {
     boolean isInitial;
     private boolean isComplete;
 
@@ -51,7 +52,7 @@ abstract class AbstractInfoPlayQueue<T extends ListInfo, U extends InfoItem> ext
     }
 
     SingleObserver<T> getHeadListObserver() {
-        return new SingleObserver<T>() {
+        return new SingleObserver<>() {
             @Override
             public void onSubscribe(@NonNull final Disposable d) {
                 if (isComplete || !isInitial || (fetchReactor != null
@@ -85,8 +86,8 @@ abstract class AbstractInfoPlayQueue<T extends ListInfo, U extends InfoItem> ext
         };
     }
 
-    SingleObserver<ListExtractor.InfoItemsPage> getNextPageObserver() {
-        return new SingleObserver<ListExtractor.InfoItemsPage>() {
+    SingleObserver<ListExtractor.InfoItemsPage<StreamInfoItem>> getNextPageObserver() {
+        return new SingleObserver<>() {
             @Override
             public void onSubscribe(@NonNull final Disposable d) {
                 if (isComplete || isInitial || (fetchReactor != null
@@ -98,7 +99,8 @@ abstract class AbstractInfoPlayQueue<T extends ListInfo, U extends InfoItem> ext
             }
 
             @Override
-            public void onSuccess(@NonNull final ListExtractor.InfoItemsPage result) {
+            public void onSuccess(
+                    @NonNull final ListExtractor.InfoItemsPage<StreamInfoItem> result) {
                 if (!result.hasNextPage()) {
                     isComplete = true;
                 }
@@ -130,10 +132,8 @@ abstract class AbstractInfoPlayQueue<T extends ListInfo, U extends InfoItem> ext
 
     private static List<PlayQueueItem> extractListItems(final List<StreamInfoItem> infoItems) {
         final List<PlayQueueItem> result = new ArrayList<>();
-        for (final InfoItem stream : infoItems) {
-            if (stream instanceof StreamInfoItem) {
-                result.add(new PlayQueueItem((StreamInfoItem) stream));
-            }
+        for (final StreamInfoItem stream : infoItems) {
+            result.add(new PlayQueueItem(stream));
         }
         return result;
     }

--- a/app/src/main/java/org/schabi/newpipe/player/playqueue/AbstractInfoPlayQueue.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playqueue/AbstractInfoPlayQueue.java
@@ -9,8 +9,8 @@ import org.schabi.newpipe.extractor.ListInfo;
 import org.schabi.newpipe.extractor.Page;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import io.reactivex.rxjava3.core.SingleObserver;
 import io.reactivex.rxjava3.disposables.Disposable;
@@ -132,10 +132,6 @@ abstract class AbstractInfoPlayQueue<T extends ListInfo<StreamInfoItem>>
     }
 
     private static List<PlayQueueItem> extractListItems(final List<StreamInfoItem> infoItems) {
-        final List<PlayQueueItem> result = new ArrayList<>();
-        for (final StreamInfoItem stream : infoItems) {
-            result.add(new PlayQueueItem(stream));
-        }
-        return result;
+        return infoItems.stream().map(PlayQueueItem::new).collect(Collectors.toList());
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/player/playqueue/AbstractInfoPlayQueue.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playqueue/AbstractInfoPlayQueue.java
@@ -4,20 +4,18 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 
-import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.ListExtractor;
 import org.schabi.newpipe.extractor.ListInfo;
 import org.schabi.newpipe.extractor.Page;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import io.reactivex.rxjava3.core.SingleObserver;
 import io.reactivex.rxjava3.disposables.Disposable;
 
-abstract class AbstractInfoPlayQueue<T extends ListInfo<StreamInfoItem>, U extends InfoItem>
+abstract class AbstractInfoPlayQueue<T extends ListInfo<StreamInfoItem>>
         extends PlayQueue {
     boolean isInitial;
     private boolean isComplete;
@@ -28,12 +26,15 @@ abstract class AbstractInfoPlayQueue<T extends ListInfo<StreamInfoItem>, U exten
 
     private transient Disposable fetchReactor;
 
-    AbstractInfoPlayQueue(final U item) {
-        this(item.getServiceId(), item.getUrl(), null, Collections.emptyList(), 0);
+    protected AbstractInfoPlayQueue(final T info) {
+        this(info.getServiceId(), info.getUrl(), info.getNextPage(), info.getRelatedItems(), 0);
     }
 
-    AbstractInfoPlayQueue(final int serviceId, final String url, final Page nextPage,
-                          final List<StreamInfoItem> streams, final int index) {
+    protected AbstractInfoPlayQueue(final int serviceId,
+                                    final String url,
+                                    final Page nextPage,
+                                    final List<StreamInfoItem> streams,
+                                    final int index) {
         super(index, extractListItems(streams));
 
         this.baseUrl = url;

--- a/app/src/main/java/org/schabi/newpipe/player/playqueue/ChannelPlayQueue.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playqueue/ChannelPlayQueue.java
@@ -3,7 +3,6 @@ package org.schabi.newpipe.player.playqueue;
 
 import org.schabi.newpipe.extractor.Page;
 import org.schabi.newpipe.extractor.channel.ChannelInfo;
-import org.schabi.newpipe.extractor.channel.ChannelInfoItem;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.util.ExtractorHelper;
 
@@ -12,13 +11,10 @@ import java.util.List;
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 
-public final class ChannelPlayQueue extends AbstractInfoPlayQueue<ChannelInfo, ChannelInfoItem> {
-    public ChannelPlayQueue(final ChannelInfoItem item) {
-        super(item);
-    }
+public final class ChannelPlayQueue extends AbstractInfoPlayQueue<ChannelInfo> {
 
     public ChannelPlayQueue(final ChannelInfo info) {
-        this(info.getServiceId(), info.getUrl(), info.getNextPage(), info.getRelatedItems(), 0);
+        super(info);
     }
 
     public ChannelPlayQueue(final int serviceId,

--- a/app/src/main/java/org/schabi/newpipe/player/playqueue/PlaylistPlayQueue.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playqueue/PlaylistPlayQueue.java
@@ -2,7 +2,6 @@ package org.schabi.newpipe.player.playqueue;
 
 import org.schabi.newpipe.extractor.Page;
 import org.schabi.newpipe.extractor.playlist.PlaylistInfo;
-import org.schabi.newpipe.extractor.playlist.PlaylistInfoItem;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.util.ExtractorHelper;
 
@@ -11,13 +10,10 @@ import java.util.List;
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 
-public final class PlaylistPlayQueue extends AbstractInfoPlayQueue<PlaylistInfo, PlaylistInfoItem> {
-    public PlaylistPlayQueue(final PlaylistInfoItem item) {
-        super(item);
-    }
+public final class PlaylistPlayQueue extends AbstractInfoPlayQueue<PlaylistInfo> {
 
     public PlaylistPlayQueue(final PlaylistInfo info) {
-        this(info.getServiceId(), info.getUrl(), info.getNextPage(), info.getRelatedItems(), 0);
+        super(info);
     }
 
     public PlaylistPlayQueue(final int serviceId,

--- a/app/src/main/java/org/schabi/newpipe/settings/tabs/Tab.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/tabs/Tab.java
@@ -8,7 +8,7 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
 import com.grack.nanojson.JsonObject;
-import com.grack.nanojson.JsonSink;
+import com.grack.nanojson.JsonStringWriter;
 
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.database.LocalItem.LocalItemType;
@@ -132,7 +132,7 @@ public abstract class Tab {
     // JSON Handling
     //////////////////////////////////////////////////////////////////////////*/
 
-    public void writeJsonOn(final JsonSink jsonSink) {
+    public void writeJsonOn(final JsonStringWriter jsonSink) {
         jsonSink.object();
 
         jsonSink.value(JSON_TAB_ID_KEY, getTabId());
@@ -141,7 +141,7 @@ public abstract class Tab {
         jsonSink.end();
     }
 
-    protected void writeDataToJson(final JsonSink writerSink) {
+    protected void writeDataToJson(final JsonStringWriter writerSink) {
         // No-op
     }
 
@@ -355,7 +355,7 @@ public abstract class Tab {
         }
 
         @Override
-        protected void writeDataToJson(final JsonSink writerSink) {
+        protected void writeDataToJson(final JsonStringWriter writerSink) {
             writerSink.value(JSON_KIOSK_SERVICE_ID_KEY, kioskServiceId)
                     .value(JSON_KIOSK_ID_KEY, kioskId);
         }
@@ -437,7 +437,7 @@ public abstract class Tab {
         }
 
         @Override
-        protected void writeDataToJson(final JsonSink writerSink) {
+        protected void writeDataToJson(final JsonStringWriter writerSink) {
             writerSink.value(JSON_CHANNEL_SERVICE_ID_KEY, channelServiceId)
                     .value(JSON_CHANNEL_URL_KEY, channelUrl)
                     .value(JSON_CHANNEL_NAME_KEY, channelName);
@@ -584,7 +584,7 @@ public abstract class Tab {
         }
 
         @Override
-        protected void writeDataToJson(final JsonSink writerSink) {
+        protected void writeDataToJson(final JsonStringWriter writerSink) {
             writerSink.value(JSON_PLAYLIST_SERVICE_ID_KEY, playlistServiceId)
                     .value(JSON_PLAYLIST_URL_KEY, playlistUrl)
                     .value(JSON_PLAYLIST_NAME_KEY, playlistName)

--- a/app/src/main/java/org/schabi/newpipe/util/ExtractorHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ExtractorHelper.java
@@ -30,6 +30,7 @@ import androidx.preference.PreferenceManager;
 
 import org.schabi.newpipe.MainActivity;
 import org.schabi.newpipe.R;
+import org.schabi.newpipe.extractor.comments.CommentsInfoItem;
 import org.schabi.newpipe.util.external_communication.TextLinkifier;
 import org.schabi.newpipe.extractor.Info;
 import org.schabi.newpipe.extractor.InfoItem;
@@ -84,11 +85,12 @@ public final class ExtractorHelper {
                                 .fromQuery(searchString, contentFilter, sortFilter)));
     }
 
-    public static Single<InfoItemsPage> getMoreSearchItems(final int serviceId,
-                                                           final String searchString,
-                                                           final List<String> contentFilter,
-                                                           final String sortFilter,
-                                                           final Page page) {
+    public static Single<InfoItemsPage<InfoItem>> getMoreSearchItems(
+            final int serviceId,
+            final String searchString,
+            final List<String> contentFilter,
+            final String sortFilter,
+            final Page page) {
         checkServiceId(serviceId);
         return Single.fromCallable(() ->
                 SearchInfo.getMoreItems(NewPipe.getService(serviceId),
@@ -124,8 +126,9 @@ public final class ExtractorHelper {
                         ChannelInfo.getInfo(NewPipe.getService(serviceId), url)));
     }
 
-    public static Single<InfoItemsPage> getMoreChannelItems(final int serviceId, final String url,
-                                                            final Page nextPage) {
+    public static Single<InfoItemsPage<StreamInfoItem>> getMoreChannelItems(final int serviceId,
+                                                                            final String url,
+                                                                            final Page nextPage) {
         checkServiceId(serviceId);
         return Single.fromCallable(() ->
                 ChannelInfo.getMoreItems(NewPipe.getService(serviceId), url, nextPage));
@@ -155,15 +158,17 @@ public final class ExtractorHelper {
                         CommentsInfo.getInfo(NewPipe.getService(serviceId), url)));
     }
 
-    public static Single<InfoItemsPage> getMoreCommentItems(final int serviceId,
-                                                            final CommentsInfo info,
-                                                            final Page nextPage) {
+    public static Single<InfoItemsPage<CommentsInfoItem>> getMoreCommentItems(
+            final int serviceId,
+            final CommentsInfo info,
+            final Page nextPage) {
         checkServiceId(serviceId);
         return Single.fromCallable(() ->
                 CommentsInfo.getMoreItems(NewPipe.getService(serviceId), info, nextPage));
     }
 
-    public static Single<PlaylistInfo> getPlaylistInfo(final int serviceId, final String url,
+    public static Single<PlaylistInfo> getPlaylistInfo(final int serviceId,
+                                                       final String url,
                                                        final boolean forceLoad) {
         checkServiceId(serviceId);
         return checkCache(forceLoad, serviceId, url, InfoItem.InfoType.PLAYLIST,
@@ -171,8 +176,9 @@ public final class ExtractorHelper {
                         PlaylistInfo.getInfo(NewPipe.getService(serviceId), url)));
     }
 
-    public static Single<InfoItemsPage> getMorePlaylistItems(final int serviceId, final String url,
-                                                             final Page nextPage) {
+    public static Single<InfoItemsPage<StreamInfoItem>> getMorePlaylistItems(final int serviceId,
+                                                                             final String url,
+                                                                             final Page nextPage) {
         checkServiceId(serviceId);
         return Single.fromCallable(() ->
                 PlaylistInfo.getMoreItems(NewPipe.getService(serviceId), url, nextPage));
@@ -184,8 +190,9 @@ public final class ExtractorHelper {
                 Single.fromCallable(() -> KioskInfo.getInfo(NewPipe.getService(serviceId), url)));
     }
 
-    public static Single<InfoItemsPage> getMoreKioskItems(final int serviceId, final String url,
-                                                          final Page nextPage) {
+    public static Single<InfoItemsPage<StreamInfoItem>> getMoreKioskItems(final int serviceId,
+                                                                          final String url,
+                                                                          final Page nextPage) {
         return Single.fromCallable(() ->
                 KioskInfo.getMoreItems(NewPipe.getService(serviceId), url, nextPage));
     }

--- a/app/src/main/java/org/schabi/newpipe/util/SerializedCache.java
+++ b/app/src/main/java/org/schabi/newpipe/util/SerializedCache.java
@@ -19,7 +19,7 @@ public final class SerializedCache {
     private static final boolean DEBUG = MainActivity.DEBUG;
     private static final SerializedCache INSTANCE = new SerializedCache();
     private static final int MAX_ITEMS_ON_CACHE = 5;
-    private static final LruCache<String, CacheData> LRU_CACHE =
+    private static final LruCache<String, CacheData<?>> LRU_CACHE =
             new LruCache<>(MAX_ITEMS_ON_CACHE);
     private static final String TAG = "SerializedCache";
 
@@ -47,7 +47,7 @@ public final class SerializedCache {
             Log.d(TAG, "get() called with: key = [" + key + "]");
         }
         synchronized (LRU_CACHE) {
-            final CacheData data = LRU_CACHE.get(key);
+            final CacheData<?> data = LRU_CACHE.get(key);
             return data != null ? getItem(data, type) : null;
         }
     }
@@ -91,7 +91,7 @@ public final class SerializedCache {
     }
 
     @Nullable
-    private <T> T getItem(@NonNull final CacheData data, @NonNull final Class<T> type) {
+    private <T> T getItem(@NonNull final CacheData<?> data, @NonNull final Class<T> type) {
         return type.isAssignableFrom(data.type) ? type.cast(data.item) : null;
     }
 

--- a/app/src/main/java/org/schabi/newpipe/util/StreamItemAdapter.java
+++ b/app/src/main/java/org/schabi/newpipe/util/StreamItemAdapter.java
@@ -12,6 +12,7 @@ import android.widget.TextView;
 
 import org.schabi.newpipe.DownloaderImpl;
 import org.schabi.newpipe.R;
+import org.schabi.newpipe.extractor.MediaFormat;
 import org.schabi.newpipe.extractor.stream.AudioStream;
 import org.schabi.newpipe.extractor.stream.Stream;
 import org.schabi.newpipe.extractor.stream.SubtitlesStream;
@@ -137,7 +138,7 @@ public class StreamItemAdapter<T extends Stream, U extends Stream> extends BaseA
         }
 
         if (streamsWrapper.getSizeInBytes(position) > 0) {
-            final SecondaryStreamHelper secondary = secondaryStreams == null ? null
+            final SecondaryStreamHelper<U> secondary = secondaryStreams == null ? null
                     : secondaryStreams.get(position);
             if (secondary != null) {
                 final long size
@@ -153,16 +154,11 @@ public class StreamItemAdapter<T extends Stream, U extends Stream> extends BaseA
 
         if (stream instanceof SubtitlesStream) {
             formatNameView.setText(((SubtitlesStream) stream).getLanguageTag());
+        } else if (stream.getFormat() == MediaFormat.WEBMA_OPUS) {
+            // noinspection AndroidLintSetTextI18n
+            formatNameView.setText("opus");
         } else {
-            switch (stream.getFormat()) {
-                case WEBMA_OPUS:
-                    // noinspection AndroidLintSetTextI18n
-                    formatNameView.setText("opus");
-                    break;
-                default:
-                    formatNameView.setText(stream.getFormat().getName());
-                    break;
-            }
+            formatNameView.setText(stream.getFormat().getName());
         }
 
         qualityView.setText(qualityString);


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
I made sure there was no **raw** use of parameterized classes. Raw means without <> when the class requires it.
- Use `<?>` for `CacheData` since the cache map `LRU_CACHE` can contain items cache data of different types
- Replace raw use of `JsonSink` with the actual classes being passed to functions. This may decrease the generality of the functions having such items as parameters, since they would work for any `JsonSynk` but are actually only called with one type of `JsonSink` each time.  Maybe just using `JsonSink<?>` is better? (btw, the definition of `JsonSink` is recursive for some reason...: `public interface JsonSink<SELF extends JsonSink<SELF>>`)
- `BaseListInfoFragment` now has two parameters: the item type to be shown in the list (`I extends InfoItem`), and the list info type  (previously `I extends InfoItemsPage` without `<>`, now renamed to `L extends InfoItemsPage<I>`). This propagated to all subclasses and allowed solving problems in all of them.
- In `AbstractInfoPlayQueue` I turned the raw `ListInfo` in `ListInfo<StreamInfoItem>` (if you look at the class, it assumes the list info provides stream info items, and strange things were already being done to cast). I also removed an unused <> parameter `U` (no idea why that existed, its usage only in an unused constructor made no sense), refactored the constructors to deduplicate code for subclasses and refactored a method to use Java streams.
- In other places, I added the `<Type>` where it was missing
- I refactored some lines in `BaseListFragment` and `StreamItemAdapter`

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
