### PR TITLE
Make thumbnails' `scaleType` `fitCenter`

### DIFF
--- a/app/src/main/res/layout/channel_header.xml
+++ b/app/src/main/res/layout/channel_header.xml
@@ -17,7 +17,7 @@
             android:layout_height="70dp"
             android:background="@android:color/black"
             android:fitsSystemWindows="true"
-            android:scaleType="centerCrop"
+            android:scaleType="fitCenter"
             android:src="@drawable/channel_banner"
             tools:ignore="ContentDescription" />
 

--- a/app/src/main/res/layout/item_stream_segment.xml
+++ b/app/src/main/res/layout/item_stream_segment.xml
@@ -17,7 +17,7 @@
         android:id="@+id/previewImage"
         android:layout_width="0dp"
         android:layout_height="@dimen/play_queue_thumbnail_width"
-        android:scaleType="centerCrop"
+        android:scaleType="fitCenter"
         android:src="@drawable/dummy_thumbnail"
         app:layout_constraintDimensionRatio="16:9"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/list_playlist_grid_item.xml
+++ b/app/src/main/res/layout/list_playlist_grid_item.xml
@@ -17,7 +17,7 @@
         android:layout_alignParentTop="true"
         android:layout_centerHorizontal="true"
         android:layout_marginRight="@dimen/video_item_search_image_right_margin"
-        android:scaleType="fitCenter"
+        android:scaleType="fitStart"
         android:src="@drawable/dummy_thumbnail_playlist"
         tools:ignore="RtlHardcoded" />
 
@@ -26,7 +26,7 @@
         android:layout_width="@dimen/playlist_item_thumbnail_stream_count_width"
         android:layout_height="match_parent"
         android:layout_alignTop="@id/itemThumbnailView"
-        android:layout_alignRight="@id/itemThumbnailView"
+        android:layout_alignEnd="@id/itemThumbnailView"
         android:layout_alignBottom="@id/itemThumbnailView"
         android:background="@color/playlist_stream_count_background_color"
         android:gravity="center"
@@ -38,7 +38,6 @@
         android:textStyle="bold"
         app:drawableTint="@color/duration_text_color"
         app:drawableTopCompat="@drawable/ic_playlist_play"
-        tools:ignore="RtlHardcoded"
         tools:text="314159" />
 
     <org.schabi.newpipe.views.NewPipeTextView

--- a/app/src/main/res/layout/list_playlist_grid_item.xml
+++ b/app/src/main/res/layout/list_playlist_grid_item.xml
@@ -17,7 +17,7 @@
         android:layout_alignParentTop="true"
         android:layout_centerHorizontal="true"
         android:layout_marginRight="@dimen/video_item_search_image_right_margin"
-        android:scaleType="centerCrop"
+        android:scaleType="fitCenter"
         android:src="@drawable/dummy_thumbnail_playlist"
         tools:ignore="RtlHardcoded" />
 

--- a/app/src/main/res/layout/list_playlist_item.xml
+++ b/app/src/main/res/layout/list_playlist_item.xml
@@ -18,7 +18,7 @@
         android:layout_alignParentLeft="true"
         android:layout_alignParentTop="true"
         android:layout_marginRight="@dimen/video_item_search_image_right_margin"
-        android:scaleType="fitCenter"
+        android:scaleType="fitStart"
         android:src="@drawable/dummy_thumbnail_playlist"
         tools:ignore="RtlHardcoded" />
 
@@ -27,7 +27,7 @@
         android:layout_width="@dimen/playlist_item_thumbnail_stream_count_width"
         android:layout_height="match_parent"
         android:layout_alignTop="@id/itemThumbnailView"
-        android:layout_alignRight="@id/itemThumbnailView"
+        android:layout_alignEnd="@id/itemThumbnailView"
         android:layout_alignBottom="@id/itemThumbnailView"
         android:background="@color/playlist_stream_count_background_color"
         android:gravity="center"
@@ -39,7 +39,6 @@
         android:textStyle="bold"
         app:drawableTint="@color/duration_text_color"
         app:drawableTopCompat="@drawable/ic_playlist_play"
-        tools:ignore="RtlHardcoded"
         tools:text="314159" />
 
     <org.schabi.newpipe.views.NewPipeTextView

--- a/app/src/main/res/layout/list_playlist_item.xml
+++ b/app/src/main/res/layout/list_playlist_item.xml
@@ -18,7 +18,7 @@
         android:layout_alignParentLeft="true"
         android:layout_alignParentTop="true"
         android:layout_marginRight="@dimen/video_item_search_image_right_margin"
-        android:scaleType="centerCrop"
+        android:scaleType="fitCenter"
         android:src="@drawable/dummy_thumbnail_playlist"
         tools:ignore="RtlHardcoded" />
 

--- a/app/src/main/res/layout/list_playlist_mini_item.xml
+++ b/app/src/main/res/layout/list_playlist_mini_item.xml
@@ -18,7 +18,7 @@
         android:layout_alignParentLeft="true"
         android:layout_alignParentTop="true"
         android:layout_marginRight="@dimen/video_item_search_image_right_margin"
-        android:scaleType="centerCrop"
+        android:scaleType="fitCenter"
         android:src="@drawable/dummy_thumbnail_playlist"
         tools:ignore="RtlHardcoded" />
 

--- a/app/src/main/res/layout/list_playlist_mini_item.xml
+++ b/app/src/main/res/layout/list_playlist_mini_item.xml
@@ -18,7 +18,7 @@
         android:layout_alignParentLeft="true"
         android:layout_alignParentTop="true"
         android:layout_marginRight="@dimen/video_item_search_image_right_margin"
-        android:scaleType="fitCenter"
+        android:scaleType="fitStart"
         android:src="@drawable/dummy_thumbnail_playlist"
         tools:ignore="RtlHardcoded" />
 
@@ -27,7 +27,7 @@
         android:layout_width="45dp"
         android:layout_height="match_parent"
         android:layout_alignTop="@id/itemThumbnailView"
-        android:layout_alignRight="@id/itemThumbnailView"
+        android:layout_alignEnd="@id/itemThumbnailView"
         android:layout_alignBottom="@id/itemThumbnailView"
         android:background="@color/playlist_stream_count_background_color"
         android:gravity="center"
@@ -39,7 +39,6 @@
         android:textStyle="bold"
         app:drawableTint="@color/duration_text_color"
         app:drawableTopCompat="@drawable/ic_playlist_play"
-        tools:ignore="RtlHardcoded"
         tools:text="3141" />
 
     <org.schabi.newpipe.views.NewPipeTextView

--- a/app/src/main/res/layout/list_stream_grid_item.xml
+++ b/app/src/main/res/layout/list_stream_grid_item.xml
@@ -14,7 +14,7 @@
         android:id="@+id/itemThumbnailView"
         android:layout_width="@dimen/video_item_grid_thumbnail_image_width"
         android:layout_height="@dimen/video_item_grid_thumbnail_image_height"
-        android:scaleType="centerCrop"
+        android:scaleType="fitCenter"
         android:src="@drawable/dummy_thumbnail"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/list_stream_item.xml
+++ b/app/src/main/res/layout/list_stream_item.xml
@@ -14,7 +14,7 @@
         android:id="@+id/itemThumbnailView"
         android:layout_width="@dimen/video_item_search_thumbnail_image_width"
         android:layout_height="@dimen/video_item_search_thumbnail_image_height"
-        android:scaleType="centerCrop"
+        android:scaleType="fitCenter"
         android:src="@drawable/dummy_thumbnail"
         app:layout_constraintBottom_toTopOf="@+id/itemProgressView"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/list_stream_mini_item.xml
+++ b/app/src/main/res/layout/list_stream_mini_item.xml
@@ -17,7 +17,7 @@
         android:layout_alignParentLeft="true"
         android:layout_alignParentTop="true"
         android:layout_marginRight="@dimen/video_item_search_image_right_margin"
-        android:scaleType="centerCrop"
+        android:scaleType="fitCenter"
         android:src="@drawable/dummy_thumbnail"
         tools:ignore="RtlHardcoded" />
 

--- a/app/src/main/res/layout/list_stream_playlist_grid_item.xml
+++ b/app/src/main/res/layout/list_stream_playlist_grid_item.xml
@@ -17,7 +17,7 @@
         android:layout_alignParentTop="true"
         android:layout_centerHorizontal="true"
         android:layout_marginRight="@dimen/video_item_search_image_right_margin"
-        android:scaleType="centerCrop"
+        android:scaleType="fitCenter"
         android:src="@drawable/dummy_thumbnail"
         tools:ignore="RtlHardcoded" />
 

--- a/app/src/main/res/layout/list_stream_playlist_item.xml
+++ b/app/src/main/res/layout/list_stream_playlist_item.xml
@@ -18,7 +18,7 @@
         android:layout_alignParentLeft="true"
         android:layout_alignParentTop="true"
         android:layout_marginRight="@dimen/video_item_search_image_right_margin"
-        android:scaleType="centerCrop"
+        android:scaleType="fitCenter"
         android:src="@drawable/dummy_thumbnail"
         tools:ignore="RtlHardcoded" />
 

--- a/app/src/main/res/layout/play_queue_item.xml
+++ b/app/src/main/res/layout/play_queue_item.xml
@@ -17,7 +17,7 @@
         android:layout_marginStart="@dimen/video_item_search_image_right_margin"
         android:layout_marginTop="@dimen/video_item_search_image_right_margin"
         android:layout_marginBottom="@dimen/video_item_search_image_right_margin"
-        android:scaleType="centerCrop"
+        android:scaleType="fitCenter"
         android:src="@drawable/dummy_thumbnail"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Since the last extractor update (which included TeamNewPipe/NewPipeExtractor#810), YouTube thumbnail urls point to thumbnails with the original aspect ratio preserved (16:9 for normal videos, 9:16 for shorts I think). Before this change, some other "legacy" urls were obtained, which instead pointed to images with pre-added black bars for shorts to make them all 16:9. This change revealed that NewPipe was not treating correctly images with aspect ratios different than 16:9, showing only their center part using the `scaleType="centerCrop"` property. Instead I used `scaleType="fitCenter"`, see the difference in the screenshots.

SoundCloud and Bandcamp square thumbnails also look better.

I also made it so that playlist thumbnails align left, so that a smaller part of the thumbnail is hidden under the black bar on the right.

#### Before/After Screenshots/Screen Record
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/36421898/177210363-9eeb0404-15a5-418a-9868-88d15928a467.png"/></td>
    <td><img src="https://user-images.githubusercontent.com/36421898/177210277-abcde3ef-6d0e-48f6-b4f2-6ec74da64247.png"/></td>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/36421898/177210459-e8b31e76-b4ce-451e-8f08-d21d84cb4474.png"/></td>
    <td><img src="https://user-images.githubusercontent.com/36421898/177210222-efdedfcf-d7b0-4b03-920a-31eef1421107.png"/></td>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/36421898/177213713-4c23e47f-8bda-4ae9-a512-bd9caa6e87d6.png"/></td>
    <td><img src="https://user-images.githubusercontent.com/36421898/177213824-3d7ed144-763c-428a-8caf-fb151b073404.png"/></td>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/36421898/177215350-b83b766f-64dd-4f49-9055-e9df170a6de6.png"/></td>
    <td><img src="https://user-images.githubusercontent.com/36421898/177215285-bd0c8e59-4735-475f-8536-1da7249daf1a.png"/></td>
  </tr>
</table>

#### Fixes the following issue(s)
- See https://github.com/TeamNewPipe/NewPipe/issues/8548#issuecomment-1172767548
- Fixes #6245 @fynngodau

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
