### PR TITLE
Fix disabled caption to no longer automatically re-enable on new player instance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - dev
       - master
+      - release/**
     paths-ignore:
       - 'README.md'
       - 'doc/**'

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -3557,14 +3557,19 @@ public final class Player implements
         }
 
         // apply caption language from previous user preference
-        final List<String> selectedPreferredLanguages =
-                trackSelector.getParameters().preferredTextLanguages;
         final String userPreferredLanguage =
                 prefs.getString(context.getString(R.string.caption_user_set_key), null);
         final int textRendererIndex = getCaptionRendererIndex();
 
-        if (userPreferredLanguage != null
-                && !selectedPreferredLanguages.contains(userPreferredLanguage)
+        if (userPreferredLanguage == null) {
+            trackSelector.setParameters(trackSelector.buildUponParameters()
+                    .setRendererDisabled(textRendererIndex, true));
+            return;
+        }
+
+        final List<String> selectedPreferredLanguages =
+                trackSelector.getParameters().preferredTextLanguages;
+        if (!selectedPreferredLanguages.contains(userPreferredLanguage)
                 && textRendererIndex != RENDERER_UNAVAILABLE) {
             trackSelector.setParameters(trackSelector.buildUponParameters()
                     .setPreferredTextLanguages(userPreferredLanguage,

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -3557,20 +3557,27 @@ public final class Player implements
         }
 
         // apply caption language from previous user preference
+        final int textRendererIndex = getCaptionRendererIndex();
+        if (textRendererIndex == RENDERER_UNAVAILABLE) {
+            return;
+        }
+
+        // If user prefers to show no caption, then disable the renderer.
+        // Otherwise, DefaultTrackSelector may automatically find an available caption
+        // and display that.
         final String userPreferredLanguage =
                 prefs.getString(context.getString(R.string.caption_user_set_key), null);
-        final int textRendererIndex = getCaptionRendererIndex();
-
         if (userPreferredLanguage == null) {
             trackSelector.setParameters(trackSelector.buildUponParameters()
                     .setRendererDisabled(textRendererIndex, true));
             return;
         }
 
+        // Only set preferred language if it does not match the user preference,
+        // otherwise there might be an infinite cycle at onTextTracksChanged.
         final List<String> selectedPreferredLanguages =
                 trackSelector.getParameters().preferredTextLanguages;
-        if (!selectedPreferredLanguages.contains(userPreferredLanguage)
-                && textRendererIndex != RENDERER_UNAVAILABLE) {
+        if (!selectedPreferredLanguages.contains(userPreferredLanguage)) {
             trackSelector.setParameters(trackSelector.buildUponParameters()
                     .setPreferredTextLanguages(userPreferredLanguage,
                             PlayerHelper.captionLanguageStemOf(userPreferredLanguage))


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This fixes another bug introduced by #8150 where `DefaultTrackSelector` will have text tracks automatically selected at start, where captions will be enabled for a playback session (i.e. new player instance) even if `No Caption` was selected in previous session. 
This change will disable text tracks when building the caption menu when `userPreferredLanguage` does not exist.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- https://github.com/TeamNewPipe/NewPipe/issues/8230#issuecomment-1100921774

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
