### PR TITLE
Possible races

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueue.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueue.java
@@ -341,21 +341,22 @@ public abstract class PlayQueue implements Serializable {
         final int currentIndex = queueIndex.get();
         final int size = size();
 
+        int nextIndex = currentIndex;
         if (currentIndex > removeIndex) {
-            queueIndex.decrementAndGet();
+            nextIndex = currentIndex - 1;
+            queueIndex.set(nextIndex);
 
         } else if (currentIndex >= size) {
-            queueIndex.set(currentIndex % (size - 1));
+            nextIndex = currentIndex % (size - 1);
+            queueIndex.set(nextIndex);
 
         } else if (currentIndex == removeIndex && currentIndex == size - 1) {
-            queueIndex.set(0);
+            queueIndex.set(nextIndex = 0);
         }
 
         if (backup != null) {
             backup.remove(getItem(removeIndex));
         }
-
-        final int nextIndex = queueIndex.get();
         history.remove(streams.remove(removeIndex));
         if (streams.size() > nextIndex) {
             history.add(streams.get(nextIndex));

--- a/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueue.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueue.java
@@ -233,8 +233,8 @@ public abstract class PlayQueue implements Serializable {
      * @return an immutable view of the play queue
      */
     @NonNull
-    public synchronized List<PlayQueueItem> getStreams() { // todo: iterator race
-        return Collections.unmodifiableList(streams);
+    public synchronized List<PlayQueueItem> getStreams() {
+        return Collections.unmodifiableList(new ArrayList<>(streams));
     }
 
     /*//////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
#### What is it?
- [x] Codebase improvement (dev facing)

#### Description of the changes in your PR
Let's start in order:
First, if you write under a lock, it doesn't mean that reading a non-thread-safe collection is thread-safe, you break HB's transitivity:
There are two ways out in this situation:
 - COW imposes additional costs on writing (copies), but at the same time reading from COW is thread-safe and without blocking
- Synchronize non-thread-safe list (which is better in this case)

But, there are still problems, the fact is that the class is non-thread-safe by design:

- You provide a list to the user, which means you provide a non-thread-safe iterator - the solution is to copy the list and give the user a snapshot


P.S eeven though the race may be out of scope for your implementation, if you are already making the methods thread-safe, you need to make those method binders thread-safe

Unfortunately, this is the first class in which I encountered a race, such a problem may be in other classes

#### Fixes the following issue(s)
Possible races in perspective
