### PR TITLE
Update NewpipeExtractor

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -190,7 +190,7 @@ dependencies {
     // name and the commit hash with the commit hash of the (pushed) commit you want to test
     // This works thanks to JitPack: https://jitpack.io/
     implementation 'com.github.TeamNewPipe:nanojson:1d9e1aea9049fc9f85e68b43ba39fe7be1c1f751'
-    implementation 'com.github.TeamNewPipe:NewPipeExtractor:v0.21.14'
+    implementation 'com.github.TeamNewPipe:NewPipeExtractor:5a1873084'
 
 /** Checkstyle **/
     checkstyle "com.puppycrawl.tools:checkstyle:${checkstyleVersion}"

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/DescriptionFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/DescriptionFragment.java
@@ -84,7 +84,7 @@ public class DescriptionFragment extends BaseFragment {
     private void setupDescription() {
         final Description description = streamInfo.getDescription();
         if (description == null || isEmpty(description.getContent())
-                || description == Description.emptyDescription) {
+                || description == Description.EMPTY_DESCRIPTION) {
             binding.detailDescriptionView.setVisibility(View.GONE);
             binding.detailSelectDescriptionButton.setVisibility(View.GONE);
             return;

--- a/app/src/main/java/org/schabi/newpipe/settings/PeertubeInstanceListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/PeertubeInstanceListFragment.java
@@ -185,7 +185,7 @@ public class PeertubeInstanceListFragment extends Fragment {
                 .setNegativeButton(R.string.cancel, null)
                 .setPositiveButton(R.string.ok, (dialog, which) -> {
                     sharedPreferences.edit().remove(savedInstanceListKey).apply();
-                    selectInstance(PeertubeInstance.defaultInstance);
+                    selectInstance(PeertubeInstance.DEFAULT_INSTANCE);
                     updateInstanceList();
                     instanceListAdapter.notifyDataSetChanged();
                 })

--- a/app/src/main/java/us/shandian/giga/get/DownloadMissionRecover.java
+++ b/app/src/main/java/us/shandian/giga/get/DownloadMissionRecover.java
@@ -132,7 +132,7 @@ public class DownloadMissionRecover extends Thread {
         switch (mRecovery.getKind()) {
             case 'a':
                 for (AudioStream audio : mExtractor.getAudioStreams()) {
-                    if (audio.average_bitrate == mRecovery.getDesiredBitrate() && audio.getFormat() == mRecovery.getFormat()) {
+                    if (audio.getAverageBitrate() == mRecovery.getDesiredBitrate() && audio.getFormat() == mRecovery.getFormat()) {
                         url = audio.getUrl();
                         break;
                     }

--- a/app/src/main/java/us/shandian/giga/get/MissionRecoveryInfo.kt
+++ b/app/src/main/java/us/shandian/giga/get/MissionRecoveryInfo.kt
@@ -21,13 +21,13 @@ class MissionRecoveryInfo(
     constructor(stream: Stream) : this(format = stream.getFormat()!!) {
         when (stream) {
             is AudioStream -> {
-                desiredBitrate = stream.average_bitrate
+                desiredBitrate = stream.averageBitrate
                 isDesired2 = false
                 kind = 'a'
             }
             is VideoStream -> {
-                desired = stream.getResolution()
-                isDesired2 = stream.isVideoOnly()
+                desired = stream.resolution
+                isDesired2 = stream.isVideoOnly
                 kind = 'v'
             }
             is SubtitlesStream -> {

--- a/app/src/test/java/org/schabi/newpipe/util/ListHelperTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/ListHelperTest.java
@@ -199,17 +199,17 @@ public class ListHelperTest {
     public void getHighestQualityAudioFormatTest() {
         AudioStream stream = AUDIO_STREAMS_TEST_LIST.get(ListHelper.getHighestQualityAudioIndex(
                 MediaFormat.M4A, AUDIO_STREAMS_TEST_LIST));
-        assertEquals(320, stream.average_bitrate);
+        assertEquals(320, stream.getAverageBitrate());
         assertEquals(MediaFormat.M4A, stream.getFormat());
 
         stream = AUDIO_STREAMS_TEST_LIST.get(ListHelper.getHighestQualityAudioIndex(
                 MediaFormat.WEBMA, AUDIO_STREAMS_TEST_LIST));
-        assertEquals(320, stream.average_bitrate);
+        assertEquals(320, stream.getAverageBitrate());
         assertEquals(MediaFormat.WEBMA, stream.getFormat());
 
         stream = AUDIO_STREAMS_TEST_LIST.get(ListHelper.getHighestQualityAudioIndex(
                 MediaFormat.MP3, AUDIO_STREAMS_TEST_LIST));
-        assertEquals(192, stream.average_bitrate);
+        assertEquals(192, stream.getAverageBitrate());
         assertEquals(MediaFormat.MP3, stream.getFormat());
     }
 
@@ -227,7 +227,7 @@ public class ListHelperTest {
         // It should fallback to the highest bitrate audio no matter what format it is
         AudioStream stream = testList.get(ListHelper.getHighestQualityAudioIndex(
                 MediaFormat.MP3, testList));
-        assertEquals(192, stream.average_bitrate);
+        assertEquals(192, stream.getAverageBitrate());
         assertEquals(MediaFormat.WEBMA, stream.getFormat());
 
         ////////////////////////////////////////////////////////
@@ -245,14 +245,14 @@ public class ListHelperTest {
         // List doesn't contains this format, it should fallback to the highest bitrate audio and
         // the highest quality format.
         stream = testList.get(ListHelper.getHighestQualityAudioIndex(MediaFormat.MP3, testList));
-        assertEquals(192, stream.average_bitrate);
+        assertEquals(192, stream.getAverageBitrate());
         assertEquals(MediaFormat.M4A, stream.getFormat());
 
         // Adding a new format and bitrate. Adding another stream will have no impact since
         // it's not a preferred format.
         testList.add(new AudioStream("", MediaFormat.WEBMA, /**/ 192));
         stream = testList.get(ListHelper.getHighestQualityAudioIndex(MediaFormat.MP3, testList));
-        assertEquals(192, stream.average_bitrate);
+        assertEquals(192, stream.getAverageBitrate());
         assertEquals(MediaFormat.M4A, stream.getFormat());
     }
 
@@ -266,17 +266,17 @@ public class ListHelperTest {
     public void getLowestQualityAudioFormatTest() {
         AudioStream stream = AUDIO_STREAMS_TEST_LIST.get(ListHelper.getMostCompactAudioIndex(
                 MediaFormat.M4A, AUDIO_STREAMS_TEST_LIST));
-        assertEquals(128, stream.average_bitrate);
+        assertEquals(128, stream.getAverageBitrate());
         assertEquals(MediaFormat.M4A, stream.getFormat());
 
         stream = AUDIO_STREAMS_TEST_LIST.get(ListHelper.getMostCompactAudioIndex(
                 MediaFormat.WEBMA, AUDIO_STREAMS_TEST_LIST));
-        assertEquals(64, stream.average_bitrate);
+        assertEquals(64, stream.getAverageBitrate());
         assertEquals(MediaFormat.WEBMA, stream.getFormat());
 
         stream = AUDIO_STREAMS_TEST_LIST.get(ListHelper.getMostCompactAudioIndex(
                 MediaFormat.MP3, AUDIO_STREAMS_TEST_LIST));
-        assertEquals(64, stream.average_bitrate);
+        assertEquals(64, stream.getAverageBitrate());
         assertEquals(MediaFormat.MP3, stream.getFormat());
     }
 
@@ -294,13 +294,13 @@ public class ListHelperTest {
         // It should fallback to the most compact audio no matter what format it is.
         AudioStream stream = testList.get(ListHelper.getMostCompactAudioIndex(
                 MediaFormat.MP3, testList));
-        assertEquals(128, stream.average_bitrate);
+        assertEquals(128, stream.getAverageBitrate());
         assertEquals(MediaFormat.M4A, stream.getFormat());
 
         // WEBMA is more compact than M4A
         testList.add(new AudioStream("", MediaFormat.WEBMA,   /**/ 128));
         stream = testList.get(ListHelper.getMostCompactAudioIndex(MediaFormat.MP3, testList));
-        assertEquals(128, stream.average_bitrate);
+        assertEquals(128, stream.getAverageBitrate());
         assertEquals(MediaFormat.WEBMA, stream.getFormat());
 
         ////////////////////////////////////////////////////////
@@ -317,12 +317,12 @@ public class ListHelperTest {
         // List doesn't contain this format
         // It should fallback to the most compact audio no matter what format it is.
         stream = testList.get(ListHelper.getMostCompactAudioIndex(MediaFormat.MP3, testList));
-        assertEquals(192, stream.average_bitrate);
+        assertEquals(192, stream.getAverageBitrate());
         assertEquals(MediaFormat.WEBMA, stream.getFormat());
 
         // Should be same as above
         stream = testList.get(ListHelper.getMostCompactAudioIndex(null, testList));
-        assertEquals(192, stream.average_bitrate);
+        assertEquals(192, stream.getAverageBitrate());
         assertEquals(MediaFormat.WEBMA, stream.getFormat());
     }
 


### PR DESCRIPTION
#### What is it?
- [x] Codebase improvement (dev facing)

#### Description of the changes in your PR
Updates NewPipeExtractor to latest dev-version.

---
**Relevant changes:**
⚠️ This version contains breaking changes (thus the bump to 0.22) due to the introduction of checkstyle - certain methods or fields may have standardized names now.

*New*
- Add MixInfoItem and extract YouTube mixes in related items https://github.com/TeamNewPipe/NewPipeExtractor/pull/788

*Improved*
- Add support for extracting channel subscriber count in StreamInfo https://github.com/TeamNewPipe/NewPipeExtractor/pull/796
- [YouTube] Make throttling decryption more resilient to API change https://github.com/TeamNewPipe/NewPipeExtractor/pull/786

*Fixed*
- Remove the need for a CommentsInfo instance in CommentsInfo.getMoreItems and fix PeertubeCommentsExtractorTest.Default test https://github.com/TeamNewPipe/NewPipeExtractor/pull/807
- [YouTube] Fix the extraction of series playlists and don't return the view count as the stream count for learning playlists https://github.com/TeamNewPipe/NewPipeExtractor/pull/811
- [YouTube] Fix music mixes in some countries https://github.com/TeamNewPipe/NewPipeExtractor/pull/804
- Fixed various tests + Youtube shorts in channels https://github.com/TeamNewPipe/NewPipeExtractor/pull/813
---


#### APK testing 
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
