### PR TITLE
Update Google Material to 1.6.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -218,7 +218,7 @@ dependencies {
     implementation 'androidx.viewpager2:viewpager2:1.1.0-beta01'
     implementation "androidx.work:work-runtime-ktx:${androidxWorkVersion}"
     implementation "androidx.work:work-rxjava3:${androidxWorkVersion}"
-    implementation 'com.google.android.material:material:1.5.0'
+    implementation 'com.google.android.material:material:1.6.1'
 
 /** Third-party libraries **/
     // Instance state boilerplate elimination

--- a/app/src/main/java/org/schabi/newpipe/player/gesture/CustomBottomSheetBehavior.java
+++ b/app/src/main/java/org/schabi/newpipe/player/gesture/CustomBottomSheetBehavior.java
@@ -8,6 +8,7 @@ import android.view.View;
 import android.widget.FrameLayout;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
@@ -18,7 +19,8 @@ import java.util.List;
 
 public class CustomBottomSheetBehavior extends BottomSheetBehavior<FrameLayout> {
 
-    public CustomBottomSheetBehavior(final Context context, final AttributeSet attrs) {
+    public CustomBottomSheetBehavior(@NonNull final Context context,
+                                     @Nullable final AttributeSet attrs) {
         super(context, attrs);
     }
 
@@ -32,7 +34,7 @@ public class CustomBottomSheetBehavior extends BottomSheetBehavior<FrameLayout> 
     @Override
     public boolean onInterceptTouchEvent(@NonNull final CoordinatorLayout parent,
                                          @NonNull final FrameLayout child,
-                                         final MotionEvent event) {
+                                         @NonNull final MotionEvent event) {
         // Drop following when action ends
         if (event.getAction() == MotionEvent.ACTION_CANCEL
                 || event.getAction() == MotionEvent.ACTION_UP) {


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
- Update Google Material 1.5.0 -> 1.6.1 ([changelog](https://github.com/material-components/material-components-android/releases))

Debug APK size increased by 37 KB.
Release APK size increased by 22 KB.

#### APK testing 
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
