### PR TITLE
Fix proguard for notification preference fragment

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -51,3 +51,6 @@
     private void writeObject(java.io.ObjectOutputStream);
     private void readObject(java.io.ObjectInputStream);
 }
+
+# for some reason NotificationModeConfigFragment wasn't kept (only referenced in a preference xml)
+-keep class org.schabi.newpipe.settings.notifications.** { *; }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
`notification_settings.xml` is the **only** file in the project that references `NotificationModeConfigFragment`. Probably there are some bugs in proguard, which didn't count the usage inside an XML as a valid usage and thus discarded the fragment when building the release apk. I don't know if this can be fixed in a more elegant way.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- https://github.com/TeamNewPipe/NewPipe/issues/8230#issuecomment-1100726643

#### APK testing 
Use this release testing apk and follow the instructions from https://github.com/TeamNewPipe/NewPipe/issues/8230#issuecomment-1100726643 : [app-release.zip](https://github.com/TeamNewPipe/NewPipe/files/8500521/app-release.zip)

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
