### PR TITLE
Specify used ExoPlayer libraries

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -238,7 +238,13 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp:3.12.13"
 
     // Media player
-    implementation "com.google.android.exoplayer:exoplayer:${exoPlayerVersion}"
+    implementation "com.google.android.exoplayer:exoplayer-core:${exoPlayerVersion}"
+    implementation "com.google.android.exoplayer:exoplayer-dash:${exoPlayerVersion}"
+    implementation "com.google.android.exoplayer:exoplayer-database:${exoPlayerVersion}"
+    implementation "com.google.android.exoplayer:exoplayer-datasource:${exoPlayerVersion}"
+    implementation "com.google.android.exoplayer:exoplayer-hls:${exoPlayerVersion}"
+    implementation "com.google.android.exoplayer:exoplayer-smoothstreaming:${exoPlayerVersion}"
+    implementation "com.google.android.exoplayer:exoplayer-ui:${exoPlayerVersion}"
     implementation "com.google.android.exoplayer:extension-mediasession:${exoPlayerVersion}"
 
     // Metadata generator for service descriptors


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
I don't know how this hadn't caught my eye before, considering I've made this exact change in other apps. Anyway, I digress.

Before, when just using `exoplayer`, *every* ExoPlayer library would be added (regardless of whether they were used). This would cause some unnecessary bloat. Now after being specific, the unused libraries (like rtsp) are not being added.

This shaves off around 103KB for debug builds and 49KB for release builds.

#### APK testing 
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
