### PR TITLE
make video title & controls more compact

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -579,19 +579,21 @@ public final class VideoDetailFragment
     }
 
     private void toggleTitleAndSecondaryControls() {
-        if (binding.detailSecondaryControlPanel.getVisibility() == View.GONE) {
-            binding.detailVideoTitleView.setMaxLines(10);
-            animateRotation(binding.detailToggleSecondaryControlsView,
-                    Player.DEFAULT_CONTROLS_DURATION, 180);
-            binding.detailSecondaryControlPanel.setVisibility(View.VISIBLE);
-        } else {
-            binding.detailVideoTitleView.setMaxLines(1);
-            animateRotation(binding.detailToggleSecondaryControlsView,
-                    Player.DEFAULT_CONTROLS_DURATION, 0);
-            binding.detailSecondaryControlPanel.setVisibility(View.GONE);
+        // only toggle if title is ellipsized
+        final int lines = binding.detailVideoTitleView.getLineCount();
+        if (binding.detailVideoTitleView.getLayout().getEllipsisCount(lines - 1) > 0) {
+            if (binding.detailVideoTitleView.getMaxLines() == 2) {
+                binding.detailVideoTitleView.setMaxLines(10);
+                animateRotation(binding.detailToggleSecondaryControlsView,
+                        Player.DEFAULT_CONTROLS_DURATION, 180);
+            } else {
+                binding.detailVideoTitleView.setMaxLines(2);
+                animateRotation(binding.detailToggleSecondaryControlsView,
+                        Player.DEFAULT_CONTROLS_DURATION, 0);
+            }
+            // view pager height has changed, update the tab layout
+            updateTabLayoutVisibility();
         }
-        // view pager height has changed, update the tab layout
-        updateTabLayoutVisibility();
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -1500,12 +1502,11 @@ public final class VideoDetailFragment
         animate(binding.positionView, false, 50);
 
         binding.detailVideoTitleView.setText(title);
-        binding.detailVideoTitleView.setMaxLines(1);
+        binding.detailVideoTitleView.setMaxLines(2);
         animate(binding.detailVideoTitleView, true, 0);
 
         binding.detailToggleSecondaryControlsView.setVisibility(View.GONE);
         binding.detailTitleRootLayout.setClickable(false);
-        binding.detailSecondaryControlPanel.setVisibility(View.GONE);
 
         if (binding.relatedItemsLayout != null) {
             if (showRelatedItems) {
@@ -1610,8 +1611,14 @@ public final class VideoDetailFragment
 
         binding.detailTitleRootLayout.setClickable(true);
         binding.detailToggleSecondaryControlsView.setRotation(0);
-        binding.detailToggleSecondaryControlsView.setVisibility(View.VISIBLE);
-        binding.detailSecondaryControlPanel.setVisibility(View.GONE);
+
+        // only enable toggle if title is ellipsized
+        final int lines = binding.detailVideoTitleView.getLineCount();
+        if (binding.detailVideoTitleView.getLayout().getEllipsisCount(lines - 1) > 0) {
+            binding.detailToggleSecondaryControlsView.setVisibility(View.VISIBLE);
+        } else {
+            binding.detailToggleSecondaryControlsView.setVisibility(View.GONE);
+        }
 
         sortedVideoStreams = ListHelper.getSortedStreamVideosList(
                 activity,

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -584,11 +584,11 @@ public final class VideoDetailFragment
         if (binding.detailVideoTitleView.getLayout().getEllipsisCount(lines - 1) > 0) {
             if (binding.detailVideoTitleView.getMaxLines() == 2) {
                 binding.detailVideoTitleView.setMaxLines(10);
-                animateRotation(binding.detailToggleSecondaryControlsView,
+                animateRotation(binding.detailToggleExpandTitle,
                         Player.DEFAULT_CONTROLS_DURATION, 180);
             } else {
                 binding.detailVideoTitleView.setMaxLines(2);
-                animateRotation(binding.detailToggleSecondaryControlsView,
+                animateRotation(binding.detailToggleExpandTitle,
                         Player.DEFAULT_CONTROLS_DURATION, 0);
             }
             // view pager height has changed, update the tab layout
@@ -1505,7 +1505,7 @@ public final class VideoDetailFragment
         binding.detailVideoTitleView.setMaxLines(2);
         animate(binding.detailVideoTitleView, true, 0);
 
-        binding.detailToggleSecondaryControlsView.setVisibility(View.GONE);
+        binding.detailToggleExpandTitle.setVisibility(View.GONE);
         binding.detailTitleRootLayout.setClickable(false);
 
         if (binding.relatedItemsLayout != null) {
@@ -1610,14 +1610,14 @@ public final class VideoDetailFragment
         }
 
         binding.detailTitleRootLayout.setClickable(true);
-        binding.detailToggleSecondaryControlsView.setRotation(0);
+        binding.detailToggleExpandTitle.setRotation(0);
 
         // only enable toggle if title is ellipsized
         final int lines = binding.detailVideoTitleView.getLineCount();
         if (binding.detailVideoTitleView.getLayout().getEllipsisCount(lines - 1) > 0) {
-            binding.detailToggleSecondaryControlsView.setVisibility(View.VISIBLE);
+            binding.detailToggleExpandTitle.setVisibility(View.VISIBLE);
         } else {
-            binding.detailToggleSecondaryControlsView.setVisibility(View.GONE);
+            binding.detailToggleExpandTitle.setVisibility(View.GONE);
         }
 
         sortedVideoStreams = ListHelper.getSortedStreamVideosList(

--- a/app/src/main/res/layout-large-land/fragment_video_detail.xml
+++ b/app/src/main/res/layout-large-land/fragment_video_detail.xml
@@ -185,7 +185,7 @@
                             android:layout_height="match_parent"
                             android:layout_marginEnd="30dp"
                             android:ellipsize="end"
-                            android:maxLines="1"
+                            android:maxLines="2"
                             android:paddingTop="12dp"
                             android:paddingBottom="8dp"
                             android:textAppearance="?android:attr/textAppearanceLarge"
@@ -501,21 +501,6 @@
                                 android:text="@string/download"
                                 android:textSize="@dimen/detail_control_text_size"
                                 app:drawableTopCompat="@drawable/ic_file_download" />
-
-                        </LinearLayout>
-
-                        <!-- SECONDARY CONTROLS -->
-                        <LinearLayout
-                            android:id="@+id/detail_secondary_control_panel"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:descendantFocusability="afterDescendants"
-                            android:focusable="true"
-                            android:orientation="horizontal"
-                            android:paddingHorizontal="@dimen/detail_control_padding"
-                            android:paddingBottom="@dimen/detail_control_padding"
-                            android:visibility="gone"
-                            tools:visibility="visible">
 
                             <org.schabi.newpipe.views.NewPipeTextView
                                 android:id="@+id/detail_controls_share"

--- a/app/src/main/res/layout-large-land/fragment_video_detail.xml
+++ b/app/src/main/res/layout-large-land/fragment_video_detail.xml
@@ -193,7 +193,7 @@
                             tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed a ultricies ex. Integer sit amet sodales risus. Duis non mi et urna pretium bibendum. Nunc eleifend est quis ipsum porttitor egestas. Sed facilisis, nisl quis eleifend pellentesque, orci metus egestas dolor, at accumsan eros metus quis libero." />
 
                         <ImageView
-                            android:id="@+id/detail_toggle_secondary_controls_view"
+                            android:id="@+id/detail_toggle_expand_title"
                             android:layout_width="20dp"
                             android:layout_height="20dp"
                             android:layout_gravity="top|end"

--- a/app/src/main/res/layout/fragment_video_detail.xml
+++ b/app/src/main/res/layout/fragment_video_detail.xml
@@ -173,7 +173,7 @@
                         android:layout_height="match_parent"
                         android:layout_marginEnd="30dp"
                         android:ellipsize="end"
-                        android:maxLines="1"
+                        android:maxLines="2"
                         android:paddingTop="12dp"
                         android:paddingBottom="8dp"
                         android:textAppearance="?android:attr/textAppearanceLarge"
@@ -487,19 +487,6 @@
                             android:text="@string/download"
                             android:textSize="@dimen/detail_control_text_size"
                             app:drawableTopCompat="@drawable/ic_file_download" />
-
-                    </LinearLayout>
-
-                    <!-- SECONDARY CONTROLS -->
-                    <LinearLayout
-                        android:id="@+id/detail_secondary_control_panel"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:paddingHorizontal="@dimen/detail_control_padding"
-                        android:paddingBottom="@dimen/detail_control_padding"
-                        android:visibility="gone"
-                        tools:visibility="visible">
 
                         <org.schabi.newpipe.views.NewPipeTextView
                             android:id="@+id/detail_controls_share"

--- a/app/src/main/res/layout/fragment_video_detail.xml
+++ b/app/src/main/res/layout/fragment_video_detail.xml
@@ -181,7 +181,7 @@
                         tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit sed a ultricies ex. Integer sit amet sodales risus. Duis non mi et urna pretium bibendum. Nunc eleifend est quis ipsum porttitor egestas. Sed facilisis, nisl quis eleifend pellentesque, orci metus egestas dolor, at accumsan eros metus quis libero." />
 
                     <ImageView
-                        android:id="@+id/detail_toggle_secondary_controls_view"
+                        android:id="@+id/detail_toggle_expand_title"
                         android:layout_width="20dp"
                         android:layout_height="20dp"
                         android:layout_gravity="top|end"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -88,7 +88,7 @@
     <!-- Control panel -->
     <dimen name="detail_control_text_size">12sp</dimen>
     <dimen name="detail_control_width">80dp</dimen>
-    <dimen name="detail_control_height">55dp</dimen>
+    <dimen name="detail_control_height">65dp</dimen>
     <dimen name="detail_control_padding">6dp</dimen>
     <!-- Default screen margins, per the Android Design guidelines. -->
     <dimen name="activity_horizontal_margin">16dp</dimen>


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [X] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Increase default video title to 2 lines: I have found that almost every video title fits in two lines, but not in one (which is the current default). Also everywhere else in the app (and in the official YT app iirc) video titles currently can take up two lines, so this will unify the UI throughout the app.
- merge primary and secondary controls: This decouples showing additional options from expanding the title and thus makes the UI more intuitive in my opinion. I have tested it on various screen sizes and even on very small screens it works fine, so I currently don't see any downsides of always showing all controls.
- only show the expansion arrow when the title is ellipsized (longer than 2 lines)

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
<table>
  <tr>
    <th>Before (default)</th>
    <th>Before (expanded)</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/36965186/171856104-14f9efa0-d790-43fa-a9e6-938738465de0.png" height="400px"/></td>
    <td><img src="https://user-images.githubusercontent.com/36965186/171855916-ed132cdd-3746-4601-aeed-2032f8d1a748.png" height="400px"/></td>
    <td><img src="https://user-images.githubusercontent.com/36965186/171998201-b27ebf50-5495-4aac-a572-f4d19d0c4b5e.png" height="400px"/></td>
  </tr>
</table>

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [X] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
