### PR TITLE
Make volume progress bar match system volume when we start sliding

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/event/PlayerGestureListener.java
+++ b/app/src/main/java/org/schabi/newpipe/player/event/PlayerGestureListener.java
@@ -126,6 +126,14 @@ public class PlayerGestureListener
     }
 
     private void onScrollMainVolume(final float distanceX, final float distanceY) {
+        // If we just started sliding, change the progress bar to match the system volume
+        if (player.getVolumeRelativeLayout().getVisibility() != View.VISIBLE) {
+            final float volumePercent = player
+                    .getAudioReactor().getVolume() / (float) maxVolume;
+            player.getVolumeProgressBar().setProgress(
+                    (int) (volumePercent * player.getMaxGestureLength()));
+        }
+
         player.getVolumeProgressBar().incrementProgressBy((int) distanceY);
         final float currentProgressPercent = (float) player
                 .getVolumeProgressBar().getProgress() / player.getMaxGestureLength();


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- Bugfix (user facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
This PR makes the volume progress bar (the slider used to change the volume) match the system volume when we start sliding. Otherwise, the slider would remember its last position, and the system volume would be ignored.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before:  https://www.veed.io/view/116181aa-48c0-4399-8ecd-40353c2563ad
- After:  https://www.veed.io/view/451faf5c-c952-4bdb-a0d3-4cdcbfef916f

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #8375

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).