### PR TITLE
Actually fix history view count

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/database/history/model/StreamHistoryEntity.java
+++ b/app/src/main/java/org/schabi/newpipe/database/history/model/StreamHistoryEntity.java
@@ -4,7 +4,6 @@ import androidx.annotation.NonNull;
 import androidx.room.ColumnInfo;
 import androidx.room.Entity;
 import androidx.room.ForeignKey;
-import androidx.room.Ignore;
 import androidx.room.Index;
 
 import org.schabi.newpipe.database.stream.model.StreamEntity;
@@ -42,16 +41,17 @@ public class StreamHistoryEntity {
     @ColumnInfo(name = STREAM_REPEAT_COUNT)
     private long repeatCount;
 
-    public StreamHistoryEntity(final long streamUid, @NonNull final OffsetDateTime accessDate,
+    /**
+     * @param streamUid the stream id this history item will refer to
+     * @param accessDate the last time the stream was accessed
+     * @param repeatCount the total number of views this stream received
+     */
+    public StreamHistoryEntity(final long streamUid,
+                               @NonNull final OffsetDateTime accessDate,
                                final long repeatCount) {
         this.streamUid = streamUid;
         this.accessDate = accessDate;
         this.repeatCount = repeatCount;
-    }
-
-    @Ignore
-    public StreamHistoryEntity(final long streamUid, @NonNull final OffsetDateTime accessDate) {
-        this(streamUid, accessDate, 0); // start with 0 views (adding views will be done elsewhere)
     }
 
     public long getStreamUid() {

--- a/app/src/main/java/org/schabi/newpipe/local/history/HistoryRecordManager.java
+++ b/app/src/main/java/org/schabi/newpipe/local/history/HistoryRecordManager.java
@@ -128,13 +128,11 @@ public class HistoryRecordManager {
 
             // Add a history entry
             final StreamHistoryEntity latestEntry = streamHistoryTable.getLatestEntry(streamId);
-            if (latestEntry != null) {
-                streamHistoryTable.delete(latestEntry);
-                latestEntry.setAccessDate(currentTime);
-                latestEntry.setRepeatCount(latestEntry.getRepeatCount() + 1);
-                return streamHistoryTable.insert(latestEntry);
+            if (latestEntry == null) {
+                // never actually viewed: add history entry but with 0 views
+                return streamHistoryTable.insert(new StreamHistoryEntity(streamId, currentTime, 0));
             } else {
-                return streamHistoryTable.insert(new StreamHistoryEntity(streamId, currentTime));
+                return 0L;
             }
         })).subscribeOn(Schedulers.io());
     }
@@ -155,7 +153,8 @@ public class HistoryRecordManager {
                 latestEntry.setRepeatCount(latestEntry.getRepeatCount() + 1);
                 return streamHistoryTable.insert(latestEntry);
             } else {
-                return streamHistoryTable.insert(new StreamHistoryEntity(streamId, currentTime));
+                // just viewed for the first time: set 1 view
+                return streamHistoryTable.insert(new StreamHistoryEntity(streamId, currentTime, 1));
             }
         })).subscribeOn(Schedulers.io());
     }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
#8336 did not really fix the problem, it just made so that each item in history has 1 less view. This meant that, even though the bug appeared to be fixed the first time a video is opened (since that video's views are correctly set to 1), the second time the same video is opened the views are incorrectly set to 3. And #8336 actually introduced a regression, since e.g. enqueued videos were registered as "No views" as reported in https://github.com/TeamNewPipe/NewPipe/pull/8336#issuecomment-1149998538.

The underlying problem was an incorrect usage of Java's `==` (*same*) operator: it was used in the player's `onEvents` function to check if the media item tag in the **ExoPlayer** was equal to the one currently set in our `Player`. The problem with this is, when the player is started from scratch, the media item tag is first updated with a tag with no `LoadedMediaSource` attached (since the player is still loading the media source), and then updated again when the media source was loaded. The second update created a new instance of the media item tag (see `StreamInfoTag.withExtras()` and its usage in `LoadedMediaSource` and `FailedMediaSource`), so the `==` operator is not suitable for comparing them. When the player is not started from scratch, but rather just switches to the next item in the queue, only 1 view was (correctly) registered, since the media source is usually already loaded because of the mechanism of pre-fetching the next item in the queue. 

This PR solves the issue by comparing the stream info url associated with the media item tag before calling `updateMetadataWith()` with the new stream info.

This PR also makes it so that marking a video as watched does not add one view to it, and also does not update its last access time. Now a new history entry **with 0 views** is added, and this happens only if one did not exist before. Tell me if I should revert this.

#### Fixes the following issue(s)
- Replaces #8336
- Really fixes #8330

#### APK testing 
[app-debug.zip](https://github.com/TeamNewPipe/NewPipe/files/9029513/app-debug.zip)

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
