### PR TITLE
Adapt opacity of popup close button to allow touches in other apps on Android >=12

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
@@ -78,6 +78,20 @@ public final class PlayerHelper {
     private static final NumberFormat SPEED_FORMATTER = new DecimalFormat("0.##x");
     private static final NumberFormat PITCH_FORMATTER = new DecimalFormat("##%");
 
+    /**
+     * Maximum opacity allowed for Android 12 and higher to allow touches on other apps when using
+     * NewPipe's popup player.
+     *
+     * <p>
+     * This value is hardcoded instead of being get dynamically with the method linked of the
+     * constant documentation below, because it is not static and popup player layout parameters
+     * are generated with static methods.
+     * </p>
+     *
+     * @see WindowManager.LayoutParams#FLAG_NOT_TOUCHABLE
+     */
+    private static final float MAXIMUM_OPACITY_ALLOWED_FOR_S_AND_HIGHER = 0.8f;
+
     @Retention(SOURCE)
     @IntDef({AUTOPLAY_TYPE_ALWAYS, AUTOPLAY_TYPE_WIFI,
             AUTOPLAY_TYPE_NEVER})
@@ -571,6 +585,12 @@ public final class PlayerHelper {
                 popupLayoutParamType(),
                 flags,
                 PixelFormat.TRANSLUCENT);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            // Setting maximum opacity allowed for touch events to other apps for Android 12 and
+            // higher to prevent non interaction when using other apps with the popup player
+            closeOverlayLayoutParams.alpha = MAXIMUM_OPACITY_ALLOWED_FOR_S_AND_HIGHER;
+        }
 
         closeOverlayLayoutParams.gravity = Gravity.LEFT | Gravity.TOP;
         closeOverlayLayoutParams.softInputMode =


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)

#### Description of the changes in your PR
This PR sets the opacity, on Android 12 and higher, of the popup close button to [the maximum one which allows touches on other apps for these Android versions](https://developer.android.com/reference/android/view/WindowManager.LayoutParams#maximum-obscuring-opacity).

See the documentation of the [`FLAG_NOT_TOUCHABLE`](https://developer.android.com/reference/android/view/WindowManager.LayoutParams#FLAG_NOT_TOUCHABLE) flag, used in the popup close button, for more details.

These changes have been tested on an Android 12 emulator and by several users (from [the corresponding issue](https://github.com/TeamNewPipe/NewPipe/issues/6770) and from [Reddit](https://www.reddit.com/r/NewPipe/comments/u69r9c/about_non_interactivity_on_other_apps_than/)) and the changes restore the ability to interact with other apps on Android 12 (and probably higher, I didn't test the changes on Android 13 Developer Previews at all).

#### Before/After Screenshots/Screen Record

Remember that **these changes only apply on Android 12 and higher**.

- Before:

  <img src="https://user-images.githubusercontent.com/74829229/164723942-a4af41c2-81a7-48ac-b08c-87cbcb6750e1.png" width="150px" alt="before_opacity_change">

- After:

  <img src="https://user-images.githubusercontent.com/74829229/164724116-34cf9132-892d-4041-bbf2-f000a071c3ec.png" width="150px" alt="after_opacity_change">

#### Fixes the following issue(s)
- Fixes #6770

#### APK testing 
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).