### PR TITLE
Fixed accidental reset of ``PlaybackParameterDialog`` on initialization

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlaybackParameterDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlaybackParameterDialog.java
@@ -213,7 +213,7 @@ public class PlaybackParameterDialog extends DialogFragment {
 
         getPitchControlModeComponentMappings()
                 .forEach(this::setupPitchControlModeTextView);
-        changePitchControlMode(isCurrentPitchControlModeSemitone());
+        // Initialization is done at the end
 
         // Pitch - Percent
         setText(binding.pitchPercentMinimumText, PlayerHelper::formatPitch, MIN_PITCH_OR_SPEED);
@@ -275,6 +275,9 @@ public class PlaybackParameterDialog extends DialogFragment {
             skipSilence = isChecked;
             updateCallback();
         });
+
+        // PitchControlMode has to be initialized at the end because it requires the unhookCheckbox
+        changePitchControlMode(isCurrentPitchControlModeSemitone());
     }
 
     // -- General formatting --


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)

#### Description of the changes in your PR
* This fixes the problem of ``PlaybackParameterDialog`` automatically resetting the speed value upon initialization
* This was caused by calling ``changePitchControlMode`` before the required values/components were initialized.

Thanks to @TiA4f8R for noticing and informing me about the bug.

#### APK testing 
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).