### PR TITLE
Add an ExoPlayer settings page

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -263,7 +263,9 @@ public final class Player implements PlaybackListener, Listener {
         final PlayerDataSource dataSource = new PlayerDataSource(context,
                 new DefaultBandwidthMeter.Builder(context).build());
         loadController = new LoadController();
-        renderFactory = new DefaultRenderersFactory(context);
+        renderFactory = new DefaultRenderersFactory(context)
+                .setEnableDecoderFallback(prefs.getBoolean(
+                        context.getString(R.string.use_exoplayer_decoder_fallback_key), false));
 
         videoResolver = new VideoPlaybackResolver(context, dataSource, getQualityResolver());
         audioResolver = new AudioPlaybackResolver(context, dataSource);

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -69,7 +69,6 @@ import com.google.android.exoplayer2.ExoPlayer;
 import com.google.android.exoplayer2.PlaybackException;
 import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Player.PositionInfo;
-import com.google.android.exoplayer2.RenderersFactory;
 import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.Tracks;
 import com.google.android.exoplayer2.source.MediaSource;
@@ -95,6 +94,7 @@ import org.schabi.newpipe.local.history.HistoryRecordManager;
 import org.schabi.newpipe.player.event.PlayerEventListener;
 import org.schabi.newpipe.player.event.PlayerServiceEventListener;
 import org.schabi.newpipe.player.helper.AudioReactor;
+import org.schabi.newpipe.player.helper.CustomRenderersFactory;
 import org.schabi.newpipe.player.helper.LoadController;
 import org.schabi.newpipe.player.helper.PlayerDataSource;
 import org.schabi.newpipe.player.helper.PlayerHelper;
@@ -196,7 +196,7 @@ public final class Player implements PlaybackListener, Listener {
 
     @NonNull private final DefaultTrackSelector trackSelector;
     @NonNull private final LoadController loadController;
-    @NonNull private final RenderersFactory renderFactory;
+    @NonNull private final DefaultRenderersFactory renderFactory;
 
     @NonNull private final VideoPlaybackResolver videoResolver;
     @NonNull private final AudioPlaybackResolver audioResolver;
@@ -261,9 +261,16 @@ public final class Player implements PlaybackListener, Listener {
         final PlayerDataSource dataSource = new PlayerDataSource(context,
                 new DefaultBandwidthMeter.Builder(context).build());
         loadController = new LoadController();
-        renderFactory = new DefaultRenderersFactory(context)
-                .setEnableDecoderFallback(prefs.getBoolean(
-                        context.getString(R.string.use_exoplayer_decoder_fallback_key), false));
+
+        renderFactory = prefs.getBoolean(
+                context.getString(
+                        R.string.always_use_exoplayer_set_output_surface_workaround_key), false)
+                ? new CustomRenderersFactory(context) : new DefaultRenderersFactory(context);
+
+        renderFactory.setEnableDecoderFallback(
+                prefs.getBoolean(
+                        context.getString(
+                                R.string.use_exoplayer_decoder_fallback_key), false));
 
         videoResolver = new VideoPlaybackResolver(context, dataSource, getQualityResolver());
         audioResolver = new AudioPlaybackResolver(context, dataSource);

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -77,7 +77,6 @@ import com.google.android.exoplayer2.text.CueGroup;
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
 import com.google.android.exoplayer2.trackselection.MappingTrackSelector;
 import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
-import com.google.android.exoplayer2.util.Util;
 import com.google.android.exoplayer2.video.VideoSize;
 import com.squareup.picasso.Picasso;
 import com.squareup.picasso.Target;
@@ -115,7 +114,6 @@ import org.schabi.newpipe.player.ui.PlayerUiList;
 import org.schabi.newpipe.player.ui.PopupPlayerUi;
 import org.schabi.newpipe.player.ui.VideoPlayerUi;
 import org.schabi.newpipe.util.DependentPreferenceHelper;
-import org.schabi.newpipe.util.DeviceUtils;
 import org.schabi.newpipe.util.ListHelper;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.PicassoHelper;
@@ -522,16 +520,11 @@ public final class Player implements PlaybackListener, Listener {
         // Setup UIs
         UIs.call(PlayerUi::initPlayer);
 
-        // enable media tunneling
-        if (DEBUG && PreferenceManager.getDefaultSharedPreferences(context)
+        // Disable media tunneling if requested by the user from ExoPlayer settings
+        if (!PreferenceManager.getDefaultSharedPreferences(context)
                 .getBoolean(context.getString(R.string.disable_media_tunneling_key), false)) {
-            Log.d(TAG, "[" + Util.DEVICE_DEBUG_INFO + "] "
-                    + "media tunneling disabled in debug preferences");
-        } else if (DeviceUtils.shouldSupportMediaTunneling()) {
             trackSelector.setParameters(trackSelector.buildUponParameters()
                     .setTunnelingEnabled(true));
-        } else if (DEBUG) {
-            Log.d(TAG, "[" + Util.DEVICE_DEBUG_INFO + "] does not support media tunneling");
         }
     }
     //endregion

--- a/app/src/main/java/org/schabi/newpipe/player/helper/CustomMediaCodecVideoRenderer.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/CustomMediaCodecVideoRenderer.java
@@ -1,0 +1,54 @@
+package org.schabi.newpipe.player.helper;
+
+import android.content.Context;
+import android.os.Handler;
+
+import androidx.annotation.Nullable;
+
+import com.google.android.exoplayer2.mediacodec.MediaCodecAdapter;
+import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
+import com.google.android.exoplayer2.video.MediaCodecVideoRenderer;
+import com.google.android.exoplayer2.video.VideoRendererEventListener;
+
+/**
+ * A {@link MediaCodecVideoRenderer} which always enable the output surface workaround that
+ * ExoPlayer enables on several devices which are known to implement
+ * {@link android.media.MediaCodec#setOutputSurface(android.view.Surface)
+ * MediaCodec.setOutputSurface(Surface)} incorrectly.
+ *
+ * <p>
+ * See {@link MediaCodecVideoRenderer#codecNeedsSetOutputSurfaceWorkaround(String)} for more
+ * details.
+ * </p>
+ *
+ * <p>
+ * This custom {@link MediaCodecVideoRenderer} may be useful in the case a device is affected by
+ * this issue but is not present in ExoPlayer's list.
+ * </p>
+ *
+ * <p>
+ * This class has only effect on devices with Android 6 and higher, as the {@code setOutputSurface}
+ * method is only implemented in these Android versions and the method used as a workaround is
+ * always applied on older Android versions (releasing and re-instantiating video codec instances).
+ * </p>
+ */
+public final class CustomMediaCodecVideoRenderer extends MediaCodecVideoRenderer {
+
+    @SuppressWarnings({"checkstyle:ParameterNumber", "squid:S107"})
+    public CustomMediaCodecVideoRenderer(final Context context,
+                                         final MediaCodecAdapter.Factory codecAdapterFactory,
+                                         final MediaCodecSelector mediaCodecSelector,
+                                         final long allowedJoiningTimeMs,
+                                         final boolean enableDecoderFallback,
+                                         @Nullable final Handler eventHandler,
+                                         @Nullable final VideoRendererEventListener eventListener,
+                                         final int maxDroppedFramesToNotify) {
+        super(context, codecAdapterFactory, mediaCodecSelector, allowedJoiningTimeMs,
+                enableDecoderFallback, eventHandler, eventListener, maxDroppedFramesToNotify);
+    }
+
+    @Override
+    protected boolean codecNeedsSetOutputSurfaceWorkaround(final String name) {
+        return true;
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/helper/CustomRenderersFactory.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/CustomRenderersFactory.java
@@ -1,0 +1,43 @@
+package org.schabi.newpipe.player.helper;
+
+import android.content.Context;
+import android.os.Handler;
+
+import com.google.android.exoplayer2.DefaultRenderersFactory;
+import com.google.android.exoplayer2.Renderer;
+import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
+import com.google.android.exoplayer2.video.VideoRendererEventListener;
+
+import java.util.ArrayList;
+
+/**
+ * A {@link DefaultRenderersFactory} which only uses {@link CustomMediaCodecVideoRenderer} as an
+ * implementation of video codec renders.
+ *
+ * <p>
+ * As no ExoPlayer extension is currently used, the reflection code used by ExoPlayer to try to
+ * load video extension libraries is not needed in our case and has been removed. This should be
+ * changed in the case an extension is shipped with the app, such as the AV1 one.
+ * </p>
+ */
+public final class CustomRenderersFactory extends DefaultRenderersFactory {
+
+    public CustomRenderersFactory(final Context context) {
+        super(context);
+    }
+
+    @SuppressWarnings("checkstyle:ParameterNumber")
+    @Override
+    protected void buildVideoRenderers(final Context context,
+                                       @ExtensionRendererMode final int extensionRendererMode,
+                                       final MediaCodecSelector mediaCodecSelector,
+                                       final boolean enableDecoderFallback,
+                                       final Handler eventHandler,
+                                       final VideoRendererEventListener eventListener,
+                                       final long allowedVideoJoiningTimeMs,
+                                       final ArrayList<Renderer> out) {
+        out.add(new CustomMediaCodecVideoRenderer(context, getCodecAdapterFactory(),
+                mediaCodecSelector, allowedVideoJoiningTimeMs, enableDecoderFallback, eventHandler,
+                eventListener, MAX_DROPPED_VIDEO_FRAME_COUNT_TO_NOTIFY));
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/settings/ExoPlayerSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/ExoPlayerSettingsFragment.java
@@ -1,0 +1,14 @@
+package org.schabi.newpipe.settings;
+
+import android.os.Bundle;
+
+import androidx.annotation.Nullable;
+
+public class ExoPlayerSettingsFragment extends BasePreferenceFragment {
+
+    @Override
+    public void onCreatePreferences(@Nullable final Bundle savedInstanceState,
+                                    @Nullable final String rootKey) {
+        addPreferencesFromResourceRegistry();
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/settings/SettingsResourceRegistry.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/SettingsResourceRegistry.java
@@ -40,6 +40,7 @@ public final class SettingsResourceRegistry {
         add(PlayerNotificationSettingsFragment.class, R.xml.player_notification_settings);
         add(UpdateSettingsFragment.class, R.xml.update_settings);
         add(VideoAudioSettingsFragment.class, R.xml.video_audio_settings);
+        add(ExoPlayerSettingsFragment.class, R.xml.exoplayer_settings);
     }
 
     private SettingRegistryEntry add(

--- a/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
@@ -36,22 +36,6 @@ public final class DeviceUtils {
     private static Boolean isTV = null;
     private static Boolean isFireTV = null;
 
-    /*
-     * Devices that do not support media tunneling
-     */
-    // Formuler Z8 Pro, Z8, CC, Z Alpha, Z+ Neo
-    private static final boolean HI3798MV200 = Build.VERSION.SDK_INT == 24
-            && Build.DEVICE.equals("Hi3798MV200");
-    // Zephir TS43UHD-2
-    private static final boolean CVT_MT5886_EU_1G = Build.VERSION.SDK_INT == 24
-            && Build.DEVICE.equals("cvt_mt5886_eu_1g");
-    // Hilife TV
-    private static final boolean REALTEKATV = Build.VERSION.SDK_INT == 25
-            && Build.DEVICE.equals("RealtekATV");
-    // Philips QM16XE
-    private static final boolean QM16XE_U = Build.VERSION.SDK_INT == 23
-            && Build.DEVICE.equals("QM16XE_U");
-
     private DeviceUtils() {
     }
 
@@ -209,18 +193,6 @@ public final class DeviceUtils {
                 TypedValue.COMPLEX_UNIT_SP,
                 sp,
                 context.getResources().getDisplayMetrics());
-    }
-
-    /**
-     * Some devices have broken tunneled video playback but claim to support it.
-     * See https://github.com/TeamNewPipe/NewPipe/issues/5911
-     * @return false if affected device
-     */
-    public static boolean shouldSupportMediaTunneling() {
-        return !HI3798MV200
-                && !CVT_MT5886_EU_1G
-                && !REALTEKATV
-                && !QM16XE_U;
     }
 
     public static boolean isLandscape(final Context context) {

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -729,7 +729,6 @@
     <string name="detail_pinned_comment_view_description">تعليق مثبت</string>
     <string name="leak_canary_not_available">LeakCanary غير متوفر</string>
     <string name="progressive_load_interval_exoplayer_default">الافتراضي ExoPlayer</string>
-    <string name="progressive_load_interval_summary">تغيير حجم الفاصل الزمني للتحميل (حاليا %s). قد تؤدي القيمة الأقل إلى تسريع تحميل الفيديو الأولي. تتطلب التغييرات إعادة تشغيل المشغل</string>
     <string name="settings_category_player_notification_summary">تكوين إشعار مشغل البث الحالي</string>
     <string name="notifications">الإشعارات</string>
     <string name="loading_stream_details">تحميل تفاصيل البث…</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -496,7 +496,6 @@
     <string name="hash_channel_description">Video fayl xülasəsi prosesi üçün bildirişlər</string>
     <string name="on">Aç</string>
     <string name="notification_scale_to_square_image_title">Miniatürü 1:1 görünüş nisbətinə kəs</string>
-    <string name="progressive_load_interval_summary">Yükləmə intervalı həcmini dəyişdir (hazırda %s). Daha aşağı dəyər ilkin video yükləməni sürətləndirə bilər. Dəyişikliklər oynadıcını yenidən başlatmağı tələb edir</string>
     <string name="show_meta_info_summary">Yayım yaradıcısı, məzmunu və ya axtarış sorğusu haqqında əlavə məlumat olan üst məlumat qutularını gizlətmək üçün söndür</string>
     <string name="auto_queue_summary">Əlaqəli yayımı əlavə etməklə (təkrarlanmayan) sonlanacaq oynatma növbəsini davam etdir</string>
     <string name="remote_search_suggestions">Kənar axtarış təklifləri</string>

--- a/app/src/main/res/values-bs/strings.xml
+++ b/app/src/main/res/values-bs/strings.xml
@@ -70,7 +70,6 @@
     <string name="popup_remember_size_pos_summary">Zapamtite posljednju veličinu i položaj iskočnog prozora</string>
     <string name="use_inexact_seek_title">Koristite brzo neprecizno premotavanje</string>
     <string name="use_inexact_seek_summary">Neprecizno premotavanje dozvoljava pokretaču brže premotavanje s gorom preciznošću. Premotavanje za 5, 15 ili 25 sekundi ne radi s ovim</string>
-    <string name="progressive_load_interval_summary">Promijenite veličinu intervala za učitavanje (trenutačno %s). Niža vrijednost bi vam moglo ubrzat učitavanje videa. Trebate te ponovno učitati pokretač za promjenu.</string>
     <string name="clear_queue_confirmation_summary">Prebacivanje sa jednog pokretača na drugi bi van moglo zamijeniti pokretni red</string>
     <string name="show_comments_summary">Isključite da sakrijete komentare</string>
     <string name="clear_queue_confirmation_title">Pitajte za potvrdu prije isčišćavanja reda</string>

--- a/app/src/main/res/values-ckb/strings.xml
+++ b/app/src/main/res/values-ckb/strings.xml
@@ -700,7 +700,6 @@
     <string name="delete_downloaded_files_confirm">هەموو فایلە دابەزێنراوەکان لە دیسک بسڕدرێتەوە؟</string>
     <string name="notifications_disabled">پەیامەکان ناکاراکراون</string>
     <string name="get_notified">پەیامم بکە</string>
-    <string name="progressive_load_interval_summary">"قەبارەی نێوان بارکردنەکە بگۆڕە (لە ئێستادا %s) .    بەهایەکی کەمتر لەوانەیە بارکردنی ڤیدیۆی سەرەتایی خێراتر بکات.  گۆڕانکارییەکان پێویستیان بە داگیرساندنەوەی لێدەر هەیە"</string>
     <string name="percent">لەسەدا</string>
     <string name="semitone">نیمچەتەن</string>
     <string name="progressive_load_interval_exoplayer_default">بنەڕەتی ExoPlayer</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -691,7 +691,6 @@
     <string name="show_error_snackbar">Zobrazit krátké oznámení o chybě</string>
     <string name="detail_pinned_comment_view_description">Připnutý komentář</string>
     <string name="crash_the_player">Shodit přehrávač</string>
-    <string name="progressive_load_interval_summary">Změnit interval načítání (aktuálně %s). Menší hodnota může zrychlit počáteční načítání videa. Změna vyžaduje restart přehrávače</string>
     <string name="leak_canary_not_available">LeakCanary není dostupné</string>
     <string name="progressive_load_interval_exoplayer_default">Výchozí ExoPlayer</string>
     <string name="settings_category_player_notification_summary">Nastavit oznámení o právě přehrávaném streamu</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -462,7 +462,6 @@
         <item quantity="one">Download fuldført</item>
         <item quantity="other">%s downloads fuldført</item>
     </plurals>
-    <string name="progressive_load_interval_summary">Ændr indlæsningsintervallets størrelse (som nu er på %s). En lavere værdi kan øge videoindlæsningshastigheden. Ændringer kræver en genstart af afspiller</string>
     <string name="clear_queue_confirmation_description">Den aktive spilleliste bliver udskiftet</string>
     <string name="clear_queue_confirmation_summary">Hvis du skifter fra en spiller til en anden, kan din kø blive erstattet</string>
     <string name="show_meta_info_title">Vis metainformation</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -682,7 +682,6 @@
 \nBitte installiere einen Storage Access Framework kompatiblen Dateimanager</string>
     <string name="detail_pinned_comment_view_description">Angehefteter Kommentar</string>
     <string name="leak_canary_not_available">LeakCanary ist nicht verfügbar</string>
-    <string name="progressive_load_interval_summary">Ändern der Größe des Ladeintervalls (derzeit %s). Ein niedrigerer Wert kann das anfängliche Laden des Videos beschleunigen. Änderungen erfordern einen Neustart des Players</string>
     <string name="progressive_load_interval_exoplayer_default">ExoPlayer Standard</string>
     <string name="notifications">Benachrichtigungen</string>
     <string name="streams_notification_channel_description">Benachrichtigen über neue abonnierbare Streams</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -681,7 +681,6 @@
     <string name="detail_pinned_comment_view_description">Καρφιτσωμένο σχόλιο</string>
     <string name="leak_canary_not_available">Το LeakCanary δεν είναι διαθέσιμο</string>
     <string name="progressive_load_interval_exoplayer_default">Εξ\' ορισμού ExoPlayer</string>
-    <string name="progressive_load_interval_summary">Αλλάξτε το μέγεθος του διαστήματος φόρτωσης (επί του παρόντος είναι %s). Μια χαμηλότερη τιμή μπορεί να επιταχύνει την αρχική φόρτωση βίντεο. Οι αλλαγές απαιτούν επανεκκίνηση της εφαρμογής</string>
     <string name="notifications">Ειδοποιήσεις</string>
     <plurals name="new_streams">
         <item quantity="one">%s νέα ροή</item>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -696,7 +696,6 @@
     <string name="detail_pinned_comment_view_description">Comentario fijado</string>
     <string name="leak_canary_not_available">LeakCanary no está disponible</string>
     <string name="progressive_load_interval_exoplayer_default">ExoPlayer valor por defecto</string>
-    <string name="progressive_load_interval_summary">Cambie el tamaño del intervalo de carga (actualmente %s). Un valor más bajo puede acelerar la carga inicial de video. Los cambios requieren un reinicio del reproductor</string>
     <string name="notifications">Notificaciones</string>
     <string name="streams_notification_channel_name">Nuevos streams</string>
     <string name="settings_category_player_notification_title">Notificación del reproductor</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -681,7 +681,6 @@
     <string name="detail_pinned_comment_view_description">Esiletõstetud kommentaar</string>
     <string name="leak_canary_not_available">LeakCanary pole saadaval</string>
     <string name="progressive_load_interval_exoplayer_default">ExoPlayer\'i vaikimisi väärtused</string>
-    <string name="progressive_load_interval_summary">Muuda video laadimise välpa (hetkel %s). Väiksemast väärtusest võib abi olla, kui tahad et video esitamine algaks varem. Muudatuste jõustamine eeldab rakenduse uuesti käivitamist</string>
     <string name="settings_category_player_notification_title">Meediamängija teavitused</string>
     <string name="notifications_disabled">Teavitused pole kasutusel</string>
     <string name="streams_notifications_interval_title">Kontrollimise sagedus</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -690,7 +690,6 @@
     <string name="you_successfully_subscribed">Kanal honetara harpidetu zara</string>
     <string name="enumeration_comma">,</string>
     <string name="toggle_all">Txandakatu denak</string>
-    <string name="progressive_load_interval_summary">Aldatu karga maiztasun tamaina (unean %s). Balio txikiago batek bideoaren hasierako karga azkartu dezake. Erreproduzigailuaren berrabiaraztea behar du</string>
     <string name="enable_streams_notifications_summary">Harpidetzen jario berriei buruz jakinarazi</string>
     <string name="delete_downloaded_files_confirm">Ezabatu deskargatutako fitxategi guztiak biltegitik\?</string>
     <string name="streams_notification_channel_description">Harpidetzentzako jario berrien jakinarazpenak</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -680,7 +680,6 @@
     <string name="error_report_notification_toast">خطایی رخ داد. آگاهی را ببینید</string>
     <string name="detail_pinned_comment_view_description">نظر سنجاق شده</string>
     <string name="leak_canary_not_available">لیک‌کاناری موجود نیست</string>
-    <string name="progressive_load_interval_summary">تغییر اندازهٔ بازهٔ بار (هم‌اکنون %s). مقداری پایین‌تر، می‌تواند بار کردن نخستین ویدیو را سرعت بخشد. تغییرها نیاز به یک آغاز دوبارهٔ پخش‌کننده دارند</string>
     <string name="progressive_load_interval_exoplayer_default">پیش‌گزیدهٔ اگزوپلیر</string>
     <string name="notifications">آگاهی‌ها</string>
     <string name="loading_stream_details">بار کردن جزییات جریان…</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -48,7 +48,6 @@
     <string name="notification_action_1_title">Pangalawang action button</string>
     <string name="notification_action_2_title">Pangatlong action button</string>
     <string name="use_inexact_seek_summary">Pinapayagan ng di-saktong seek ang player na mag-seek sa mga posisyon nang mabilis ngunit na may pinababang kasaktuhan. Di ito gagana sa pag-seek nang 5, 15, o 25 segundo.</string>
-    <string name="progressive_load_interval_summary">Baguhin ang laki ng pagitan na ilo-load (kasalukuyang %s). Maaaring mapabilis ang unang pag-load sa video kung mababa ito. Kailangang i-restart ang player para gumana ang pagbabago.</string>
     <string name="download_thumbnail_summary">Patayin para mapigilan ang pag-load sa mga thumbnail, para makatipid ng data at paggamit sa memory. Lilinisin ang parehong image cache na nasa memory at nasa disk</string>
     <string name="show_search_suggestions_summary">Piliin ang mga mungkahing ipapakita habang naghahanap</string>
     <string name="show_description_summary">Patayin para itago ang paglalarawan ng video at karagdagang impormasyon</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -694,7 +694,6 @@
 \nVeuillez installer un gestionnaire de fichiers ou essayez de désactiver « %s » dans les paramètres de téléchargement</string>
     <string name="detail_pinned_comment_view_description">Commentaire épinglé</string>
     <string name="leak_canary_not_available">LeakCanary n\'est pas disponible</string>
-    <string name="progressive_load_interval_summary">Modifie la taille de l\'intervalle de chargement (actuellement %s). Une valeur plus faible peut accélérer le chargement initial des vidéos. Changer cette valeur nécessite de redémarrer le lecteur</string>
     <string name="progressive_load_interval_exoplayer_default">Valeur par défaut d’ExoPlayer</string>
     <string name="streams_notification_channel_name">Nouveaux flux</string>
     <string name="settings_category_player_notification_summary">Configurer la notification du flux en cours de lecture</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -671,7 +671,6 @@
     <string name="manual_update_description">Procurar manualmente novas versións</string>
     <string name="checking_updates_toast">A procurar actualizacións…</string>
     <string name="downloads_storage_use_saf_summary_api_29">A partir do Android 10, só o \'Sistema de Acceso ao Almacenamento\' está soportado</string>
-    <string name="progressive_load_interval_summary">Cambial dimensión do intervalo de carga (actualmente %s). Un valor máis baixo pode alixeirala carga inicial do vídeo. Os cambios requiren un reinicio da aplicacion</string>
     <string name="processing_may_take_a_moment">Procesando... Pode devagar un momento</string>
     <string name="create_error_notification">Crear unha notificación de erro</string>
     <string name="show_image_indicators_summary">Amosar fitas coloridas de Picasso na cima das imaxes que indican a súa fonte: vermello para a rede, azul para o disco e verde para a memoria</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -705,7 +705,6 @@
     <string name="detail_pinned_comment_view_description">הערה ננעצה</string>
     <string name="leak_canary_not_available">LeakCanary אינה זמינה</string>
     <string name="progressive_load_interval_exoplayer_default">ברירת מחדל של ExoPlayer</string>
-    <string name="progressive_load_interval_summary">שינוי גודל מרווח הטעינה (כרגע %s). ערך נמוך יותר עשוי להאיץ את טעינת הווידאו הראשונית. שינויים דורשים את הפעלת הנגן מחדש</string>
     <string name="streams_notification_channel_description">התראות על תזרימים חדשים להרשמה</string>
     <string name="streams_notifications_interval_title">תדירות בדיקה</string>
     <string name="streams_notifications_network_title">נדרש חיבור לרשת</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -669,7 +669,6 @@
     <string name="detail_pinned_comment_view_description">Komentar dipin</string>
     <string name="leak_canary_not_available">LeakCanary tidak tersedia</string>
     <string name="progressive_load_interval_exoplayer_default">Default ExoPlayer</string>
-    <string name="progressive_load_interval_summary">Ubah ukuran interval pemuatan (saat ini %s). Nilai yang rendah mungkin dapat membuat pemuatan video awal lebih cepat. Perubahan membutuhkan pemutar dimulai ulang</string>
     <string name="loading_stream_details">Memuat detail stream…</string>
     <string name="streams_notifications_interval_title">Frekuensi pemeriksaan</string>
     <string name="streams_notifications_network_title">Dibutuhkan koneksi jaringan</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -693,7 +693,6 @@
     <string name="detail_pinned_comment_view_description">Commento in primo piano</string>
     <string name="leak_canary_not_available">LeakCanary non è disponibile</string>
     <string name="progressive_load_interval_exoplayer_default">Predefinito ExoPlayer</string>
-    <string name="progressive_load_interval_summary">Cambia la dimensione dell\'intervallo da caricare (attualmente %s). Un valore basso può velocizzare il caricamento iniziale del video. La modifica richiede il riavvio del lettore</string>
     <string name="streams_notification_channel_description">Notifiche di nuovi contenuti dalle iscrizioni</string>
     <string name="streams_notifications_interval_title">Frequenza controllo</string>
     <string name="streams_notifications_network_title">Connessione di rete richiesta</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -688,7 +688,6 @@
     <string name="streams_notification_channel_name">新しいストリーム</string>
     <string name="notifications">通知</string>
     <string name="settings_category_player_notification_summary">現在再生しているストリームの通知を構成</string>
-    <string name="progressive_load_interval_summary">読み込み間隔を変更します (現在 %s)。小さくすると再生開始までの時間が短くなります。変更を適用するには再起動が必要です</string>
     <string name="streams_notifications_network_title">必要なネットワークの種類</string>
     <string name="percent">パーセント</string>
     <string name="semitone">半音</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -677,7 +677,6 @@
     </plurals>
     <string name="description_select_note">Tagad varat atlasīt tekstu video aprakstā.</string>
     <string name="notifications">Notifikācijas</string>
-    <string name="progressive_load_interval_summary">Izmainīt ielādēšanas intervāla izmēru (pašlaik %s). Zemāka vērtība var paātrināt sākotnējo video ielādi. Izmainot vērtību, nepieciešams restartēt atskaņotāju.</string>
     <string name="crash_the_player">Avarēt atskaņotāju</string>
     <string name="settings_category_player_notification_summary">Pielāgojiet pašlaik atskaņotās plūsmas notifikāciju</string>
     <string name="settings_category_player_notification_title">Atskaņotāja notifikācija</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -653,6 +653,5 @@
     <string name="notifications">അറിയിപ്പുകൾ</string>
     <string name="settings_category_player_notification_title">പ്ലേയർ അറിയിപ്പ്</string>
     <string name="streams_notification_channel_name">പുതിയ സ്ട്രീമുകൾ</string>
-    <string name="progressive_load_interval_summary">ലോഡ് ഇടവേള മാറ്റുക (ഇപ്പൊൾ %s). കുറഞ്ഞ മൂല്യം വീഡിയോ വേഗത്തിൽ ലോഡ് ചെയ്യാൻ ഇടയാക്കാം. മാറ്റങ്ങൾ പ്രാഭല്യതിൽ വരുത്താൻ പ്ലേയർ പുനരാരംഭിക്കണം.</string>
     <string name="crash_the_player">പ്ലേയർ തകർക്കുക</string>
 </resources>

--- a/app/src/main/res/values-nl-rBE/strings.xml
+++ b/app/src/main/res/values-nl-rBE/strings.xml
@@ -625,7 +625,6 @@
     <string name="streams_notification_channel_name">Nieuwe streams</string>
     <string name="streams_notification_channel_description">Meldingen over nieuwe streams voor abonnementen</string>
     <string name="error_report_notification_title">NewPipe meldt een fout, tik om te rapporteren</string>
-    <string name="progressive_load_interval_summary">Verander het laadinterval (momenteel %s). Een lagere waarde kan het laden van video versnellen. Vereist een herstart van de speler.</string>
     <plurals name="new_streams">
         <item quantity="one">%s nieuwe stream</item>
         <item quantity="other">%s nieuwe streams</item>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -680,7 +680,6 @@
 \nInstalleer een bestandsbeheerder die compatibel is met het Storage Access Framework</string>
     <string name="detail_pinned_comment_view_description">Vastgemaakt commentaar</string>
     <string name="leak_canary_not_available">LeakCanary is niet beschikbaar</string>
-    <string name="progressive_load_interval_summary">Verander de laad interval tijd (nu %s). Een lagere waarde kan het initiële laden van de video versnellen. De wijziging vereist een herstart van de speler</string>
     <string name="progressive_load_interval_exoplayer_default">ExoPlayer standaard</string>
     <string name="settings_category_player_notification_title">Speler melding</string>
     <string name="settings_category_player_notification_summary">Configureer meldingen van de huidige spelende stream</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -700,7 +700,6 @@
     <string name="detail_pinned_comment_view_description">Przypięty komentarz</string>
     <string name="leak_canary_not_available">LeakCanary jest niedostępne</string>
     <string name="progressive_load_interval_title">Rozmiar interwału ładowania odtwarzania</string>
-    <string name="progressive_load_interval_summary">Zmień rozmiar interwału ładowania (aktualnie %s). Niższa wartość może przyspieszyć początkowe ładowanie wideo. Zmiany wymagają ponownego uruchomienia odtwarzacza</string>
     <string name="progressive_load_interval_exoplayer_default">domyślny ExoPlayera</string>
     <string name="settings_category_player_notification_title">Powiadomienie odtwarzacza</string>
     <string name="settings_category_player_notification_summary">Skonfiguruj powiadomienie aktualnie odtwarzanego strumienia</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -692,7 +692,6 @@
 \nInstale um gerenciador de arquivos ou tente desativar \'%s\' nas configurações de download</string>
     <string name="detail_pinned_comment_view_description">Comentário fixado</string>
     <string name="leak_canary_not_available">O LeakCanary não está disponível</string>
-    <string name="progressive_load_interval_summary">Altere o tamanho do intervalo de carregamento (atualmente %s). Um valor menor pode acelerar o carregamento inicial do vídeo. As alterações exigem que o player seja reiniciado</string>
     <string name="progressive_load_interval_exoplayer_default">ExoPlayer padrão</string>
     <string name="settings_category_player_notification_title">Notificação do reprodutor</string>
     <string name="settings_category_player_notification_summary">Configurar a notificação do fluxo da reprodução atual</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -692,7 +692,6 @@
 \nPor favor, instale um gestor de ficheiros compatível com o Storage Access Framework</string>
     <string name="detail_pinned_comment_view_description">Comentário fixado</string>
     <string name="leak_canary_not_available">LeakCanary não está disponível</string>
-    <string name="progressive_load_interval_summary">Altere o tamanho do intervalo de carregamento (atualmente %s). Um valor menor pode acelerar o carregamento inicial do vídeo. As alterações exigem que o player seja reiniciado</string>
     <string name="progressive_load_interval_exoplayer_default">Predefinido do ExoPlayer</string>
     <string name="notifications">Notificações</string>
     <string name="loading_stream_details">A carregar detalhes do fluxo…</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -693,7 +693,6 @@
     <string name="detail_pinned_comment_view_description">Comentário fixado</string>
     <string name="leak_canary_not_available">LeakCanary não está disponível</string>
     <string name="progressive_load_interval_exoplayer_default">Predefinido do ExoPlayer</string>
-    <string name="progressive_load_interval_summary">Altere o tamanho do intervalo de carregamento (atualmente %s). Um valor menor pode acelerar o carregamento inicial do vídeo. Se fizer alterações é necessário reiniciar</string>
     <string name="settings_category_player_notification_title">Notificação do reprodutor</string>
     <string name="settings_category_player_notification_summary">Configurar a notificação da reprodução do vídeo atual</string>
     <string name="notifications">Notificações</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -705,7 +705,6 @@
     <string name="percent">Procent</string>
     <string name="semitone">Semiton</string>
     <string name="progressive_load_interval_exoplayer_default">Implicit ExoPlayer</string>
-    <string name="progressive_load_interval_summary">Modificați dimensiunea intervalului de încărcare (în prezent %s). O valoare mai mică poate accelera încărcarea inițială a videoclipului. Modificările necesită o repornire a playerului</string>
     <string name="crash_the_player">Dați crash player-ului</string>
     <string name="leak_canary_not_available">LeakCanary nu este disponibil</string>
     <string name="notifications">Notificări</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -715,7 +715,6 @@
     <string name="detail_pinned_comment_view_description">Закреплённый комментарий</string>
     <string name="leak_canary_not_available">LeakCanary недоступна</string>
     <string name="progressive_load_interval_exoplayer_default">Стандартное значение ExoPlayer</string>
-    <string name="progressive_load_interval_summary">Изменить интервал загрузки (сейчас %s). Меньшее значение может ускорить запуск видео. Нужен перезапуск плеера</string>
     <string name="loading_stream_details">Загрузка сведений о трансляции…</string>
     <string name="check_new_streams">Проверить наличие новых трансляций</string>
     <string name="delete_downloaded_files_confirm">Удалить все загруженные файлы\?</string>

--- a/app/src/main/res/values-sc/strings.xml
+++ b/app/src/main/res/values-sc/strings.xml
@@ -681,7 +681,6 @@
     <string name="detail_pinned_comment_view_description">Cummentu apicadu</string>
     <string name="leak_canary_not_available">LeakCanary no est a disponimentu</string>
     <string name="progressive_load_interval_exoplayer_default">Valore ExoPlayer predefinidu</string>
-    <string name="progressive_load_interval_summary">Muda sa mannària de s\'intervallu de carrigamentu (in custu momentu %s). Unu valore prus bassu diat pòdere allestrare su carrigamentu de incumintzu de su vìdeu. Sas modìficas tenent bisòngiu de torrare a allùghere su riproduidore</string>
     <string name="settings_category_player_notification_summary">Cunfigura sa notìfica de su flussu in cursu de riprodutzione</string>
     <string name="streams_notification_channel_description">Notìficas de flussos noos dae sas iscritziones</string>
     <plurals name="new_streams">

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -693,7 +693,6 @@
     <string name="show_error_snackbar">Zobraziť krátke oznámenie chyby</string>
     <string name="create_error_notification">Oznámte chybu</string>
     <string name="progressive_load_interval_exoplayer_default">ExoPlayer preddefinovaný</string>
-    <string name="progressive_load_interval_summary">Zmeniť interval načítania (aktuálne %s). Menšia hodnota môže zvýšiť rýchlosť prvotného načítania videa. Zmena vyžaduje reštart</string>
     <string name="notifications">Upozornenia</string>
     <string name="streams_notifications_interval_title">Frekvencia kontroly</string>
     <string name="delete_downloaded_files_confirm">Vymazať všetky stiahnuté súbory z disku\?</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -681,7 +681,6 @@
     <string name="detail_pinned_comment_view_description">Fäst kommentar</string>
     <string name="leak_canary_not_available">LeakCanary är inte tillgänglig</string>
     <string name="progressive_load_interval_exoplayer_default">ExoPlayer standard</string>
-    <string name="progressive_load_interval_summary">Ändra inläsningsintervallets storlek (för närvarande %s). Ett lägre värde kan påskynda den första videoinläsningen. Ändringar kräver omstart av spelaren</string>
     <string name="streams_notifications_interval_title">Uppdateringsintervall</string>
     <string name="streams_notifications_network_title">Nödvändig nätverksanslutning</string>
     <string name="any_network">Alla nätverk</string>

--- a/app/src/main/res/values-te/strings.xml
+++ b/app/src/main/res/values-te/strings.xml
@@ -417,7 +417,6 @@
     <string name="resize_zoom">పరివీక్షణ</string>
     <string name="switch_to_popup">తేలియాడే విధంగా మార్చు</string>
     <string name="auto_queue_title">తదుపరి స్ట్రీమ్‌ను స్వీయ-ఎన్క్యూ</string>
-    <string name="progressive_load_interval_summary">లోడ్ విరామం పరిమాణాన్ని మార్చండి (ప్రస్తుతం %s). తక్కువ విలువ ప్రారంభ వీడియో లోడింగ్‌ని వేగవంతం చేయవచ్చు. మార్పులకు ప్లేయర్ రీస్టార్ట్ అవసరం.</string>
     <string name="leak_canary_not_available">LeakCanary అందుబాటులో లేదు</string>
     <string name="caption_setting_description">ప్లేయర్ శీర్షిక వచన స్థాయి మరియు నేపథ్య శైలులను సవరించండి. అమలులోకి రావడానికి యాప్ రీస్టార్ట్ అవసరం</string>
     <string name="playlist_no_uploader">స్వయంచాలకంగా రూపొందించబడింది (ఎక్కించినవారు కనబడుటలేదు)</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -679,7 +679,6 @@
     <string name="crash_the_player">Oynatıcıyı çöktür</string>
     <string name="detail_pinned_comment_view_description">Sabitlenmiş yorum</string>
     <string name="leak_canary_not_available">LeakCanary yok</string>
-    <string name="progressive_load_interval_summary">Yükleme ara boyutunu değiştir (şu anda %s). Düşük bir değer videonun ilk yüklenişini hızlandırabilir. Değişiklikler oynatıcının yeniden başlatılmasını gerektirir</string>
     <string name="progressive_load_interval_exoplayer_default">ExoPlayer öntanımlısı</string>
     <string name="enable_streams_notifications_title">Yeni akış bildirimleri</string>
     <string name="notifications">Bildirimler</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -697,7 +697,6 @@
     <string name="detail_pinned_comment_view_description">Закріплений коментар</string>
     <string name="leak_canary_not_available">LeakCanary недоступний</string>
     <string name="progressive_load_interval_exoplayer_default">Типовий ExoPlayer</string>
-    <string name="progressive_load_interval_summary">Змінити розмір інтервалу завантаження (наразі %s). Менше значення може прискорити початкове завантаження відео. Зміни вимагають перезапуску програвача</string>
     <string name="you_successfully_subscribed">Ви підписалися на цей канал</string>
     <string name="enumeration_comma">,</string>
     <string name="streams_notification_channel_description">Сповіщення про нові трансляції для підписок</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -666,7 +666,6 @@
 \nVui lòng cài đặt ứng dụng quản lý tệp tương thích với Storage Access Framework.</string>
     <string name="no_appropriate_file_manager_message">Không tìm thấy ứng dụng quản lý tệp phù hợp nào để thực hiện hành động.
 \nVui lòng cài đặt ứng dụng quản lý tệp hoặc tắt \'%s\' trong cài đặt tải xuống</string>
-    <string name="progressive_load_interval_summary">Thay đổi kích thước khoảng thời gian tải (tầm khoảng %s). Để ở giá trị thấp hơn có thể sẽ tăng tốc độ tải video hơn ban đầu. Khởi động lại trình phát để áp dụng thay đổi</string>
     <string name="leak_canary_not_available">LeakCanary không khả dụng</string>
     <string name="progressive_load_interval_exoplayer_default">ExoPlayer mặc định</string>
     <string name="detail_pinned_comment_view_description">Bình luận được ghim</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -668,7 +668,6 @@
     <string name="error_report_notification_title">NewPipe 遇到了一个错误，点击此处报告此错误</string>
     <string name="detail_pinned_comment_view_description">置顶评论</string>
     <string name="leak_canary_not_available">LeakCanary 不可用</string>
-    <string name="progressive_load_interval_summary">更改加载间隔的大小（当前为 %s），较低的值可以加快视频的首次加载速度。更改需要重启播放器</string>
     <string name="progressive_load_interval_exoplayer_default">ExoPlayer 默认</string>
     <string name="settings_category_player_notification_summary">配置当前正在播放的串流的通知</string>
     <string name="enable_streams_notifications_title">新串流通知</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -646,7 +646,6 @@
     <string name="delete_playback_states_alert">係咪要全部剷走晒播放到邊個位？</string>
     <string name="percent">百分比</string>
     <string name="semitone">半音</string>
-    <string name="progressive_load_interval_summary">更改載入斬件大細 (目前係 %s)。細啲或者可以等條片快啲開波。更改要開過個播放器至生效</string>
     <string name="clear_queue_confirmation_title">問過先至將排隊播清零</string>
     <string name="clear_queue_confirmation_description">目前播放器入面嘅排隊播將會清零</string>
     <string name="peertube_instance_add_title">加一個站</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -669,7 +669,6 @@
     <string name="detail_pinned_comment_view_description">釘選的留言</string>
     <string name="leak_canary_not_available">LeakCanary 無法使用</string>
     <string name="progressive_load_interval_exoplayer_default">ExoPlayer 預設值</string>
-    <string name="progressive_load_interval_summary">變更載入間隔大小（目前為 %s）。較低的值可能會提昇初始影片載入速度。變更需要重新啟動播放器</string>
     <string name="settings_category_player_notification_title">播放器通知</string>
     <string name="notifications">通知</string>
     <string name="loading_stream_details">正在載入串流詳細資訊……</string>

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -227,7 +227,6 @@
     <string name="show_memory_leaks_key">show_memory_leaks_key</string>
     <string name="allow_disposed_exceptions_key">allow_disposed_exceptions_key</string>
     <string name="show_original_time_ago_key">show_original_time_ago_key</string>
-    <string name="disable_media_tunneling_key">disable_media_tunneling_key</string>
     <string name="show_image_indicators_key">show_image_indicators_key</string>
     <string name="show_crash_the_player_key">show_crash_the_player_key</string>
     <string name="check_new_streams_key">check_new_streams</string>
@@ -1369,5 +1368,6 @@
 
     <!-- ExoPlayer settings -->
     <string name="exoplayer_settings_key">exoplayer_settings_key</string>
+    <string name="disable_media_tunneling_key">disable_media_tunneling_key</string>
     <string name="use_exoplayer_decoder_fallback_key">use_exoplayer_decoder_fallback_key</string>
 </resources>

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -1367,5 +1367,7 @@
     <string name="streams_notifications_channels_key">streams_notifications_channels</string>
     <string name="player_notification_screen_key">player_notification_screen</string>
 
+    <!-- ExoPlayer settings -->
     <string name="exoplayer_settings_key">exoplayer_settings_key</string>
+    <string name="use_exoplayer_decoder_fallback_key">use_exoplayer_decoder_fallback_key</string>
 </resources>

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -1370,4 +1370,5 @@
     <string name="exoplayer_settings_key">exoplayer_settings_key</string>
     <string name="disable_media_tunneling_key">disable_media_tunneling_key</string>
     <string name="use_exoplayer_decoder_fallback_key">use_exoplayer_decoder_fallback_key</string>
+    <string name="always_use_exoplayer_set_output_surface_workaround_key">always_use_exoplayer_set_output_surface_workaround_key</string>
 </resources>

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -1366,4 +1366,6 @@
     </string-array>
     <string name="streams_notifications_channels_key">streams_notifications_channels</string>
     <string name="player_notification_screen_key">player_notification_screen</string>
+
+    <string name="exoplayer_settings_key">exoplayer_settings_key</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -777,4 +777,6 @@
     <string name="settings_category_exoplayer_summary">Manage some ExoPlayer settings. These changes require a player restart to take effect</string>
     <string name="use_exoplayer_decoder_fallback_title">Use ExoPlayer\'s decoder fallback feature</string>
     <string name="use_exoplayer_decoder_fallback_summary">Enable this option if you have decoder initialization issues, which falls back to lower-priority decoders if primary decoders initialization fail. This may result in poor playback performance than when using primary decoders</string>
+    <string name="always_use_exoplayer_set_output_surface_workaround_title">Always use ExoPlayer\'s video output surface setting workaround</string>
+    <string name="always_use_exoplayer_set_output_surface_workaround_summary">This workaround releases and re-instantiates video codecs when a surface change occurs, instead of setting the surface to the codec directly. Already used by ExoPlayer on some devices with this issue, this setting has only an effect on Android 6 and higher\n\nEnabling this option may prevent playback errors when switching the current video player or switching to fullscreen</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -773,4 +773,8 @@
     <string name="feed_show_partially_watched">Partially watched</string>
     <string name="feed_show_upcoming">Upcoming</string>
     <string name="sort">Sort</string>
+    <string name="settings_category_exoplayer_title">ExoPlayer settings</string>
+    <string name="settings_category_exoplayer_summary">Manage some ExoPlayer settings. These changes require a player restart to take effect</string>
+    <string name="use_exoplayer_decoder_fallback_title">Use ExoPlayer\'s decoder fallback feature</string>
+    <string name="use_exoplayer_decoder_fallback_summary">Enable this option if you have decoder initialization issues, which falls back to lower-priority decoders if primary decoders initialization fail. This may result in poor playback performance than when using primary decoders</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,7 +79,7 @@
     <string name="use_inexact_seek_summary">Inexact seek allows the player to seek to positions faster with reduced precision. Seeking for 5, 15 or 25 seconds doesn\'t work with this</string>
     <string name="seek_duration_title">Fast-forward/-rewind seek duration</string>
     <string name="progressive_load_interval_title">Playback load interval size</string>
-    <string name="progressive_load_interval_summary">Change the load interval size (currently %s). A lower value may speed up initial video loading. Changes require a player restart</string>
+    <string name="progressive_load_interval_summary">Change the load interval size on progressive contents (currently %s). A lower value may speed up their initial loading</string>
     <string name="clear_queue_confirmation_title">Ask for confirmation before clearing a queue</string>
     <string name="clear_queue_confirmation_summary">Switching from one player to another may replace your queue</string>
     <string name="clear_queue_confirmation_description">The active player queue will be replaced</string>

--- a/app/src/main/res/xml/debug_settings.xml
+++ b/app/src/main/res/xml/debug_settings.xml
@@ -36,14 +36,6 @@
 
     <SwitchPreferenceCompat
         android:defaultValue="false"
-        android:key="@string/disable_media_tunneling_key"
-        android:summary="@string/disable_media_tunneling_summary"
-        android:title="@string/disable_media_tunneling_title"
-        app:singleLineTitle="false"
-        app:iconSpaceReserved="false" />
-
-    <SwitchPreferenceCompat
-        android:defaultValue="false"
         android:key="@string/show_image_indicators_key"
         android:summary="@string/show_image_indicators_summary"
         android:title="@string/show_image_indicators_title"

--- a/app/src/main/res/xml/exoplayer_settings.xml
+++ b/app/src/main/res/xml/exoplayer_settings.xml
@@ -13,4 +13,12 @@
         app:singleLineTitle="false"
         app:iconSpaceReserved="false" />
 
+    <SwitchPreferenceCompat
+        android:defaultValue="false"
+        android:key="@string/use_exoplayer_decoder_fallback_key"
+        android:summary="@string/use_exoplayer_decoder_fallback_summary"
+        android:title="@string/use_exoplayer_decoder_fallback_title"
+        app:singleLineTitle="false"
+        app:iconSpaceReserved="false" />
+
 </PreferenceScreen>

--- a/app/src/main/res/xml/exoplayer_settings.xml
+++ b/app/src/main/res/xml/exoplayer_settings.xml
@@ -21,4 +21,12 @@
         app:singleLineTitle="false"
         app:iconSpaceReserved="false" />
 
+    <SwitchPreferenceCompat
+        android:defaultValue="false"
+        android:key="@string/disable_media_tunneling_key"
+        android:summary="@string/disable_media_tunneling_summary"
+        android:title="@string/disable_media_tunneling_title"
+        app:singleLineTitle="false"
+        app:iconSpaceReserved="false" />
+
 </PreferenceScreen>

--- a/app/src/main/res/xml/exoplayer_settings.xml
+++ b/app/src/main/res/xml/exoplayer_settings.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:title="@string/settings_category_exoplayer_title">
+
+    <ListPreference
+        android:defaultValue="@string/progressive_load_interval_default_value"
+        android:entries="@array/progressive_load_interval_descriptions"
+        android:entryValues="@array/progressive_load_interval_values"
+        android:key="@string/progressive_load_interval_key"
+        android:summary="@string/progressive_load_interval_summary"
+        android:title="@string/progressive_load_interval_title"
+        app:singleLineTitle="false"
+        app:iconSpaceReserved="false" />
+
+</PreferenceScreen>

--- a/app/src/main/res/xml/exoplayer_settings.xml
+++ b/app/src/main/res/xml/exoplayer_settings.xml
@@ -29,4 +29,12 @@
         app:singleLineTitle="false"
         app:iconSpaceReserved="false" />
 
+    <SwitchPreferenceCompat
+        android:defaultValue="false"
+        android:key="@string/always_use_exoplayer_set_output_surface_workaround_key"
+        android:summary="@string/always_use_exoplayer_set_output_surface_workaround_summary"
+        android:title="@string/always_use_exoplayer_set_output_surface_workaround_title"
+        app:singleLineTitle="false"
+        app:iconSpaceReserved="false" />
+
 </PreferenceScreen>

--- a/app/src/main/res/xml/video_audio_settings.xml
+++ b/app/src/main/res/xml/video_audio_settings.xml
@@ -61,13 +61,11 @@
         app:iconSpaceReserved="false"
         app:useSimpleSummaryProvider="true" />
 
-    <ListPreference
-        android:defaultValue="@string/progressive_load_interval_default_value"
-        android:entries="@array/progressive_load_interval_descriptions"
-        android:entryValues="@array/progressive_load_interval_values"
-        android:key="@string/progressive_load_interval_key"
-        android:summary="@string/progressive_load_interval_summary"
-        android:title="@string/progressive_load_interval_title"
+    <PreferenceScreen
+        android:fragment="org.schabi.newpipe.settings.ExoPlayerSettingsFragment"
+        android:key="@string/exoplayer_settings_key"
+        android:summary="@string/settings_category_exoplayer_summary"
+        android:title="@string/settings_category_exoplayer_title"
         app:singleLineTitle="false"
         app:iconSpaceReserved="false" />
 


### PR DESCRIPTION
#### What is it?
- [x] Feature (user facing)

#### Description of the changes in your PR
This PR adds an ExoPlayer settings page to NewPipe's settings, at the current place of the playback load interval size setting (`Video and audio` settings page).

This page contains three settings:

- the playback load interval size one, for which its description has been updated to reflect its effect on progressive sources only (its translations have been removed);
- a new setting to enable [ExoPlayer's decoder fallback feature](https://exoplayer.dev/doc/reference/com/google/android/exoplayer2/DefaultRenderersFactory.html#setEnableDecoderFallback(boolean)), which could help for issues such as #8016;
- the media tunneling setting, which is now controllable by the user and not only for debug builds. Media tunneling may be not supported by more devices than the ones on which we disabled this feature before, so I think it is a good idea to allow users to not wait for us to disable this setting on their device on a future release, and also for future code complexity purposes. **Users of devices on which media tunneling has been disabled will have to enable manually this setting again on their devices with this change.**

More settings could be added in the future, such as ones to change buffer settings.

**These settings require a player restart to take effect** (this information has been written on the link of this page, in `Video and audio` settings).

#### Before/After Screenshots/Screen Record
- Before:
<img src="https://user-images.githubusercontent.com/74829229/186469730-be07b684-99e3-4908-a4a6-ca5a250c5bf7.jpg" width="300px" alt="Video and audio settings before">

- After:

| <img src="https://user-images.githubusercontent.com/74829229/186470104-b1b45982-4943-4f09-8dea-8a22e9f8090b.jpg" width="300px" alt="Video and audio settings after"> | <img src="https://user-images.githubusercontent.com/74829229/222810884-01381126-46d7-4fc6-8b0e-d006185aaead.jpg" width="300px" alt="ExoPlayer settings"> |
|:-:|:-:|

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes no issue, but it could help for #8016 and #9023.

#### APK testing 
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).