### PR TITLE
Fix new streams notifications preference screen

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/settings/NotificationsSettingsFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/NotificationsSettingsFragment.kt
@@ -89,9 +89,6 @@ class NotificationsSettingsFragment : BasePreferenceFragment(), OnSharedPreferen
                     show()
                 }
             }
-        } else {
-            notificationWarningSnackbar?.dismiss()
-            notificationWarningSnackbar = null
         }
 
         // (Re-)Create loader
@@ -105,6 +102,9 @@ class NotificationsSettingsFragment : BasePreferenceFragment(), OnSharedPreferen
     override fun onPause() {
         loader?.dispose()
         loader = null
+
+        notificationWarningSnackbar?.dismiss()
+        notificationWarningSnackbar = null
 
         super.onPause()
     }

--- a/app/src/main/java/org/schabi/newpipe/settings/NotificationsSettingsFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/NotificationsSettingsFragment.kt
@@ -26,6 +26,10 @@ class NotificationsSettingsFragment : BasePreferenceFragment(), OnSharedPreferen
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         addPreferencesFromResource(R.xml.notifications_settings)
+
+        // main check is done in onResume, but also do it here to prevent flickering
+        preferenceScreen.isEnabled =
+            NotificationHelper.areNotificationsEnabledOnDevice(requireContext())
     }
 
     override fun onStart() {
@@ -64,7 +68,7 @@ class NotificationsSettingsFragment : BasePreferenceFragment(), OnSharedPreferen
         // If they are disabled, show a snackbar informing the user about that
         // while allowing them to open the device's app settings.
         val enabled = NotificationHelper.areNotificationsEnabledOnDevice(requireContext())
-        preferenceScreen.isEnabled = enabled
+        preferenceScreen.isEnabled = enabled // it is disabled by default, see the xml
         if (!enabled) {
             if (notificationWarningSnackbar == null) {
                 notificationWarningSnackbar = Snackbar.make(


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This PR fixes two issues with the new streams notifications preference screen:
- Check whether to enable the preference screen also in `onCreatePreferences`, since doing it only in `onResume` causes flickering as reported by @TiA4f8R on IRC
- Fix the persistent "Go to settings" snackbar not dismissed properly when exiting from the fragment

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
