### PR TITLE
Update extractor to fix Jitpack failures in CI

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -187,7 +187,7 @@ dependencies {
     // name and the commit hash with the commit hash of the (pushed) commit you want to test
     // This works thanks to JitPack: https://jitpack.io/
     implementation 'com.github.TeamNewPipe:nanojson:1d9e1aea9049fc9f85e68b43ba39fe7be1c1f751'
-    implementation 'com.github.TeamNewPipe:NewPipeExtractor:5c710da160f488bb40ab2cf4469bec9bd4cefd38'
+    implementation 'com.github.TeamNewPipe:NewPipeExtractor:9ffdd0948b2ecd82655f5ff2a3e127b2b7695d5b'
     implementation 'com.github.TeamNewPipe:NoNonsense-FilePicker:5.0.0'
 
 /** Checkstyle **/


### PR DESCRIPTION
Jitpack seems to have deleted the previous commit form their servers (5c710da160f488bb40ab2cf4469bec9bd4cefd38). This PR will be merged as soon as the CI passes.