### PR TITLE
Update NewPipeExtractor again to fix throttling on age restricted videos

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -189,7 +189,7 @@ dependencies {
     // name and the commit hash with the commit hash of the (pushed) commit you want to test
     // This works thanks to JitPack: https://jitpack.io/
     implementation 'com.github.TeamNewPipe:nanojson:1d9e1aea9049fc9f85e68b43ba39fe7be1c1f751'
-    implementation 'com.github.TeamNewPipe:NewPipeExtractor:bebdc55ad42ef964a547059110573a177331cf4d'
+    implementation 'com.github.TeamNewPipe:NewPipeExtractor:b77c72fb8826c3ffca0be5f96b066cca0a07b1c9'
 
 /** Checkstyle **/
     checkstyle "com.puppycrawl.tools:checkstyle:${checkstyleVersion}"


### PR DESCRIPTION
The release apk contains this fix, but I accidentally forgot to push the local change before merging the release PR :sweat_smile: 