### PR TITLE
Fix wrong thumbnail in notification on Android 13

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -1509,48 +1509,50 @@ public final class Player implements PlaybackListener, Listener {
             Log.d(TAG, "Playback - onPlaybackSynchronize(was blocked: " + wasBlocked
                     + ") called with item=[" + item.getTitle() + "], url=[" + item.getUrl() + "]");
         }
-        if (exoPlayerIsNull() || playQueue == null) {
-            return;
+        if (exoPlayerIsNull() || playQueue == null || currentItem == item) {
+            return; // nothing to synchronize
         }
 
-        final boolean hasPlayQueueItemChanged = currentItem != item;
+        final int playQueueIndex = playQueue.indexOf(item);
+        final int playlistIndex = simpleExoPlayer.getCurrentMediaItemIndex();
+        final int playlistSize = simpleExoPlayer.getCurrentTimeline().getWindowCount();
+        final boolean removeThumbnailBeforeSync = currentItem == null
+                || currentItem.getServiceId() != item.getServiceId()
+                || !currentItem.getUrl().equals(item.getUrl());
 
-        final int currentPlayQueueIndex = playQueue.indexOf(item);
-        final int currentPlaylistIndex = simpleExoPlayer.getCurrentMediaItemIndex();
-        final int currentPlaylistSize = simpleExoPlayer.getCurrentTimeline().getWindowCount();
-
-        // If nothing to synchronize
-        if (!hasPlayQueueItemChanged) {
-            return;
-        }
         currentItem = item;
 
-        // Check if on wrong window
-        if (currentPlayQueueIndex != playQueue.getIndex()) {
-            Log.e(TAG, "Playback - Play Queue may be desynchronized: item "
-                    + "index=[" + currentPlayQueueIndex + "], "
-                    + "queue index=[" + playQueue.getIndex() + "]");
+        if (playQueueIndex != playQueue.getIndex()) {
+            // wrong window (this should be impossible, as this method is called with
+            // `item=playQueue.getItem()`, so the index of that item must be equal to `getIndex()`)
+            Log.e(TAG, "Playback - Play Queue may be not in sync: item index=["
+                    + playQueueIndex + "], " + "queue index=[" + playQueue.getIndex() + "]");
 
-            // Check if bad seek position
-        } else if ((currentPlaylistSize > 0 && currentPlayQueueIndex >= currentPlaylistSize)
-                || currentPlayQueueIndex < 0) {
-            Log.e(TAG, "Playback - Trying to seek to invalid "
-                    + "index=[" + currentPlayQueueIndex + "] with "
-                    + "playlist length=[" + currentPlaylistSize + "]");
+        } else if ((playlistSize > 0 && playQueueIndex >= playlistSize) || playQueueIndex < 0) {
+            // the queue and the player's timeline are not in sync, since the play queue index
+            // points outside of the timeline
+            Log.e(TAG, "Playback - Trying to seek to invalid index=[" + playQueueIndex
+                    + "] with playlist length=[" + playlistSize + "]");
 
-        } else if (wasBlocked || currentPlaylistIndex != currentPlayQueueIndex || !isPlaying()) {
+        } else if (wasBlocked || playlistIndex != playQueueIndex || !isPlaying()) {
+            // either the player needs to be unblocked, or the play queue index has just been
+            // changed and needs to be synchronized, or the player is not playing
             if (DEBUG) {
-                Log.d(TAG, "Playback - Rewinding to correct "
-                        + "index=[" + currentPlayQueueIndex + "], "
-                        + "from=[" + currentPlaylistIndex + "], "
-                        + "size=[" + currentPlaylistSize + "].");
+                Log.d(TAG, "Playback - Rewinding to correct index=[" + playQueueIndex + "], "
+                        + "from=[" + playlistIndex + "], size=[" + playlistSize + "].");
             }
 
+            if (removeThumbnailBeforeSync) {
+                // unset the current (now outdated) thumbnail to ensure it is not used during sync
+                onThumbnailLoaded(null);
+            }
+
+            // sync the player index with the queue index, and seek to the correct position
             if (item.getRecoveryPosition() != PlayQueueItem.RECOVERY_UNSET) {
-                simpleExoPlayer.seekTo(currentPlayQueueIndex, item.getRecoveryPosition());
-                playQueue.unsetRecovery(currentPlayQueueIndex);
+                simpleExoPlayer.seekTo(playQueueIndex, item.getRecoveryPosition());
+                playQueue.unsetRecovery(playQueueIndex);
             } else {
-                simpleExoPlayer.seekToDefaultPosition(currentPlayQueueIndex);
+                simpleExoPlayer.seekToDefaultPosition(playQueueIndex);
             }
         }
     }

--- a/app/src/main/java/org/schabi/newpipe/player/notification/NotificationPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/notification/NotificationPlayerUi.java
@@ -43,7 +43,7 @@ public final class NotificationPlayerUi extends PlayerUi {
     @Override
     public void onThumbnailLoaded(@Nullable final Bitmap bitmap) {
         super.onThumbnailLoaded(bitmap);
-        notificationUtil.createNotificationIfNeededAndUpdate(false);
+        notificationUtil.updateThumbnail();
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/player/notification/NotificationUtil.java
+++ b/app/src/main/java/org/schabi/newpipe/player/notification/NotificationUtil.java
@@ -24,6 +24,8 @@ import org.schabi.newpipe.player.mediasession.MediaSessionPlayerUi;
 import org.schabi.newpipe.util.NavigationHelper;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 import static android.app.PendingIntent.FLAG_UPDATE_CURRENT;
 import static androidx.media.app.NotificationCompat.MediaStyle;
@@ -40,8 +42,6 @@ import static org.schabi.newpipe.player.notification.NotificationConstants.ACTIO
 
 /**
  * This is a utility class for player notifications.
- *
- * @author cool-student
  */
 public final class NotificationUtil {
     private static final String TAG = NotificationUtil.class.getSimpleName();
@@ -77,6 +77,19 @@ public final class NotificationUtil {
         }
         updateNotification();
         notificationManager.notify(NOTIFICATION_ID, notificationBuilder.build());
+    }
+
+    public synchronized void updateThumbnail() {
+        if (notificationBuilder != null) {
+            if (DEBUG) {
+                Log.d(TAG, "updateThumbnail() called with thumbnail = [" + Integer.toHexString(
+                        Optional.ofNullable(player.getThumbnail()).map(Objects::hashCode).orElse(0))
+                        + "], title = [" + player.getVideoTitle() + "]");
+            }
+
+            setLargeIcon(notificationBuilder);
+            notificationManager.notify(NOTIFICATION_ID, notificationBuilder.build());
+        }
     }
 
     private synchronized NotificationCompat.Builder createNotification() {
@@ -123,6 +136,9 @@ public final class NotificationUtil {
                 .setDeleteIntent(PendingIntent.getBroadcast(player.getContext(), NOTIFICATION_ID,
                         new Intent(ACTION_CLOSE), FLAG_UPDATE_CURRENT));
 
+        // set the initial value for the video thumbnail, updatable with updateNotificationThumbnail
+        setLargeIcon(builder);
+
         return builder;
     }
 
@@ -142,7 +158,6 @@ public final class NotificationUtil {
         notificationBuilder.setTicker(player.getVideoTitle());
 
         updateActions(notificationBuilder);
-        setLargeIcon(notificationBuilder);
     }
 
 

--- a/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
@@ -109,7 +109,6 @@ public abstract class VideoPlayerUi extends PlayerUi
     private final Handler controlsVisibilityHandler = new Handler(Looper.getMainLooper());
     @Nullable private SurfaceHolderCallback surfaceHolderCallback;
     boolean surfaceIsSetup = false;
-    @Nullable private Bitmap thumbnail = null;
 
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -385,9 +384,7 @@ public abstract class VideoPlayerUi extends PlayerUi
     @Override
     public void destroy() {
         super.destroy();
-        if (binding != null) {
-            binding.endScreen.setImageBitmap(null);
-        }
+        binding.endScreen.setImageDrawable(null);
         deinitPlayerSeekOverlay();
         deinitListeners();
     }
@@ -422,12 +419,10 @@ public abstract class VideoPlayerUi extends PlayerUi
     public void onBroadcastReceived(final Intent intent) {
         super.onBroadcastReceived(intent);
         if (Intent.ACTION_CONFIGURATION_CHANGED.equals(intent.getAction())) {
-            // When the orientation changed, the screen height might be smaller.
-            // If the end screen thumbnail is not re-scaled,
-            // it can be larger than the current screen height
-            // and thus enlarging the whole player.
-            // This causes the seekbar to be ouf the visible area.
-            updateEndScreenThumbnail();
+            // When the orientation changes, the screen height might be smaller. If the end screen
+            // thumbnail is not re-scaled, it can be larger than the current screen height and thus
+            // enlarging the whole player. This causes the seekbar to be out of the visible area.
+            updateEndScreenThumbnail(player.getThumbnail());
         }
     }
     //endregion
@@ -449,11 +444,10 @@ public abstract class VideoPlayerUi extends PlayerUi
     @Override
     public void onThumbnailLoaded(@Nullable final Bitmap bitmap) {
         super.onThumbnailLoaded(bitmap);
-        thumbnail = bitmap;
-        updateEndScreenThumbnail();
+        updateEndScreenThumbnail(bitmap);
     }
 
-    private void updateEndScreenThumbnail() {
+    private void updateEndScreenThumbnail(@Nullable final Bitmap thumbnail) {
         if (thumbnail == null) {
             // remove end screen thumbnail
             binding.endScreen.setImageDrawable(null);


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This PR fixes yet another issue about the notification thumbnail not changing when going to the previous or next item in the player queue (see https://github.com/TeamNewPipe/NewPipe/issues/8890#issuecomment-1229464123).

What I think the problem was (though this might need more investigation) is this:
1. when tapping on "next", NewPipe's queue implementation would go to the next item
2. then the ExoPlayer's internal media item queue gets synchronized, by telling the player to go to the next item
3. the player internally switches to the next item, and it starts loading its stream details to be able to play it, also updating the item index in the media session (a component that the system can read to get info)
4. the player switches state to `onBuffering`, which triggers a notification update for NewPipe
5. notification updates are implemented not based on the selected queue item (`currentItem`) but rather on the StreamInfo (`currentMetadata`) and the `currentThumbnail` stored in the player. That StreamInfo, though, still belongs to the previous item in the queue, since stream details have not finished loading yet. This causes the wrong title, uploader and thumbnail to be temporarily set in the notification.
6. the stream details finally load, they are set in the player and the notification is updated again, this time with the correct information
7. title and uploader are correctly updated in the notification, but the thumbnail is not. This happens probably because the system associated the thumbnail of the previous item to the index of the next, and then tries to avoid reloading the thumbnail again to save cpu, assuming the first set thumbnail was the correct one. Triggering notification updates in other ways (e.g. play-pause) does not make a difference.

So in the PR that will merge `NotificationUtil` and `NotificationPlayerUi`, the notification, the player and the media session should be switched to using data not about the player StreamInfo, but rather the actual current play queue item (except for the thumbnail, for which we need the high-res one from the fully-loaded stream details). Though it might not be this simple.

This PR fixes the problem by detecting when the queue item changes and then setting `currentThumbnail` to `null`. This happens in-between points 1 and 2 above, i.e. before the exoPlayer internal queue is synced and before the notification update is triggered.

The commits strictly necessary to solve the issue are the first two, though the other two are also important in my opinion.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- https://github.com/TeamNewPipe/NewPipe/issues/8890#issuecomment-1229464123

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
