### PR TITLE
Fix enqueuing behavior

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/info_list/dialog/InfoItemDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/dialog/InfoItemDialog.java
@@ -245,18 +245,16 @@ public final class InfoItemDialog {
         }
 
         /**
-         * Adds {@link StreamDialogDefaultEntry#ENQUEUE} if the player is open and
+         * Adds {@link StreamDialogDefaultEntry#ENQUEUE} unconditionally and
          * {@link StreamDialogDefaultEntry#ENQUEUE_NEXT} if there are multiple streams
          * in the play queue.
          * @return the current {@link Builder} instance
          */
         public Builder addEnqueueEntriesIfNeeded() {
-            if (PlayerHolder.getInstance().isPlayQueueReady()) {
-                addEntry(StreamDialogDefaultEntry.ENQUEUE);
+            addEntry(StreamDialogDefaultEntry.ENQUEUE);
 
-                if (PlayerHolder.getInstance().getQueueSize() > 1) {
-                    addEntry(StreamDialogDefaultEntry.ENQUEUE_NEXT);
-                }
+            if (PlayerHolder.getInstance().getQueueSize() > 1) {
+                addEntry(StreamDialogDefaultEntry.ENQUEUE_NEXT);
             }
             return this;
         }

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -898,6 +898,11 @@ public final class Player implements
 
         simpleExoPlayer.setVolume(isMuted ? 0 : 1);
         notifyQueueUpdateToListeners();
+
+        // Buffer paused streams when users add streams to the play queue.
+        if (!playOnReady && !playQueue.isEmpty()) {
+            simpleExoPlayer.prepare();
+        }
     }
     //endregion
 

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHolder.java
@@ -84,7 +84,7 @@ public final class PlayerHolder {
     }
 
     public int getQueueSize() {
-        if (player == null || player.getPlayQueue() == null) {
+        if (!isPlayQueueReady()) {
             // player play queue might be null e.g. while player is starting
             return 0;
         }

--- a/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
@@ -114,8 +114,14 @@ public final class NavigationHelper {
         // - if there is nothing already playing, it is useful for the enqueue action to have a
         //   slightly different behaviour than the normal play action: the latter resumes playback,
         //   the former doesn't. (note that enqueue can be triggered when nothing is playing only
-        //   by long pressing the video detail fragment, playlist or channel controls
-        return getPlayerIntent(context, targetClazz, playQueue, false)
+        //   by long pressing the feed fragment, video detail fragment, playlist or channel
+        //   controls)
+        final boolean resumePlayback = false;
+        // `playWhenReady` is false if the play queue is empty.
+        // Users may start playing manually after queuing up a bunch of videos.
+        // For more details, please see #2611 and #8151.
+        final boolean playWhenReady = PlayerHolder.getInstance().getQueueSize() > 0;
+        return getPlayerIntent(context, targetClazz, playQueue, resumePlayback, playWhenReady)
                 .putExtra(Player.ENQUEUE, true);
     }
 
@@ -524,6 +530,7 @@ public final class NavigationHelper {
      * Opens {@link ChannelFragment}.
      * Use this instead of {@link #openChannelFragment(FragmentManager, int, String, String)}
      * when no fragments are used / no FragmentManager is available.
+     *
      * @param context
      * @param serviceId
      * @param url


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Show ```Enqueue``` menu item even when the play queue is empty.
- First enqueued video/audio will remain paused by setting ```playWhenReady``` to false.
- Buffering the paused video/audio (Tested on my device, but I can't tell from the visual feedback that it's working).

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before:

https://user-images.githubusercontent.com/15650457/164134776-c806b891-b5ac-4070-b18a-29f9a8e688fc.mp4


- After:

https://user-images.githubusercontent.com/15650457/164134787-ebc99119-f109-492d-9f10-f217f0685b2d.mp4


#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also, add any other relevant links. -->
- Fixes #2611
- Fixes #8151

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "comment fix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
[Debug APK](https://github.com/TeamNewPipe/NewPipe/suites/6183214268/artifacts/217353359)

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
