### PR TITLE
Add database test for SubscriptionManager

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/local/subscription/SubscriptionManagerTest.java
+++ b/app/src/androidTest/java/org/schabi/newpipe/local/subscription/SubscriptionManagerTest.java
@@ -1,0 +1,144 @@
+package org.schabi.newpipe.local.subscription;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.schabi.newpipe.database.AppDatabase;
+import org.schabi.newpipe.database.subscription.SubscriptionEntity;
+import org.schabi.newpipe.extractor.channel.ChannelInfo;
+import org.schabi.newpipe.extractor.exceptions.ExtractionException;
+import org.schabi.newpipe.extractor.stream.StreamInfo;
+import org.schabi.newpipe.testUtil.TestDatabase;
+import org.schabi.newpipe.testUtil.TrampolineSchedulerRule;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+
+public class SubscriptionManagerTest {
+    private AppDatabase database;
+    private SubscriptionManager manager;
+    private SubscriptionEntity subscription;
+    private SubscriptionEntity anotherSubscription;
+
+    @Rule
+    public TrampolineSchedulerRule trampolineScheduler = new TrampolineSchedulerRule();
+
+    @Before
+    public void setup() throws ExtractionException, IOException {
+        database = TestDatabase.Companion.createReplacingNewPipeDatabase();
+        manager = new SubscriptionManager(ApplicationProvider.getApplicationContext());
+
+        ChannelInfo info = ChannelInfo.getInfo("https://www.youtube.com/c/3blue1brown");
+        subscription = SubscriptionEntity.from(info);
+        manager.insertSubscription(subscription, info);
+        var entities = manager.getSubscriptions(-1L, subscription.getName(), false).blockingFirst();
+        assertEquals(1, entities.size());
+        anotherSubscription = entities.get(0);
+    }
+
+    @After
+    public void cleanUp() {
+        database.close();
+    }
+
+    @Test
+    public void testInsert1() {
+        //This test fails because the uid of those two SubscriptionEntity aren't the same.
+        assertEquals(subscription, anotherSubscription);
+    }
+
+    @Test
+    public void testInsert2() {
+        assertEquals(subscription.getUid(), anotherSubscription.getUid());
+    }
+
+    @Test
+    public void testInsert3() {
+        assertEquals(subscription.getServiceId(), anotherSubscription.getServiceId());
+        assertEquals(subscription.getUrl(), anotherSubscription.getUrl());
+        assertEquals(subscription.getName(), anotherSubscription.getName());
+        assertEquals(subscription.getAvatarUrl(), anotherSubscription.getAvatarUrl());
+        assertEquals(subscription.getSubscriberCount(), anotherSubscription.getSubscriberCount());
+        assertEquals(subscription.getDescription(), anotherSubscription.getDescription());
+    }
+
+
+    @Test
+    public void testUpdateNotificationMode1() throws ExtractionException, IOException {
+        var info = ChannelInfo.getInfo("https://www.youtube.com/c/veritasium");
+        var subscription = SubscriptionEntity.from(info);
+        subscription.setNotificationMode(0);
+        assertEquals(0, subscription.getNotificationMode());
+        manager.insertSubscription(subscription, info);
+        manager.updateNotificationMode(subscription.getServiceId(), subscription.getUrl(), 1);
+        var entities = manager.getSubscriptions(-1L, subscription.getName(), false).blockingFirst();
+        assertEquals(1, entities.size());
+        var anotherSubscription = entities.get(0);
+
+        assertEquals(subscription.getUrl(), anotherSubscription.getUrl());
+        assertEquals(1, anotherSubscription.getNotificationMode());
+    }
+
+    @Test
+    public void testUpdateNotificationMode2() throws ExtractionException, IOException {
+        var info = ChannelInfo.getInfo("https://www.youtube.com/c/Radiohead");
+        var subscription = SubscriptionEntity.from(info);
+        subscription.setNotificationMode(0);
+        assertEquals(0, subscription.getNotificationMode());
+        manager.insertSubscription(subscription, info);
+        manager.updateNotificationMode(subscription.getServiceId(), subscription.getUrl(), 1);
+
+        assertEquals(1, subscription.getNotificationMode());
+    }
+
+    @Test
+    public void testUpdateNotificationMode3() throws ExtractionException, IOException {
+        var info = ChannelInfo.getInfo("https://www.youtube.com/c/LinusTechTips");
+        var subscription = SubscriptionEntity.from(info);
+        subscription.setNotificationMode(1);
+        assertEquals(1, subscription.getNotificationMode());
+        manager.insertSubscription(subscription, info);
+        manager.updateNotificationMode(subscription.getServiceId(), subscription.getUrl(), 0);
+        var entities = manager.getSubscriptions(-1L, subscription.getName(), false).blockingFirst();
+        assertEquals(1, entities.size());
+        var anotherSubscription = entities.get(0);
+
+        assertEquals(subscription.getUrl(), anotherSubscription.getUrl());
+        assertEquals(0, anotherSubscription.getNotificationMode());
+    }
+
+    @Test
+    public void testUpdateNotificationMode4() throws ExtractionException, IOException {
+        var info = ChannelInfo.getInfo("https://www.youtube.com/c/JetBrainsTV");
+        var subscription = SubscriptionEntity.from(info);
+        subscription.setNotificationMode(1);
+        assertEquals(1, subscription.getNotificationMode());
+        manager.insertSubscription(subscription, info);
+        manager.updateNotificationMode(subscription.getServiceId(), subscription.getUrl(), 0);
+
+        assertEquals(0, subscription.getNotificationMode());
+    }
+
+    @Test
+    public void testRememberAllStreams() throws ExtractionException, IOException {
+        database.streamDAO().deleteAll();
+        var info = ChannelInfo.getInfo("https://www.youtube.com/c/Polyphia");
+        var subscription = SubscriptionEntity.from(info);
+        manager.insertSubscription(subscription, info);
+
+//        var Stream1 = StreamInfo.getInfo("https://www.youtube.com/watch?v=Z5NoQg8LdDk");
+//        var Stream2 = StreamInfo.getInfo("https://www.youtube.com/watch?v=2hln1TOQUZ0");
+//        var Stream3 = StreamInfo.getInfo("https://www.youtube.com/watch?v=9_gkpYORQLU");
+//        var Stream4 = StreamInfo.getInfo("https://www.youtube.com/watch?v=per9Wz0N-QA");
+
+        var streams = database.streamDAO().getAll().blockingFirst();
+        assertTrue(streams.size() >= 4);
+    }
+}

--- a/app/src/androidTest/java/org/schabi/newpipe/local/subscription/SubscriptionManagerTest.java
+++ b/app/src/androidTest/java/org/schabi/newpipe/local/subscription/SubscriptionManagerTest.java
@@ -1,8 +1,6 @@
 package org.schabi.newpipe.local.subscription;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 import androidx.test.core.app.ApplicationProvider;
 
@@ -11,36 +9,43 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.schabi.newpipe.database.AppDatabase;
+import org.schabi.newpipe.database.feed.model.FeedGroupEntity;
+import org.schabi.newpipe.database.stream.model.StreamEntity;
 import org.schabi.newpipe.database.subscription.SubscriptionEntity;
 import org.schabi.newpipe.extractor.channel.ChannelInfo;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
-import org.schabi.newpipe.extractor.stream.StreamInfo;
+import org.schabi.newpipe.extractor.localization.DateWrapper;
+import org.schabi.newpipe.extractor.stream.StreamInfoItem;
+import org.schabi.newpipe.extractor.stream.StreamType;
 import org.schabi.newpipe.testUtil.TestDatabase;
 import org.schabi.newpipe.testUtil.TrampolineSchedulerRule;
 
 import java.io.IOException;
-import java.lang.reflect.Method;
+import java.time.OffsetDateTime;
+import java.util.Comparator;
+import java.util.List;
 
 public class SubscriptionManagerTest {
     private AppDatabase database;
     private SubscriptionManager manager;
-    private SubscriptionEntity subscription;
-    private SubscriptionEntity anotherSubscription;
 
     @Rule
     public TrampolineSchedulerRule trampolineScheduler = new TrampolineSchedulerRule();
 
+
+    private SubscriptionEntity getAssertOneSubscriptionEntity() {
+        final List<SubscriptionEntity> entities = manager
+                .getSubscriptions(FeedGroupEntity.GROUP_ALL_ID, "", false)
+                .blockingFirst();
+        assertEquals(1, entities.size());
+        return entities.get(0);
+    }
+
+
     @Before
-    public void setup() throws ExtractionException, IOException {
+    public void setup() {
         database = TestDatabase.Companion.createReplacingNewPipeDatabase();
         manager = new SubscriptionManager(ApplicationProvider.getApplicationContext());
-
-        ChannelInfo info = ChannelInfo.getInfo("https://www.youtube.com/c/3blue1brown");
-        subscription = SubscriptionEntity.from(info);
-        manager.insertSubscription(subscription, info);
-        var entities = manager.getSubscriptions(-1L, subscription.getName(), false).blockingFirst();
-        assertEquals(1, entities.size());
-        anotherSubscription = entities.get(0);
     }
 
     @After
@@ -49,96 +54,66 @@ public class SubscriptionManagerTest {
     }
 
     @Test
-    public void testInsert1() {
-        //This test fails because the uid of those two SubscriptionEntity aren't the same.
-        assertEquals(subscription, anotherSubscription);
-    }
+    public void testInsert() throws ExtractionException, IOException {
+        final ChannelInfo info = ChannelInfo.getInfo("https://www.youtube.com/c/3blue1brown");
+        final SubscriptionEntity subscription = SubscriptionEntity.from(info);
 
-    @Test
-    public void testInsert2() {
-        assertEquals(subscription.getUid(), anotherSubscription.getUid());
-    }
-
-    @Test
-    public void testInsert3() {
-        assertEquals(subscription.getServiceId(), anotherSubscription.getServiceId());
-        assertEquals(subscription.getUrl(), anotherSubscription.getUrl());
-        assertEquals(subscription.getName(), anotherSubscription.getName());
-        assertEquals(subscription.getAvatarUrl(), anotherSubscription.getAvatarUrl());
-        assertEquals(subscription.getSubscriberCount(), anotherSubscription.getSubscriberCount());
-        assertEquals(subscription.getDescription(), anotherSubscription.getDescription());
-    }
-
-
-    @Test
-    public void testUpdateNotificationMode1() throws ExtractionException, IOException {
-        var info = ChannelInfo.getInfo("https://www.youtube.com/c/veritasium");
-        var subscription = SubscriptionEntity.from(info);
-        subscription.setNotificationMode(0);
-        assertEquals(0, subscription.getNotificationMode());
         manager.insertSubscription(subscription, info);
-        manager.updateNotificationMode(subscription.getServiceId(), subscription.getUrl(), 1);
-        var entities = manager.getSubscriptions(-1L, subscription.getName(), false).blockingFirst();
-        assertEquals(1, entities.size());
-        var anotherSubscription = entities.get(0);
+        final SubscriptionEntity readSubscription = getAssertOneSubscriptionEntity();
 
+        // the uid has changed, since the uid is chosen upon inserting, but the rest should match
+        assertEquals(subscription.getServiceId(), readSubscription.getServiceId());
+        assertEquals(subscription.getUrl(), readSubscription.getUrl());
+        assertEquals(subscription.getName(), readSubscription.getName());
+        assertEquals(subscription.getAvatarUrl(), readSubscription.getAvatarUrl());
+        assertEquals(subscription.getSubscriberCount(), readSubscription.getSubscriberCount());
+        assertEquals(subscription.getDescription(), readSubscription.getDescription());
+    }
+
+    @Test
+    public void testUpdateNotificationMode() throws ExtractionException, IOException {
+        final ChannelInfo info = ChannelInfo.getInfo("https://www.youtube.com/c/veritasium");
+        final SubscriptionEntity subscription = SubscriptionEntity.from(info);
+        subscription.setNotificationMode(0);
+
+        manager.insertSubscription(subscription, info);
+        manager.updateNotificationMode(subscription.getServiceId(), subscription.getUrl(), 1)
+                .blockingAwait();
+        final SubscriptionEntity anotherSubscription = getAssertOneSubscriptionEntity();
+
+        assertEquals(0, subscription.getNotificationMode());
         assertEquals(subscription.getUrl(), anotherSubscription.getUrl());
         assertEquals(1, anotherSubscription.getNotificationMode());
     }
 
     @Test
-    public void testUpdateNotificationMode2() throws ExtractionException, IOException {
-        var info = ChannelInfo.getInfo("https://www.youtube.com/c/Radiohead");
-        var subscription = SubscriptionEntity.from(info);
-        subscription.setNotificationMode(0);
-        assertEquals(0, subscription.getNotificationMode());
+    public void testRememberRecentStreams() throws ExtractionException, IOException {
+        final ChannelInfo info = ChannelInfo.getInfo("https://www.youtube.com/c/Polyphia");
+        final List<StreamInfoItem> relatedItems = List.of(
+                new StreamInfoItem(0, "a", "b", StreamType.VIDEO_STREAM),
+                new StreamInfoItem(1, "c", "d", StreamType.AUDIO_STREAM),
+                new StreamInfoItem(2, "e", "f", StreamType.AUDIO_LIVE_STREAM),
+                new StreamInfoItem(3, "g", "h", StreamType.LIVE_STREAM));
+        relatedItems.forEach(item -> {
+            // these two fields must be non-null for the insert to succeed
+            item.setUploaderUrl(info.getUrl());
+            item.setUploaderName(info.getName());
+            // the upload date must not be too much in the past for the item to actually be inserted
+            item.setUploadDate(new DateWrapper(OffsetDateTime.now()));
+        });
+        info.setRelatedItems(relatedItems);
+        final SubscriptionEntity subscription = SubscriptionEntity.from(info);
+
         manager.insertSubscription(subscription, info);
-        manager.updateNotificationMode(subscription.getServiceId(), subscription.getUrl(), 1);
+        final List<StreamEntity> streams = database.streamDAO().getAll().blockingFirst();
 
-        assertEquals(1, subscription.getNotificationMode());
-    }
-
-    @Test
-    public void testUpdateNotificationMode3() throws ExtractionException, IOException {
-        var info = ChannelInfo.getInfo("https://www.youtube.com/c/LinusTechTips");
-        var subscription = SubscriptionEntity.from(info);
-        subscription.setNotificationMode(1);
-        assertEquals(1, subscription.getNotificationMode());
-        manager.insertSubscription(subscription, info);
-        manager.updateNotificationMode(subscription.getServiceId(), subscription.getUrl(), 0);
-        var entities = manager.getSubscriptions(-1L, subscription.getName(), false).blockingFirst();
-        assertEquals(1, entities.size());
-        var anotherSubscription = entities.get(0);
-
-        assertEquals(subscription.getUrl(), anotherSubscription.getUrl());
-        assertEquals(0, anotherSubscription.getNotificationMode());
-    }
-
-    @Test
-    public void testUpdateNotificationMode4() throws ExtractionException, IOException {
-        var info = ChannelInfo.getInfo("https://www.youtube.com/c/JetBrainsTV");
-        var subscription = SubscriptionEntity.from(info);
-        subscription.setNotificationMode(1);
-        assertEquals(1, subscription.getNotificationMode());
-        manager.insertSubscription(subscription, info);
-        manager.updateNotificationMode(subscription.getServiceId(), subscription.getUrl(), 0);
-
-        assertEquals(0, subscription.getNotificationMode());
-    }
-
-    @Test
-    public void testRememberAllStreams() throws ExtractionException, IOException {
-        database.streamDAO().deleteAll();
-        var info = ChannelInfo.getInfo("https://www.youtube.com/c/Polyphia");
-        var subscription = SubscriptionEntity.from(info);
-        manager.insertSubscription(subscription, info);
-
-//        var Stream1 = StreamInfo.getInfo("https://www.youtube.com/watch?v=Z5NoQg8LdDk");
-//        var Stream2 = StreamInfo.getInfo("https://www.youtube.com/watch?v=2hln1TOQUZ0");
-//        var Stream3 = StreamInfo.getInfo("https://www.youtube.com/watch?v=9_gkpYORQLU");
-//        var Stream4 = StreamInfo.getInfo("https://www.youtube.com/watch?v=per9Wz0N-QA");
-
-        var streams = database.streamDAO().getAll().blockingFirst();
-        assertTrue(streams.size() >= 4);
+        assertEquals(4, streams.size());
+        streams.sort(Comparator.comparing(StreamEntity::getServiceId));
+        for (int i = 0; i < 4; i++) {
+            assertEquals(relatedItems.get(0).getServiceId(), streams.get(0).getServiceId());
+            assertEquals(relatedItems.get(0).getUrl(), streams.get(0).getUrl());
+            assertEquals(relatedItems.get(0).getName(), streams.get(0).getTitle());
+            assertEquals(relatedItems.get(0).getStreamType(), streams.get(0).getStreamType());
+        }
     }
 }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Codebase improvement (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- A JUnit test file is added to test SubscriptionManager.kt (see #2335). However, the test result shows that either the original methods or my understanding of those methods has some problem, so I made this a draft.
- The first problem is that the `ChannelInfo` I insert doesn't equal to the one I searched. The test result shows that it's because of their difference in the uid. IDK if it is designed to operate like that. If it is, I will delete the corresponding test cases in later commit.
- The second problem is that the `updateNotificationMode()` method doesn't seems to function correctly. The `testUpdateNotificationMode()` method 2 and 4 seems to be problematic and redundant, but I will temporarily keep them until this problem is solved or clairfied.
- The third problem is that the `rememberAllStreams()` method doesn't seems to fetch all videos as it should be (in my test case, it just fetched two instead of the total number of 100+)

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- The total test result:
![image](https://user-images.githubusercontent.com/49272922/170854772-f4a407a6-a79d-4592-859d-65e57473a3b1.png)


#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- [x] Fixes #8080
- [ ] Related to #2758




#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
