### PR TITLE
Fix Open action menu not working on cold start

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/RouterActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/RouterActivity.java
@@ -114,6 +114,11 @@ public class RouterActivity extends AppCompatActivity {
 
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
+        ThemeHelper.setDayNightMode(this);
+        setTheme(ThemeHelper.isLightThemeSelected(this)
+                ? R.style.RouterActivityThemeLight : R.style.RouterActivityThemeDark);
+        Localization.assureCorrectAppLanguage(this);
+
         super.onCreate(savedInstanceState);
         Icepick.restoreInstanceState(this, savedInstanceState);
 
@@ -125,11 +130,6 @@ public class RouterActivity extends AppCompatActivity {
                 finish();
             }
         }
-
-        ThemeHelper.setDayNightMode(this);
-        setTheme(ThemeHelper.isLightThemeSelected(this)
-                ? R.style.RouterActivityThemeLight : R.style.RouterActivityThemeDark);
-        Localization.assureCorrectAppLanguage(this);
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/RouterActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/RouterActivity.java
@@ -397,7 +397,8 @@ public class RouterActivity extends AppCompatActivity {
                 .setNegativeButton(R.string.just_once, dialogButtonsClickListener)
                 .setPositiveButton(R.string.always, dialogButtonsClickListener)
                 .setOnDismissListener(dialog -> {
-                    if (!selectionIsDownload && !selectionIsAddToPlaylist) {
+                    if (!selectionIsDownload && !selectionIsAddToPlaylist
+                            && !isChangingConfigurations()) { // allow recreate on screen rotate
                         finish();
                     }
                 })


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
So I think I hit a bug (similar to #3129).  Sorry if it seems like a rolled up bug report + pull request, but I'll just set out the steps to reproduce below, for the sake of clarity/testing:
##### Preparation
- Have the 0.24.0 release apk installed
- Ensure that `Settings` -> `Video & audio` -> `Preferred 'open' action` is set to `Always ask` (the default setting)
- Change the theme and/or app language to something _different from_ the system default
(say, my phone is on light, I choose the dark theme)
##### Steps to reproduce
- Force stop the app (in system `Settings` -> `Apps`)
- Share a YouTube video link to NewPipe (eg from a browser)
##### Observation
- (if you've set the dark app theme like me, you might see the background dims for a brief moment)
- Nothing happens (the Open action selection dialog does not pop up as expected)
- If you try again (by sharing/clicking on the link the second time), this time `RouterActivity` dialog appears as expected

[Repeat the above with the debug apk to see if this fixes the issue ie the dialog should appear as expected the first time (on cold start)]

#### Hypothesis and PR changes
- It's a bit tricky to identify since there's no error message and the selection dialog just seems to be silently dropped (but only) the first time (on cold start).
- A hypothesis (my suspicion) is that the theme/locale setup in `onCreate()` caused the `RouterActivity` to recreate.  Thus I move up those lines to before `super.onCreate()` (for this I'm indebted to the generous answers on StackOverflow) and voila, it seems issue solved.
- The second commit addresses the balance of the issue by avoiding (accidentally) calling `finish()` in `onDismissListener()` (which will be triggered in `onStop()` when cleaning up the dialog) to allow the activity to be recreated on screen rotation.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- (Potentially) fixes #3129
(sorry for pinging if it doesn't solve the exact same issue; but I tried)

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
