### PR TITLE
PoC for limited PIP mode support on MainPlayer.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,7 +28,8 @@
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name"
-            android:launchMode="singleTask">
+            android:launchMode="singleTask"
+            android:supportsPictureInPicture="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -72,6 +72,7 @@ import org.schabi.newpipe.fragments.BackPressable;
 import org.schabi.newpipe.fragments.MainFragment;
 import org.schabi.newpipe.fragments.detail.VideoDetailFragment;
 import org.schabi.newpipe.fragments.list.search.SearchFragment;
+import org.schabi.newpipe.player.PictureInPictureControl;
 import org.schabi.newpipe.player.Player;
 import org.schabi.newpipe.player.event.OnKeyDownListener;
 import org.schabi.newpipe.player.helper.PlayerHolder;
@@ -96,6 +97,8 @@ import java.util.Objects;
 
 public class MainActivity extends AppCompatActivity {
     private static final String TAG = "MainActivity";
+    private static final PictureInPictureControl PIP_CONTROL =
+            PictureInPictureControl.MainPlayerPictureInPicture.CONTROLLER;
     @SuppressWarnings("ConstantConditions")
     public static final boolean DEBUG = !BuildConfig.BUILD_TYPE.equals("release");
 
@@ -839,5 +842,16 @@ public class MainActivity extends AppCompatActivity {
         final int sheetState = bottomSheetBehavior.getState();
         return sheetState == BottomSheetBehavior.STATE_HIDDEN
                 || sheetState == BottomSheetBehavior.STATE_COLLAPSED;
+    }
+
+    @Override
+    protected void onUserLeaveHint() {
+        super.onUserLeaveHint();
+        final Fragment fragmentPlayer = getSupportFragmentManager()
+                .findFragmentById(R.id.fragment_player_holder);
+        final boolean bottomSheetCollapsed = bottomSheetHiddenOrCollapsed();
+        if (fragmentPlayer != null && !bottomSheetCollapsed) {
+            PIP_CONTROL.onUserLeaveHint(this);
+        }
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/player/PictureInPictureControl.java
+++ b/app/src/main/java/org/schabi/newpipe/player/PictureInPictureControl.java
@@ -43,16 +43,16 @@ public interface PictureInPictureControl {
 
         @Override
         public void onUserLeaveHint(@NonNull final Activity activity) {
+            if (!shouldEnterPip(activity)) {
+                return;
+            }
+
             if (pipSupported == null) {
                 pipSupported = isPipSupported(activity);
             }
 
             if (!pipSupported) {
                 showPipSupportMissing(activity);
-                return;
-            }
-
-            if (!shouldEnterPip(activity)) {
                 return;
             }
 

--- a/app/src/main/java/org/schabi/newpipe/player/PictureInPictureControl.java
+++ b/app/src/main/java/org/schabi/newpipe/player/PictureInPictureControl.java
@@ -1,0 +1,134 @@
+package org.schabi.newpipe.player;
+
+import android.annotation.SuppressLint;
+import android.app.Activity;
+import android.app.PendingIntent;
+import android.app.PictureInPictureParams;
+import android.app.RemoteAction;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.graphics.drawable.Icon;
+import android.os.Build;
+import android.widget.Toast;
+
+import org.schabi.newpipe.R;
+import org.schabi.newpipe.player.helper.PlayerHelper;
+import org.schabi.newpipe.player.helper.PlayerHolder;
+
+import java.util.Arrays;
+import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
+
+import static android.app.PendingIntent.FLAG_UPDATE_CURRENT;
+import static android.content.pm.PackageManager.FEATURE_PICTURE_IN_PICTURE;
+import static android.widget.Toast.LENGTH_SHORT;
+import static org.schabi.newpipe.player.MainPlayer.ACTION_PLAY_NEXT;
+import static org.schabi.newpipe.player.MainPlayer.ACTION_PLAY_PREVIOUS;
+import static org.schabi.newpipe.player.helper.PlayerHelper.MinimizeMode.MINIMIZE_ON_EXIT_MODE_PIP;
+
+public interface PictureInPictureControl {
+
+    void onUserLeaveHint(@NonNull Activity activity);
+
+    final class MainPlayerPictureInPicture implements PictureInPictureControl {
+        public static final PictureInPictureControl CONTROLLER = new MainPlayerPictureInPicture();
+        private static final int BROADCAST_ID = 846221;
+        private Boolean pipSupported;
+        private Toast pipToast;
+        private PictureInPictureParams pipParameters;
+        private MainPlayerPictureInPicture() { }
+
+        @Override
+        public void onUserLeaveHint(@NonNull final Activity activity) {
+            if (pipSupported == null) {
+                pipSupported = isPipSupported(activity);
+            }
+
+            if (!pipSupported) {
+                showPipSupportMissing(activity);
+                return;
+            }
+
+            if (!shouldEnterPip(activity)) {
+                return;
+            }
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                enterPictureInPictureMode(activity);
+            }
+        }
+
+        @RequiresApi(api = Build.VERSION_CODES.O)
+        private void enterPictureInPictureMode(@NonNull final Activity activity) {
+            if (pipParameters == null) {
+                pipParameters = new PictureInPictureParams.Builder()
+                        .setActions(buildActions(activity))
+                        .build();
+            }
+            activity.enterPictureInPictureMode(pipParameters);
+        }
+
+        private void showPipSupportMissing(@NonNull final Context context) {
+            if (pipToast != null) {
+                pipToast.cancel();
+            }
+            pipToast = Toast.makeText(context, R.string.pip_mode_unsupported, LENGTH_SHORT);
+            pipToast.show();
+        }
+
+        @RequiresApi(api = Build.VERSION_CODES.O)
+        @SuppressLint("UnspecifiedImmutableFlag")
+        private List<RemoteAction> buildActions(@NonNull final Context context) {
+            final Icon playPreviousIcon =
+                    Icon.createWithResource(context, R.drawable.exo_icon_previous);
+            final PendingIntent playPreviousIntent = PendingIntent.getBroadcast(
+                    context, BROADCAST_ID, new Intent(ACTION_PLAY_PREVIOUS), FLAG_UPDATE_CURRENT);
+            // title and contentDescription do not accept string resource and are not displayed
+            final RemoteAction playPreviousAction = new RemoteAction(
+                    playPreviousIcon, "Previous", "Play Previous", playPreviousIntent);
+
+            final Icon playNextIcon = Icon.createWithResource(context, R.drawable.exo_icon_next);
+            final PendingIntent playNextIntent = PendingIntent.getBroadcast(
+                    context, BROADCAST_ID, new Intent(ACTION_PLAY_NEXT), FLAG_UPDATE_CURRENT);
+            final RemoteAction playNextAction = new RemoteAction(
+                    playNextIcon, "Next", "Play Next", playNextIntent);
+
+            return Arrays.asList(playPreviousAction, playNextAction);
+        }
+
+        /**
+         * Checks if PIP is supported on the device:
+         * - Android version must be 8.0+
+         * - Must be PIP-capable (i.e. RAM is sufficient)
+         *
+         * @param activity the activity hosting a PIP-entering player
+         * @return boolean indicating PIP is supported on this device
+         **/
+        private static boolean isPipSupported(@NonNull final Activity activity) {
+            final PackageManager packageManager = activity.getPackageManager();
+            return Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+                    && packageManager.hasSystemFeature(FEATURE_PICTURE_IN_PICTURE);
+        }
+
+        /**
+         * Determines if the current player state is suitable for entering PIP:
+         * - User must enable PIP mode on player minimize
+         * - Player must be playing in MainPlayer video mode
+         *
+         * Not meeting the second criteria will cause PIP to enter when the player ui is cluttered,
+         * e.g. when paused.
+         *
+         * @param activity the activity hosting a PIP-entering player
+         * @return boolean indicating if the underlying player is in a good state for entering PIP
+         **/
+        private static boolean shouldEnterPip(@NonNull final Activity activity) {
+            final PlayerHolder player = PlayerHolder.getInstance();
+            return MINIMIZE_ON_EXIT_MODE_PIP == PlayerHelper.getMinimizeOnExitAction(activity)
+                    && MainPlayer.PlayerType.VIDEO == player.getType()
+                    && player.isPlaying();
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -28,6 +28,7 @@ import static org.schabi.newpipe.player.MainPlayer.ACTION_REPEAT;
 import static org.schabi.newpipe.player.MainPlayer.ACTION_SHUFFLE;
 import static org.schabi.newpipe.player.helper.PlayerHelper.MinimizeMode.MINIMIZE_ON_EXIT_MODE_BACKGROUND;
 import static org.schabi.newpipe.player.helper.PlayerHelper.MinimizeMode.MINIMIZE_ON_EXIT_MODE_NONE;
+import static org.schabi.newpipe.player.helper.PlayerHelper.MinimizeMode.MINIMIZE_ON_EXIT_MODE_PIP;
 import static org.schabi.newpipe.player.helper.PlayerHelper.MinimizeMode.MINIMIZE_ON_EXIT_MODE_POPUP;
 import static org.schabi.newpipe.player.helper.PlayerHelper.buildCloseOverlayLayoutParams;
 import static org.schabi.newpipe.player.helper.PlayerHelper.formatSpeed;
@@ -4110,6 +4111,7 @@ public final class Player implements
         if (videoPlayerSelected() && (isPlaying() || isLoading())) {
             switch (getMinimizeOnExitAction(context)) {
                 case MINIMIZE_ON_EXIT_MODE_BACKGROUND:
+                case MINIMIZE_ON_EXIT_MODE_PIP:
                     useVideoSource(false);
                     break;
                 case MINIMIZE_ON_EXIT_MODE_POPUP:

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
@@ -10,6 +10,7 @@ import static org.schabi.newpipe.player.helper.PlayerHelper.AutoplayType.AUTOPLA
 import static org.schabi.newpipe.player.helper.PlayerHelper.AutoplayType.AUTOPLAY_TYPE_WIFI;
 import static org.schabi.newpipe.player.helper.PlayerHelper.MinimizeMode.MINIMIZE_ON_EXIT_MODE_BACKGROUND;
 import static org.schabi.newpipe.player.helper.PlayerHelper.MinimizeMode.MINIMIZE_ON_EXIT_MODE_NONE;
+import static org.schabi.newpipe.player.helper.PlayerHelper.MinimizeMode.MINIMIZE_ON_EXIT_MODE_PIP;
 import static org.schabi.newpipe.player.helper.PlayerHelper.MinimizeMode.MINIMIZE_ON_EXIT_MODE_POPUP;
 import static java.lang.annotation.RetentionPolicy.SOURCE;
 
@@ -89,11 +90,12 @@ public final class PlayerHelper {
 
     @Retention(SOURCE)
     @IntDef({MINIMIZE_ON_EXIT_MODE_NONE, MINIMIZE_ON_EXIT_MODE_BACKGROUND,
-            MINIMIZE_ON_EXIT_MODE_POPUP})
+            MINIMIZE_ON_EXIT_MODE_POPUP, MINIMIZE_ON_EXIT_MODE_PIP})
     public @interface MinimizeMode {
         int MINIMIZE_ON_EXIT_MODE_NONE = 0;
         int MINIMIZE_ON_EXIT_MODE_BACKGROUND = 1;
         int MINIMIZE_ON_EXIT_MODE_POPUP = 2;
+        int MINIMIZE_ON_EXIT_MODE_PIP = 3;
     }
 
     private PlayerHelper() { }
@@ -263,6 +265,8 @@ public final class PlayerHelper {
             return MINIMIZE_ON_EXIT_MODE_POPUP;
         } else if (action.equals(context.getString(R.string.minimize_on_exit_none_key))) {
             return MINIMIZE_ON_EXIT_MODE_NONE;
+        } else if (action.equals(context.getString(R.string.minimize_on_exit_pip_key))) {
+            return MINIMIZE_ON_EXIT_MODE_PIP;
         } else {
             return MINIMIZE_ON_EXIT_MODE_BACKGROUND; // default
         }

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -77,15 +77,18 @@
     <string name="minimize_on_exit_none_key">minimize_on_exit_none_key</string>
     <string name="minimize_on_exit_background_key">minimize_on_exit_background_key</string>
     <string name="minimize_on_exit_popup_key">minimize_on_exit_popup_key</string>
+    <string name="minimize_on_exit_pip_key">minimize_on_exit_pip_key</string>
     <string-array name="minimize_on_exit_action_key">
         <item>@string/minimize_on_exit_none_key</item>
         <item>@string/minimize_on_exit_background_key</item>
         <item>@string/minimize_on_exit_popup_key</item>
+        <item>@string/minimize_on_exit_pip_key</item>
     </string-array>
     <string-array name="minimize_on_exit_action_description">
         <item>@string/minimize_on_exit_none_description</item>
         <item>@string/minimize_on_exit_background_description</item>
         <item>@string/minimize_on_exit_popup_description</item>
+        <item>@string/minimize_on_exit_pip_description</item>
     </string-array>
 
     <string name="start_main_player_fullscreen_key">start_main_player_fullscreen_key</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -439,6 +439,7 @@
     <string name="resize_fill">Fill</string>
     <string name="resize_zoom">Zoom</string>
     <string name="caption_auto_generated">Auto-generated</string>
+    <string name="pip_mode_unsupported">The Android version of this device does not support PIP Mode.</string>
     <!-- Caption Settings -->
     <string name="caption_setting_title">Captions</string>
     <string name="caption_setting_description">Modify player caption text scale and background styles. Requires app restart to take effect</string>
@@ -521,6 +522,7 @@
     <string name="minimize_on_exit_none_description">None</string>
     <string name="minimize_on_exit_background_description">Minimize to background player</string>
     <string name="minimize_on_exit_popup_description">Minimize to popup player</string>
+    <string name="minimize_on_exit_pip_description">Minimize to PIP (Android 8+) - Feature in test, use at your own risk</string>
     <!-- Autoplay behavior -->
     <string name="autoplay_summary">Start playback automatically — %s</string>
     <string name="wifi_only">Only on Wi-Fi</string>


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
I know it might not a good idea to do this now before the full player refactor, but did it anyways since I keep on seeing reports of unusable Android 12 popups. To avoid making too many changes in the Player, I've restricted the PIP mode to be accessible through minimize action only. There is a user-defined option with clear warning this is a feature under test, since I just want this PR to unblock users so they can play with a minimally viable PIP while devs have more time refactoring the player. This also means the original popups will co-exist with PIP mode.

@Team, please let me know if there are major issues with this implementation or its later maintenance so I can retract the PR and don't go crazy because "this works on my machine". On the Android side, PIP mode is able to take the view at the top of the current activity and expose that through PIP. You can see this when expanding the PIP view, it will also show the `VideoDetailFragment` title, which may or may not be a desirable effect. But since this change aims to touch the internal player code as little as possible, the current video player fragment layout pretty much worked to our advantage. 

Unfortunately, because of this, when other player ui elements are showing, the layout will clutter the PIP view and would need manual intervention by expand the activity (`VideoDetailFragment` fragment) back to fix it. This is especially apparent when a queue finishes playing or when the player throws an exception. There is also an issue with aspect ratio when restarting a queue after playback has ended. Though these problems can't really be fixed without a player ui update/rewrite. Similarly, because of how the app's activity and fragments are structured, while in PIP mode, you cannot access other parts of the app, such as changing settings or searching for videos. To do this, you will have to wait for a full player refactor IF the team decides to make the player an activity. 

If you are comfortable with these caveats, please give the PR build a test, especially if you have an Android 12 device, and let me know if there is any non-ui related issue or if there is major issue with the video view. 

#### Before/After Screenshots/Screen Record
<img src="https://user-images.githubusercontent.com/5570482/158498110-e352bee4-db45-4a70-bf32-78bf7d06faed.png" width="200"/><img src="https://user-images.githubusercontent.com/5570482/158498115-59efb479-f891-4e5a-8cd2-062ed6ce690f.png" width="200"/><img src="https://user-images.githubusercontent.com/5570482/158498119-a8b8962a-e811-4148-b977-4c72bb8c807f.png" width="200"/><img src="https://user-images.githubusercontent.com/5570482/158499187-642e4c2b-1502-469c-ac07-d2046a2906dc.jpg" width="200"/>

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Partially fixes #6770

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.
Once installed, go to Settings -> Video and audio -> Minimize on app switch -> Minimize to PIP ... -> Start up a video and context switch when the video is playing

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
