### PR TITLE
Fix keyboard showing after the search box acquiring focus

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/list/search/SearchFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/search/SearchFragment.java
@@ -141,8 +141,7 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
     @State
     boolean wasSearchFocused = false;
 
-    @Nullable
-    private Map<Integer, String> menuItemToFilterName = null;
+    @Nullable private Map<Integer, String> menuItemToFilterName = null;
     private StreamingService service;
     private Page nextPage;
     private boolean showLocalSuggestions = true;
@@ -561,15 +560,6 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
                     && hasFocus && !isErrorPanelVisible()) {
                 showSuggestionsPanel();
             }
-
-            // The state of keyboard will be maintained before onResume()
-            if (!isResumed() && hasFocus) {
-                if (TextUtils.isEmpty(searchString) || wasSearchFocused) {
-                    showKeyboardSearch();
-                } else {
-                    hideKeyboardSearch();
-                }
-            }
         });
 
         suggestionListAdapter.setListener(new SuggestionListAdapter.OnSuggestionItemSelected() {
@@ -856,8 +846,7 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
         disposables.add(historyRecordManager.onSearched(serviceId, theSearchString)
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
-                        ignored -> {
-                        },
+                        ignored -> { },
                         throwable -> showSnackBarError(new ErrorInfo(throwable, UserAction.SEARCHED,
                                 theSearchString, serviceId))
                 ));

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/search/SearchFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/search/SearchFragment.java
@@ -141,7 +141,8 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
     @State
     boolean wasSearchFocused = false;
 
-    @Nullable private Map<Integer, String> menuItemToFilterName = null;
+    @Nullable
+    private Map<Integer, String> menuItemToFilterName = null;
     private StreamingService service;
     private Page nextPage;
     private boolean showLocalSuggestions = true;
@@ -560,6 +561,15 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
                     && hasFocus && !isErrorPanelVisible()) {
                 showSuggestionsPanel();
             }
+
+            // The state of keyboard will be maintained before onResume()
+            if (!isResumed() && hasFocus) {
+                if (TextUtils.isEmpty(searchString) || wasSearchFocused) {
+                    showKeyboardSearch();
+                } else {
+                    hideKeyboardSearch();
+                }
+            }
         });
 
         suggestionListAdapter.setListener(new SuggestionListAdapter.OnSuggestionItemSelected() {
@@ -724,9 +734,9 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
                 .getRelatedSearches(query, similarQueryLimit, 25)
                 .toObservable()
                 .map(searchHistoryEntries ->
-                    searchHistoryEntries.stream()
-                            .map(entry -> new SuggestionItem(true, entry))
-                            .collect(Collectors.toList()));
+                        searchHistoryEntries.stream()
+                                .map(entry -> new SuggestionItem(true, entry))
+                                .collect(Collectors.toList()));
     }
 
     private Observable<List<SuggestionItem>> getRemoteSuggestionsObservable(final String query) {
@@ -793,12 +803,12 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
                             } else if (listNotification.isOnError()
                                     && listNotification.getError() != null
                                     && !ExceptionUtils.isInterruptedCaused(
-                                            listNotification.getError())) {
+                                    listNotification.getError())) {
                                 showSnackBarError(new ErrorInfo(listNotification.getError(),
                                         UserAction.GET_SUGGESTIONS, searchString, serviceId));
                             }
                         }, throwable -> showSnackBarError(new ErrorInfo(
-                            throwable, UserAction.GET_SUGGESTIONS, searchString, serviceId)));
+                                throwable, UserAction.GET_SUGGESTIONS, searchString, serviceId)));
     }
 
     @Override
@@ -846,7 +856,8 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
         disposables.add(historyRecordManager.onSearched(serviceId, theSearchString)
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
-                        ignored -> { },
+                        ignored -> {
+                        },
                         throwable -> showSnackBarError(new ErrorInfo(throwable, UserAction.SEARCHED,
                                 theSearchString, serviceId))
                 ));

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/search/SearchFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/search/SearchFragment.java
@@ -724,9 +724,9 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
                 .getRelatedSearches(query, similarQueryLimit, 25)
                 .toObservable()
                 .map(searchHistoryEntries ->
-                        searchHistoryEntries.stream()
-                                .map(entry -> new SuggestionItem(true, entry))
-                                .collect(Collectors.toList()));
+                    searchHistoryEntries.stream()
+                            .map(entry -> new SuggestionItem(true, entry))
+                            .collect(Collectors.toList()));
     }
 
     private Observable<List<SuggestionItem>> getRemoteSuggestionsObservable(final String query) {
@@ -793,12 +793,12 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
                             } else if (listNotification.isOnError()
                                     && listNotification.getError() != null
                                     && !ExceptionUtils.isInterruptedCaused(
-                                    listNotification.getError())) {
+                                            listNotification.getError())) {
                                 showSnackBarError(new ErrorInfo(listNotification.getError(),
                                         UserAction.GET_SUGGESTIONS, searchString, serviceId));
                             }
                         }, throwable -> showSnackBarError(new ErrorInfo(
-                                throwable, UserAction.GET_SUGGESTIONS, searchString, serviceId)));
+                            throwable, UserAction.GET_SUGGESTIONS, searchString, serviceId)));
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/util/KeyboardUtil.java
+++ b/app/src/main/java/org/schabi/newpipe/util/KeyboardUtil.java
@@ -24,7 +24,19 @@ public final class KeyboardUtil {
         if (editText.requestFocus()) {
             final InputMethodManager imm = ContextCompat.getSystemService(activity,
                     InputMethodManager.class);
-            imm.showSoftInput(editText, InputMethodManager.SHOW_FORCED);
+            if (!imm.showSoftInput(editText, InputMethodManager.SHOW_FORCED)) {
+                /*
+                 * Sometimes the keyboard can't be shown because Android's ImeFocusController is in
+                 * a incorrect state e.g. when animations are disabled or the unfocus event of the
+                 * previous view arrives in the wrong moment (see #7647 for details).
+                 * The invalid state can be fixed by to re-focusing the editText.
+                 */
+                editText.clearFocus();
+                editText.requestFocus();
+
+                // Try again
+                imm.showSoftInput(editText, InputMethodManager.SHOW_FORCED);
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- The code block on onResume() for showing/hiding the soft keyboard failed in a specific scenario. It is because the current view of InputMethodManager is not searchEditText. This problem is handled just when searchEditText gets the focus.
- (**Update**) Fix the underlying problem as described in #7647. It just tries again to request focus and show the soft keyboard when it fails.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before:


https://user-images.githubusercontent.com/15650457/163761718-ba6fc388-73be-4425-9af8-2fbc86bb07bd.mp4




- After:




https://user-images.githubusercontent.com/15650457/163761735-2a86f962-7e62-4182-843b-d6ded03292cc.mp4



#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also, add any other relevant links. -->
- Fixes #7647

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "comment fix" if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
