### PR TITLE
Keep strong references to Picasso notification icon loading targets

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/feed/notifications/NotificationHelper.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/notifications/NotificationHelper.kt
@@ -4,6 +4,8 @@ import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.os.Build
 import android.provider.Settings
@@ -11,6 +13,8 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
 import androidx.preference.PreferenceManager
+import com.squareup.picasso.Picasso
+import com.squareup.picasso.Target
 import org.schabi.newpipe.R
 import org.schabi.newpipe.extractor.stream.StreamInfoItem
 import org.schabi.newpipe.local.feed.service.FeedUpdateInfo
@@ -26,6 +30,8 @@ class NotificationHelper(val context: Context) {
     private val manager = context.getSystemService(
         Context.NOTIFICATION_SERVICE
     ) as NotificationManager
+
+    private val iconLoadingTargets = ArrayList<Target>()
 
     /**
      * Show a notification about new streams from a single channel.
@@ -77,10 +83,29 @@ class NotificationHelper(val context: Context) {
             )
         )
 
-        PicassoHelper.loadNotificationIcon(data.avatarUrl) { bitmap ->
-            bitmap?.let { builder.setLargeIcon(it) } // set only if != null
-            manager.notify(data.pseudoId, builder.build())
+        // a Target is like a listener for image loading events
+        val target = object : Target {
+            override fun onBitmapLoaded(bitmap: Bitmap, from: Picasso.LoadedFrom) {
+                builder.setLargeIcon(bitmap) // set only if there is actually one
+                manager.notify(data.pseudoId, builder.build())
+                iconLoadingTargets.remove(this) // allow it to be garbage-collected
+            }
+
+            override fun onBitmapFailed(e: Exception, errorDrawable: Drawable) {
+                manager.notify(data.pseudoId, builder.build())
+                iconLoadingTargets.remove(this) // allow it to be garbage-collected
+            }
+
+            override fun onPrepareLoad(placeHolderDrawable: Drawable) {
+                // Nothing to do
+            }
         }
+
+        // add the target to the list to hold a strong reference and prevent it from being garbage
+        // collected, since Picasso only holds weak references to targets
+        iconLoadingTargets.add(target)
+
+        PicassoHelper.loadNotificationIcon(data.avatarUrl).into(target)
     }
 
     companion object {

--- a/app/src/main/java/org/schabi/newpipe/util/PicassoHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/PicassoHelper.java
@@ -5,7 +5,6 @@ import static org.schabi.newpipe.extractor.utils.Utils.isBlank;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Bitmap;
-import android.graphics.drawable.Drawable;
 
 import androidx.annotation.Nullable;
 
@@ -14,7 +13,6 @@ import com.squareup.picasso.LruCache;
 import com.squareup.picasso.OkHttp3Downloader;
 import com.squareup.picasso.Picasso;
 import com.squareup.picasso.RequestCreator;
-import com.squareup.picasso.Target;
 import com.squareup.picasso.Transformation;
 
 import org.schabi.newpipe.R;
@@ -22,7 +20,6 @@ import org.schabi.newpipe.R;
 import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 
 import okhttp3.OkHttpClient;
 
@@ -120,6 +117,10 @@ public final class PicassoHelper {
         return picassoInstance.load(url);
     }
 
+    public static RequestCreator loadNotificationIcon(final String url) {
+        return loadImageDefault(url, R.drawable.ic_newpipe_triangle_white);
+    }
+
 
     public static RequestCreator loadScaledDownThumbnail(final Context context, final String url) {
         // scale down the notification thumbnail for performance
@@ -168,27 +169,6 @@ public final class PicassoHelper {
     public static Bitmap getImageFromCacheIfPresent(final String imageUrl) {
         // URLs in the internal cache finish with \n so we need to add \n to image URLs
         return picassoCache.get(imageUrl + "\n");
-    }
-
-    public static void loadNotificationIcon(final String url,
-                                            final Consumer<Bitmap> bitmapConsumer) {
-        loadImageDefault(url, R.drawable.ic_newpipe_triangle_white)
-                .into(new Target() {
-                    @Override
-                    public void onBitmapLoaded(final Bitmap bitmap, final Picasso.LoadedFrom from) {
-                        bitmapConsumer.accept(bitmap);
-                    }
-
-                    @Override
-                    public void onBitmapFailed(final Exception e, final Drawable errorDrawable) {
-                        bitmapConsumer.accept(null);
-                    }
-
-                    @Override
-                    public void onPrepareLoad(final Drawable placeHolderDrawable) {
-                        // Nothing to do
-                    }
-                });
     }
 
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Before the Target would sometimes be garbage collected before being called with the loaded channel icon, since Picasso holds weak references to targets. This meant that sometimes a new streams notification would not be shown, because the lambda that should have shown it had already been garbage collected.

I don't know if there was a way to properly reproduce something wrong with the previous behavior, but Picasso clearly states in `RequestCreator#into(Target)`:

> This method keeps a weak reference to the `Target` instance and will be garbage collected if you do not keep a strong reference to it.

Anyway, I tested the new code by subscribing to the usual Roel Van De Paar and it works.

Note that this is also one of the causes of a missing thumbnail in the notification, that will be fixed with #8678.

#### Fixes the following issue(s)
None that I could find

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
