### PR TITLE
Removed the "(beta)"-tag from services

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -374,8 +374,7 @@ public class MainActivity extends AppCompatActivity {
 
     private void showServices() {
         for (final StreamingService s : NewPipe.getServices()) {
-            final String title = s.getServiceInfo().getName()
-                    + (ServiceHelper.isBeta(s) ? " (beta)" : "");
+            final String title = s.getServiceInfo().getName();
 
             final MenuItem menuItem = drawerLayoutBinding.navigation.getMenu()
                     .add(R.id.menu_services_group, s.getServiceId(), ORDER, title)
@@ -393,7 +392,7 @@ public class MainActivity extends AppCompatActivity {
 
     private void enhancePeertubeMenu(final StreamingService s, final MenuItem menuItem) {
         final PeertubeInstance currentInstance = PeertubeHelper.getCurrentInstance();
-        menuItem.setTitle(currentInstance.getName() + (ServiceHelper.isBeta(s) ? " (beta)" : ""));
+        menuItem.setTitle(currentInstance.getName());
         final Spinner spinner = InstanceSpinnerLayoutBinding.inflate(LayoutInflater.from(this))
                 .getRoot();
         final List<PeertubeInstance> instances = PeertubeHelper.getInstanceList(this);

--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -382,7 +382,7 @@ public class MainActivity extends AppCompatActivity {
 
             // peertube specifics
             if (s.getServiceId() == 3) {
-                enhancePeertubeMenu(s, menuItem);
+                enhancePeertubeMenu(menuItem);
             }
         }
         drawerLayoutBinding.navigation.getMenu()
@@ -390,7 +390,7 @@ public class MainActivity extends AppCompatActivity {
                 .setChecked(true);
     }
 
-    private void enhancePeertubeMenu(final StreamingService s, final MenuItem menuItem) {
+    private void enhancePeertubeMenu(final MenuItem menuItem) {
         final PeertubeInstance currentInstance = PeertubeHelper.getCurrentInstance();
         menuItem.setTitle(currentInstance.getName());
         final Spinner spinner = InstanceSpinnerLayoutBinding.inflate(LayoutInflater.from(this))

--- a/app/src/main/java/org/schabi/newpipe/util/ServiceHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ServiceHelper.java
@@ -169,15 +169,6 @@ public final class ServiceHelper {
         }
     }
 
-    public static boolean isBeta(final StreamingService s) {
-        switch (s.getServiceInfo().getName()) {
-            case "YouTube":
-                return false;
-            default:
-                return true;
-        }
-    }
-
     public static void initService(final Context context, final int serviceId) {
         if (serviceId == ServiceList.PeerTube.getServiceId()) {
             final SharedPreferences sharedPreferences = PreferenceManager


### PR DESCRIPTION
#### What is it?
- [x] Codebase improvement (dev facing)

#### Description of the changes in your PR
Some time ago we removed the "beta"-tag from all services inside the Readme.
This PR adjusts the app accordingly.

I'm also not sure why there ever was a (beta) flag inside the services as all services are in theory beta (even YT) because we can't guarantee that they are stable as we don't control the remote side.

#### Before/After Screenshots/Screen Record
![grafik](https://user-images.githubusercontent.com/40789489/179358179-6059e499-a932-4fdc-b1d1-8d7f3a57c883.png)


#### APK testing 
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
