### PR TITLE
Fix inconsistency between user interaction and database commit order when re-adding videos to the playlist

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/MainFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/MainFragment.java
@@ -38,6 +38,7 @@ import org.schabi.newpipe.R;
 import org.schabi.newpipe.databinding.FragmentMainBinding;
 import org.schabi.newpipe.error.ErrorUtil;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
+import org.schabi.newpipe.local.playlist.LocalPlaylistFragment;
 import org.schabi.newpipe.settings.tabs.Tab;
 import org.schabi.newpipe.settings.tabs.TabsManager;
 import org.schabi.newpipe.util.NavigationHelper;
@@ -217,6 +218,12 @@ public class MainFragment extends BaseFragment implements TabLayout.OnTabSelecte
         setTitle(tabsList.get(tabPosition).getTabName(requireContext()));
     }
 
+    public void commitPlaylistTabs() {
+        pagerAdapter.getLocalPlaylistFragments()
+                .stream()
+                .forEach(LocalPlaylistFragment::commitChanges);
+    }
+
     private void updateTabLayoutPosition() {
         final ScrollableTabLayout tabLayout = binding.mainTabLayout;
         final ViewPager viewPager = binding.pager;
@@ -268,10 +275,18 @@ public class MainFragment extends BaseFragment implements TabLayout.OnTabSelecte
         updateTitleForTab(tab.getPosition());
     }
 
-    private static final class SelectedTabsPagerAdapter
+    public static final class SelectedTabsPagerAdapter
             extends FragmentStatePagerAdapterMenuWorkaround {
         private final Context context;
         private final List<Tab> internalTabsList;
+        /**
+         * Keep reference to LocalPlaylistFragments, because their data can be modified by the user
+         * during runtime and changes are not committed immediately. However, in some cases,
+         * the changes need to be committed immediately by calling
+         * {@link LocalPlaylistFragment#commitChanges()}.
+         * The fragments are removed when {@link LocalPlaylistFragment#onDestroy()} is called.
+         */
+        private final List<LocalPlaylistFragment> localPlaylistFragments = new ArrayList<>();
 
         private SelectedTabsPagerAdapter(final Context context,
                                          final FragmentManager fragmentManager,
@@ -298,7 +313,15 @@ public class MainFragment extends BaseFragment implements TabLayout.OnTabSelecte
                 ((BaseFragment) fragment).useAsFrontPage(true);
             }
 
+            if (fragment instanceof LocalPlaylistFragment) {
+                localPlaylistFragments.add((LocalPlaylistFragment) fragment);
+            }
+
             return fragment;
+        }
+
+        public List<LocalPlaylistFragment> getLocalPlaylistFragments() {
+            return localPlaylistFragments;
         }
 
         @Override

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -85,6 +85,7 @@ import org.schabi.newpipe.extractor.stream.VideoStream;
 import org.schabi.newpipe.fragments.BackPressable;
 import org.schabi.newpipe.fragments.BaseStateFragment;
 import org.schabi.newpipe.fragments.EmptyFragment;
+import org.schabi.newpipe.fragments.MainFragment;
 import org.schabi.newpipe.fragments.list.comments.CommentsFragment;
 import org.schabi.newpipe.fragments.list.videos.RelatedItemsFragment;
 import org.schabi.newpipe.ktx.AnimationType;
@@ -482,6 +483,8 @@ public final class VideoDetailFragment
                 // commit previous pending changes to database
                 if (fragment instanceof LocalPlaylistFragment) {
                     ((LocalPlaylistFragment) fragment).commitChanges();
+                } else if (fragment instanceof MainFragment) {
+                    ((MainFragment) fragment).commitPlaylistTabs();
                 }
 
                 disposables.add(PlaylistDialog.createCorrespondingDialog(requireContext(),

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -54,6 +54,7 @@ import androidx.appcompat.content.res.AppCompatResources;
 import androidx.appcompat.widget.Toolbar;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import androidx.core.content.ContextCompat;
+import androidx.fragment.app.Fragment;
 import androidx.preference.PreferenceManager;
 
 import com.google.android.exoplayer2.PlaybackException;
@@ -89,6 +90,7 @@ import org.schabi.newpipe.fragments.list.videos.RelatedItemsFragment;
 import org.schabi.newpipe.ktx.AnimationType;
 import org.schabi.newpipe.local.dialog.PlaylistDialog;
 import org.schabi.newpipe.local.history.HistoryRecordManager;
+import org.schabi.newpipe.local.playlist.LocalPlaylistFragment;
 import org.schabi.newpipe.player.Player;
 import org.schabi.newpipe.player.PlayerService;
 import org.schabi.newpipe.player.PlayerType;
@@ -472,10 +474,21 @@ public final class VideoDetailFragment
 
         binding.detailControlsBackground.setOnClickListener(v -> openBackgroundPlayer(false));
         binding.detailControlsPopup.setOnClickListener(v -> openPopupPlayer(false));
-        binding.detailControlsPlaylistAppend.setOnClickListener(makeOnClickListener(info ->
+        binding.detailControlsPlaylistAppend.setOnClickListener(makeOnClickListener(info -> {
+            if (getFM() != null && currentInfo != null) {
+                final Fragment fragment = getParentFragmentManager().
+                        findFragmentById(R.id.fragment_holder);
+
+                // commit previous pending changes to database
+                if (fragment instanceof LocalPlaylistFragment) {
+                    ((LocalPlaylistFragment) fragment).commitChanges();
+                }
+
                 disposables.add(PlaylistDialog.createCorrespondingDialog(requireContext(),
                         List.of(new StreamEntity(info)),
-                        dialog -> dialog.show(getParentFragmentManager(), TAG)))));
+                        dialog -> dialog.show(getParentFragmentManager(), TAG)));
+            }
+        }));
         binding.detailControlsDownload.setOnClickListener(v -> {
             if (PermissionHelper.checkStoragePermissions(activity,
                     PermissionHelper.DOWNLOAD_DIALOG_REQUEST_CODE)) {

--- a/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
@@ -158,6 +158,15 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
         return headerBinding;
     }
 
+    // Commit changes immediately when the user turns to the player.
+    // Delete operations will be committed to ensure that the database
+    // is up to date when the user adds the just deleted stream by the player.
+    public void commitChanges() {
+        if (isModified != null && isModified.get()) {
+            saveImmediate();
+        }
+    }
+
     @Override
     protected void initListeners() {
         super.initListeners();

--- a/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
@@ -41,6 +41,7 @@ import org.schabi.newpipe.databinding.PlaylistControlBinding;
 import org.schabi.newpipe.error.ErrorInfo;
 import org.schabi.newpipe.error.UserAction;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
+import org.schabi.newpipe.fragments.MainFragment;
 import org.schabi.newpipe.fragments.list.playlist.PlaylistControlViewHolder;
 import org.schabi.newpipe.info_list.dialog.InfoItemDialog;
 import org.schabi.newpipe.info_list.dialog.StreamDialogDefaultEntry;
@@ -71,7 +72,7 @@ import io.reactivex.rxjava3.subjects.PublishSubject;
 
 public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistStreamEntry>, Void>
         implements PlaylistControlViewHolder {
-    // Save the list 10 seconds after the last change occurred
+    /** Save the list 10 seconds after the last change occurred. */
     private static final long SAVE_DEBOUNCE_MILLIS = 10000;
     private static final int MINIMUM_INITIAL_DRAG_VELOCITY = 12;
     @State
@@ -92,12 +93,19 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
     private PublishSubject<Long> debouncedSaveSignal;
     private CompositeDisposable disposables;
 
-    /* Has the playlist been fully loaded from db */
+    /** Whether the playlist has been fully loaded from db. */
     private AtomicBoolean isLoadingComplete;
-    /* Has the playlist been modified (e.g. items reordered or deleted) */
+    /** Whether the playlist has been modified (e.g. items reordered or deleted) */
     private AtomicBoolean isModified;
-    /* Flag to prevent simultaneous rewrites of the playlist */
+    /** Flag to prevent simultaneous rewrites of the playlist. */
     private boolean isRewritingPlaylist = false;
+
+    /**
+     * The pager adapter that the fragment is created from when it is used as frontpage, i.e.
+     * {@link #useAsFrontPage} is {@link true}.
+     */
+    @Nullable
+    private MainFragment.SelectedTabsPagerAdapter tabsPagerAdapter = null;
 
     public static LocalPlaylistFragment getInstance(final long playlistId, final String name) {
         final LocalPlaylistFragment instance = new LocalPlaylistFragment();
@@ -158,9 +166,11 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
         return headerBinding;
     }
 
-    // Commit changes immediately when the user turns to the player.
-    // Delete operations will be committed to ensure that the database
-    // is up to date when the user adds the just deleted stream by the player.
+    /**
+     * <p>Commit changes immediately if the playlist has been modified.</p>
+     *  Delete operations and other modifications will be committed to ensure that the database
+     *  is up to date, e.g. when the user adds the just deleted stream from another fragment.
+     */
     public void commitChanges() {
         if (isModified != null && isModified.get()) {
             saveImmediate();
@@ -299,6 +309,9 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
         }
         if (disposables != null) {
             disposables.dispose();
+        }
+        if (tabsPagerAdapter != null) {
+            tabsPagerAdapter.getLocalPlaylistFragments().remove(this);
         }
 
         debouncedSaveSignal = null;
@@ -885,6 +898,11 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
                     sharePlaylist(/* shouldSharePlaylistDetails= */ false)
                 )
                 .show();
+    }
+
+    public void setTabsPagerAdapter(
+            @Nullable final MainFragment.SelectedTabsPagerAdapter tabsPagerAdapter) {
+        this.tabsPagerAdapter = tabsPagerAdapter;
     }
 }
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
The reason for this issue is an inconsistency between user interaction and database commit order.

###### Expected behavior
delete - commit (delete) - add - commit (add)
###### Actual behavior
delete - add - commit (add, commit immediately) - commit (delete, commit after ~10s due to the debouncedSaveSignal)
###### Best Solution
Removes all debounced commit strategies. Sequential consistency is guaranteed by database transactions.

But I don't know why the delete operation uses the deferred commit strategy. BTW, I realize PR #8221 could have many conflicts with this solution. So I took a conservative approach to fix it.
###### Current Solution
Concurrent operations on the playlist database occur if and only if the user opens both LocalPlaylistFragment and VideoDetailFragment as described in the related issue. So I force all delete operations to be committed to the database before adding.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before:


https://user-images.githubusercontent.com/15650457/163764963-2ef2b4ee-7e0f-426d-9967-7e1d1381e943.mp4



- After:


https://user-images.githubusercontent.com/15650457/163764983-3438a231-a65e-4b3e-965a-8aedad61fafe.mp4

From main page tab:

https://user-images.githubusercontent.com/15650457/166681029-af08dfa5-6c94-4afa-b72b-0679cbef122e.mp4



#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also, add any other relevant links. -->
- Fixes #7402

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "comment fix" if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
