### PR TITLE
Only show "Enqueue next" when in the middle of the queue

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/info_list/dialog/InfoItemDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/dialog/InfoItemDialog.java
@@ -252,10 +252,11 @@ public final class InfoItemDialog {
          * @return the current {@link Builder} instance
          */
         public Builder addEnqueueEntriesIfNeeded() {
-            if (PlayerHolder.getInstance().isPlayQueueReady()) {
+            final PlayerHolder holder = PlayerHolder.getInstance();
+            if (holder.isPlayQueueReady()) {
                 addEntry(StreamDialogDefaultEntry.ENQUEUE);
 
-                if (PlayerHolder.getInstance().getQueueSize() > 1) {
+                if (holder.getQueuePosition() < holder.getQueueSize() - 1) {
                     addEntry(StreamDialogDefaultEntry.ENQUEUE_NEXT);
                 }
             }

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHolder.java
@@ -92,6 +92,13 @@ public final class PlayerHolder {
         return player.getPlayQueue().size();
     }
 
+    public int getQueuePosition() {
+        if (player == null || player.getPlayQueue() == null) {
+            return 0;
+        }
+        return player.getPlayQueue().getIndex();
+    }
+
     public void setListener(@Nullable final PlayerServiceExtendedEventListener newListener) {
         listener = newListener;
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
Add a check that the queue position is not the last in the queue before
showing "Enqueue next".

Previously the "Enqueue next" action would always be shown if the queue
length was greater than one, this meant even if you were at the end of
the queue (when "Enqueue" would have the same effect as "Enqueue next")
the action would still be shown.

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
