### PR TITLE
Added Toast Notification "Hold to enqueue"

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
@@ -22,6 +22,7 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
+import androidx.preference.PreferenceManager;
 import androidx.recyclerview.widget.ItemTouchHelper;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.viewbinding.ViewBinding;
@@ -505,17 +506,25 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
 
         playlistControlBinding.playlistCtrlPlayAllButton.setOnClickListener(view -> {
             NavigationHelper.playOnMainPlayer(activity, getPlayQueue());
-            Toast.makeText(activity, R.string.hold_to_append, Toast.LENGTH_SHORT).show();
+            if (PreferenceManager.getDefaultSharedPreferences(activity)
+                    .getBoolean(getString(R.string.show_hold_to_append_key), true)) {
+                Toast.makeText(activity, R.string.hold_to_append, Toast.LENGTH_SHORT).show();
+            }
         });
         playlistControlBinding.playlistCtrlPlayPopupButton.setOnClickListener(view -> {
             NavigationHelper.playOnPopupPlayer(activity, getPlayQueue(), false);
-            Toast.makeText(activity, R.string.hold_to_append, Toast.LENGTH_SHORT).show();
+            if (PreferenceManager.getDefaultSharedPreferences(activity)
+                    .getBoolean(getString(R.string.show_hold_to_append_key), true)) {
+                Toast.makeText(activity, R.string.hold_to_append, Toast.LENGTH_SHORT).show();
+            }
         });
         playlistControlBinding.playlistCtrlPlayBgButton.setOnClickListener(view -> {
             NavigationHelper.playOnBackgroundPlayer(activity, getPlayQueue(), false);
-            Toast.makeText(activity, R.string.hold_to_append, Toast.LENGTH_SHORT).show();
+            if (PreferenceManager.getDefaultSharedPreferences(activity)
+                    .getBoolean(getString(R.string.show_hold_to_append_key), true)) {
+                Toast.makeText(activity, R.string.hold_to_append, Toast.LENGTH_SHORT).show();
+            }
         });
-
         playlistControlBinding.playlistCtrlPlayPopupButton.setOnLongClickListener(view -> {
             NavigationHelper.enqueueOnPlayer(activity, getPlayQueue(), PlayerType.POPUP);
             return true;

--- a/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
@@ -503,12 +503,18 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
         }
         setVideoCount(itemListAdapter.getItemsList().size());
 
-        playlistControlBinding.playlistCtrlPlayAllButton.setOnClickListener(view ->
-                NavigationHelper.playOnMainPlayer(activity, getPlayQueue()));
-        playlistControlBinding.playlistCtrlPlayPopupButton.setOnClickListener(view ->
-                NavigationHelper.playOnPopupPlayer(activity, getPlayQueue(), false));
-        playlistControlBinding.playlistCtrlPlayBgButton.setOnClickListener(view ->
-                NavigationHelper.playOnBackgroundPlayer(activity, getPlayQueue(), false));
+        playlistControlBinding.playlistCtrlPlayAllButton.setOnClickListener(view -> {
+            NavigationHelper.playOnMainPlayer(activity, getPlayQueue());
+            Toast.makeText(activity, R.string.hold_to_append, Toast.LENGTH_SHORT).show();
+        });
+        playlistControlBinding.playlistCtrlPlayPopupButton.setOnClickListener(view -> {
+            NavigationHelper.playOnPopupPlayer(activity, getPlayQueue(), false);
+            Toast.makeText(activity, R.string.hold_to_append, Toast.LENGTH_SHORT).show();
+        });
+        playlistControlBinding.playlistCtrlPlayBgButton.setOnClickListener(view -> {
+            NavigationHelper.playOnBackgroundPlayer(activity, getPlayQueue(), false);
+            Toast.makeText(activity, R.string.hold_to_append, Toast.LENGTH_SHORT).show();
+        });
 
         playlistControlBinding.playlistCtrlPlayPopupButton.setOnLongClickListener(view -> {
             NavigationHelper.enqueueOnPlayer(activity, getPlayQueue(), PlayerType.POPUP);

--- a/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
@@ -506,24 +506,15 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
 
         playlistControlBinding.playlistCtrlPlayAllButton.setOnClickListener(view -> {
             NavigationHelper.playOnMainPlayer(activity, getPlayQueue());
-            if (PreferenceManager.getDefaultSharedPreferences(activity)
-                    .getBoolean(getString(R.string.show_hold_to_append_key), true)) {
-                Toast.makeText(activity, R.string.hold_to_append, Toast.LENGTH_SHORT).show();
-            }
+            showHoldToAppendTipIfNeeded();
         });
         playlistControlBinding.playlistCtrlPlayPopupButton.setOnClickListener(view -> {
             NavigationHelper.playOnPopupPlayer(activity, getPlayQueue(), false);
-            if (PreferenceManager.getDefaultSharedPreferences(activity)
-                    .getBoolean(getString(R.string.show_hold_to_append_key), true)) {
-                Toast.makeText(activity, R.string.hold_to_append, Toast.LENGTH_SHORT).show();
-            }
+            showHoldToAppendTipIfNeeded();
         });
         playlistControlBinding.playlistCtrlPlayBgButton.setOnClickListener(view -> {
             NavigationHelper.playOnBackgroundPlayer(activity, getPlayQueue(), false);
-            if (PreferenceManager.getDefaultSharedPreferences(activity)
-                    .getBoolean(getString(R.string.show_hold_to_append_key), true)) {
-                Toast.makeText(activity, R.string.hold_to_append, Toast.LENGTH_SHORT).show();
-            }
+            showHoldToAppendTipIfNeeded();
         });
         playlistControlBinding.playlistCtrlPlayPopupButton.setOnLongClickListener(view -> {
             NavigationHelper.enqueueOnPlayer(activity, getPlayQueue(), PlayerType.POPUP);
@@ -536,6 +527,13 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
         });
 
         hideLoading();
+    }
+
+    private void showHoldToAppendTipIfNeeded() {
+        if (PreferenceManager.getDefaultSharedPreferences(activity)
+                .getBoolean(getString(R.string.show_hold_to_append_key), true)) {
+            Toast.makeText(activity, R.string.hold_to_append, Toast.LENGTH_SHORT).show();
+        }
     }
 
     ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Display a Toast with the text "Hold to enqueue" when either one of the headers(background, play all, popup) in a playlist is clicked

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before: 

https://user-images.githubusercontent.com/111133681/197704289-9b91cb74-7e78-403e-a029-dc79e00838d1.mov

- After:

https://user-images.githubusercontent.com/111133681/197704754-96f61ea1-ed58-4fb5-b7e8-7d5b88753878.mov

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes  #9130


#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
