### PR TITLE
Add option to hide future videos in feed

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
@@ -98,6 +98,7 @@ class FeedFragment : BaseStateFragment<FeedState>() {
 
     private lateinit var groupAdapter: GroupieAdapter
     @State @JvmField var showPlayedItems: Boolean = true
+    @State @JvmField var showFutureItems: Boolean = true
 
     private var onSettingsChangeListener: SharedPreferences.OnSharedPreferenceChangeListener? = null
     private var updateListViewModeOnResume = false
@@ -137,6 +138,7 @@ class FeedFragment : BaseStateFragment<FeedState>() {
         val factory = FeedViewModel.Factory(requireContext(), groupId)
         viewModel = ViewModelProvider(this, factory).get(FeedViewModel::class.java)
         showPlayedItems = viewModel.getShowPlayedItemsFromPreferences()
+        showFutureItems = viewModel.getShowFutureItemsFromPreferences()
         viewModel.stateLiveData.observe(viewLifecycleOwner) { it?.let(::handleResult) }
 
         groupAdapter = GroupieAdapter().apply {
@@ -212,6 +214,7 @@ class FeedFragment : BaseStateFragment<FeedState>() {
 
         inflater.inflate(R.menu.menu_feed_fragment, menu)
         updateTogglePlayedItemsButton(menu.findItem(R.id.menu_item_feed_toggle_played_items))
+        updateToggleFutureItemsButton(menu.findItem(R.id.menu_item_feed_toggle_future_items))
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
@@ -241,6 +244,11 @@ class FeedFragment : BaseStateFragment<FeedState>() {
             updateTogglePlayedItemsButton(item)
             viewModel.togglePlayedItems(showPlayedItems)
             viewModel.saveShowPlayedItemsToPreferences(showPlayedItems)
+        } else if (item.itemId == R.id.menu_item_feed_toggle_future_items) {
+            showFutureItems = !item.isChecked
+            updateToggleFutureItemsButton(item)
+            viewModel.toggleFutureItems(showFutureItems)
+            viewModel.saveShowFutureItemsToPreferences(showFutureItems)
         }
 
         return super.onOptionsItemSelected(item)
@@ -277,6 +285,14 @@ class FeedFragment : BaseStateFragment<FeedState>() {
         menuItem.icon = AppCompatResources.getDrawable(
             requireContext(),
             if (showPlayedItems) R.drawable.ic_visibility_on else R.drawable.ic_visibility_off
+        )
+    }
+
+    private fun updateToggleFutureItemsButton(menuItem: MenuItem) {
+        menuItem.isChecked = showFutureItems
+        menuItem.icon = AppCompatResources.getDrawable(
+            requireContext(),
+            if (showFutureItems) R.drawable.ic_history_future else R.drawable.ic_history
         )
     }
 

--- a/app/src/main/res/drawable/ic_history_future.xml
+++ b/app/src/main/res/drawable/ic_history_future.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="@color/defaultIconTint"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <group
+        android:name="flip"
+        android:pivotX="12"
+        android:scaleX="-1">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M13,3c-4.97,0 -9,4.03 -9,9L1,12l3.89,3.89 0.07,0.14L9,12L6,12c0,-3.87 3.13,-7 7,-7s7,3.13 7,7 -3.13,7 -7,7c-1.93,0 -3.68,-0.79 -4.94,-2.06l-1.42,1.42C8.27,19.99 10.51,21 13,21c4.97,0 9,-4.03 9,-9s-4.03,-9 -9,-9zM12,8v5l4.28,2.54 0.72,-1.21 -3.5,-2.08L13.5,8L12,8z" />
+    </group>
+</vector>

--- a/app/src/main/res/menu/menu_feed_fragment.xml
+++ b/app/src/main/res/menu/menu_feed_fragment.xml
@@ -4,11 +4,20 @@
 
     <item
         android:id="@+id/menu_item_feed_toggle_played_items"
-        android:orderInCategory="2"
+        android:orderInCategory="1"
         android:checkable="true"
         android:checked="true"
         android:icon="@drawable/ic_visibility_on"
         android:title="@string/feed_toggle_show_played_items"
+        app:showAsAction="ifRoom" />
+
+    <item
+        android:id="@+id/menu_item_feed_toggle_future_items"
+        android:orderInCategory="2"
+        android:checkable="true"
+        android:checked="true"
+        android:icon="@drawable/ic_history_future"
+        android:title="@string/feed_toggle_show_future_items"
         app:showAsAction="ifRoom" />
 
     <item

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -284,6 +284,7 @@
     <string name="feed_update_threshold_key">feed_update_threshold_key</string>
     <string name="feed_update_threshold_default_value">300</string>
     <string name="feed_show_played_items_key">feed_show_played_items</string>
+    <string name="feed_show_future_items_key">feed_show_future_items</string>
 
     <string name="show_thumbnail_key">show_thumbnail_key</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -747,4 +747,5 @@
     <string name="select_quality_external_players">Select quality for external players</string>
     <string name="unknown_format">Unknown format</string>
     <string name="unknown_quality">Unknown quality</string>
+    <string name="feed_toggle_show_future_items">Show future videos</string>
 </resources>


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Allows to hide videos that are not yet released. Some accounts schedule videos to be released in the future and sorting by release date makes those videos to be always on top.

#### Before/After Screenshots/Screen Record
- Before: (notice video release date saying "dentro de x meses" which means "in x months")
![image](https://user-images.githubusercontent.com/10256660/175574621-b1062d4d-6d14-41c5-83ae-9ab697d399fd.png)
- After:
![image](https://user-images.githubusercontent.com/10256660/175574767-cd0f5e4f-902b-4a1a-bdbf-fbb9375ec395.png)


#### Fixes the following issue(s)
N/A

#### Relies on the following changes

#### APK testing 
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
