### PR TITLE
Replace `R.string.yes` with `R.string.ok`

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
@@ -350,7 +350,7 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
                 new AlertDialog.Builder(requireContext())
                         .setMessage(R.string.remove_watched_popup_warning)
                         .setTitle(R.string.remove_watched_popup_title)
-                        .setPositiveButton(R.string.yes,
+                        .setPositiveButton(R.string.ok,
                                 (DialogInterface d, int id) -> removeWatchedStreams(false))
                         .setNeutralButton(
                                 R.string.remove_watched_popup_yes_and_partially_watched_videos,

--- a/app/src/main/java/org/schabi/newpipe/settings/PeertubeInstanceListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/PeertubeInstanceListFragment.java
@@ -191,7 +191,7 @@ public class PeertubeInstanceListFragment extends Fragment {
                 .setTitle(R.string.restore_defaults)
                 .setMessage(R.string.restore_defaults_confirmation)
                 .setNegativeButton(R.string.cancel, null)
-                .setPositiveButton(R.string.yes, (dialog, which) -> {
+                .setPositiveButton(R.string.ok, (dialog, which) -> {
                     sharedPreferences.edit().remove(savedInstanceListKey).apply();
                     selectInstance(PeertubeInstance.defaultInstance);
                     updateInstanceList();

--- a/app/src/main/java/org/schabi/newpipe/settings/tabs/ChooseTabsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/tabs/ChooseTabsFragment.java
@@ -136,7 +136,7 @@ public class ChooseTabsFragment extends Fragment {
                 .setTitle(R.string.restore_defaults)
                 .setMessage(R.string.restore_defaults_confirmation)
                 .setNegativeButton(R.string.cancel, null)
-                .setPositiveButton(R.string.yes, (dialog, which) -> {
+                .setPositiveButton(R.string.ok, (dialog, which) -> {
                     tabsManager.resetTabs();
                     updateTabList();
                     selectedTabsAdapter.notifyDataSetChanged();

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -91,7 +91,6 @@
     <string name="show_age_restricted_content_title">محتوى مقيد للبالغين</string>
     <string name="duration_live">بث مباشر</string>
     <string name="error_report_title">تقرير عن المشكلة</string>
-    <string name="yes">نعم</string>
     <string name="disabled">متوقف</string>
     <string name="clear">تنظيف</string>
     <string name="best_resolution">أفضل دقة</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -169,7 +169,6 @@
     <string name="best_resolution">Ən yaxşı görüntü keyfiyyəti</string>
     <string name="clear">Təmizlə</string>
     <string name="disabled">Deaktiv edilib</string>
-    <string name="yes">Bəli</string>
     <string name="artists">İfaçılar</string>
     <string name="albums">Albomlar</string>
     <string name="songs">Mahnılar</string>

--- a/app/src/main/res/values-b+ast/strings.xml
+++ b/app/src/main/res/values-b+ast/strings.xml
@@ -44,7 +44,6 @@
     <string name="detail_dislikes_img_view_description">Tarrezmes</string>
     <string name="default_video_format_title">Formatu de videu predetermináu</string>
     <string name="black_theme_title">Prietu</string>
-    <string name="yes">Sí</string>
     <string name="short_thousand">mil</string>
     <string name="short_million">mill.</string>
     <string name="short_billion">mil mill.</string>

--- a/app/src/main/res/values-b+uz+Latn/strings.xml
+++ b/app/src/main/res/values-b+uz+Latn/strings.xml
@@ -112,7 +112,6 @@
     <string name="best_resolution">Eng yaxshi qaror</string>
     <string name="clear">Tozalash</string>
     <string name="disabled">Ijrochilar o\'chirib qo\'yilgan</string>
-    <string name="yes">Ha</string>
     <string name="artists">Artistlar</string>
     <string name="albums">Albomlar</string>
     <string name="songs">Qo\'shiqlar</string>

--- a/app/src/main/res/values-b+zh+HANS+CN/strings.xml
+++ b/app/src/main/res/values-b+zh+HANS+CN/strings.xml
@@ -28,7 +28,6 @@
     <string name="unsupported_url">不支持的 URL</string>
     <string name="settings_category_appearance_title">外观</string>
     <string name="all">全部</string>
-    <string name="yes">是</string>
     <string name="network_error">网络错误</string>
     <plurals name="videos">
         <item quantity="other">%s 个视频</item>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -97,7 +97,6 @@
     <string name="playlists">Плэйлісты</string>
     <string name="tracks">Дарожкі</string>
     <string name="users">Карыстальнікі</string>
-    <string name="yes">Так</string>
     <string name="disabled">Адключана</string>
     <string name="clear">Ачысціць</string>
     <string name="best_resolution">Лепшае разрозненне</string>

--- a/app/src/main/res/values-ber/strings.xml
+++ b/app/src/main/res/values-ber/strings.xml
@@ -56,7 +56,6 @@
     <string name="file">ⴰⴼⴰⵢⵍⵓ</string>
     <string name="play_all">ⵖⵔ ⵎⴰⵕⵕⴰ</string>
     <string name="file_deleted">ⵉⵜⵜⵡⴰⴽⴽⵙ ⵓⴼⴰⵢⵍⵓ</string>
-    <string name="yes">ⵢⴰⵀ</string>
     <string name="videos_string">ⵉⴼⵉⴷⵢⵓⵜⵏ</string>
     <string name="all">ⵎⴰⵕⵕⴰ</string>
     <string name="downloads_title">ⵓⴳⴳⴰⵎⵏ</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -75,7 +75,6 @@
     <string name="downloads_title">Изтегляния</string>
     <string name="error_report_title">Съобщение за грешка</string>
     <string name="all">Всички</string>
-    <string name="yes">Да</string>
     <string name="disabled">Забранено</string>
     <string name="clear">Изчисти</string>
     <string name="best_resolution">Най-добра резолюция</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -55,7 +55,6 @@
     <string name="downloads_title">ডাউনলোডগুলি</string>
     <string name="error_report_title">ত্রুটি প্রতিবেদন</string>
     <string name="all">সবগুলি</string>
-    <string name="yes">হ্যাঁ</string>
     <string name="disabled">নিস্ক্রীয়</string>
     <string name="clear">পরিষ্কার</string>
     <!-- error strings -->

--- a/app/src/main/res/values-bn-rIN/strings.xml
+++ b/app/src/main/res/values-bn-rIN/strings.xml
@@ -53,7 +53,6 @@
     <string name="always">সবসময়</string>
     <string name="clear">পরিষ্কার</string>
     <string name="disabled">নিস্ক্রীয়</string>
-    <string name="yes">হ্যাঁ</string>
     <string name="all">সবগুলি</string>
     <string name="error_report_title">ত্রুটি প্রতিবেদন</string>
     <string name="downloads_title">ডাউনলোডগুলি</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -176,7 +176,6 @@
     <string name="best_resolution">সেরা রেজুলিউসন</string>
     <string name="clear">পরিষ্কার</string>
     <string name="disabled">নিস্ক্রীয়</string>
-    <string name="yes">হ্যাঁ</string>
     <string name="artists">শিল্পীরা</string>
     <string name="albums">অ্যালবাম গুলি</string>
     <string name="songs">গান গুলি</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -37,7 +37,6 @@
     <string name="downloads">Baixades</string>
     <string name="downloads_title">Baixades</string>
     <string name="all">Tot</string>
-    <string name="yes">Sí</string>
     <string name="disabled">Desactivat</string>
     <string name="clear">Neteja</string>
     <string name="best_resolution">Millor resolució</string>

--- a/app/src/main/res/values-ckb/strings.xml
+++ b/app/src/main/res/values-ckb/strings.xml
@@ -101,7 +101,6 @@
     <string name="title_licenses">مۆڵەتنامەی لایەنی-سێیەم</string>
     <string name="app_license_title">مۆڵەتنامەی نیوپایپ</string>
     <string name="show_hold_to_append_title">پیشاندانی ڕێنمایی ”داگرتن تا پاشکۆ”</string>
-    <string name="yes">بەڵێ</string>
     <string name="msg_threads">دابەشکراوەکان</string>
     <string name="title_most_played">زۆرترین لێدراو</string>
     <string name="unbookmark_playlist">لادانی نیشانه‌كراو</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -84,7 +84,6 @@
     <string name="no_available_dir">Určete prosím složku pro stahování později v nastavení</string>
     <string name="info_labels">Co:\\nŽádost:\\nJazyk obsahu\\nZemě obsahu:\\nJazyk aplikace:\\nSlužba:\\nČas GMT:\\nBalíček:\\nVerze:\\nVerze OS:</string>
     <string name="all">Vše</string>
-    <string name="yes">Ano</string>
     <string name="short_thousand">tis.</string>
     <string name="open_in_popup_mode">Otevřít ve vyskakovacím okně</string>
     <string name="short_million">mil.</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -108,7 +108,6 @@
     </plurals>
     <string name="tracks">Numre</string>
     <string name="users">Brugere</string>
-    <string name="yes">Ja</string>
     <string name="disabled">Slået fra</string>
     <string name="clear">Slet</string>
     <string name="best_resolution">Bedste opløsning</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -88,7 +88,6 @@
     <string name="black_theme_title">Schwarz</string>
     <string name="title_activity_recaptcha">reCAPTCHA-Aufgabe</string>
     <string name="recaptcha_request_toast">reCAPTCHA-Aufgabe angefordert</string>
-    <string name="yes">Ja</string>
     <string name="all">Alle</string>
     <string name="disabled">Deaktiviert</string>
     <string name="open_in_popup_mode">Im Pop-up-Modus öffnen</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -52,7 +52,6 @@
     <string name="downloads">Λήψεις</string>
     <string name="downloads_title">Λήψεις</string>
     <string name="all">Όλα</string>
-    <string name="yes">Ναι</string>
     <string name="general_error">Σφάλμα</string>
     <string name="error_snackbar_action">Αναφορά</string>
     <string name="what_device_headline">Πληροφορίες:</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -95,7 +95,6 @@
         <item quantity="one">%s filmeto</item>
         <item quantity="other">%s filmetoj</item>
     </plurals>
-    <string name="yes">Jes</string>
     <string name="msg_popup_permission">Tiu permeso estas necesa por
 \nmalfermi en ŝprucfenestra modo</string>
     <string name="popup_playing_toast">Ludante en ŝprucfenestra modo</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -82,7 +82,6 @@
     <string name="info_labels">Lo sucedido:\\nPetición:\\nIdioma del contenido:\\nPaís del contenido:\\nIdioma de la aplicación:\\nServicio:\\nHora GMT:\\nPaquete:\\nVersión:\\nVersión del SO:</string>
     <string name="black_theme_title">Negro</string>
     <string name="all">Todo</string>
-    <string name="yes">Sí</string>
     <string name="short_thousand">k</string>
     <string name="short_million">M</string>
     <string name="short_billion">MM</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -93,7 +93,6 @@
     <string name="downloads_title">Allalaadimised</string>
     <string name="error_report_title">Vea teatamine</string>
     <string name="all">Kõik</string>
-    <string name="yes">Jah</string>
     <string name="disabled">Keelatud</string>
     <string name="clear">Kustuta</string>
     <string name="best_resolution">Parim lahutus</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -62,7 +62,6 @@
     <string name="downloads_title">Deskargak</string>
     <string name="error_report_title">Errore-txostena</string>
     <string name="all">Dena</string>
-    <string name="yes">Bai</string>
     <string name="disabled">Desgaituta</string>
     <string name="clear">Garbitu</string>
     <string name="best_resolution">Bereizmen onena</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -109,7 +109,6 @@
     <string name="channels">کانال‌ها</string>
     <string name="playlists">سیاهه‌های پخش</string>
     <string name="users">کاربران</string>
-    <string name="yes">بله</string>
     <string name="disabled">غیرفعال</string>
     <string name="clear">پاک‌کردن</string>
     <string name="play_all">پخش همه</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -73,7 +73,6 @@
     <string name="downloads_title">Lataukset</string>
     <string name="error_report_title">Virheraportti</string>
     <string name="all">Kaikki</string>
-    <string name="yes">Kyllä</string>
     <string name="disabled">Poistettu käytöstä</string>
     <string name="clear">Pyyhi</string>
     <string name="best_resolution">Paras resoluutio</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -86,7 +86,6 @@
     <string name="recaptcha_request_toast">Défi reCAPTCHA demandé</string>
     <string name="open_in_popup_mode">Ouvrir en mode pop-up</string>
     <string name="popup_playing_toast">Lecture en mode flottant</string>
-    <string name="yes">Oui</string>
     <string name="disabled">Désactivés</string>
     <string name="info_labels">Quoi :\\nRequest :\\nContent Language :\\nContent Country :\\nApp Language :\\nService :\\nGMT Time :\\nPackage :\\nVersion :\\nOS version :</string>
     <string name="short_thousand">k</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -96,7 +96,6 @@
     <string name="playlists">Listas de reprodución</string>
     <string name="tracks">Pistas</string>
     <string name="users">Usuarios</string>
-    <string name="yes">Si</string>
     <string name="disabled">Desactivado</string>
     <string name="clear">Limpar</string>
     <string name="best_resolution">Mellor resolución</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -58,7 +58,6 @@
     <string name="downloads_title">הורדות</string>
     <string name="error_report_title">דוח שגיאה</string>
     <string name="all">הכול</string>
-    <string name="yes">כן</string>
     <string name="disabled">מושבת</string>
     <string name="clear">ניקוי</string>
     <string name="general_error">שגיאה</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -90,7 +90,6 @@
     <string name="downloads_title">डाउनलोड</string>
     <string name="error_report_title">त्रुटी की रिपोर्ट</string>
     <string name="all">सारे</string>
-    <string name="yes">सहमत हूँ</string>
     <string name="disabled">बंद करे</string>
     <string name="clear">साफ़</string>
     <string name="best_resolution">बेहतर विडियो की क्वालिटी</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -71,7 +71,6 @@
     <string name="downloads_title">Preuzimanja</string>
     <string name="error_report_title">Prijavi grešku</string>
     <string name="all">Sve</string>
-    <string name="yes">Da</string>
     <string name="disabled">Isključeno</string>
     <string name="clear">Očisti</string>
     <string name="best_resolution">Najbolja rezolucija</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -111,7 +111,6 @@
     <string name="settings_category_debug_title">Hibaelhárítás</string>
     <string name="popup_playing_toast">Lejátszás felugró ablakban</string>
     <string name="all">Összes</string>
-    <string name="yes">Igen</string>
     <string name="disabled">Letiltva</string>
     <string name="clear">Törlés</string>
     <string name="best_resolution">Legjobb felbontás</string>

--- a/app/src/main/res/values-hy/strings.xml
+++ b/app/src/main/res/values-hy/strings.xml
@@ -65,7 +65,6 @@
     <string name="file_deleted">Ֆայլը ջնջվեց</string>
     <string name="file">Ֆայլ</string>
     <string name="songs">Երգեր</string>
-    <string name="yes">Այո</string>
     <string name="enable_search_history_title">Որոնման պատմություն</string>
     <string name="close">Փակել</string>
     <plurals name="days">

--- a/app/src/main/res/values-ia/strings.xml
+++ b/app/src/main/res/values-ia/strings.xml
@@ -85,7 +85,6 @@
     <string name="tracks">Pistas</string>
     <string name="users">Usatores</string>
     <string name="events">Eventos</string>
-    <string name="yes">Si</string>
     <string name="disabled">Disactivate</string>
     <string name="clear">Vacuar</string>
     <string name="best_resolution">Melior resolution</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -86,7 +86,6 @@
     <string name="short_thousand">r</string>
     <string name="short_million">J</string>
     <string name="short_billion">T</string>
-    <string name="yes">Ya</string>
     <string name="open_in_popup_mode">Buka dalam mode popup</string>
     <string name="msg_popup_permission">Izin ini dibutuhkan untuk
 \nmembuka di mode sembul</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -87,7 +87,6 @@
     <string name="short_million">M</string>
     <string name="short_billion">Mrd</string>
     <string name="recaptcha_request_toast">È richiesta la risoluzione del reCAPTCHA</string>
-    <string name="yes">Sì</string>
     <string name="open_in_popup_mode">Apri in modalità popup</string>
     <string name="popup_playing_toast">Riproduzione in modalità popup</string>
     <string name="disabled">Disattivato</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -87,7 +87,6 @@
     <string name="short_thousand">k</string>
     <string name="short_million">M</string>
     <string name="short_billion">B</string>
-    <string name="yes">はい</string>
     <string name="open_in_popup_mode">ポップアップモードで開く</string>
     <string name="msg_popup_permission">ポップアップモードで開くには
 \n権限の許可が必要です</string>

--- a/app/src/main/res/values-kab/strings.xml
+++ b/app/src/main/res/values-kab/strings.xml
@@ -30,7 +30,6 @@
     <string name="export_to">Sifeḍ ɣer</string>
     <string name="controls_add_to_playlist_title">Rnu ɣer</string>
     <string name="playback_step">Amecwaṛ</string>
-    <string name="yes">Ih</string>
     <string name="msg_running">Azdam n NewPipe</string>
     <string name="restore_defaults">Err-d imezwar</string>
     <string name="channel_created_by">Yerna-t %s</string>

--- a/app/src/main/res/values-kmr/strings.xml
+++ b/app/src/main/res/values-kmr/strings.xml
@@ -169,7 +169,6 @@
     <string name="app_license">NewPipe nermalava kopîleft libre ye: Hûn dikarin li gorî kêfa xwe bikar bînin, parve bikin û baştir bikin. Bi taybetî hûn dikarin wê di bin mercên Lîsansa Giştî ya GNU ya Giştî ya ku ji hêla Weqfa Nermalava Azad ve hatî weşandin de, an guhertoya 3 ya Lîsansê, an jî (li gorî vebijarka we) guhertoyek paşîn ji nû ve belav bikin û / an biguherînin.</string>
     <string name="clear">Zelal</string>
     <string name="disabled">Bêmecel</string>
-    <string name="yes">Erê</string>
     <string name="artists">Hunermend</string>
     <string name="albums">Album</string>
     <string name="songs">Stran</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -102,7 +102,6 @@
     <string name="popup_playing_toast">팝업 모드에서 재생 중</string>
     <string name="error_report_title">오류 보고</string>
     <string name="all">전부</string>
-    <string name="yes">네</string>
     <string name="disabled">해제됨</string>
     <string name="clear">지우기</string>
     <string name="best_resolution">최대 해상도</string>

--- a/app/src/main/res/values-ku/strings.xml
+++ b/app/src/main/res/values-ku/strings.xml
@@ -86,7 +86,6 @@
     <string name="downloads_title">دابەزاندنەکان</string>
     <string name="error_report_title">ناتوانرێ سکاڵابکرێ</string>
     <string name="all">گشتی</string>
-    <string name="yes">بەڵێ</string>
     <string name="disabled">ناکارایە</string>
     <string name="clear">پاککردنەوە</string>
     <string name="best_resolution">باشترین قەبارە</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -58,7 +58,6 @@
     <string name="downloads_title">Atsisiuntimai</string>
     <string name="error_report_title">Klaidų ataskaita</string>
     <string name="all">Visi</string>
-    <string name="yes">Taip</string>
     <string name="disabled">Išjungta</string>
     <string name="clear">Išvalyti</string>
     <string name="best_resolution">Geriausia raiška</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -236,7 +236,6 @@
     <string name="best_resolution">Labākā izšķirtspēja</string>
     <string name="clear">Notīrīt</string>
     <string name="disabled">Atspējots</string>
-    <string name="yes">Jā</string>
     <string name="artists">Mākslinieki</string>
     <string name="albums">Albūmi</string>
     <string name="songs">Dziesmas</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -93,7 +93,6 @@
     <string name="downloads_title">Превземања</string>
     <string name="error_report_title">Извештај за грешки</string>
     <string name="all">Сите</string>
-    <string name="yes">Да</string>
     <string name="disabled">Оневозможено</string>
     <string name="clear">Избриши</string>
     <string name="best_resolution">Најдобра резолуција</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -270,7 +270,6 @@
     <string name="best_resolution">മികച്ച റിസല്യൂഷൻ</string>
     <string name="clear">തെളിക്കുക</string>
     <string name="disabled">അസാധുവാക്കപ്പെട്ടു</string>
-    <string name="yes">അതെ</string>
     <string name="artists">കലാകാരന്മാർ</string>
     <string name="albums">ആൽബങ്ങൾ</string>
     <string name="songs">പാട്ടുകൾ</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -105,7 +105,6 @@
     <string name="tracks">Trek</string>
     <string name="users">Pengguna</string>
     <string name="events">Peristiwa</string>
-    <string name="yes">Ya</string>
     <string name="disabled">Dinyahdayakan</string>
     <string name="clear">Bersihkan</string>
     <string name="best_resolution">Resolusi terbaik</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -89,7 +89,6 @@
     <string name="black_theme_title">Svart</string>
     <string name="popup_playing_toast">Spiller av i oppsprettsmodus</string>
     <string name="all">Alle</string>
-    <string name="yes">Ja</string>
     <string name="disabled">Avskrudd</string>
     <string name="short_thousand">k</string>
     <string name="short_million">M</string>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -111,7 +111,6 @@
     <string name="tracks">ट्रयाकहरु</string>
     <string name="users">प्रयोगकर्ताहरु</string>
     <string name="events">घटनाहरू</string>
-    <string name="yes">हो</string>
     <string name="disabled">अक्षम</string>
     <string name="clear">स्पष्ट</string>
     <string name="best_resolution">सर्वश्रेष्ठ रेसोलुशन</string>

--- a/app/src/main/res/values-nl-rBE/strings.xml
+++ b/app/src/main/res/values-nl-rBE/strings.xml
@@ -93,7 +93,6 @@
     <string name="downloads_title">Downloads</string>
     <string name="error_report_title">Foutrapport</string>
     <string name="all">Alles</string>
-    <string name="yes">Ja</string>
     <string name="disabled">Uitgeschakeld</string>
     <string name="clear">Wissen</string>
     <string name="best_resolution">Beste resolutie</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -85,7 +85,6 @@
     <string name="recaptcha_request_toast">reCAPTCHA-uitdaging gevraagd</string>
     <string name="open_in_popup_mode">Openen in pop-upmodus</string>
     <string name="all">Alles</string>
-    <string name="yes">Ja</string>
     <string name="short_thousand">k</string>
     <string name="short_million">M</string>
     <string name="short_billion">B</string>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -92,7 +92,6 @@
     <string name="downloads_title">ਡਾਊਨਲੋਡਸ</string>
     <string name="error_report_title">Error ਰਿਪੋਰਟ</string>
     <string name="all">ਸਾਰੇ</string>
-    <string name="yes">ਹਾਂ</string>
     <string name="disabled">ਬੰਦ ਕੀਤਾ</string>
     <string name="clear">ਮਿਟਾਓ</string>
     <string name="best_resolution">ਵਧੀਆ Resolution</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -95,7 +95,6 @@
     <string name="show_search_suggestions_summary">Wybierz podpowiedzi, które będą wyświetlane podczas wyszukiwania</string>
     <string name="popup_playing_toast">Odtwarzanie w trybie okienkowym</string>
     <string name="all">Wszystkie</string>
-    <string name="yes">Tak</string>
     <string name="disabled">Wyłączone</string>
     <string name="clear">Wyczyść</string>
     <string name="short_thousand">tys.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -90,7 +90,6 @@
     <string name="default_video_format_title">Formato de vídeo padrão</string>
     <string name="popup_playing_toast">Reproduzindo em modo popup</string>
     <string name="all">Tudo</string>
-    <string name="yes">Sim</string>
     <string name="disabled">Desativado</string>
     <string name="short_thousand">k</string>
     <string name="short_million">M</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -395,7 +395,6 @@
     <string name="max_retry_msg">Tentativas máximas</string>
     <string name="title_activity_history">Histórico</string>
     <string name="playback_pitch">Velocidade</string>
-    <string name="yes">Sim</string>
     <string name="error_download_resource_gone">Não é possível recuperar esta descarga</string>
     <string name="rename_playlist">Mudar nome</string>
     <string name="feed_group_dialog_empty_selection">Nenhuma subscrição selecionada</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -83,7 +83,6 @@
     <string name="open_in_popup_mode">Abrir no modo popup</string>
     <string name="black_theme_title">Preto</string>
     <string name="all">Tudo</string>
-    <string name="yes">Sim</string>
     <string name="short_thousand">k</string>
     <string name="short_million">M</string>
     <string name="short_billion">MM</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -90,7 +90,6 @@
     <string name="black_theme_title">Negru</string>
     <string name="popup_playing_toast">Redare în mod pop-up</string>
     <string name="all">Toate</string>
-    <string name="yes">Da</string>
     <string name="disabled">Dezactivat</string>
     <string name="app_ui_crash">Aplicația/UI s-a oprit</string>
     <string name="info_labels">Ce:\\nSolicitare:\\nLimba conținutului:\\nȚara conținutului:\\nLimba aplicației:\\nServiciu:\\nOra GMT:\\nPachet:\\nVersiune: \\nVersiune SO:</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -86,7 +86,6 @@
     <string name="black_theme_title">Чёрная</string>
     <string name="popup_remember_size_pos_title">Помнить параметры окна</string>
     <string name="popup_playing_toast">Воспроизведение во всплывающем окне</string>
-    <string name="yes">Да</string>
     <string name="clear">Очистить</string>
     <string name="all">Всё</string>
     <string name="info_labels">Что:\\nЗапрос:\\nЯзык контента:\\nСтрана контента:\\nЯзык приложения:\\nСервис:\\nВремя по Гринвичу:\\nПакет:\\nВерсия пакета:\\nВерсия ОС:</string>

--- a/app/src/main/res/values-sc/strings.xml
+++ b/app/src/main/res/values-sc/strings.xml
@@ -415,7 +415,6 @@
     <string name="best_resolution">Risolutzione mègius</string>
     <string name="clear">Isbòida</string>
     <string name="disabled">Disabilitadu</string>
-    <string name="yes">Eja</string>
     <string name="artists">Artista</string>
     <string name="albums">Albums</string>
     <string name="songs">Cantzones</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -87,7 +87,6 @@
     <string name="short_million">M</string>
     <string name="short_billion">B</string>
     <string name="recaptcha_request_toast">Požiadavka reCAPTCHA</string>
-    <string name="yes">Áno</string>
     <string name="open_in_popup_mode">Spustiť v okne</string>
     <string name="msg_popup_permission">Tieto práva sú potrebné pre
 \nprehrávanie v mini okne</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -87,7 +87,6 @@
     <string name="short_thousand">k</string>
     <string name="short_million">mio</string>
     <string name="short_billion">mrd</string>
-    <string name="yes">Da</string>
     <string name="open_in_popup_mode">Odpri v pojavnem načinu</string>
     <string name="msg_popup_permission">To dovoljenje je potrebno za odpiranje 
 \nv pojavnem načinu</string>

--- a/app/src/main/res/values-so/strings.xml
+++ b/app/src/main/res/values-so/strings.xml
@@ -319,7 +319,6 @@
     <string name="duration_live">Toos</string>
     <string name="undo">Soo celi</string>
     <string name="disabled">Xidhan</string>
-    <string name="yes">Haa</string>
     <string name="users">Isticmaale</string>
     <string name="videos_string">Muuqaalo</string>
     <string name="all">Dhammaan</string>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -34,7 +34,6 @@
     <string name="downloads_title">Shkarkimet</string>
     <string name="error_report_title">Raporti i gabimit</string>
     <string name="all">Të gjitha</string>
-    <string name="yes">Po</string>
     <string name="missions_header_pending">Në pritje</string>
     <plurals name="feed_group_dialog_selection_count">
         <item quantity="one">%d i zgjedhur</item>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -87,7 +87,6 @@
     <string name="short_thousand">хиљ</string>
     <string name="short_million">мил</string>
     <string name="short_billion">млрд</string>
-    <string name="yes">Да</string>
     <string name="open_in_popup_mode">Отвори у искачућем режиму</string>
     <string name="msg_popup_permission">Ова дозвола је потребна за
 \nотварање у искачућем режиму</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -58,7 +58,6 @@
     <string name="downloads_title">Hämtningar</string>
     <string name="error_report_title">Felrapport</string>
     <string name="all">Alla</string>
-    <string name="yes">Ja</string>
     <string name="disabled">Inaktiverad</string>
     <string name="clear">Rensa</string>
     <string name="best_resolution">Bästa upplösningen</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -73,7 +73,6 @@
     <string name="all">அனைத்தும்</string>
     <string name="playlists">ஒளிச்சரங்கள்</string>
     <string name="users">பயனர்கள்</string>
-    <string name="yes">ஆம்</string>
     <string name="clear">அழி</string>
     <string name="always">எப்பொழுதும்</string>
     <string name="just_once">ஒரு முறை</string>

--- a/app/src/main/res/values-te/strings.xml
+++ b/app/src/main/res/values-te/strings.xml
@@ -52,7 +52,6 @@
     <string name="downloads_title">డౌన్ లోడ్</string>
     <string name="error_report_title">లోపం నివేదిక</string>
     <string name="all">అన్ని</string>
-    <string name="yes">అవును</string>
     <string name="play_all">అన్నింటినీ ప్లే చేయండి</string>
     <string name="notification_channel_name">న్యూప్యాప్ నోటిఫికేషన్</string>
     <string name="general_error">లోపం</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -104,7 +104,6 @@
     <string name="tracks">แทร็ค</string>
     <string name="users">ผู้ใช้</string>
     <string name="events">เหตุการณ์</string>
-    <string name="yes">ใช่</string>
     <string name="disabled">ปิดการใช้งาน</string>
     <string name="clear">ล้าง</string>
     <string name="best_resolution">ความละเอียดที่ดีที่สุด</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -86,7 +86,6 @@
     <string name="black_theme_title">Siyah</string>
     <string name="popup_playing_toast">Açılır pencere kipinde oynatılıyor</string>
     <string name="all">Tümü</string>
-    <string name="yes">Evet</string>
     <string name="disabled">Devre dışı</string>
     <string name="your_comment">Yorumunuz (İngilizce):</string>
     <string name="error_details_headline">Ayrıntılar:</string>

--- a/app/src/main/res/values-tzm/strings.xml
+++ b/app/src/main/res/values-tzm/strings.xml
@@ -123,7 +123,6 @@
     <string name="file">Afaylu</string>
     <string name="always">Ku dwal</string>
     <string name="clear">Sfeḍ</string>
-    <string name="yes">Yah</string>
     <string name="artists">Inaẓuṛen</string>
     <string name="songs">Tiɣennijin</string>
     <string name="events">Imezza</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -58,7 +58,6 @@
     <string name="downloads_title">Завантаження</string>
     <string name="error_report_title">Звіт про помилку</string>
     <string name="all">Усе</string>
-    <string name="yes">Так</string>
     <string name="disabled">Вимкнено</string>
     <string name="app_ui_crash">Збій застосунку/інтерфейсу</string>
     <string name="your_comment">Ваш коментар (англійською):</string>

--- a/app/src/main/res/values-ur/strings.xml
+++ b/app/src/main/res/values-ur/strings.xml
@@ -92,7 +92,6 @@
     <string name="downloads_title">ڈاؤن لوڈز</string>
     <string name="error_report_title">خرابی کی اطلاع</string>
     <string name="all">تمام</string>
-    <string name="yes">ہاں</string>
     <string name="disabled">غیر فعال</string>
     <string name="clear">صاف</string>
     <string name="best_resolution">بہترین ریزولوشن</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -56,7 +56,6 @@
     <string name="downloads_title">Tải xuống</string>
     <string name="error_report_title">Báo lỗi</string>
     <string name="all">Tất cả</string>
-    <string name="yes">Có</string>
     <string name="disabled">Vô hiệu</string>
     <string name="clear">Xóa</string>
     <string name="best_resolution">Độ phân giải tốt nhất</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -28,7 +28,6 @@
     <string name="unsupported_url">不支持的 URL</string>
     <string name="settings_category_appearance_title">外观</string>
     <string name="all">全部</string>
-    <string name="yes">是</string>
     <string name="network_error">网络错误</string>
     <plurals name="videos">
         <item quantity="other">%s 个视频</item>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -86,7 +86,6 @@
     <string name="black_theme_title">純黑</string>
     <string name="popup_playing_toast">以畫中畫模式播放</string>
     <string name="all">所有</string>
-    <string name="yes">是</string>
     <string name="app_ui_crash">App/界面閃退</string>
     <string name="info_labels">經過：\\n請求：\\n內容語言：\\n內容國家：\\nApp 語言：\\n服務：\\nGMT 時間：\\n封裝：\\n版本：\\nOS 版本：</string>
     <string name="short_thousand">千</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -61,7 +61,6 @@
     <string name="downloads_title">下載</string>
     <string name="error_report_title">錯誤回報</string>
     <string name="all">全部</string>
-    <string name="yes">是的</string>
     <string name="disabled">已停用</string>
     <string name="clear">清除</string>
     <string name="best_resolution">最佳解析度</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -168,7 +168,6 @@
     <string name="songs">Songs</string>
     <string name="albums">Albums</string>
     <string name="artists">Artists</string>
-    <string name="yes">Yes</string>
     <string name="disabled">Disabled</string>
     <string name="clear">Clear</string>
     <string name="best_resolution">Best resolution</string>


### PR DESCRIPTION
Android doesn't use yes/no but ok/cancel usually, so this should be done here, too

<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Related info
This can be considered a followup to #7024. I thought all `yes` were replaced by `ok` in that PR, but apparently it was not the case (as I could notice in #5878), hence this PR.

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
