### PR TITLE
Fix `SparseItemUtil` so we don't enqueue twice

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/util/SparseItemUtil.java
+++ b/app/src/main/java/org/schabi/newpipe/util/SparseItemUtil.java
@@ -54,6 +54,7 @@ public final class SparseItemUtil {
             // if the duration is >= 0 (provided that the item is not a livestream) and there is an
             // uploader url, probably all info is already there, so there is no need to fetch it
             callback.accept(new SinglePlayQueue(item));
+            return;
         }
 
         // either the duration or the uploader url are not available, so fetch more info
@@ -80,12 +81,12 @@ public final class SparseItemUtil {
                                                 @NonNull final String url,
                                                 @Nullable final String uploaderUrl,
                                                 @NonNull final Consumer<String> callback) {
-        if (isNullOrEmpty(uploaderUrl)) {
-            fetchStreamInfoAndSaveToDatabase(context, serviceId, url,
-                    streamInfo -> callback.accept(streamInfo.getUploaderUrl()));
-        } else {
+        if (!isNullOrEmpty(uploaderUrl)) {
             callback.accept(uploaderUrl);
+            return;
         }
+        fetchStreamInfoAndSaveToDatabase(context, serviceId, url,
+                streamInfo -> callback.accept(streamInfo.getUploaderUrl()));
     }
 
     /**


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)

#### Description of the changes in your PR
Fix `SparseItemUtil` loading
* Added a missing `return` statement
* `fetchUploaderUrlIfSparse` now has a similar code-layout to `fetchItemInfoIfSparse`

In https://github.com/TeamNewPipe/NewPipe/pull/8020#pullrequestreview-926589637 I noticed that the enqueuing function enqueues streams twice.

The problem was introduced in #7981 and I didn't noticed it until now.

#### APK testing 
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
