### PR TITLE
Removed unused ``strings.xml`` resources

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -730,11 +730,8 @@
     <string name="show_error_snackbar">إظهار خطأ snackbar</string>
     <string name="no_appropriate_file_manager_message_android_10">لم يتم العثور على مدير ملفات مناسب لهذا الإجراء.
 \nالرجاء تثبيت مدير ملفات متوافق مع Storage Access Framework.</string>
-    <string name="background_player_already_playing_toast">يتم تشغيله في الخلفية</string>
     <string name="detail_pinned_comment_view_description">تعليق مثبت</string>
     <string name="leak_canary_not_available">LeakCanary غير متوفر</string>
-    <string name="adjust_by_semitones_checkbox">ضبط الصوت من خلال النغمات الموسيقية النصفية</string>
-    <string name="playback_tempo_step">خطوة الإيقاع</string>
     <string name="progressive_load_interval_exoplayer_default">الافتراضي ExoPlayer</string>
     <string name="progressive_load_interval_summary">تغيير حجم الفاصل الزمني للتحميل (حاليا %s). قد تؤدي القيمة الأقل إلى تسريع تحميل الفيديو الأولي. تتطلب التغييرات إعادة تشغيل المشغل.</string>
     <string name="settings_category_player_notification_summary">تكوين إشعار مشغل البث الحالي</string>

--- a/app/src/main/res/values-b+zh+HANS+CN/strings.xml
+++ b/app/src/main/res/values-b+zh+HANS+CN/strings.xml
@@ -670,11 +670,8 @@
     <string name="no_appropriate_file_manager_message_android_10">找不到适合此操作的文件管理器。
 \n请安装与存储访问框架(SAF)兼容的文件管理器。</string>
     <string name="error_report_notification_title">NewPipe 遇到了一个错误，点击此处报告此错误</string>
-    <string name="background_player_already_playing_toast">已经在后台播放</string>
     <string name="detail_pinned_comment_view_description">置顶评论</string>
     <string name="leak_canary_not_available">LeakCanary 不可用</string>
-    <string name="adjust_by_semitones_checkbox">以音乐半音调整音高</string>
-    <string name="playback_tempo_step">节奏步长</string>
     <string name="progressive_load_interval_summary">改变加载间隔的大小（当前%s），较低的值可以加快初始的视频加载速度，改变需要重启播放器。</string>
     <string name="progressive_load_interval_exoplayer_default">ExoPlayer 默认</string>
     <string name="settings_category_player_notification_summary">配置当前正在播放的串流的通知</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -650,7 +650,6 @@
     <string name="start_main_player_fullscreen_title">Inicia el reproductor principal en pantalla completa</string>
     <string name="main_page_content_swipe_remove">Llisqueu els elements per eliminar-los</string>
     <string name="start_main_player_fullscreen_summary">Si la rotació automàtica està bloquejada, no inicieu vídeos al mini reproductor, sinó que aneu directament al mode de pantalla completa. Podeu accedir igualment al mini reproductor sortint de pantalla completa</string>
-    <string name="background_player_already_playing_toast">Ja s\'està reproduint en segon pla</string>
     <string name="error_report_channel_name">Notificació d\'informe d\'error</string>
     <string name="crash_the_player">Tancar abruptament el reproductor</string>
     <string name="manual_update_title">Comprovar si hi ha actualitzacions</string>

--- a/app/src/main/res/values-ckb/strings.xml
+++ b/app/src/main/res/values-ckb/strings.xml
@@ -672,7 +672,6 @@
     <string name="show_crash_the_player_title">پیشاندانی ”کڕاش کردنی لێدەرەکە“</string>
     <string name="create_error_notification">سازاندنی پەیامی کێشەیەک</string>
     <string name="manual_update_title">پشکنین بۆ نوێکردنەوە</string>
-    <string name="background_player_already_playing_toast">وا لە پاشبنەمادا لێدەدرێت</string>
     <string name="error_report_channel_name">کێشە لە سکاڵا کردنی پەیام</string>
     <string name="error_report_channel_description">پەیامەکانی سکاڵاکردن لە کێشەکان</string>
     <string name="feed_new_items">بابەتە نوێیەکانی فیید</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -684,7 +684,6 @@
     <string name="create_error_notification">Vytvořit oznámení o chybě</string>
     <string name="checking_updates_toast">Kontrola aktualizací…</string>
     <string name="show_crash_the_player_title">Ukázat „Shodit přehrávač“</string>
-    <string name="background_player_already_playing_toast">Hraje již v pozadí</string>
     <string name="feed_new_items">Nové položky feedů</string>
     <string name="no_appropriate_file_manager_message_android_10">Pro tuto akci nebyl nalezen žádný vhodný správce souborů.
 \nProsím, nainstalujte správce souborů kompatibilní se Storage Access Framework.</string>
@@ -698,7 +697,5 @@
     <string name="crash_the_player">Shodit přehrávač</string>
     <string name="progressive_load_interval_summary">Změnit interval načítání (aktuálně %s). Menší hodnota může zrychlit počáteční načítání videa. Změna vyžaduje restart přehrávače.</string>
     <string name="leak_canary_not_available">LeakCanary není dostupné</string>
-    <string name="adjust_by_semitones_checkbox">Upravit výšku tónů po půltónech</string>
-    <string name="playback_tempo_step">Krok tempa</string>
     <string name="progressive_load_interval_exoplayer_default">Výchozí ExoPlayer</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -684,12 +684,9 @@
 \nBitte installiere einen Dateimanager oder versuche, \'%s\' in den Downloadeinstellungen zu deaktivieren.</string>
     <string name="no_appropriate_file_manager_message_android_10">Es wurde kein geeigneter Dateimanager für diese Aktion gefunden.
 \nBitte installiere einen Storage Access Framework kompatiblen Dateimanager.</string>
-    <string name="background_player_already_playing_toast">Wird bereits im Hintergrund abgespielt</string>
     <string name="detail_pinned_comment_view_description">Angehefteter Kommentar</string>
     <string name="leak_canary_not_available">LeakCanary ist nicht verfügbar</string>
-    <string name="adjust_by_semitones_checkbox">Tonhöhe nach musikalischen Halbtönen anpassen</string>
     <string name="progressive_load_interval_summary">Ändern der Größe des Ladeintervalls (derzeit %s). Ein niedrigerer Wert kann das anfängliche Laden des Videos beschleunigen. Änderungen erfordern einen Neustart des Players.</string>
-    <string name="playback_tempo_step">Geschwindigkeitsstufe</string>
     <string name="progressive_load_interval_exoplayer_default">ExoPlayer Standard</string>
     <string name="notifications">Benachrichtigungen</string>
     <string name="streams_notification_channel_description">Benachrichtigen über neue abonnierbare Streams</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -682,11 +682,8 @@
 \nΕγκαταστήστε έναν συμβατό με το Πλαίσιο Πρόσβασης Αποθήκευσης.</string>
     <string name="error_report_notification_title">Το NewPipe παρουσίασε ένα σφάλμα. Πατήστε για αναφορά</string>
     <string name="show_error_snackbar">Εμφάνιση μιας snackbar σφάλματος</string>
-    <string name="background_player_already_playing_toast">Αναπαράγεται ήδη στο παρασκήνιο</string>
     <string name="detail_pinned_comment_view_description">Καρφιτσωμένο σχόλιο</string>
     <string name="leak_canary_not_available">Το LeakCanary δεν είναι διαθέσιμο</string>
-    <string name="adjust_by_semitones_checkbox">Προσαρμόστε τον τόνο με βάση τα μουσικά ημιτόνια</string>
-    <string name="playback_tempo_step">Βήμα τέμπο</string>
     <string name="progressive_load_interval_exoplayer_default">Εξ\' ορισμού ExoPlayer</string>
     <string name="progressive_load_interval_summary">Αλλάξτε το μέγεθος του διαστήματος φόρτωσης (επί του παρόντος είναι %s). Μια χαμηλότερη τιμή μπορεί να επιταχύνει την αρχική φόρτωση βίντεο. Οι αλλαγές απαιτούν επανεκκίνηση της εφαρμογής.</string>
     <string name="notifications">Ειδοποιήσεις</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -686,12 +686,9 @@
     <string name="no_appropriate_file_manager_message_android_10">No se encontró ningún gestor de archivos adecuado para esta acción.
 \nPor favor instale un gestor de archivos compatible con \"Sistema de Acceso al Almacenamiento\".</string>
     <string name="detail_pinned_comment_view_description">Comentario fijado</string>
-    <string name="background_player_already_playing_toast">Ya se reproduce en segundo plano</string>
     <string name="leak_canary_not_available">LeakCanary no está disponible</string>
     <string name="progressive_load_interval_exoplayer_default">ExoPlayer valor por defecto</string>
-    <string name="playback_tempo_step">Paso de tempo</string>
     <string name="progressive_load_interval_summary">Cambia el tamaño del intervalo de carga (actualmente %s). Un valor más bajo puede acelerar la carga inicial del vídeo. Los cambios requieren un reinicio del reproductor.</string>
-    <string name="adjust_by_semitones_checkbox">Ajustar el tono por semitonos musicales</string>
     <string name="notifications">Notificaciones</string>
     <string name="streams_notification_channel_name">Nuevos streams</string>
     <string name="settings_category_player_notification_title">Notificación del reproductor</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -674,7 +674,6 @@
     <string name="error_report_notification_title">NewPipe töös tekkis viga, sellest teavitamiseks klõpsi</string>
     <string name="crash_the_player">Jooksuta meediamängija kokku</string>
     <string name="show_error_snackbar">Näita veateate akent</string>
-    <string name="background_player_already_playing_toast">Meedia esitamine taustal toimib juba</string>
     <string name="error_report_channel_name">Teavitus vigadest</string>
     <string name="error_report_channel_description">Teavitused vigadest informeerimiseks</string>
     <string name="error_report_notification_toast">Tekkis viga, vaata vastavat teadet</string>
@@ -709,6 +708,4 @@
     <string name="you_successfully_subscribed">Sa oled nüüd selle kanali tellija</string>
     <string name="enumeration_comma">,</string>
     <string name="toggle_all">Lülita kõik sisse</string>
-    <string name="adjust_by_semitones_checkbox">Reguleeri helikõrgust muusikaliste pooltoonide kaupa</string>
-    <string name="playback_tempo_step">Tempo samm</string>
 </resources>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -666,7 +666,6 @@
     <string name="enqueue_next_stream">Gehitu bideo hau isatsari</string>
     <string name="show_crash_the_player_title">Erakutsi \"Itxi erreproduzigailua\"</string>
     <string name="processing_may_take_a_moment">Prozesatzen... Itxoin mesedez</string>
-    <string name="background_player_already_playing_toast">Atzeko planoan erreproduzitzen dagoeneko</string>
     <string name="error_report_channel_name">Erroreen txostenen jakinarazpena</string>
     <string name="error_report_channel_description">Jakinarazpenak erroreen berri emateko</string>
     <string name="error_report_notification_title">NewPipe-k errore bat aurkitu du, sakatu berri emateko</string>
@@ -695,8 +694,6 @@
     <string name="you_successfully_subscribed">Kanal honetara harpidetu zara</string>
     <string name="enumeration_comma">,</string>
     <string name="toggle_all">Txandakatu denak</string>
-    <string name="adjust_by_semitones_checkbox">Doitu tonua semitono musikalen arabera</string>
-    <string name="playback_tempo_step">Tempo urratsa</string>
     <string name="progressive_load_interval_summary">Aldatu karga maiztasun tamaina (unean %s). Balio txikiago batek bideoaren hasierako karga azkartu dezake. Erreproduzigailuaren berrabiarazte bat behar du.</string>
     <string name="enable_streams_notifications_summary">Harpidetzen jario berriei buruz jakinarazi</string>
     <string name="delete_downloaded_files_confirm">Ezabatu deskargatutako fitxategi guztiak biltegitik\?</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -683,10 +683,7 @@
     <string name="error_report_notification_title">نیوپایپ به خطایی برخورد. برای گزارش، بزنید</string>
     <string name="error_report_notification_toast">خطایی رخ داد. آگاهی را ببینید</string>
     <string name="detail_pinned_comment_view_description">نظر سنجاق شده</string>
-    <string name="background_player_already_playing_toast">در حال پخش در پس‌زمینه</string>
     <string name="leak_canary_not_available">لیک‌کاناری موجود نیست</string>
-    <string name="playback_tempo_step">گام سرعت</string>
-    <string name="adjust_by_semitones_checkbox">تنظیم زیر و بم با شبه‌تن‌ها</string>
     <string name="progressive_load_interval_summary">تغییر اندازهٔ بازهٔ بار (هم‌اکنون %s). مقداری پایین‌تر، می‌تواند بار کردن نخستین ویدیو را سرعت بخشد. تغییرها نیاز به یک آغاز دوبارهٔ پخش‌کننده دارند.</string>
     <string name="progressive_load_interval_exoplayer_default">پیش‌گزیدهٔ اگزوپلیر</string>
     <string name="notifications">آگاهی‌ها</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -685,11 +685,8 @@
     <string name="no_appropriate_file_manager_message">Aucun gestionnaire de fichier approprié n\'a été trouvé pour cette action.
 \nVeuillez installer un gestionnaire de fichiers ou essayez de désactiver \'%s\' dans les paramètres de téléchargement.</string>
     <string name="detail_pinned_comment_view_description">Commentaire épinglé</string>
-    <string name="background_player_already_playing_toast">Une lecture est déjà en arrière-plan</string>
     <string name="leak_canary_not_available">LeakCanary n\'est pas disponible</string>
     <string name="progressive_load_interval_summary">Modifie la taille de l\'intervalle de chargement (actuellement %s). Une valeur plus faible peut accélérer le chargement initial des vidéos .</string>
-    <string name="adjust_by_semitones_checkbox">Règler la hauteur par demi-tons musicaux</string>
-    <string name="playback_tempo_step">Pas du tempo</string>
     <string name="progressive_load_interval_exoplayer_default">Valeur par défaut d’ExoPlayer</string>
     <string name="streams_notification_channel_name">Nouveaux flux</string>
     <string name="settings_category_player_notification_summary">Configurer la notification du flux en cours de lecture</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -672,8 +672,6 @@
     <string name="enqueued_next">Enfileirado</string>
     <string name="manual_update_title">Procurar actualizacións</string>
     <string name="manual_update_description">Procurar manualmente novas versións</string>
-    <string name="adjust_by_semitones_checkbox">Axustar o ton do semitóns musicais</string>
-    <string name="playback_tempo_step">Paso do tempo</string>
     <string name="checking_updates_toast">A procurar actualizacións…</string>
     <string name="downloads_storage_use_saf_summary_api_29">A partir do Android 10, só o \'Sistema de Acceso ao Almacenamento\' está soportado</string>
     <string name="progressive_load_interval_summary">Cambia o tamaño do intervalo de carga (actualmente %s). Un valor menor pode acelerar o carregamento do vídeo. Cambios poden precisar un reinicio do reprodutor.</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -706,11 +706,8 @@
     <string name="error_report_channel_name">התראת דיווח שגיאה</string>
     <string name="no_appropriate_file_manager_message_android_10">לא נמצאו מנהלי קבצים שמתאימים לפעולה הזאת.
 \nנא להתקין מנהל קבצים שתומך בתשתית גישה לאחסון.</string>
-    <string name="background_player_already_playing_toast">כבר מתנגן ברקע</string>
     <string name="detail_pinned_comment_view_description">הערה ננעצה</string>
     <string name="leak_canary_not_available">LeakCanary אינה זמינה</string>
-    <string name="adjust_by_semitones_checkbox">התאמת גובה הצליל לפי חצאי טונים מוזיקליים</string>
-    <string name="playback_tempo_step">צעד מקצב</string>
     <string name="progressive_load_interval_exoplayer_default">ברירת מחדל של ExoPlayer</string>
     <string name="progressive_load_interval_summary">שינוי גודל מרווח הטעינה (כרגע %s). ערך נמוך יותר עשוי להאיץ את טעינת הווידאו הראשונית. שינויים דורשים את הפעלת הנגן מחדש.</string>
     <string name="streams_notification_channel_description">התראות על תזרימים חדשים להרשמה</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -683,6 +683,5 @@
         <item quantity="other">%1$s letöltés törölve</item>
     </plurals>
     <string name="detail_pinned_comment_view_description">Rögzített megjegyzés</string>
-    <string name="background_player_already_playing_toast">Már megy a lejátszás a háttérben</string>
     <string name="leak_canary_not_available">LeakCanary nem elérhető</string>
 </resources>

--- a/app/src/main/res/values-ia/strings.xml
+++ b/app/src/main/res/values-ia/strings.xml
@@ -229,7 +229,6 @@
     <string name="open_with">Aperir con</string>
     <string name="remote_search_suggestions">Suggestiones de recerca remote</string>
     <string name="download_thumbnail_title">Cargar miniaturas</string>
-    <string name="settings_category_notification_title">Notification</string>
     <string name="search_showing_result_for">Monstrante resultatos pro: %s</string>
     <string name="show_higher_resolutions_summary">Solmente alicun apparatos pote reproducer videos 2K/4K</string>
     <string name="start_main_player_fullscreen_title">Initiar le reproductor principal in schermo plen</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -671,11 +671,8 @@
     <string name="no_appropriate_file_manager_message_android_10">Tidak ada manajer file yang ditemukan untuk tindakan ini.
 \nMohon instal sebuah manajer file yang kompatibel dengan Storage Access Framework.</string>
     <string name="detail_pinned_comment_view_description">Komentar dipin</string>
-    <string name="background_player_already_playing_toast">Sudah diputar di latar belakang</string>
     <string name="leak_canary_not_available">LeakCanary tidak tersedia</string>
-    <string name="playback_tempo_step">Langkah tempo</string>
     <string name="progressive_load_interval_exoplayer_default">Default ExoPlayer</string>
-    <string name="adjust_by_semitones_checkbox">Atur nada berdasarkan semitone musik</string>
     <string name="progressive_load_interval_summary">Ubah ukuran interval pemuatan (saat ini %s). Sebuah nilai yang rendah mungkin dapat membuat pemuatan video awal lebih cepat. Membutuhkan sebuah pemulaian ulang pada pemain.</string>
     <string name="loading_stream_details">Memuat detail stream…</string>
     <string name="streams_notifications_interval_title">Frekuensi pemeriksaan</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -683,12 +683,9 @@
     <string name="no_appropriate_file_manager_message_android_10">Non è stato trovato alcun gestore di file appropriato per questa azione.
 \nInstallane uno compatibile con Storage Access Framework.</string>
     <string name="detail_pinned_comment_view_description">Commento in primo piano</string>
-    <string name="background_player_already_playing_toast">Già in riproduzione in sottofondo</string>
     <string name="leak_canary_not_available">LeakCanary non è disponibile</string>
-    <string name="adjust_by_semitones_checkbox">Regola il tono secondo i semitoni musicali</string>
     <string name="progressive_load_interval_exoplayer_default">Predefinito ExoPlayer</string>
     <string name="progressive_load_interval_summary">Cambia la dimensione dell\'intervallo da caricare (attualmente %s). Un valore basso può velocizzare il caricamento iniziale del video. La modifica richiede il riavvio del lettore.</string>
-    <string name="playback_tempo_step">Passo tempo</string>
     <string name="streams_notification_channel_description">Notifiche di nuove stream dalle iscrizioni</string>
     <string name="streams_notifications_interval_title">Frequenza controllo</string>
     <string name="streams_notifications_network_title">Richiesta connessione alla rete</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -663,7 +663,6 @@
     <string name="error_report_notification_toast">エラーが発生しました。通知をご覧ください</string>
     <string name="error_report_notification_title">NewPipe はエラーに遭遇しました。タップして報告</string>
     <string name="show_error_snackbar">スナックバーにエラーを表示</string>
-    <string name="background_player_already_playing_toast">既にバックグラウンドで再生されています</string>
     <string name="detail_pinned_comment_view_description">固定されたコメント</string>
     <string name="no_appropriate_file_manager_message_android_10">この動作に適切なファイルマネージャが見つかりませんでした。
 \nStorage Access Frameworkと互換性のあるファイルマネージャをインストールしてください。</string>
@@ -673,7 +672,6 @@
     <string name="create_error_notification">エラー通知を作成</string>
     <string name="error_report_channel_description">エラーを報告する通知</string>
     <string name="leak_canary_not_available">LeakCanaryが利用不可能です</string>
-    <string name="playback_tempo_step">緩急音階</string>
     <string name="settings_category_player_notification_title">プレイヤー通知</string>
     <string name="loading_stream_details">ストリームの詳細を読み込んでいます…</string>
     <string name="enable_streams_notifications_summary">登録チャンネルの新しいストリームについて通知する</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -672,7 +672,6 @@
     <string name="show_crash_the_player_summary">Viser et krasjalternativ ved bruk av avspilleren</string>
     <string name="error_report_notification_toast">Det oppstod en feil. Sjekk merknaden.</string>
     <string name="detail_pinned_comment_view_description">Festet kommentar</string>
-    <string name="background_player_already_playing_toast">Spilles allerede i bakgrunnen</string>
     <string name="error_report_channel_name">Feilrapport-merknad</string>
     <string name="error_report_channel_description">Merknader for innrapportering av feil</string>
     <string name="error_report_notification_title">NewPipe-feil. Trykk for å rapportere.</string>
@@ -682,6 +681,4 @@
     <string name="no_appropriate_file_manager_message_android_10">Installer en filbehandler som støtter lagringstilgangsrammeverk først.</string>
     <string name="leak_canary_not_available">LeakCanary er ikke tilgjengelig</string>
     <string name="progressive_load_interval_exoplayer_default">ExoPlayer-forvalg</string>
-    <string name="adjust_by_semitones_checkbox">Juster toneart etter musikalske halvtoner</string>
-    <string name="playback_tempo_step">Tempo-steg</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -677,7 +677,6 @@
     <string name="error_report_notification_title">NewPipe meldt fout, tik voor bericht</string>
     <string name="error_report_notification_toast">Foutmelding</string>
     <string name="create_error_notification">Maak een foutmelding</string>
-    <string name="background_player_already_playing_toast">Speelt al op de achtergrond</string>
     <string name="show_error_snackbar">Korte foutmelding weergeven</string>
     <string name="no_appropriate_file_manager_message">Er is geen geschikte bestandsbeheerder gevonden voor deze actie.
 \nInstalleer een bestandsbeheerder of probeer \'%s\' uit te schakelen in de download instellingen.</string>
@@ -686,7 +685,5 @@
     <string name="detail_pinned_comment_view_description">Vastgemaakt commentaar</string>
     <string name="leak_canary_not_available">LeakCanary is niet beschikbaar</string>
     <string name="progressive_load_interval_summary">Verander de laad interval tijd (nu %s). Een lagere waarde kan het initiële laden van de video versnellen. De wijziging vereist een herstart van de speler.</string>
-    <string name="adjust_by_semitones_checkbox">Pas de toonhoogte aan met muzikale halve tonen</string>
-    <string name="playback_tempo_step">Tempo stap</string>
     <string name="progressive_load_interval_exoplayer_default">ExoPlayer standaard</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -701,14 +701,11 @@
 \nZainstaluj menedżer plików lub spróbuj wyłączyć „%s” w ustawieniach pobierania.</string>
     <string name="no_appropriate_file_manager_message_android_10">Nie znaleziono odpowiedniego menedżera plików dla tej akcji.
 \nZainstaluj menedżer plików zgodny z Storage Access Framework.</string>
-    <string name="background_player_already_playing_toast">Już jest odtwarzane w tle</string>
     <string name="detail_pinned_comment_view_description">Przypięty komentarz</string>
     <string name="leak_canary_not_available">LeakCanary jest niedostępne</string>
     <string name="progressive_load_interval_title">Rozmiar interwału ładowania odtwarzania</string>
     <string name="progressive_load_interval_summary">Zmień rozmiar interwału ładowania (aktualnie %s). Niższa wartość może przyspieszyć początkowe ładowanie wideo. Zmiany wymagają ponownego uruchomienia odtwarzacza</string>
     <string name="progressive_load_interval_exoplayer_default">domyślny ExoPlayera</string>
-    <string name="adjust_by_semitones_checkbox">Dostosuj wysokość półtonami</string>
-    <string name="playback_tempo_step">Krok tempa</string>
     <string name="settings_category_player_notification_title">Powiadomienie odtwarzacza</string>
     <string name="settings_category_player_notification_summary">Skonfiguruj powiadomienie aktualnie odtwarzanego strumienia</string>
     <string name="check_new_streams">Uruchom sprawdzenie nowych strumieni</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -682,12 +682,9 @@
     <string name="show_error_snackbar">Mostrar um snackbar de erro</string>
     <string name="no_appropriate_file_manager_message">Nenhum gerenciador de arquivos apropriado foi encontrado para esta ação.
 \nInstale um gerenciador de arquivos ou tente desativar \'%s\' nas configurações de download.</string>
-    <string name="background_player_already_playing_toast">Já está tocando em segundo plano</string>
     <string name="detail_pinned_comment_view_description">Comentário fixado</string>
     <string name="leak_canary_not_available">O LeakCanary não está disponível</string>
-    <string name="playback_tempo_step">Passo do tempo</string>
     <string name="progressive_load_interval_summary">Altere o tamanho do intervalo de carregamento (atualmente %s). Um valor menor pode acelerar o carregamento inicial do vídeo. As alterações exigem que o player reinicie.</string>
-    <string name="adjust_by_semitones_checkbox">Ajustar o tom por semitons musicais</string>
     <string name="progressive_load_interval_exoplayer_default">ExoPlayer padrão</string>
     <string name="settings_category_player_notification_title">Notificação do reprodutor</string>
     <string name="settings_category_player_notification_summary">Configurar a notificação do fluxo da reprodução atual</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -683,11 +683,8 @@
     <string name="no_appropriate_file_manager_message_android_10">Nenhum gestor de ficheiros apropriado foi encontrado para esta ação.
 \nPor favor, instale um gestor de ficheiros compatível com o Storage Access Framework.</string>
     <string name="detail_pinned_comment_view_description">Comentário fixado</string>
-    <string name="background_player_already_playing_toast">Já está a reproduzir em segundo plano</string>
     <string name="leak_canary_not_available">LeakCanary não está disponível</string>
     <string name="progressive_load_interval_summary">Altere o tamanho do intervalo de carregamento (atualmente %s). Um valor menor pode acelerar o carregamento inicial do vídeo. Se fizer alterações é necessário reiniciar.</string>
-    <string name="adjust_by_semitones_checkbox">Ajustar o tom por semitons musicais</string>
-    <string name="playback_tempo_step">Passo do tempo</string>
     <string name="progressive_load_interval_exoplayer_default">Predefinido do ExoPlayer</string>
     <string name="notifications">Notificações</string>
     <string name="loading_stream_details">A carregar detalhes do fluxo…</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -554,7 +554,6 @@
     <string name="unsupported_url_dialog_message">URL não reconhecido. Abrir com outra aplicação\?</string>
     <string name="auto_queue_toggle">Enfileiramento automático</string>
     <string name="notification_action_shuffle">Embaralhar</string>
-    <string name="settings_category_notification_title">Notificação</string>
     <string name="wifi_only">Apenas em Wi-Fi</string>
     <string name="notification_action_nothing">Nada</string>
     <string name="clear_queue_confirmation_summary">Mudar de um reprodutor para outro pode substituir a sua fila</string>
@@ -683,13 +682,10 @@
 \nPor favor, instale um gestor de ficheiros ou tente desativar \'%s\' nas configurações de descarregar.</string>
     <string name="no_appropriate_file_manager_message_android_10">Nenhum gestor de ficheiros apropriado foi encontrado para esta ação.
 \nPor favor, instale um gestor de ficheiros compatível com o Storage Access Framework.</string>
-    <string name="background_player_already_playing_toast">Já está a reproduzir em segundo plano</string>
     <string name="detail_pinned_comment_view_description">Comentário fixado</string>
     <string name="leak_canary_not_available">LeakCanary não está disponível</string>
-    <string name="adjust_by_semitones_checkbox">Ajustar o tom por semitons musicais</string>
     <string name="progressive_load_interval_exoplayer_default">Predefinido do ExoPlayer</string>
     <string name="progressive_load_interval_summary">Altere o tamanho do intervalo de carregamento (atualmente %s). Um valor menor pode acelerar o carregamento inicial do vídeo. Se fizer alterações é necessário reiniciar.</string>
-    <string name="playback_tempo_step">Passo do tempo</string>
     <string name="settings_category_player_notification_title">Notificação do reprodutor</string>
     <string name="settings_category_player_notification_summary">Configurar a notificação da reprodução do fluxo atual</string>
     <string name="notifications">Notificações</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -679,7 +679,6 @@
     <string name="processing_may_take_a_moment">Procesarea.. Poate dura un moment</string>
     <string name="manual_update_title">Verifică dacă există actualizări</string>
     <string name="manual_update_description">Verifică manual dacă există versiuni noi</string>
-    <string name="background_player_already_playing_toast">Se redă deja pe fundal</string>
     <string name="detail_pinned_comment_view_description">Comentariu lipit</string>
     <string name="error_report_channel_name">Notificare cu raport de eroare</string>
     <string name="show_crash_the_player_summary">Afișează opțiunea de a întrerupe atunci când utilizați playerul</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -691,8 +691,6 @@
     <string name="manual_update_title">Проверить обновления</string>
     <string name="checking_updates_toast">Проверка обновлений…</string>
     <string name="feed_new_items">Новое на канале</string>
-    <string name="report_player_errors_title">Отчёт об ошибках плеера</string>
-    <string name="report_player_errors_summary">Подробные отчёты об ошибках плеера вместо коротких всплывающих сообщений (полезно при диагностике проблем)</string>
     <string name="notifications">Уведомления</string>
     <string name="streams_notification_channel_name">Новые видео</string>
     <string name="streams_notification_channel_description">Уведомления о новых видео в подписках</string>
@@ -718,11 +716,8 @@
 \nПожалуйста, установите файловый менеджер, или попробуйте отключить \'%s\' в настройках загрузок.</string>
     <string name="no_appropriate_file_manager_message_android_10">Для этого действия не найдено подходящего файлового менеджера.
 \nПожалуйста, установите файловый менеджер, совместимый со Storage Access Framework (SAF).</string>
-    <string name="background_player_already_playing_toast">Уже проигрывается в фоне</string>
     <string name="detail_pinned_comment_view_description">Закреплённый комментарий</string>
     <string name="leak_canary_not_available">LeakCanary недоступна</string>
-    <string name="adjust_by_semitones_checkbox">Регулировка высоты тона по музыкальным полутонам</string>
-    <string name="playback_tempo_step">Шаг темпа</string>
     <string name="progressive_load_interval_exoplayer_default">Стандартное значение ExoPlayer</string>
     <string name="progressive_load_interval_summary">Изменить размер интервала загрузки (сейчас %s). Меньшее значение может ускорить начальную загрузку видео. Изменение значения потребует перезапуска плеера.</string>
     <string name="loading_stream_details">Загрузка деталей трансляции…</string>

--- a/app/src/main/res/values-sc/strings.xml
+++ b/app/src/main/res/values-sc/strings.xml
@@ -683,10 +683,7 @@
 \nPro praghere installa unu gestore de documentos cumpatìbile cun su \"Sistema de Atzessu a s\'Archiviatzione\".</string>
     <string name="crash_the_player">Faghe serrare su riproduidore</string>
     <string name="detail_pinned_comment_view_description">Cummentu apicadu</string>
-    <string name="background_player_already_playing_toast">Giai in riprodutzione in s\'isfundu</string>
     <string name="leak_canary_not_available">LeakCanary no est a disponimentu</string>
-    <string name="adjust_by_semitones_checkbox">Règula s\'intonatzione in base a sos semitonos musicales</string>
-    <string name="playback_tempo_step">Passu de tempus</string>
     <string name="progressive_load_interval_exoplayer_default">Valore ExoPlayer predefinidu</string>
     <string name="progressive_load_interval_summary">Muda sa mannària de s\'intervallu de carrigamentu (in custu momentu %s). Unu valore prus bassu diat pòdere allestrare su carrigamentu de incumintzu de su vìdeu. Sas modìficas tenent bisòngiu de torrare a allùghere su riproduidore.</string>
     <string name="settings_category_player_notification_summary">Cunfigura sa notìfica de su flussu in cursu de riprodutzione</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -647,8 +647,6 @@
     <string name="downloads_storage_ask_summary_no_saf_notice">Pri každom sťahovaní sa zobrazí výzva kam uložiť súbor</string>
     <string name="no_dir_yet">Nie je nastavený adresár na sťahovanie, nastavte ho teraz</string>
     <string name="mark_as_watched">Označiť ako videné</string>
-    <string name="loading_channel_details">Načítavanie podrobností o kanáli…</string>
-    <string name="error_show_channel_details">Chyba pri zobrazení podrobností kanála</string>
     <string name="off">Vypnuté</string>
     <string name="on">Zapnuté</string>
     <string name="tablet_mode_title">Režim tabletu</string>
@@ -698,8 +696,6 @@
     <string name="show_crash_the_player_summary">Zobrazí možnosť zlyhania pri používaní prehrávača</string>
     <string name="show_error_snackbar">Zobraziť krátke oznámenie chyby</string>
     <string name="create_error_notification">Oznámte chybu</string>
-    <string name="adjust_by_semitones_checkbox">Upraviť výšku poltónov</string>
-    <string name="playback_tempo_step">Krok tempa</string>
     <string name="progressive_load_interval_exoplayer_default">ExoPlayer preddefinovaný</string>
     <string name="progressive_load_interval_summary">Zmeniť interval načítania (aktuálne %s). Menšia hodnota môže zvýšiť rýchlosť prvotného načítania videa. Zmena vyžaduje reštart.</string>
     <string name="notifications">Upozornenia</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -682,13 +682,10 @@
 \nInstallera en filhanterare eller testa att inaktivera \'%s\' i nedladdningsinställningarna.</string>
     <string name="no_appropriate_file_manager_message_android_10">Ingen lämplig filhanterare hittades för denna åtgärd.
 \nInstallera en filhanterare som är kompatibel med Storage Access Framework.</string>
-    <string name="background_player_already_playing_toast">Spelas redan i bakgrunden</string>
     <string name="detail_pinned_comment_view_description">Fäst kommentar</string>
     <string name="leak_canary_not_available">LeakCanary är inte tillgänglig</string>
-    <string name="adjust_by_semitones_checkbox">Justera tonhöjden med musikaliska halvtoner</string>
     <string name="progressive_load_interval_exoplayer_default">ExoPlayer standard</string>
     <string name="progressive_load_interval_summary">Ändra inläsningsintervallets storlek (för närvarande %s). Ett lägre värde kan påskynda den första videoinläsningen. Ändringar kräver omstart av spelaren.</string>
-    <string name="playback_tempo_step">Temposteg</string>
     <string name="streams_notifications_interval_title">Validera frekvens</string>
     <string name="streams_notifications_network_title">Kräver nätverksanslutning</string>
     <string name="any_network">Alla nätverk</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -253,7 +253,6 @@
     <string name="resume_on_audio_focus_gain_title">இயக்குதலைத் மறுதொடர்</string>
     <string name="short_billion">நி</string>
     <string name="peertube_instance_add_exists">நிகழ்வு ஏற்கனவே உள்ளது</string>
-    <string name="settings_category_notification_title">அறிவிப்பு</string>
     <string name="youtube_restricted_mode_enabled_title">யூடியூபின் \"கட்டுப்பாடு பயன்முறை\"ஐ இயக்கு</string>
     <string name="songs">பாடல்கள்</string>
     <string name="error_report_channel_description">பிழைகளைப் புகாரளிக்க அறிவிப்புகள்</string>

--- a/app/src/main/res/values-te/strings.xml
+++ b/app/src/main/res/values-te/strings.xml
@@ -371,7 +371,6 @@
     <string name="title_activity_recaptcha">reCAPTCHA సవాలు</string>
     <string name="recaptcha_request_toast">reCAPTCHA సవాలు అభ్యర్థించబడింది</string>
     <string name="select_a_playlist">ప్లేజాబితాను ఎంచుకోండి</string>
-    <string name="background_player_already_playing_toast">ఇప్పటికే వెనుకగా ప్లే అవుతోంది</string>
     <string name="export_data_title">డాటాబేసుని ఎగుమతిచేయుము</string>
     <string name="localization_changes_requires_app_restart">యాప్ పునఃప్రారంభించబడిన తర్వాత భాష మారుతుంది</string>
     <string name="show_channel_details">ఛానెల్ వివరాలను చూపు</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -682,13 +682,10 @@
     <string name="error_report_channel_description">Hata raporları için bildirimler</string>
     <string name="show_crash_the_player_summary">Oynatıcı kullanırken çöktürme seçeneği gösterir</string>
     <string name="crash_the_player">Oynatıcıyı çöktür</string>
-    <string name="background_player_already_playing_toast">Zaten arka planda oynuyor</string>
     <string name="detail_pinned_comment_view_description">Sabitlenmiş yorum</string>
     <string name="leak_canary_not_available">LeakCanary yok</string>
     <string name="progressive_load_interval_summary">Yükleme ara boyutunu değiştir (şu anda %s). Düşük bir değer videonun ilk yüklenişini hızlandırabilir. Değişiklikler oynatıcının yeniden başlatılmasını gerektirir.</string>
     <string name="progressive_load_interval_exoplayer_default">ExoPlayer öntanımlısı</string>
-    <string name="playback_tempo_step">Tempo adımı</string>
-    <string name="adjust_by_semitones_checkbox">Perdeyi müzikal yarım tonlarla uyarla</string>
     <string name="enable_streams_notifications_title">Yeni akış bildirimleri</string>
     <string name="notifications">Bildirimler</string>
     <plurals name="new_streams">

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -58,7 +58,6 @@
     <string name="downloads_title">Завантаження</string>
     <string name="error_report_title">Звіт про помилку</string>
     <string name="all">Усе</string>
-    <string name="yes">Так</string>
     <string name="disabled">Вимкнено</string>
     <string name="app_ui_crash">Збій застосунку/інтерфейсу</string>
     <string name="your_comment">Ваш коментар (англійською):</string>
@@ -699,11 +698,8 @@
 \nУстановіть файловий менеджер, сумісний зі Storage Access Framework.</string>
     <string name="show_error_snackbar">Показати панель помилок</string>
     <string name="create_error_notification">Створити сповіщення про помилку</string>
-    <string name="background_player_already_playing_toast">Уже відтворюється у фоновому режимі</string>
     <string name="detail_pinned_comment_view_description">Закріплений коментар</string>
     <string name="leak_canary_not_available">LeakCanary недоступний</string>
-    <string name="playback_tempo_step">Крок темпу</string>
-    <string name="adjust_by_semitones_checkbox">Регулювання висоти звуку за музичними півтонами</string>
     <string name="progressive_load_interval_exoplayer_default">Типовий ExoPlayer</string>
     <string name="progressive_load_interval_summary">Змінити розмір інтервалу завантаження (наразі %s). Менше значення може прискорити початкове завантаження відео. Зміни вимагають перезапуску програвача.</string>
     <string name="you_successfully_subscribed">Ви підписалися на цей канал</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -672,8 +672,6 @@
 \nVui lòng cài đặt ứng dụng quản lý tệp hoặc tắt \'%s\' trong cài đặt tải xuống.</string>
     <string name="progressive_load_interval_summary">Thay đổi kích thước khoảng thời gian tải (tầm khoảng %s). Để ở giá trị thấp hơn có thể sẽ tăng tốc độ tải video hơn ban đầu. Khởi động lại trình phát để áp dụng thay đổi.</string>
     <string name="leak_canary_not_available">LeakCanary không khả dụng</string>
-    <string name="adjust_by_semitones_checkbox">Điều chỉnh cao độ theo nhạc nền âm nhạc</string>
-    <string name="playback_tempo_step">Nhịp độ tiếp theo</string>
     <string name="progressive_load_interval_exoplayer_default">ExoPlayer mặc định</string>
     <string name="detail_pinned_comment_view_description">Bình luận được ghim</string>
 </resources>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -603,10 +603,8 @@
     <plurals name="new_streams">
         <item quantity="other">%s 個新加串流</item>
     </plurals>
-    <string name="adjust_by_semitones_checkbox">按樂音半度調整音高</string>
     <string name="enable_streams_notifications_title">新加串流通知</string>
     <string name="delete_downloaded_files_confirm">係咪要喺磁碟機上面消除晒全部下載咗嘅檔案？</string>
     <string name="notifications_disabled">通知已停用</string>
     <string name="tracks">單曲</string>
-    <string name="playback_tempo_step">節奏步伐</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -539,7 +539,6 @@
     <string name="clear_queue_confirmation_description">作用中播放器的佇列可能會被取代</string>
     <string name="clear_queue_confirmation_summary">從一個播放器切換到另一個可能會取代您的佇列</string>
     <string name="clear_queue_confirmation_title">清除佇列前要求確認</string>
-    <string name="settings_category_notification_title">通知</string>
     <string name="notification_action_nothing">無</string>
     <string name="notification_action_buffering">正在緩衝</string>
     <string name="notification_action_shuffle">隨機播放</string>
@@ -638,8 +637,6 @@
     <string name="seekbar_preview_thumbnail_title">拖動列縮圖預覽</string>
     <string name="detail_heart_img_view_description">被創作者加心號</string>
     <string name="mark_as_watched">標記為已看過</string>
-    <string name="loading_channel_details">正在載入頻道詳細資訊……</string>
-    <string name="error_show_channel_details">顯示頻道詳細資訊時發生錯誤</string>
     <string name="show_image_indicators_summary">在圖片頂部顯示畢卡索彩色絲帶，指示其來源：紅色代表網路、藍色代表磁碟、綠色代表記憶體</string>
     <string name="show_image_indicators_title">顯示圖片指示器</string>
     <string name="remote_search_suggestions">遠端搜尋建議</string>
@@ -674,12 +671,9 @@
     <string name="error_report_notification_title">NewPipe 遇到錯誤，點擊以回報</string>
     <string name="error_report_notification_toast">發生錯誤，請檢視通知</string>
     <string name="detail_pinned_comment_view_description">釘選的留言</string>
-    <string name="background_player_already_playing_toast">已經在背景播放</string>
     <string name="leak_canary_not_available">LeakCanary 無法使用</string>
-    <string name="playback_tempo_step">步進時間</string>
     <string name="progressive_load_interval_exoplayer_default">ExoPlayer 預設值</string>
     <string name="progressive_load_interval_summary">變更載入間隔大小（目前為 %s）。較低的值可能會提昇初始影片載入速度。變更需要重新啟動播放器。</string>
-    <string name="adjust_by_semitones_checkbox">按音樂半音調整音高</string>
     <string name="settings_category_player_notification_title">播放器通知</string>
     <string name="notifications">通知</string>
     <string name="loading_stream_details">正在載入串流詳細資訊……</string>


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
I recently noticed that the following warning:
```
> Task :app:compressDebugAssets
warn: removing resource org.schabi.newpipe.debug:string/adjust_by_semitones_checkbox without required default value.
warn: removing resource org.schabi.newpipe.debug:string/background_player_already_playing_toast without required default value.
warn: removing resource org.schabi.newpipe.debug:string/error_show_channel_details without required default value.
warn: removing resource org.schabi.newpipe.debug:string/loading_channel_details without required default value.
warn: removing resource org.schabi.newpipe.debug:string/playback_tempo_step without required default value.
warn: removing resource org.schabi.newpipe.debug:string/report_player_errors_summary without required default value.
warn: removing resource org.schabi.newpipe.debug:string/report_player_errors_title without required default value.
warn: removing resource org.schabi.newpipe.debug:string/settings_category_notification_title without required default value.
warn: removing resource org.schabi.newpipe.debug:string/yes without required default value.
```

Looks like these warnings got in there since we merged Weblate in the latest release.
Anyway, I removed the affected unused strings to get rid of them.


#### APK testing 
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
