### PR TITLE
Clean up proguard file

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -18,7 +18,6 @@
 
 -dontobfuscate
 -keep class org.schabi.newpipe.extractor.timeago.patterns.** { *; }
--keep class org.ocpsoft.prettytime.i18n.** { *; }
 
 -keep class org.mozilla.javascript.** { *; }
 
@@ -26,9 +25,6 @@
 -keep class com.google.android.exoplayer2.** { *; }
 
 -dontwarn org.mozilla.javascript.tools.**
--dontwarn android.arch.util.paging.CountedDataSource
--dontwarn android.arch.persistence.room.paging.LimitOffsetDataSource
-
 
 # Rules for icepick. Copy paste from https://github.com/frankiesardo/icepick
 -dontwarn icepick.**
@@ -39,12 +35,11 @@
 }
 -keepnames class * { @icepick.State *;}
 
-# Rules for OkHttp. Copy paste from https://github.com/square/okhttp
+## Rules for OkHttp. Copy paste from https://github.com/square/okhttp
 -dontwarn okhttp3.**
 -dontwarn okio.**
--dontwarn javax.annotation.**
-# A resource is loaded with a relative path so the package of this class must be preserved.
--keepnames class okhttp3.internal.publicsuffix.PublicSuffixDatabase
+##
+
 -keepclassmembers class * implements java.io.Serializable {
     static final long serialVersionUID;
     !static !transient <fields>;


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR

I went down the git blame hole and found that PrettyTime was first added using 4.0.1. Meanwhile, consumer proguard rules were [added to PrettyTime in 4.0.3](https://github.com/ocpsoft/prettytime/commit/602b3a9bb6efbc9f7032fb7307f4866227aa4135). Therefore we no longer need this rule (and also ours is now [outdated](https://github.com/ocpsoft/prettytime/blob/master/core/src/main/resources/META-INF/proguard/prettytime.pro) anyway).

```-keep class org.ocpsoft.prettytime.i18n.** { *; }```

These are from before AndroidX. I don't think I need to explain these :)

```
-dontwarn android.arch.util.paging.CountedDataSource
-dontwarn android.arch.persistence.room.paging.LimitOffsetDataSource
```

The OkHttp rules are embedded into the library as of [3.11.0](https://square.github.io/okhttp//changelogs/changelog_3x/#version-3110:~:text=New%3A%20Embed%20R8/ProGuard%20rules%20in%20the%20jar). OkHttp was [first added using 3.9.1](https://github.com/TeamNewPipe/NewPipe/commit/76e082159dbbf5b7bc14fc26ad6030bffed7484b). Therefore, these specific ones are now obsolete and safe to remove.

```
-dontwarn javax.annotation.**
-keepnames class okhttp3.internal.publicsuffix.PublicSuffixDatabase
```

#### APK testing 
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
