### PR TITLE
Youtube kiosk (Trending Music) addition Issue #8801 (Partial Solution) 

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -242,10 +242,6 @@ public class MainActivity extends AppCompatActivity {
         drawerLayoutBinding.navigation.getMenu()
                 .add(R.id.menu_tabs_group, ITEM_ID_HISTORY, ORDER, R.string.action_history)
                 .setIcon(R.drawable.ic_history);
-        drawerLayoutBinding.navigation.getMenu()
-                .add(R.id.menu_tabs_group, ITEM_ID_TRENDING_MUSIC, ORDER,
-                        R.string.tab_trending_music)
-                .setIcon(R.drawable.ic_trending_up);
 
         //Settings and About
         drawerLayoutBinding.navigation.getMenu()
@@ -305,10 +301,6 @@ public class MainActivity extends AppCompatActivity {
                 break;
             case ITEM_ID_HISTORY:
                 NavigationHelper.openStatisticFragment(getSupportFragmentManager());
-                break;
-            case ITEM_ID_TRENDING_MUSIC:
-                NavigationHelper.openKioskFragment(getSupportFragmentManager(),
-                        ITEM_ID_TRENDING_MUSIC, "Trending Music");
                 break;
             default:
                 final int currentServiceId = ServiceHelper.getSelectedServiceId(this);

--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -306,6 +306,10 @@ public class MainActivity extends AppCompatActivity {
             case ITEM_ID_HISTORY:
                 NavigationHelper.openStatisticFragment(getSupportFragmentManager());
                 break;
+            case ITEM_ID_TRENDING_MUSIC:
+                NavigationHelper.openKioskFragment(getSupportFragmentManager(),
+                        ITEM_ID_TRENDING_MUSIC, "Trending Music");
+                break;
             default:
                 final int currentServiceId = ServiceHelper.getSelectedServiceId(this);
                 final StreamingService service = NewPipe.getService(currentServiceId);

--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -113,6 +113,7 @@ public class MainActivity extends AppCompatActivity {
     private static final int ITEM_ID_BOOKMARKS = -3;
     private static final int ITEM_ID_DOWNLOADS = -4;
     private static final int ITEM_ID_HISTORY = -5;
+    private static final int ITEM_ID_TRENDING_MUSIC = -6;
     private static final int ITEM_ID_SETTINGS = 0;
     private static final int ITEM_ID_ABOUT = 1;
 
@@ -225,7 +226,6 @@ public class MainActivity extends AppCompatActivity {
                     .setIcon(KioskTranslator.getKioskIcon(ks));
             kioskId++;
         }
-
         drawerLayoutBinding.navigation.getMenu()
                 .add(R.id.menu_tabs_group, ITEM_ID_SUBSCRIPTIONS, ORDER,
                         R.string.tab_subscriptions)
@@ -242,6 +242,10 @@ public class MainActivity extends AppCompatActivity {
         drawerLayoutBinding.navigation.getMenu()
                 .add(R.id.menu_tabs_group, ITEM_ID_HISTORY, ORDER, R.string.action_history)
                 .setIcon(R.drawable.ic_history);
+        drawerLayoutBinding.navigation.getMenu()
+                .add(R.id.menu_tabs_group, ITEM_ID_TRENDING_MUSIC, ORDER,
+                        R.string.tab_trending_music)
+                .setIcon(R.drawable.ic_trending_up);
 
         //Settings and About
         drawerLayoutBinding.navigation.getMenu()

--- a/app/src/main/java/org/schabi/newpipe/util/KioskTranslator.java
+++ b/app/src/main/java/org/schabi/newpipe/util/KioskTranslator.java
@@ -77,6 +77,8 @@ public final class KioskTranslator {
                 return R.drawable.ic_stars;
             case "Radio":
                 return R.drawable.ic_radio;
+            case "Trending Music":
+                return R.drawable.ic_music_note;
             default:
                 return 0;
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,6 +29,7 @@
     <string name="subscription_change_failed">Could not change subscription</string>
     <string name="subscription_update_failed">Could not update subscription</string>
     <string name="show_info">Show info</string>
+    <string name="tab_trending_music">Trending Music</string>
     <string name="tab_subscriptions">Subscriptions</string>
     <string name="tab_bookmarks">Bookmarked Playlists</string>
     <string name="tab_choose">Choose Tab</string>

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,8 +4,8 @@ include ':app'
 // We assume, that NewPipe and NewPipe Extractor have the same parent directory.
 // If this is not the case, please change the path in includeBuild().
 
-//includeBuild('../NewPipeExtractor') {
-//    dependencySubstitution {
-//        substitute module('com.github.TeamNewPipe:NewPipeExtractor') using project(':extractor')
-//    }
-//}
+includeBuild('../NewPipeExtractor') {
+    dependencySubstitution {
+        substitute module('com.github.TeamNewPipe:NewPipeExtractor') using project(':extractor')
+    }
+}


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
I have added the Youtube Music Trending Kiosk. However I was unable to get a link to the YouTube music trending page so the Youtube Trending Music kiosk diusplays Trending feed until a fix can be found.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #8801

NewPipeExtractor: https://github.com/TeamNewPipe/NewPipeExtractor/pull/955
#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
