### PR TITLE
Fix ListHelperTest failure caused by immutable list being used

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
@@ -230,14 +230,15 @@ public final class ListHelper {
     }
 
     /**
-     * Return the index of the default stream in the list, based on the parameters
-     * defaultResolution and defaultFormat.
+     * Return the index of the default stream in the list, that will be sorted in the process, based
+     * on the parameters defaultResolution and defaultFormat.
      *
      * @param defaultResolution the default resolution to look for
      * @param bestResolutionKey key of the best resolution
      * @param defaultFormat     the default format to look for
-     * @param videoStreams      list of the video streams to check
-     * @return index of the default resolution&format
+     * @param videoStreams      a mutable list of the video streams to check (it will be sorted in
+     *                          place)
+     * @return index of the default resolution&format in the sorted videoStreams
      */
     static int getDefaultResolutionIndex(final String defaultResolution,
                                          final String bestResolutionKey,

--- a/app/src/test/java/org/schabi/newpipe/util/ListHelperTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/ListHelperTest.java
@@ -140,7 +140,7 @@ public class ListHelperTest {
 
     @Test
     public void getDefaultResolutionTest() {
-        final List<VideoStream> testList = List.of(
+        final List<VideoStream> testList = new ArrayList<>(List.of(
                 generateVideoStream("mpeg_4-720", MediaFormat.MPEG_4, "720p", false),
                 generateVideoStream("v3gpp-240", MediaFormat.v3GPP, "240p", false),
                 generateVideoStream("webm-480",  MediaFormat.WEBM, "480p", false),
@@ -148,7 +148,7 @@ public class ListHelperTest {
                 generateVideoStream("mpeg_4-240", MediaFormat.MPEG_4, "240p", false),
                 generateVideoStream("webm-144", MediaFormat.WEBM, "144p", false),
                 generateVideoStream("mpeg_4-360", MediaFormat.MPEG_4, "360p", false),
-                generateVideoStream("webm-360", MediaFormat.WEBM, "360p", false));
+                generateVideoStream("webm-360", MediaFormat.WEBM, "360p", false)));
         VideoStream result = testList.get(ListHelper.getDefaultResolutionIndex(
                 "720p", BEST_RESOLUTION_KEY, MediaFormat.MPEG_4, testList));
         assertEquals("720p", result.getResolution());


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
#8631 replaced list creation with `List.of()`, which creates an immutable list, but for this test we need a mutable list. I added a comment in the javadoc to explain this. This fixes the CI failing everywhere (my fault with merging #8631 once I saw it built fine on my PC, before waiting for the CI to finish). @Isira-Seneviratne 

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
