### PR TITLE
Use minimum required permissions for GitHub workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,10 @@ on:
 jobs:
   build-and-test-jvm:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
     steps:
       - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1
@@ -64,6 +68,10 @@ jobs:
       matrix:
         # api-level 19 is min sdk, but throws errors related to desugaring
         api-level: [ 21, 29 ]
+
+    permissions:
+      contents: read
+
     steps:
       - uses: actions/checkout@v3
 
@@ -81,7 +89,7 @@ jobs:
           # workaround to emulator bug: https://github.com/ReactiveCircus/android-emulator-runner/issues/160
           emulator-build: 7425822
           script: ./gradlew connectedCheck --stacktrace
-        
+
       - name: Upload test report when tests fail # because the printed out stacktrace (console) is too short, see also #7553
         uses: actions/upload-artifact@v3
         if: failure()
@@ -91,6 +99,10 @@ jobs:
 
   sonar:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/image-minimizer.yml
+++ b/.github/workflows/image-minimizer.yml
@@ -6,6 +6,10 @@ on:
   issues:
     types: [opened, edited]
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   try-minimize:
     runs-on: ubuntu-latest

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -9,6 +9,10 @@ on:
     # Run daily at midnight.
     - cron: '0 0 * * *'
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   noResponse:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Meta improvement to the project (dev facing)

#### Description of the changes in your PR

Use minimum needed permissions for GitHub workflows and jobs. This reduces the attack surface if the workflows are ever compromised.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
