### PR TITLE
Improve screen rotation handling in Open action menu

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/RouterActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/RouterActivity.java
@@ -114,6 +114,11 @@ public class RouterActivity extends AppCompatActivity {
 
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
+        ThemeHelper.setDayNightMode(this);
+        setTheme(ThemeHelper.isLightThemeSelected(this)
+                ? R.style.RouterActivityThemeLight : R.style.RouterActivityThemeDark);
+        Localization.assureCorrectAppLanguage(this);
+
         super.onCreate(savedInstanceState);
         Icepick.restoreInstanceState(this, savedInstanceState);
 
@@ -125,11 +130,6 @@ public class RouterActivity extends AppCompatActivity {
                 finish();
             }
         }
-
-        ThemeHelper.setDayNightMode(this);
-        setTheme(ThemeHelper.isLightThemeSelected(this)
-                ? R.style.RouterActivityThemeLight : R.style.RouterActivityThemeDark);
-        Localization.assureCorrectAppLanguage(this);
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/RouterActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/RouterActivity.java
@@ -669,13 +669,7 @@ public class RouterActivity extends AppCompatActivity {
     }
 
     private void openAddToPlaylistDialog() {
-        // Getting the stream info usually takes a moment
-        // Notifying the user here to ensure that no confusion arises
-        Toast.makeText(
-                getApplicationContext(),
-                getString(R.string.processing_may_take_a_moment),
-                Toast.LENGTH_SHORT)
-                .show();
+        pleaseWait();
 
         disposables.add(ExtractorHelper.getStreamInfo(currentServiceId, currentUrl, false)
                 .subscribeOn(Schedulers.io())
@@ -705,6 +699,8 @@ public class RouterActivity extends AppCompatActivity {
 
     @SuppressLint("CheckResult")
     private void openDownloadDialog() {
+        pleaseWait();
+
         disposables.add(ExtractorHelper.getStreamInfo(currentServiceId, currentUrl, true)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
@@ -717,6 +713,16 @@ public class RouterActivity extends AppCompatActivity {
                     downloadDialog.show(fm, "downloadDialog");
                     fm.executePendingTransactions();
                 }, throwable -> showUnsupportedUrlDialog(currentUrl)));
+    }
+
+    private void pleaseWait() {
+        // Getting the stream info usually takes a moment
+        // Notifying the user here to ensure that no confusion arises
+        Toast.makeText(
+                        getApplicationContext(),
+                        getString(R.string.processing_may_take_a_moment),
+                        Toast.LENGTH_LONG)
+                .show();
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/RouterActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/RouterActivity.java
@@ -751,6 +751,7 @@ public class RouterActivity extends AppCompatActivity {
         private void playback() {
             if (activityGone()) {
                 done();
+                return;
             }
             if (buffer.size() == 0 || isPaused) {
                 return;
@@ -774,6 +775,7 @@ public class RouterActivity extends AppCompatActivity {
         private void runOnVisible(final ResultRunnable runnable) {
             if (activityGone()) {
                 done();
+                return;
             }
             if (isPaused) {
                 buffer.add(runnable);

--- a/app/src/main/java/org/schabi/newpipe/RouterActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/RouterActivity.java
@@ -161,6 +161,14 @@ public class RouterActivity extends AppCompatActivity {
         disposables.clear();
     }
 
+    @Override
+    public void finish() {
+        // allow the activity to recreate in case orientation changes
+        if (!isChangingConfigurations()) {
+            super.finish();
+        }
+    }
+
     private void handleUrl(final String url) {
         disposables.add(Observable
                 .fromCallable(() -> {

--- a/app/src/main/java/org/schabi/newpipe/RouterActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/RouterActivity.java
@@ -758,10 +758,10 @@ public class RouterActivity extends AppCompatActivity {
             while (buffer.size() > 0) {
                 final ResultRunnable runnable = buffer.elementAt(0);
                 buffer.removeElementAt(0);
-                getActivityContext().runOnUiThread(() -> {
+                getActivityContext().runOnUiThread(() ->
                     // execute queued task with new context, in case activity has been recreated
-                    runnable.run(getActivityContext());
-                });
+                    runnable.run(getActivityContext())
+                );
             }
             done();
         }

--- a/app/src/main/java/org/schabi/newpipe/RouterActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/RouterActivity.java
@@ -16,6 +16,7 @@ import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.RadioButton;
 import android.widget.RadioGroup;
@@ -119,6 +120,14 @@ public class RouterActivity extends AppCompatActivity {
         setTheme(ThemeHelper.isLightThemeSelected(this)
                 ? R.style.RouterActivityThemeLight : R.style.RouterActivityThemeDark);
         Localization.assureCorrectAppLanguage(this);
+
+        // Pass-through touch events to background activities
+        // so that our transparent window won't lock UI in the mean time
+        // network request is underway before showing PlaylistDialog or DownloadDialog
+        // (courtesy of https://stackoverflow.com/a/10606141)
+        getWindow().addFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
+                | WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL
+                | WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE);
 
         super.onCreate(savedInstanceState);
         Icepick.restoreInstanceState(this, savedInstanceState);

--- a/app/src/main/java/org/schabi/newpipe/RouterActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/RouterActivity.java
@@ -124,10 +124,20 @@ public class RouterActivity extends AppCompatActivity {
         // Pass-through touch events to background activities
         // so that our transparent window won't lock UI in the mean time
         // network request is underway before showing PlaylistDialog or DownloadDialog
-        // (courtesy of https://stackoverflow.com/a/10606141)
+        // (ref: https://stackoverflow.com/a/10606141)
         getWindow().addFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
                 | WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL
                 | WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE);
+
+        // Android never fails to impress us with a list of new restrictions per API.
+        // Starting with S (Android 12) one of the prerequisite conditions has to be met
+        // before the FLAG_NOT_TOUCHABLE flag is allowed to kick in:
+        // @see WindowManager.LayoutParams#FLAG_NOT_TOUCHABLE
+        // For our present purpose it seems we can just set LayoutParams.alpha to 0
+        // on the strength of "4. Fully transparent windows" without affecting the scrim of dialogs
+        final WindowManager.LayoutParams params = getWindow().getAttributes();
+        params.alpha = 0f;
+        getWindow().setAttributes(params);
 
         super.onCreate(savedInstanceState);
         Icepick.restoreInstanceState(this, savedInstanceState);

--- a/app/src/main/java/org/schabi/newpipe/RouterActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/RouterActivity.java
@@ -10,6 +10,7 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
+import android.os.Build;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.view.ContextThemeWrapper;
@@ -776,7 +777,10 @@ public class RouterActivity extends AppCompatActivity {
             }
             if (isPaused) {
                 buffer.add(runnable);
-                if (!getActivityContext().isChangingConfigurations()) {
+                // this trick doesn't seem to work on Android 10+ (API 29)
+                // which places restrictions on starting activities from the background
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q
+                        && !getActivityContext().isChangingConfigurations()) {
                     // try to bring the activity back to front if minimised
                     final Intent i = new Intent(getActivityContext(), RouterActivity.class);
                     i.setFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
Currently when sharing to NewPipe (when set to `Always ask`), the Open action menu dialog would rotate away on orientation change (since `finish()` would be called by onDismissListener during dialog cleanup thus preventing `RouterActivity` to be recreated when screen rotates).  This PR tries to improve that by making the dialogs stay across screen rotations.

~~_Known issue:_ Ongoing network requests, however, won't survive config change (which would somehow require keeping track of the `Observable`s across recreation of activity).  If user selects Add to Playlist or Download and rotates away while stream info is being fetched, the network request underway would be dropped and `RouterActivity` would start over again when recreated on orientation change.  That would (unfortunately) be another PR for another day.~~ Addressed this using a retained fragment the other day

##### Misc changes
- Fixes a bug on older Android where the Open action dialog won't appear the first time on cold start
- Shows on Download action as well the toast that asks the user to wait
- When fetching stream info (for Add to Playlist and Download), the transparent activity no longer blocks touch events and inadvertently locks UI thus giving the impression that NewPipe freezes

##### To test:
- Make sure `Settings` -> `Video & audio` -> `Preferred 'open' action` is set to `Always ask` (the default setting)
- Share a (YouTube) URL to NewPipe (Debug apk) (say, from a browser)
- Happy screen rotating :)

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #3129

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
