### PR TITLE
Added higher resolutions to the default res settings when they are enabled

### DIFF
--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -139,6 +139,12 @@
         <item>240p</item>
         <item>144p</item>
     </string-array>
+
+    <string-array name="resolution_list_values_additional_resolutions">
+        <item>2160p</item>
+        <item>1440p</item>
+    </string-array>
+
     <string-array name="resolution_list_description">
         <item>@string/best_resolution</item>
         <item>1080p60</item>
@@ -149,6 +155,11 @@
         <item>360p</item>
         <item>240p</item>
         <item>144p</item>
+    </string-array>
+
+    <string-array name="resolution_list_description_additional_resolutions">
+        <item>2160p</item>
+        <item>1440p</item>
     </string-array>
 
     <string name="scale_to_square_image_in_notifications_key">scale_to_square_image_in_notifications</string>
@@ -1250,6 +1261,11 @@
         <item>360p</item>
         <item>240p</item>
         <item>144p</item>
+    </string-array>
+
+    <string-array name="limit_data_usage_values_list_additional_resolutions">
+        <item>2160p</item>
+        <item>1440p</item>
     </string-array>
 
     <string name="list_view_mode_key">list_view_mode</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -520,6 +520,11 @@
         <item>240p</item>
         <item>144p</item>
     </string-array>
+
+    <string-array name="limit_data_usage_description_list_additional_resolutions">
+        <item>2160p</item>
+        <item>1440p</item>
+    </string-array>
     <!-- Notifications settings -->
     <string name="enable_streams_notifications_title">New streams notifications</string>
     <string name="enable_streams_notifications_summary">Notify about new streams from subscriptions</string>


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

Added higher resolutions the the default resolution settings.
They are only visible, when show higher resolutions are turned on.

When the user has selected a higher resolution as default and he turns "show higher resolutions" off, the highest now available resolution will be used as a fallback.

#### Before/After Screenshots/Screen Record
- Before:
![Screenshot_20220420-092024_NewPipe Debug](https://user-images.githubusercontent.com/46609883/164173213-c5a2dc7e-4a64-444e-af9b-9b604d8028c6.jpg)
- After:
![Screenshot_20220420-092033_NewPipe Debug](https://user-images.githubusercontent.com/46609883/164173233-ff1b0dd2-2378-4ba2-acfa-bfd395a5db4f.jpg)


#### Fixes the following issue(s)
- Fixes   #2941 



#### APK testing 
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
