### PR TITLE
Deduplicate SQL queries to get feed streams

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedDatabaseManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedDatabaseManager.kt
@@ -41,19 +41,15 @@ class FeedDatabaseManager(context: Context) {
     fun database() = database
 
     fun getStreams(
-        groupId: Long = FeedGroupEntity.GROUP_ALL_ID,
-        getPlayedStreams: Boolean = true
+        groupId: Long,
+        includePlayedStreams: Boolean,
+        includeFutureStreams: Boolean
     ): Maybe<List<StreamWithState>> {
-        return when (groupId) {
-            FeedGroupEntity.GROUP_ALL_ID -> {
-                if (getPlayedStreams) feedTable.getAllStreams()
-                else feedTable.getLiveOrNotPlayedStreams()
-            }
-            else -> {
-                if (getPlayedStreams) feedTable.getAllStreamsForGroup(groupId)
-                else feedTable.getLiveOrNotPlayedStreamsForGroup(groupId)
-            }
-        }
+        return feedTable.getStreams(
+            groupId,
+            includePlayedStreams,
+            if (includeFutureStreams) null else OffsetDateTime.now()
+        )
     }
 
     fun outdatedSubscriptions(outdatedThreshold: OffsetDateTime) = feedTable.getAllOutdated(outdatedThreshold)

--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedViewModel.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedViewModel.kt
@@ -65,9 +65,8 @@ class FeedViewModel(
         .map { (event, showPlayedItems, showFutureItems, notLoadedCount, oldestUpdate) ->
             val streamItems = if (event is SuccessResultEvent || event is IdleEvent)
                 feedDatabaseManager
-                    .getStreams(groupId, showPlayedItems)
+                    .getStreams(groupId, showPlayedItems, showFutureItems)
                     .blockingGet(arrayListOf())
-                    .filter { s -> showFutureItems || s.stream.uploadDate?.isBefore(OffsetDateTime.now()) ?: true }
             else
                 arrayListOf()
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
While merging #8545 I noticed there was much duplicated code in the feed loading. There were 4 different SQL queries based on the wanted filtering (all the combination of "filter or not by group" and "include or not played items"). Furthermore #8545 included another condition, but it wasn't implemented in SQL (as it would have meant adding 4 more queries) but rather in code. This PR removes duplicate queries by making the now-only-one query take as input the various filtering conditions. I tested and noticed no changes in the UI behavior.

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
