### PR TITLE
Show correct tooltips for actions in feed

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
@@ -41,6 +41,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.content.edit
 import androidx.core.os.bundleOf
+import androidx.core.view.MenuItemCompat
 import androidx.core.view.isVisible
 import androidx.lifecycle.ViewModelProvider
 import androidx.preference.PreferenceManager
@@ -286,6 +287,15 @@ class FeedFragment : BaseStateFragment<FeedState>() {
             requireContext(),
             if (showPlayedItems) R.drawable.ic_visibility_on else R.drawable.ic_visibility_off
         )
+        MenuItemCompat.setTooltipText(
+            menuItem,
+            getString(
+                if (showPlayedItems)
+                    R.string.feed_toggle_hide_played_items
+                else
+                    R.string.feed_toggle_show_played_items
+            )
+        )
     }
 
     private fun updateToggleFutureItemsButton(menuItem: MenuItem) {
@@ -293,6 +303,15 @@ class FeedFragment : BaseStateFragment<FeedState>() {
         menuItem.icon = AppCompatResources.getDrawable(
             requireContext(),
             if (showFutureItems) R.drawable.ic_history_future else R.drawable.ic_history
+        )
+        MenuItemCompat.setTooltipText(
+            menuItem,
+            getString(
+                if (showPlayedItems)
+                    R.string.feed_toggle_hide_future_items
+                else
+                    R.string.feed_toggle_show_future_items
+            )
         )
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -684,6 +684,7 @@
 \n
 \nSo the choice boils down to what you prefer: speed or precise information.</string>
     <string name="feed_toggle_show_played_items">Show watched items</string>
+    <string name="feed_toggle_hide_played_items">Hide watched items</string>
     <string name="content_not_supported">This content is not yet supported by NewPipe.\n\nIt will hopefully be supported in a future version.</string>
     <string name="detail_sub_channel_thumbnail_view_description">Channel\'s avatar thumbnail</string>
     <string name="channel_created_by">Created by %s</string>
@@ -746,5 +747,6 @@
     <string name="select_quality_external_players">Select quality for external players</string>
     <string name="unknown_format">Unknown format</string>
     <string name="unknown_quality">Unknown quality</string>
-    <string name="feed_toggle_show_future_items">Show future videos</string>
+    <string name="feed_toggle_show_future_items">Show future items</string>
+    <string name="feed_toggle_hide_future_items">Hide future items</string>
 </resources>


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This PR shows the correct `tooltip`s for hide/show actions in the feed. So when watched/future items are shown, the tooltip is "Hide watched/future items", otherwise it is "Show watched/future items". This is because the tooltip should represent the action performed by clicking on the button, as requested [here](https://github.com/TeamNewPipe/NewPipe/issues/8890#issuecomment-1230466338). The item's `title`s, though, should just be a description of the button, and so stay the same (always "Show ... items"). This PR also changes "Show/hide future videos" to "Show/hide future items", in order to be consistent with "Show/hide watched videos", and also because a user's feed may not be composed of only videos.

While testing I noticed that, when pressing the buttons, sometimes the future-items tooltip wouldn't be updated right away, while the watched-items would. I don't know why this is, since the code for updating the two is exactly the same. Anyway, the tooltip set when the button is first shown is correct, and the tooltip also *becomes* correct after a while or after the menu gets reloaded. Maybe this problem has to do with some caching done by the system? Idk, but I wouldn't spend too much time on this anyway.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- https://github.com/TeamNewPipe/NewPipe/issues/8890#issuecomment-1230466338

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
