### PR TITLE
Add "needs triage" label to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: Create a bug report to help us improve
-labels: [bug]
+labels: [bug, needs triage]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Suggest an idea for this project
-labels: [enhancement]
+labels: [enhancement, needs triage]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,6 +1,6 @@
 name: Question
 description: Ask about anything NewPipe-related
-labels: [question]
+labels: [question, needs triage]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Add a "needs triage" label to the issue templates.

This label would make it easier for issue triagers to know what they haven't triaged yet.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
