### PR TITLE
Fixed viewed counting

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/database/history/model/StreamHistoryEntity.java
+++ b/app/src/main/java/org/schabi/newpipe/database/history/model/StreamHistoryEntity.java
@@ -51,7 +51,7 @@ public class StreamHistoryEntity {
 
     @Ignore
     public StreamHistoryEntity(final long streamUid, @NonNull final OffsetDateTime accessDate) {
-        this(streamUid, accessDate, 1);
+        this(streamUid, accessDate, 0);
     }
 
     public long getStreamUid() {

--- a/app/src/main/java/org/schabi/newpipe/database/history/model/StreamHistoryEntity.java
+++ b/app/src/main/java/org/schabi/newpipe/database/history/model/StreamHistoryEntity.java
@@ -51,7 +51,7 @@ public class StreamHistoryEntity {
 
     @Ignore
     public StreamHistoryEntity(final long streamUid, @NonNull final OffsetDateTime accessDate) {
-        this(streamUid, accessDate, 0);
+        this(streamUid, accessDate, 0); // start with 0 views (adding views will be done elsewhere)
     }
 
     public long getStreamUid() {


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR

When watching a video that you have not seen before and going to the history.
Note that the history entry shows 2 views instead of 1 view for said video.

I then modified a function to solve the problem.
So when we go to the video history we see that he has 1 marked view.

#### Before/After Screenshots/Screen Record

- Before:
![Capture d’écran du 2022-05-02 15-25-46](https://user-images.githubusercontent.com/92532045/166241927-4a04afbc-aae9-4279-a110-1726fc2263e3.png)

- After:
![Capture d’écran du 2022-05-02 15-24-11](https://user-images.githubusercontent.com/92532045/166241944-b211d5e4-c348-423e-9ccb-9530d6bdcc1b.png)

#### Fixes the following issue(s)

- Fixes https://github.com/TeamNewPipe/NewPipe/issues/8330

##### Test Manuel
- Watch a video you've never seen
- Go down in history
- And you see the video shows 1 view

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
