### PR TITLE
Update fragment_video_detail.xml to better display on large-land devices

### DIFF
--- a/app/src/main/res/layout-large-land/fragment_video_detail.xml
+++ b/app/src/main/res/layout-large-land/fragment_video_detail.xml
@@ -19,7 +19,7 @@
             android:id="@+id/detail_main_content"
             android:layout_width="0dp"
             android:layout_height="match_parent"
-            android:layout_weight="5"
+            android:layout_weight="6"
             android:isScrollContainer="true">
 
             <com.google.android.material.appbar.AppBarLayout


### PR DESCRIPTION
Hi, I I slightly increased the width of the video player on the left because it is a bit small on large-land devices, such as projecting it onto a TV.

![MuMu20220731100911](https://user-images.githubusercontent.com/66421771/182006778-4f6a85c8-5adc-419c-a5cf-80a77d42a219.png)
