### PR TITLE
Replace coerceIn() with MathUtils.clamp().

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/gesture/PopupPlayerGestureListener.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/gesture/PopupPlayerGestureListener.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewConfiguration
+import androidx.core.math.MathUtils
 import org.schabi.newpipe.MainActivity
 import org.schabi.newpipe.ktx.AnimationType
 import org.schabi.newpipe.ktx.animate
@@ -234,11 +235,13 @@ class PopupPlayerGestureListener(
         isMoving = true
 
         val diffX = (movingEvent.rawX - initialEvent.rawX)
-        val posX = (initialPopupX + diffX).coerceIn(
+        val posX = MathUtils.clamp(
+            initialPopupX + diffX,
             0f, (playerUi.screenWidth - playerUi.popupLayoutParams.width).toFloat()
         )
         val diffY = (movingEvent.rawY - initialEvent.rawY)
-        val posY = (initialPopupY + diffY).coerceIn(
+        val posY = MathUtils.clamp(
+            initialPopupY + diffY,
             0f, (playerUi.screenHeight - playerUi.popupLayoutParams.height).toFloat()
         )
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Use [`MathUtils.clamp()`](https://developer.android.com/reference/androidx/core/math/MathUtils#clamp(float,float,float)) instead of Kotlin's `coerceIn()` in `PopupPlayerGestureListener`. This avoids an issue found by @Stypox  in #8651, as `coerceIn()` throws an exception if the maximum is less than the minimum while `MathUtils.clamp()` doesn't.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #

#### APK testing 
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
