### PR TITLE
Fix duplicate videos in feed group "All"

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/database/feed/dao/FeedDAO.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/feed/dao/FeedDAO.kt
@@ -48,7 +48,10 @@ abstract class FeedDAO {
         ON s.uid = f.stream_id
 
         LEFT JOIN feed_group_subscription_join fgs
-        ON fgs.subscription_id = f.subscription_id
+        ON (
+            :groupId <> ${FeedGroupEntity.GROUP_ALL_ID}
+            AND fgs.subscription_id = f.subscription_id
+        )
 
         WHERE (
             :groupId = ${FeedGroupEntity.GROUP_ALL_ID}

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
@@ -27,7 +27,7 @@ import com.xwray.groupie.viewbinding.GroupieViewHolder
 import icepick.State
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import org.schabi.newpipe.R
-import org.schabi.newpipe.database.feed.model.FeedGroupEntity
+import org.schabi.newpipe.database.feed.model.FeedGroupEntity.Companion.GROUP_ALL_ID
 import org.schabi.newpipe.databinding.DialogTitleBinding
 import org.schabi.newpipe.databinding.FeedItemCarouselBinding
 import org.schabi.newpipe.databinding.FragmentSubscriptionBinding
@@ -276,14 +276,8 @@ class SubscriptionFragment : BaseStateFragment<SubscriptionState>() {
                 }
             }
             carouselAdapter.setOnItemLongClickListener { item, _ ->
-                if ((
-                    item is FeedGroupCardItem &&
-                        item.groupId == FeedGroupEntity.GROUP_ALL_ID
-                    ) ||
-                    (
-                        item is FeedGroupCardGridItem &&
-                            item.groupId == FeedGroupEntity.GROUP_ALL_ID
-                        )
+                if ((item is FeedGroupCardItem && item.groupId == GROUP_ALL_ID) ||
+                    (item is FeedGroupCardGridItem && item.groupId == GROUP_ALL_ID)
                 ) {
                     return@setOnItemLongClickListener false
                 }
@@ -437,10 +431,10 @@ class SubscriptionFragment : BaseStateFragment<SubscriptionState>() {
                 clear()
                 if (listViewMode) {
                     add(FeedGroupAddNewItem())
-                    add(FeedGroupCardItem(-1, getString(R.string.all), FeedGroupIcon.RSS))
+                    add(FeedGroupCardItem(GROUP_ALL_ID, getString(R.string.all), FeedGroupIcon.RSS))
                 } else {
                     add(FeedGroupAddNewGridItem())
-                    add(FeedGroupCardGridItem(-1, getString(R.string.all), FeedGroupIcon.RSS))
+                    add(FeedGroupCardGridItem(GROUP_ALL_ID, getString(R.string.all), FeedGroupIcon.RSS))
                 }
                 addAll(groups)
             }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
In #8621 I deduplicated the queries to get feed info, but I made a mistake regarding the "All" group. The LEFT JOIN of the subscription table with the feed groups table rightfully generates multiple results for each subscription (since it is a join), but, for user-created groups, all results except for at most one are, in the end, filtered out by the first condition in the WHERE, because a subscription can appear in a group at most once. When the query was used for the "All" group, though, the first condition in the WHERE would not do anything (the reasoning behind this was to allow subscriptions independently of groups), causing duplicate subscription results to be generated (i.e. one per group the subscription belonged to). This PR fixes the problem by just making the condition on the LEFT JOIN stricter: since when we are selecting all subscriptions we don't need data about groups, the LEFT JOIN now always fails since the condition in the ON would evaluate to false when groupId=all. Therefore, since we are using a left join, it is ok for the groups table columns to not exist, and hence exactly one result gets generated.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #9024

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
