### PR TITLE
Fix random NullPointerException when adding video player view

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -1313,9 +1313,11 @@ public final class VideoDetailFragment
         // Prevent from re-adding a view multiple times
         new Handler(Looper.getMainLooper()).post(() ->
                 player.UIs().get(MainPlayerUi.class).ifPresent(playerUi -> {
-                    playerUi.removeViewFromParent();
-                    binding.playerPlaceholder.addView(playerUi.getBinding().getRoot());
-                    playerUi.setupVideoSurfaceIfNeeded();
+                    if (binding != null) {
+                        playerUi.removeViewFromParent();
+                        binding.playerPlaceholder.addView(playerUi.getBinding().getRoot());
+                        playerUi.setupVideoSurfaceIfNeeded();
+                    }
                 }));
     }
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Followup to #8170, bug reported by @opusforlife2. I don't know why the `binding` could be `null` when `getView()` returns a non-null value, unless the view is destroyed exactly in between `new Handler().post()` being called and the passed function being actually called, but anyway... 

#### Fixes the following *comments*
- https://github.com/TeamNewPipe/NewPipe/pull/8170#issuecomment-1184735382 https://github.com/TeamNewPipe/NewPipe/pull/8170#issuecomment-1185762001
- https://github.com/TeamNewPipe/NewPipe/issues/8646#issuecomment-1186609499

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
