### PR TITLE
Rename "waiting-for-author" label to "waiting for author"

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -21,4 +21,4 @@ jobs:
         with:
           token: ${{ github.token }}
           daysUntilClose: 14
-          responseRequiredLabel: waiting-for-author
+          responseRequiredLabel: waiting for author


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
Use "waiting for author" label instead of "waiting-for-author".

The current labels are inconsistent with regards to usage of spaces vs. hyphens, and I ended up settling on spaces.

Immediately before this is merged, the label should be renamed from the GitHub UI too.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
