### PR TITLE
Use newInstance in PlaylistDialog

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/dialog/PlaylistAppendDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/local/dialog/PlaylistAppendDialog.java
@@ -33,8 +33,16 @@ public final class PlaylistAppendDialog extends PlaylistDialog {
 
     private final CompositeDisposable playlistDisposables = new CompositeDisposable();
 
-    public PlaylistAppendDialog(final List<StreamEntity> streamEntities) {
-        super(streamEntities);
+    /**
+     * Create a new instance of {@link PlaylistAppendDialog}.
+     *
+     * @param streamEntities    a list of {@link StreamEntity} to be added to playlists
+     * @return a new instance of {@link PlaylistAppendDialog}
+     */
+    public static PlaylistAppendDialog newInstance(final List<StreamEntity> streamEntities) {
+        final PlaylistAppendDialog dialog = new PlaylistAppendDialog();
+        dialog.setStreamEntities(streamEntities);
+        return dialog;
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -103,13 +111,14 @@ public final class PlaylistAppendDialog extends PlaylistDialog {
     // Helper
     //////////////////////////////////////////////////////////////////////////*/
 
+    /** Display create playlist dialog. */
     public void openCreatePlaylistDialog() {
         if (getStreamEntities() == null || !isAdded()) {
             return;
         }
 
         final PlaylistCreationDialog playlistCreationDialog =
-                new PlaylistCreationDialog(getStreamEntities());
+                PlaylistCreationDialog.newInstance(getStreamEntities());
         // Move the dismissListener to the new dialog.
         playlistCreationDialog.setOnDismissListener(this.getOnDismissListener());
         this.setOnDismissListener(null);

--- a/app/src/main/java/org/schabi/newpipe/local/dialog/PlaylistCreationDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/local/dialog/PlaylistCreationDialog.java
@@ -21,8 +21,17 @@ import java.util.List;
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 
 public final class PlaylistCreationDialog extends PlaylistDialog {
-    public PlaylistCreationDialog(final List<StreamEntity> streamEntities) {
-        super(streamEntities);
+
+    /**
+     * Create a new instance of {@link PlaylistCreationDialog}.
+     *
+     * @param streamEntities    a list of {@link StreamEntity} to be added to playlists
+     * @return a new instance of {@link PlaylistCreationDialog}
+     */
+    public static PlaylistCreationDialog newInstance(final List<StreamEntity> streamEntities) {
+        final PlaylistCreationDialog dialog = new PlaylistCreationDialog();
+        dialog.setStreamEntities(streamEntities);
+        return dialog;
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/app/src/main/java/org/schabi/newpipe/local/dialog/PlaylistDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/local/dialog/PlaylistDialog.java
@@ -31,10 +31,6 @@ public abstract class PlaylistDialog extends DialogFragment implements StateSave
 
     private org.schabi.newpipe.util.SavedState savedState;
 
-    public PlaylistDialog(final List<StreamEntity> streamEntities) {
-        this.streamEntities = streamEntities;
-    }
-
     /*//////////////////////////////////////////////////////////////////////////
     // LifeCycle
     //////////////////////////////////////////////////////////////////////////*/
@@ -120,6 +116,10 @@ public abstract class PlaylistDialog extends DialogFragment implements StateSave
         this.onDismissListener = onDismissListener;
     }
 
+    protected void setStreamEntities(final List<StreamEntity> streamEntities) {
+        this.streamEntities = streamEntities;
+    }
+
     /*//////////////////////////////////////////////////////////////////////////
     // Dialog creation
     //////////////////////////////////////////////////////////////////////////*/
@@ -143,8 +143,8 @@ public abstract class PlaylistDialog extends DialogFragment implements StateSave
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(hasPlaylists ->
                         onExec.accept(hasPlaylists
-                                ? new PlaylistAppendDialog(streamEntities)
-                                : new PlaylistCreationDialog(streamEntities))
+                                ? PlaylistAppendDialog.newInstance(streamEntities)
+                                : PlaylistCreationDialog.newInstance(streamEntities))
                 );
     }
 }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- delete the constructors in `PlaylistDialog`
- use `newInstance()` instead

See https://stackoverflow.com/questions/51831053/could-not-find-fragment-constructor
#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes https://github.com/TeamNewPipe/NewPipe/issues/7825

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
