### PR TITLE
Mitigating long buffering on initial video playback

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerDataSource.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerDataSource.java
@@ -31,11 +31,13 @@ public class PlayerDataSource {
     private static final int MANIFEST_MINIMUM_RETRY = 5;
     private static final int EXTRACTOR_MINIMUM_RETRY = Integer.MAX_VALUE;
 
+    private final int continueLoadingCheckIntervalBytes;
     private final DataSource.Factory cacheDataSourceFactory;
     private final DataSource.Factory cachelessDataSourceFactory;
 
     public PlayerDataSource(@NonNull final Context context, @NonNull final String userAgent,
                             @NonNull final TransferListener transferListener) {
+        continueLoadingCheckIntervalBytes = PlayerHelper.getProgressiveLoadIntervalBytes(context);
         cacheDataSourceFactory = new CacheFactory(context, userAgent, transferListener);
         cachelessDataSourceFactory
                 = new DefaultDataSourceFactory(context, userAgent, transferListener);
@@ -91,6 +93,7 @@ public class PlayerDataSource {
 
     public ProgressiveMediaSource.Factory getExtractorMediaSourceFactory() {
         return new ProgressiveMediaSource.Factory(cacheDataSourceFactory)
+                .setContinueLoadingCheckIntervalBytes(continueLoadingCheckIntervalBytes)
                 .setLoadErrorHandlingPolicy(
                         new DefaultLoadErrorHandlingPolicy(EXTRACTOR_MINIMUM_RETRY));
     }

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
@@ -34,6 +34,7 @@ import androidx.preference.PreferenceManager;
 import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Player.RepeatMode;
 import com.google.android.exoplayer2.SeekParameters;
+import com.google.android.exoplayer2.source.ProgressiveMediaSource;
 import com.google.android.exoplayer2.trackselection.AdaptiveTrackSelection;
 import com.google.android.exoplayer2.trackselection.ExoTrackSelection;
 import com.google.android.exoplayer2.ui.AspectRatioFrameLayout;
@@ -389,6 +390,19 @@ public final class PlayerHelper {
         // 0: Screen orientation is locked
         return android.provider.Settings.System.getInt(
                 context.getContentResolver(), Settings.System.ACCELEROMETER_ROTATION, 0) == 0;
+    }
+
+    public static int getProgressiveLoadIntervalBytes(@NonNull final Context context) {
+        final String preferredIntervalBytes = getPreferences(context).getString(
+                context.getString(R.string.progressive_load_interval_key),
+                context.getString(R.string.progressive_load_interval_default_value));
+
+        if (context.getString(R.string.progressive_load_interval_default_value)
+                .equals(preferredIntervalBytes)) {
+            return ProgressiveMediaSource.DEFAULT_LOADING_CHECK_INTERVAL_BYTES;
+        }
+        // Keeping the same KiB unit used by ProgressiveMediaSource
+        return Integer.parseInt(preferredIntervalBytes) * 1024;
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -55,6 +55,23 @@
         <item>30000</item>
     </string-array>
 
+    <string name="progressive_load_interval_key">progressive_load_interval</string>
+    <string name="progressive_load_interval_default_value">default</string>
+    <string-array name="progressive_load_interval_descriptions">
+        <item>1 KiB</item>
+        <item>16 KiB</item>
+        <item>64 KiB</item>
+        <item>256 KiB</item>
+        <item>@string/progressive_load_interval_default</item>
+    </string-array>
+    <string-array name="progressive_load_interval_values">
+        <item>1</item>
+        <item>16</item>
+        <item>64</item>
+        <item>256</item>
+        <item>default</item>
+    </string-array>
+
     <string name="minimize_on_exit_key">minimize_on_exit_key</string>
     <string name="minimize_on_exit_value">@string/minimize_on_exit_background_key</string>
     <string name="minimize_on_exit_none_key">minimize_on_exit_none_key</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -78,6 +78,8 @@
     <string name="use_inexact_seek_title">Use fast inexact seek</string>
     <string name="use_inexact_seek_summary">Inexact seek allows the player to seek to positions faster with reduced precision. Seeking for 5, 15 or 25 seconds doesn\'t work with this</string>
     <string name="seek_duration_title">Fast-forward/-rewind seek duration</string>
+    <string name="progressive_load_interval_title">Playback load interval size</string>
+    <string name="progressive_load_interval_summary">Change the load interval size (currently at %s). A lower value may speed up initial video loading. Changes require a player restart.</string>
     <string name="clear_queue_confirmation_title">Ask for confirmation before clearing a queue</string>
     <string name="clear_queue_confirmation_summary">Switching from one player to another may replace your queue</string>
     <string name="clear_queue_confirmation_description">The active player queue will be replaced</string>
@@ -717,4 +719,6 @@
     <!-- Show Channel Details -->
     <string name="error_show_channel_details">Error at Show Channel Details</string>
     <string name="loading_channel_details">Loading Channel Details…</string>
+    <!-- Progressive Load Interval -->
+    <string name="progressive_load_interval_default">ExoPlayer default</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,7 +79,7 @@
     <string name="use_inexact_seek_summary">Inexact seek allows the player to seek to positions faster with reduced precision. Seeking for 5, 15 or 25 seconds doesn\'t work with this</string>
     <string name="seek_duration_title">Fast-forward/-rewind seek duration</string>
     <string name="progressive_load_interval_title">Playback load interval size</string>
-    <string name="progressive_load_interval_summary">Change the load interval size (currently at %s). A lower value may speed up initial video loading. Changes require a player restart.</string>
+    <string name="progressive_load_interval_summary">Change the load interval size (currently %s). A lower value may speed up initial video loading. Changes require a player restart.</string>
     <string name="clear_queue_confirmation_title">Ask for confirmation before clearing a queue</string>
     <string name="clear_queue_confirmation_summary">Switching from one player to another may replace your queue</string>
     <string name="clear_queue_confirmation_description">The active player queue will be replaced</string>

--- a/app/src/main/res/xml/video_audio_settings.xml
+++ b/app/src/main/res/xml/video_audio_settings.xml
@@ -61,6 +61,16 @@
         app:singleLineTitle="false"
         app:iconSpaceReserved="false" />
 
+    <ListPreference
+        android:defaultValue="@string/progressive_load_interval_default_value"
+        android:entries="@array/progressive_load_interval_descriptions"
+        android:entryValues="@array/progressive_load_interval_values"
+        android:key="@string/progressive_load_interval_key"
+        android:summary="@string/progressive_load_interval_summary"
+        android:title="@string/progressive_load_interval_title"
+        app:singleLineTitle="false"
+        app:iconSpaceReserved="false" />
+
     <PreferenceCategory
         android:layout="@layout/settings_category_header_layout"
         android:title="@string/settings_category_player_title"
@@ -203,16 +213,6 @@
             android:key="@string/seek_duration_key"
             android:summary="%s"
             android:title="@string/seek_duration_title"
-            app:singleLineTitle="false"
-            app:iconSpaceReserved="false" />
-
-        <ListPreference
-            android:defaultValue="@string/progressive_load_interval_default_value"
-            android:entries="@array/progressive_load_interval_descriptions"
-            android:entryValues="@array/progressive_load_interval_values"
-            android:key="@string/progressive_load_interval_key"
-            android:summary="@string/progressive_load_interval_summary"
-            android:title="@string/progressive_load_interval_title"
             app:singleLineTitle="false"
             app:iconSpaceReserved="false" />
 

--- a/app/src/main/res/xml/video_audio_settings.xml
+++ b/app/src/main/res/xml/video_audio_settings.xml
@@ -206,6 +206,16 @@
             app:singleLineTitle="false"
             app:iconSpaceReserved="false" />
 
+        <ListPreference
+            android:defaultValue="@string/progressive_load_interval_default_value"
+            android:entries="@array/progressive_load_interval_descriptions"
+            android:entryValues="@array/progressive_load_interval_values"
+            android:key="@string/progressive_load_interval_key"
+            android:summary="@string/progressive_load_interval_summary"
+            android:title="@string/progressive_load_interval_title"
+            app:singleLineTitle="false"
+            app:iconSpaceReserved="false" />
+
         <SwitchPreferenceCompat
             android:defaultValue="false"
             android:key="@string/clear_queue_confirmation_key"


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Hi team, long time no see. 
I've long since had issue with the buffering time when starting out a new video in the built-in player. Sometimes this gets so bad, there's a 10 seconds wait before any picture would even show up. Of course, your experience might differ depending on the phones, network conditions, or luck etc. 

After digging a bit, I found a `continueLoadingCheckIntervalBytes` parameter on ExoPlayer progressive media source that controls the size of data loaded per call from the playback loader. By default, ExoPlayer will load 1MB per call. Reducing this number seems to have solved the initial buffering woes on my side, though I have no idea how it affects other users. So if you have a similar issue with buffering under fast network speed, please give this a try and test extensively to see if it works and if lowering the values has any side effects.

#### Screenshots
<img src="https://user-images.githubusercontent.com/5570482/154877953-8695b6be-fb29-40b0-8a70-9e9db2ef2cb4.jpg" width="400" />

#### Fixes the following issue(s)
- Fixes #7630, #6927

#### APK testing 
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).