### PR TITLE
replace possible dirty URL with clean URL when sharing

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
@@ -207,12 +207,12 @@ public class ChannelFragment extends BaseListInfoFragment<StreamInfoItem, Channe
                 break;
             case R.id.menu_item_openInBrowser:
                 if (currentInfo != null) {
-                    ShareUtils.openUrlInBrowser(requireContext(), currentInfo.getOriginalUrl());
+                    ShareUtils.openUrlInBrowser(requireContext(), currentInfo.getUrl());
                 }
                 break;
             case R.id.menu_item_share:
                 if (currentInfo != null) {
-                    ShareUtils.shareText(requireContext(), name, currentInfo.getOriginalUrl(),
+                    ShareUtils.shareText(requireContext(), name, currentInfo.getUrl(),
                             currentInfo.getAvatarUrl());
                 }
                 break;

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
@@ -226,11 +226,11 @@ public class PlaylistFragment extends BaseListInfoFragment<StreamInfoItem, Playl
                 NavigationHelper.openSettings(requireContext());
                 break;
             case R.id.menu_item_openInBrowser:
-                ShareUtils.openUrlInBrowser(requireContext(), url);
+                ShareUtils.openUrlInBrowser(requireContext(), currentInfo.getUrl());
                 break;
             case R.id.menu_item_share:
                 if (currentInfo != null) {
-                    ShareUtils.shareText(requireContext(), name, url,
+                    ShareUtils.shareText(requireContext(), name, currentInfo.getUrl(),
                             currentInfo.getThumbnailUrl());
                 }
                 break;


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- The share and open in browser options use a clean URL instead of possibly "dirty" origin URL
- Finished undone work in #3262
- every call of `ShareUtils.shareText()` and `ShareUtils.openUrlInBrowser()` is checked

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #3247 

#### Test Building
The basic sharing function works well, but in order to build a dirty URL for further testing, we need to add some parameters. I've tried every parameter listed in the [guidance of youtube player parameters](https://developers.google.com/youtube/player_parameters), and the only parameter that works in the web player is `start`, but it neither work at NewPipe(`start=30` should work the same as `t=30`) nor shown in the original URL shared in the prefix version.
So I didn't write any test yet, and helps are needed here.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
