### PR TITLE
Hotfix release v0.23.3

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,8 +16,8 @@ android {
         resValue "string", "app_name", "NewPipe"
         minSdk 19
         targetSdk 29
-        versionCode 988
-        versionName "0.23.2"
+        versionCode 989
+        versionName "0.23.3"
 
         multiDexEnabled true
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -190,7 +190,7 @@ dependencies {
     // name and the commit hash with the commit hash of the (pushed) commit you want to test
     // This works thanks to JitPack: https://jitpack.io/
     implementation 'com.github.TeamNewPipe:nanojson:1d9e1aea9049fc9f85e68b43ba39fe7be1c1f751'
-    implementation 'com.github.TeamNewPipe:NewPipeExtractor:76aad92fa54524f20c3338ab568c9cd6b50c9d33'
+    implementation 'com.github.TeamNewPipe:NewPipeExtractor:6a858368c86bc9a55abee586eb6c733e86c26b97'
 
 /** Checkstyle **/
     checkstyle "com.puppycrawl.tools:checkstyle:${checkstyleVersion}"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -231,7 +231,7 @@ dependencies {
     kapt "frankiesardo:icepick-processor:${icepickVersion}"
 
     // HTML parser
-    implementation "org.jsoup:jsoup:1.14.3"
+    implementation "org.jsoup:jsoup:1.15.3"
 
     // HTTP client
     //noinspection GradleDependency --> do not update okhttp to keep supporting Android 4.4 users

--- a/fastlane/metadata/android/en-US/changelogs/989.txt
+++ b/fastlane/metadata/android/en-US/changelogs/989.txt
@@ -1,0 +1,2 @@
+• [YouTube] Fix videos loading indefinitely
+• Upgrade the jsoup library to 1.15.3, which includes a security fix


### PR DESCRIPTION
Fixes #8876
Upgrades jsoup to 0.15.3 to solve the vulnerability reported by snyk (also see https://github.com/TeamNewPipe/NewPipeExtractor/pull/911)
Release APK signed with my keys: [app-release.zip](https://github.com/TeamNewPipe/NewPipe/files/9422940/app-release.zip)