### PR TITLE
Add quality selector for livestreams, fix some seamless transition issues and more

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -2289,11 +2289,11 @@ public final class Player implements PlaybackListener, Listener, AnalyticsListen
 
     private boolean isLive() {
         try {
-            return !exoPlayerIsNull() && simpleExoPlayer.isCurrentMediaItemDynamic();
+            return !exoPlayerIsNull() && simpleExoPlayer.isCurrentMediaItemLive();
         } catch (final IndexOutOfBoundsException e) {
             // Why would this even happen =(... but lets log it anyway, better safe than sorry
             if (DEBUG) {
-                Log.d(TAG, "player.isCurrentWindowDynamic() failed: ", e);
+                Log.d(TAG, "player.isCurrentMediaItemLive() failed: ", e);
             }
             return false;
         }

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -43,6 +43,7 @@ import static org.schabi.newpipe.player.notification.NotificationConstants.ACTIO
 import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_RECREATE_NOTIFICATION;
 import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_REPEAT;
 import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_SHUFFLE;
+import static org.schabi.newpipe.util.ListHelper.computeDefaultResolution;
 import static org.schabi.newpipe.util.ListHelper.getPopupResolutionIndex;
 import static org.schabi.newpipe.util.ListHelper.getResolutionIndex;
 import static org.schabi.newpipe.util.Localization.assureCorrectAppLanguage;
@@ -67,12 +68,15 @@ import androidx.preference.PreferenceManager;
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.DefaultRenderersFactory;
 import com.google.android.exoplayer2.ExoPlayer;
+import com.google.android.exoplayer2.Format;
 import com.google.android.exoplayer2.PlaybackException;
 import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Player.PositionInfo;
 import com.google.android.exoplayer2.RenderersFactory;
 import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.Tracks;
+import com.google.android.exoplayer2.analytics.AnalyticsListener;
+import com.google.android.exoplayer2.decoder.DecoderReuseEvaluation;
 import com.google.android.exoplayer2.source.MediaSource;
 import com.google.android.exoplayer2.text.CueGroup;
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
@@ -132,7 +136,7 @@ import io.reactivex.rxjava3.disposables.CompositeDisposable;
 import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.disposables.SerialDisposable;
 
-public final class Player implements PlaybackListener, Listener {
+public final class Player implements PlaybackListener, Listener, AnalyticsListener {
     public static final boolean DEBUG = MainActivity.DEBUG;
     public static final String TAG = Player.class.getSimpleName();
 
@@ -174,6 +178,7 @@ public final class Player implements PlaybackListener, Listener {
     //////////////////////////////////////////////////////////////////////////*/
 
     public static final int RENDERER_UNAVAILABLE = -1;
+    public static final int MAX_HEIGHT_ALLOWED_WITHOUT_HIGH_RESOLUTIONS = 1080;
     private static final String PICASSO_PLAYER_THUMBNAIL_TAG = "PICASSO_PLAYER_THUMBNAIL_TAG";
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -217,6 +222,8 @@ public final class Player implements PlaybackListener, Listener {
     private boolean isAudioOnly = false;
     private boolean isPrepared = false;
     private boolean wasPlaying = false;
+
+    private boolean defaultResolutionSetForManifestsSources = false;
 
     /*//////////////////////////////////////////////////////////////////////////
     // UIs, listeners and disposables
@@ -509,6 +516,7 @@ public final class Player implements PlaybackListener, Listener {
                 .setUsePlatformDiagnostics(false)
                 .build();
         simpleExoPlayer.addListener(this);
+        simpleExoPlayer.addAnalyticsListener(this);
         simpleExoPlayer.setPlayWhenReady(playOnReady);
         simpleExoPlayer.setSeekParameters(PlayerHelper.getSeekParameters(context));
         simpleExoPlayer.setWakeMode(C.WAKE_MODE_NETWORK);
@@ -1281,7 +1289,8 @@ public final class Player implements PlaybackListener, Listener {
             Log.d(TAG, "ExoPlayer - onTracksChanged(), "
                     + "track group size = " + tracks.getGroups().size());
         }
-        UIs.call(playerUi -> playerUi.onTextTracksChanged(tracks));
+        setDefaultResolutionForManifestSourcesIfNeeded();
+        UIs.call(playerUi -> playerUi.onTracksChanged(tracks));
     }
 
     @Override
@@ -1348,6 +1357,14 @@ public final class Player implements PlaybackListener, Listener {
     @Override
     public void onCues(@NonNull final CueGroup cueGroup) {
         UIs.call(playerUi -> playerUi.onCues(cueGroup.cues));
+    }
+
+    @Override
+    public void onVideoInputFormatChanged(
+            @NonNull final EventTime eventTime,
+            @NonNull final Format format,
+            @Nullable final DecoderReuseEvaluation decoderReuseEvaluation) {
+        UIs.call(playerUi -> playerUi.onVideoInputFormatChanged(format));
     }
     //endregion
 
@@ -1655,6 +1672,7 @@ public final class Player implements PlaybackListener, Listener {
             playQueue.offsetIndex(0);
         } else {
             saveStreamProgressState();
+            defaultResolutionSetForManifestsSources = false;
             playQueue.offsetIndex(-1);
         }
         triggerProgressUpdate();
@@ -1669,6 +1687,7 @@ public final class Player implements PlaybackListener, Listener {
         }
 
         saveStreamProgressState();
+        defaultResolutionSetForManifestsSources = false;
         playQueue.offsetIndex(+1);
         triggerProgressUpdate();
     }
@@ -1806,6 +1825,89 @@ public final class Player implements PlaybackListener, Listener {
     @Nullable
     public Bitmap getThumbnail() {
         return currentThumbnail;
+    }
+    //endregion
+
+    /*//////////////////////////////////////////////////////////////////////////
+    // Manifest sources
+    //////////////////////////////////////////////////////////////////////////*/
+    //region Manifest sources
+
+    /**
+     * Set the default resolution for manifest sources according to user choice in Video and Audio
+     * settings.
+     *
+     * <p>
+     * The video format which has the highest bitrate in the formats supported by the device is
+     * always set, using
+     * {@link DefaultTrackSelector.Parameters.Builder#setForceHighestSupportedBitrate(boolean)}.
+     * </p>
+     *
+     * <p>
+     * If the resolution selected by the user is the best resolution, nothing else is set.
+     * </p>
+     *
+     * <p>
+     * If a resolution without an explicit frame rate (such as 480p) is the default one, the maximum
+     * frame rate allowed will be set to 30; otherwise the frame rate specified in the resolution
+     * will be set (such as 60 for 720p60).
+     * </p>
+     *
+     * <p>
+     * Note that if no stream matches the criteria specified, the track selection is managed by
+     * ExoPlayer in this specific case.
+     * </p>
+     */
+    private void setDefaultResolutionForManifestSourcesIfNeeded() {
+        if (defaultResolutionSetForManifestsSources || !isCurrentSourceTypeManifest()) {
+            return;
+        }
+
+        final String defaultResolution;
+        if (popupPlayerSelected()) {
+            defaultResolution = computeDefaultResolution(context,
+                    R.string.default_popup_resolution_key,
+                    R.string.default_popup_resolution_value);
+        } else {
+            defaultResolution = computeDefaultResolution(context,
+                    R.string.default_resolution_key, R.string.default_resolution_value);
+        }
+
+        final String[] defaultResolutionArray = defaultResolution.split("p");
+        final int defaultHeight = defaultResolution.equals(
+                context.getString(R.string.best_resolution_key)) ? -1
+                : Integer.parseInt(defaultResolutionArray[0]);
+        final int defaultFrameRate = defaultResolutionArray.length == 2
+                ? Integer.parseInt(defaultResolutionArray[1]) : 30;
+
+        final DefaultTrackSelector.Parameters.Builder builder = trackSelector.getParameters()
+                .buildUpon()
+                // Force playback of the highest quality
+                // Playback of qualities which don't meet constraints if there is no stream which
+                // matches them is allow by default
+                .setForceHighestSupportedBitrate(true);
+
+        if (defaultHeight != -1) {
+            // Setting minimum video size and maximum video size with the same values + forcing
+            // the highest bitrate supported should force playback of the selected resolution, if
+            // it is available
+            builder.setMinVideoSize(0, defaultHeight)
+                    .setMaxVideoSize(0, defaultHeight)
+                    .setMaxVideoFrameRate(defaultFrameRate);
+        } else if (areHigherResolutionsHidden()) {
+            builder.setMinVideoSize(0, MAX_HEIGHT_ALLOWED_WITHOUT_HIGH_RESOLUTIONS)
+                    .setMaxVideoSize(0, MAX_HEIGHT_ALLOWED_WITHOUT_HIGH_RESOLUTIONS);
+        }
+
+        trackSelector.setParameters(builder);
+        defaultResolutionSetForManifestsSources = true;
+    }
+
+    /**
+     * @return whether the {@link SourceType} of the current metadata is {@link SourceType#MANIFEST}
+     */
+    public boolean isCurrentSourceTypeManifest() {
+        return currentMetadata != null && currentMetadata.getSourceType() == SourceType.MANIFEST;
     }
     //endregion
 
@@ -2300,6 +2402,13 @@ public final class Player implements PlaybackListener, Listener {
                 .findFirst()
                 // No video renderer index with at least one track found: return unavailable index
                 .orElse(RENDERER_UNAVAILABLE);
+    }
+
+    /**
+     * @return whether higher resolutions are disabled from {@code Video and audio} settings
+     */
+    public boolean areHigherResolutionsHidden() {
+        return prefs.getBoolean(context.getString(R.string.show_higher_resolutions_key), false);
     }
     //endregion
 }

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -1664,9 +1664,10 @@ public final class Player implements PlaybackListener, Listener, AnalyticsListen
         }
 
         /* If current playback has run for PLAY_PREV_ACTIVATION_LIMIT_MILLIS milliseconds,
-         * restart current track. Also restart the track if the current track
-         * is the first in a queue.*/
-        if (simpleExoPlayer.getCurrentPosition() > PLAY_PREV_ACTIVATION_LIMIT_MILLIS
+        restart current track (not applicable for livestreams, otherwise the play queue offset
+        would never be called on livestreams with a long DVR time).
+        Also restart the track if the current track is the first in a queue. */
+        if ((!isLive() && simpleExoPlayer.getCurrentPosition() > PLAY_PREV_ACTIVATION_LIMIT_MILLIS)
                 || playQueue.getIndex() == 0) {
             seekToDefault();
             playQueue.offsetIndex(0);

--- a/app/src/main/java/org/schabi/newpipe/player/mediaitem/MediaItemTag.java
+++ b/app/src/main/java/org/schabi/newpipe/player/mediaitem/MediaItemTag.java
@@ -10,6 +10,7 @@ import com.google.android.exoplayer2.Player;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.extractor.stream.StreamType;
 import org.schabi.newpipe.extractor.stream.VideoStream;
+import org.schabi.newpipe.player.resolver.SourceType;
 
 import java.util.List;
 import java.util.Optional;
@@ -44,6 +45,10 @@ public interface MediaItemTag {
     String getUploaderUrl();
 
     StreamType getStreamType();
+
+    default SourceType getSourceType() {
+        return SourceType.UNKNOWN;
+    }
 
     @NonNull
     default Optional<StreamInfo> getMaybeStreamInfo() {

--- a/app/src/main/java/org/schabi/newpipe/player/mediaitem/StreamInfoTag.java
+++ b/app/src/main/java/org/schabi/newpipe/player/mediaitem/StreamInfoTag.java
@@ -5,6 +5,7 @@ import com.google.android.exoplayer2.MediaItem;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.extractor.stream.StreamType;
 import org.schabi.newpipe.extractor.stream.VideoStream;
+import org.schabi.newpipe.player.resolver.SourceType;
 
 import java.util.Collections;
 import java.util.List;
@@ -27,6 +28,9 @@ public final class StreamInfoTag implements MediaItemTag {
     @Nullable
     private final Object extras;
 
+    @NonNull
+    private SourceType sourceType = SourceType.UNKNOWN;
+
     private StreamInfoTag(@NonNull final StreamInfo streamInfo,
                           @Nullable final MediaItemTag.Quality quality,
                           @Nullable final Object extras) {
@@ -35,6 +39,7 @@ public final class StreamInfoTag implements MediaItemTag {
         this.extras = extras;
     }
 
+    @NonNull
     public static StreamInfoTag of(@NonNull final StreamInfo streamInfo,
                                    @NonNull final List<VideoStream> sortedVideoStreams,
                                    final int selectedVideoStreamIndex) {
@@ -42,10 +47,12 @@ public final class StreamInfoTag implements MediaItemTag {
         return new StreamInfoTag(streamInfo, quality, null);
     }
 
+    @NonNull
     public static StreamInfoTag of(@NonNull final StreamInfo streamInfo) {
         return new StreamInfoTag(streamInfo, null, null);
     }
 
+    @NonNull
     @Override
     public List<Exception> getErrors() {
         return Collections.emptyList();
@@ -93,6 +100,16 @@ public final class StreamInfoTag implements MediaItemTag {
 
     @NonNull
     @Override
+    public SourceType getSourceType() {
+        return sourceType;
+    }
+
+    public void setSourceType(@NonNull final SourceType sourceType) {
+        this.sourceType = sourceType;
+    }
+
+    @NonNull
+    @Override
     public Optional<StreamInfo> getMaybeStreamInfo() {
         return Optional.of(streamInfo);
     }
@@ -108,6 +125,7 @@ public final class StreamInfoTag implements MediaItemTag {
         return Optional.ofNullable(extras).map(type::cast);
     }
 
+    @NonNull
     @Override
     public StreamInfoTag withExtras(@NonNull final Object extra) {
         return new StreamInfoTag(streamInfo, quality, extra);

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/AudioPlaybackResolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/AudioPlaybackResolver.java
@@ -13,7 +13,6 @@ import com.google.android.exoplayer2.source.MediaSource;
 import org.schabi.newpipe.extractor.stream.AudioStream;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.player.helper.PlayerDataSource;
-import org.schabi.newpipe.player.mediaitem.MediaItemTag;
 import org.schabi.newpipe.player.mediaitem.StreamInfoTag;
 import org.schabi.newpipe.util.ListHelper;
 
@@ -49,7 +48,8 @@ public class AudioPlaybackResolver implements PlaybackResolver {
         }
 
         final AudioStream audio = info.getAudioStreams().get(index);
-        final MediaItemTag tag = StreamInfoTag.of(info);
+        final StreamInfoTag tag = StreamInfoTag.of(info);
+        tag.setSourceType(SourceType.AUDIO_ONLY);
 
         try {
             return PlaybackResolver.buildMediaSource(

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/PlaybackResolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/PlaybackResolver.java
@@ -171,6 +171,7 @@ public interface PlaybackResolver extends Resolver<StreamInfo, MediaSource> {
 
         try {
             final StreamInfoTag tag = StreamInfoTag.of(info);
+            tag.setSourceType(SourceType.MANIFEST);
             if (!info.getHlsUrl().isEmpty()) {
                 return buildLiveMediaSource(dataSource, info.getHlsUrl(), C.CONTENT_TYPE_HLS, tag);
             } else if (!info.getDashMpdUrl().isEmpty()) {

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/SourceType.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/SourceType.java
@@ -1,0 +1,55 @@
+package org.schabi.newpipe.player.resolver;
+
+import org.schabi.newpipe.extractor.stream.AudioStream;
+import org.schabi.newpipe.extractor.stream.StreamInfo;
+import org.schabi.newpipe.extractor.stream.VideoStream;
+import org.schabi.newpipe.player.mediaitem.MediaItemTag;
+
+/**
+ * Enum representing the different source types created by {@link Resolver}s.
+ */
+public enum SourceType {
+
+    /**
+     * Placeholder value for {@link MediaItemTag}s, which represents that the {@code SourceType} is
+     * not known yet or not applicable for the {@link MediaItemTag} type used.
+     */
+    UNKNOWN,
+
+    /**
+     * {@code SourceType} for media sources generated from manifests URL.
+     *
+     * <p>
+     * This value is returned when a source is not generated from an {@link AudioStream} or a
+     * {@link VideoStream} but from a manifest URL (the ones returned by
+     * {@link StreamInfo#getDashMpdUrl()} and{@link StreamInfo#getHlsUrl()}).
+     * This is the main behavior used on livestreams.
+     * </p>
+     */
+    MANIFEST,
+
+    /**
+     * {@code SourceType} for media sources generated from {@link VideoStream}s which are
+     * {@link VideoStream#isVideoOnly() video-only} with an {@link AudioStream} used as the audio
+     * of this {@link VideoStream VideoStream}.
+     */
+    VIDEO_WITH_SEPARATED_AUDIO,
+
+    /**
+     * {@code SourceType} for media sources generated from {@link VideoStream}s which are
+     * {@link VideoStream#isVideoOnly() video-only} without any audio (embedded or from an external
+     * {@link AudioStream}).
+     */
+    VIDEO_ONLY,
+
+    /**
+     * {@code SourceType} for media sources generated from {@link VideoStream}s which are not
+     * {@link VideoStream#isVideoOnly() video-only} with an audio source embedded in it.
+     */
+    VIDEO_WITH_AUDIO,
+
+    /**
+     * {@code SourceType} for media sources generated from {@link AudioStream}s only.
+     */
+    AUDIO_ONLY
+}

--- a/app/src/main/java/org/schabi/newpipe/player/ui/PlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/PlayerUi.java
@@ -7,6 +7,7 @@ import android.graphics.Bitmap;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.google.android.exoplayer2.Format;
 import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Player.RepeatMode;
 import com.google.android.exoplayer2.Tracks;
@@ -158,7 +159,7 @@ public abstract class PlayerUi {
      * @see com.google.android.exoplayer2.Player.Listener#onTracksChanged(Tracks)
      * @param currentTracks the available tracks information
      */
-    public void onTextTracksChanged(@NonNull final Tracks currentTracks) {
+    public void onTracksChanged(@NonNull final Tracks currentTracks) {
     }
 
     /**
@@ -208,5 +209,15 @@ public abstract class PlayerUi {
      * @see com.google.android.exoplayer2.Player.Listener#onVideoSizeChanged
      */
     public void onVideoSizeChanged(@NonNull final VideoSize videoSize) {
+    }
+
+    /**
+     * @param format the new video {@link Format} being consumed by a video renderer used by
+     *               ExoPlayer
+     * @see com.google.android.exoplayer2.analytics.AnalyticsListener#onVideoInputFormatChanged(
+     * com.google.android.exoplayer2.analytics.AnalyticsListener.EventTime, Format,
+     * com.google.android.exoplayer2.decoder.DecoderReuseEvaluation)
+     */
+    public void onVideoInputFormatChanged(@NonNull final Format format) {
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
@@ -210,8 +210,9 @@ public final class ListHelper {
                 .collect(Collectors.toList());
     }
 
-    private static String computeDefaultResolution(final Context context, final int key,
-                                                   final int value) {
+    public static String computeDefaultResolution(@NonNull final Context context,
+                                                  final int key,
+                                                  final int value) {
         final SharedPreferences preferences =
                 PreferenceManager.getDefaultSharedPreferences(context);
 


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [x] Feature (user facing)

#### Description of the changes in your PR

Replacement of #7260, rebased with some changes in the feature.

This pull request adds the quality selector for livestreams. This quality selector, due to limitations, will only include qualities' resolution (or its bitrate if its height is unknown and as a last resort, the `Quality unknown` string).

Contrary to the previous attempt, there is no `Auto` quality, in order to prevent confusion of this availability on videos.

The default resolution is set according to the user choices in Video and audio settings.

However, resolutions are now set using minimum and maximum video size constraints instead of selection overrides, in order to simply the code. Available resolutions are got from the first video `TrackGroupInfo` found and rebuilt each time the `onTracksChanged(TracksInfo)` event of ExoPlayer is triggered.

This PR also refactors how `SourceType`s are used by the player. Instead of being returned only by `VideoPlaybackResolver`, it is now included in `MediaItemTag`s (and the corresponding enum has been extracted from `VideoPlaybackResolver`). This allow detection of sources which require building a quality selector using the first video `TrackGroupInfo` found (like I said above), setting an `AnalyticsListener` to update the quality `TextView` depending of the quality played, and setting the default resolution using `TrackSelectionParameters`.

The `SourceType` enum has been changed to contain more values, including a one used for livestreams: `MANIFEST`. As the name suggests, it represents `MediaSource`s generated from a "master" manifest URL. This will allow us in the future to use, if needed, a manifest to play a non-live content with the ability to choose the video quality played (even if a few changes in player and resolver codes will be needed).

This enum is now also used to do the seamless transition, instead of the last resolved source, and disabling video and text tracks used for the transition is now always done (so even when the play queue manager is reloaded), in order to fix some blank video issues.

Finally, this PR also fixes playability of contents which doesn't have an audio stream and only video streams when trying to play them background (by using `Start playing in the background` or `Enqueue` commands). The default video stream will be played, with potentially text tracks if they are enabled. This is the case on several PeerTube videos.

For more detailed changes, please take a look at the code changes.

#### Before/After Screenshots/Screen Record
- Before:

<img src="https://user-images.githubusercontent.com/74829229/178158668-49e99573-d300-41c0-9b13-64fd8b1dd9c3.jpg" width="500px" alt="Quality selection livestreams before">

- After:

<img src="https://user-images.githubusercontent.com/74829229/178158686-717973cb-a9da-4ded-a704-0e5df483ac81.jpg" width="500px" alt="Quality selection livestreams after">

#### Fixes the following issue(s)
- Fixes #1239

#### APK testing 
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).