### PR TITLE
Fix wrong thumbnail used as placeholder for channel

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/info_list/holder/ChannelMiniInfoItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/holder/ChannelMiniInfoItemHolder.java
@@ -42,7 +42,7 @@ public class ChannelMiniInfoItemHolder extends InfoItemHolder {
         itemTitleView.setText(item.getName());
         itemAdditionalDetailView.setText(getDetailLine(item));
 
-        PicassoHelper.loadThumbnail(item.getThumbnailUrl()).into(itemThumbnailView);
+        PicassoHelper.loadAvatar(item.getThumbnailUrl()).into(itemThumbnailView);
 
         itemView.setOnClickListener(view -> {
             if (itemBuilder.getOnChannelSelectedListener() != null) {

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/item/ChannelItem.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/item/ChannelItem.kt
@@ -39,7 +39,7 @@ class ChannelItem(
             itemChannelDescriptionView.text = infoItem.description
         }
 
-        PicassoHelper.loadThumbnail(infoItem.thumbnailUrl).into(itemThumbnailView)
+        PicassoHelper.loadAvatar(infoItem.thumbnailUrl).into(itemThumbnailView)
 
         gesturesListener?.run {
             viewHolder.root.setOnClickListener { selected(infoItem) }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
In some places the "thumbnail" placeholder was being used instead of the "person" placeholder when loading a channel icon. Related: #8530.

#### Before/After Screenshots/Screen Record
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/36421898/180447461-5b933175-4420-4cee-8b8f-ec6cf004b366.png" height="300px"/></td>
    <td><img src="https://user-images.githubusercontent.com/36421898/180447369-5d588be7-42a9-41c0-9bad-5509ecac00ff.png" height="300px"/></td>
  </tr>
</table>

#### Fixes the following issue(s)
Could not find any.

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
