### PR TITLE
Fix crash when the user clicks download then quits the history fragment

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/info_list/dialog/StreamDialogDefaultEntry.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/dialog/StreamDialogDefaultEntry.java
@@ -112,12 +112,19 @@ public enum StreamDialogDefaultEntry {
             ShareUtils.shareText(fragment.requireContext(), item.getName(), item.getUrl(),
                     item.getThumbnailUrl())),
 
+    /**
+     * Opens a {@link DownloadDialog} after fetching some stream info.
+     * If the user quits the current fragment, it will not open a DownloadDialog.
+     */
     DOWNLOAD(R.string.download, (fragment, item) ->
             fetchStreamInfoAndSaveToDatabase(fragment.requireContext(), item.getServiceId(),
                     item.getUrl(), info -> {
-                        final DownloadDialog downloadDialog =
-                                new DownloadDialog(fragment.requireContext(), info);
-                        downloadDialog.show(fragment.getChildFragmentManager(), "downloadDialog");
+                        if (fragment.getContext() != null) {
+                            final DownloadDialog downloadDialog =
+                                    new DownloadDialog(fragment.requireContext(), info);
+                            downloadDialog.show(fragment.getChildFragmentManager(),
+                                    "downloadDialog");
+                        }
                     })
     ),
 


### PR DESCRIPTION
#### What is it?
- [X] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Add a condition to detect if the user quits the current fragment. If the user clicked "Download" in the history fragment and then quit the history fragment, a DownloadDialog will not show and not crash the program.


#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before: 

https://user-images.githubusercontent.com/111103032/196186640-74c545ed-3d28-435c-83a7-21146bd80a30.mp4


- After:

https://user-images.githubusercontent.com/111103032/196187412-e87dbef0-5c62-4931-92f7-f963e09936ed.mov



#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #9068

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [ ] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
