### PR TITLE
Fix Routeractivity theming

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/RouterActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/RouterActivity.java
@@ -2,7 +2,6 @@ package org.schabi.newpipe;
 
 import static org.schabi.newpipe.extractor.StreamingService.ServiceInfo.MediaCapability.AUDIO;
 import static org.schabi.newpipe.extractor.StreamingService.ServiceInfo.MediaCapability.VIDEO;
-import static org.schabi.newpipe.util.Localization.assureCorrectAppLanguage;
 
 import android.annotation.SuppressLint;
 import android.app.IntentService;
@@ -73,6 +72,7 @@ import org.schabi.newpipe.util.Constants;
 import org.schabi.newpipe.util.DeviceUtils;
 import org.schabi.newpipe.util.ExtractorHelper;
 import org.schabi.newpipe.util.ListHelper;
+import org.schabi.newpipe.util.Localization;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.PermissionHelper;
 import org.schabi.newpipe.util.ThemeHelper;
@@ -131,7 +131,7 @@ public class RouterActivity extends AppCompatActivity {
         ThemeHelper.setDayNightMode(this);
         setTheme(ThemeHelper.isLightThemeSelected(this)
                 ? R.style.RouterActivityThemeLight : R.style.RouterActivityThemeDark);
-        assureCorrectAppLanguage(this);
+        Localization.assureCorrectAppLanguage(this);
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/RouterActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/RouterActivity.java
@@ -2,6 +2,7 @@ package org.schabi.newpipe;
 
 import static org.schabi.newpipe.extractor.StreamingService.ServiceInfo.MediaCapability.AUDIO;
 import static org.schabi.newpipe.extractor.StreamingService.ServiceInfo.MediaCapability.VIDEO;
+import static org.schabi.newpipe.util.Localization.assureCorrectAppLanguage;
 
 import android.annotation.SuppressLint;
 import android.app.IntentService;
@@ -127,8 +128,10 @@ public class RouterActivity extends AppCompatActivity {
             }
         }
 
+        ThemeHelper.setDayNightMode(this);
         setTheme(ThemeHelper.isLightThemeSelected(this)
                 ? R.style.RouterActivityThemeLight : R.style.RouterActivityThemeDark);
+        assureCorrectAppLanguage(this);
     }
 
     @Override

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -131,10 +131,6 @@
     </style>
 
     <style name="RouterActivityThemeLight" parent="LightTheme">
-        <item name="colorPrimary">@android:color/transparent</item>
-        <item name="colorPrimaryDark">@android:color/transparent</item>
-        <item name="colorAccent">@android:color/transparent</item>
-
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:colorBackgroundCacheHint">@null</item>
@@ -143,10 +139,6 @@
     </style>
 
     <style name="RouterActivityThemeDark" parent="DarkTheme">
-        <item name="colorPrimary">@android:color/transparent</item>
-        <item name="colorPrimaryDark">@android:color/transparent</item>
-        <item name="colorAccent">@android:color/transparent</item>
-
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:colorBackgroundCacheHint">@null</item>


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
When the app is not running in the foreground and started via ``RouterActivity`` (e.g. clicking/sharing a link to NewPipe) incorrect things start to happens:
* The UI has incorrect colors (seen in #8179)
  * The day/night mode of the app is ignored
* The language is the device language

Why does this happen?
* The RouterActivityThemes are overriding the ``color*``-attributes (``colorPrimary``, ``colorPrimaryDark``, ...). I'm not sure why this was done in the first place, however it causes the theming issues on the UI.
* RouterActivity misses some code from MainActivity, e.g. ``assureCorrectAppLanguage`` and ``ThemeHelper.setDayNightMode``. This causes further problems like the incorrect language or wrong colored theme elements.

#### Before/After Screenshots/Screen Record
Done via the test manual below:

- Before: 
![grafik](https://user-images.githubusercontent.com/40789489/166508766-b54527af-ef1b-48d7-85c0-dcd3166dfbc9.png) ![grafik](https://user-images.githubusercontent.com/40789489/166163736-4cd9fea4-a9dc-4c9b-8508-58a350b1ccee.png) ![grafik](https://user-images.githubusercontent.com/40789489/166163708-fab8e57d-9905-4dc6-85a4-895920b11d28.png) ![grafik](https://user-images.githubusercontent.com/40789489/166508814-74180191-267d-4fc3-8bf6-2a9a0a7ff403.png)

- After: 
![grafik](https://user-images.githubusercontent.com/40789489/166509664-32d054bd-67d0-44e9-a365-073ad4d204c4.png) ![grafik](https://user-images.githubusercontent.com/40789489/166507781-2fe674eb-6587-4f9a-a8bd-19a55cb4d643.png) ![grafik](https://user-images.githubusercontent.com/40789489/166507985-36b0ffb4-0a36-43a0-997f-99a368bdb112.png) ![grafik](https://user-images.githubusercontent.com/40789489/166508131-7254ecb8-ccfd-4d9e-b669-0217f9510bcf.png)


#### Fixes the following issue(s)

- Fixes #8179; maybe more issues, hard to check when there are >1k open ones


#### APK testing 
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

##### Test manual
* Change theme to dark
* Change the app-language to something other then the phone-languguage (e.g. German)
* Restart the app (so that the language is applied)
* Close the app completely
* Share a stream link to NewPipe (that you never watched before)
* the ask what to do dialog should come up
* click add to playlist


#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
