### PR TITLE
Set the progressive_load_interval_default_value to 64 KiB

### DIFF
--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -56,7 +56,7 @@
     </string-array>
 
     <string name="progressive_load_interval_key">progressive_load_interval</string>
-    <string name="progressive_load_interval_default_value">default</string>
+    <string name="progressive_load_interval_default_value">64</string>
     <string-array name="progressive_load_interval_descriptions">
         <item>1 KiB</item>
         <item>16 KiB</item>


### PR DESCRIPTION
#### What is it?
- [x] Workaround (user facing)

#### Description of the changes in your PR
Set the progressive_load_interval_default_value to 64 KiB

This should workaround the problems from #8238.
https://github.com/TeamNewPipe/NewPipe/issues/8238#issuecomment-1106096644

As a theoretical drawback stuttering may occur on very low bandwith connections, but I think this is negligible (also users can change it in the settings).

#### Fixes the following issue(s)
- Works around #8238

#### APK testing 
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
