### PR TITLE
Make PendingIntents immutable on Android 6.0 and later.

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/NewVersionWorker.kt
+++ b/app/src/main/java/org/schabi/newpipe/NewVersionWorker.kt
@@ -1,6 +1,5 @@
 package org.schabi.newpipe
 
-import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.util.Log
@@ -18,6 +17,7 @@ import com.grack.nanojson.JsonParser
 import com.grack.nanojson.JsonParserException
 import org.schabi.newpipe.extractor.downloader.Response
 import org.schabi.newpipe.extractor.exceptions.ReCaptchaException
+import org.schabi.newpipe.util.PendingIntentCompat
 import org.schabi.newpipe.util.ReleaseVersionUtil.coerceUpdateCheckExpiry
 import org.schabi.newpipe.util.ReleaseVersionUtil.isLastUpdateCheckExpired
 import org.schabi.newpipe.util.ReleaseVersionUtil.isReleaseApk
@@ -49,7 +49,7 @@ class NewVersionWorker(
         // A pending intent to open the apk location url in the browser.
         val intent = Intent(Intent.ACTION_VIEW, apkLocationUrl?.toUri())
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        val pendingIntent = PendingIntent.getActivity(app, 0, intent, 0)
+        val pendingIntent = PendingIntentCompat.getActivity(app, 0, intent, 0)
         val channelId = app.getString(R.string.app_update_notification_channel_id)
         val notificationBuilder = NotificationCompat.Builder(app, channelId)
             .setSmallIcon(R.drawable.ic_newpipe_update)

--- a/app/src/main/java/org/schabi/newpipe/error/ErrorUtil.kt
+++ b/app/src/main/java/org/schabi/newpipe/error/ErrorUtil.kt
@@ -5,7 +5,6 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.graphics.Color
-import android.os.Build
 import android.view.View
 import android.widget.Toast
 import androidx.core.app.NotificationCompat
@@ -13,6 +12,7 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.fragment.app.Fragment
 import com.google.android.material.snackbar.Snackbar
 import org.schabi.newpipe.R
+import org.schabi.newpipe.util.PendingIntentCompat
 
 /**
  * This class contains all of the methods that should be used to let the user know that an error has
@@ -104,11 +104,6 @@ class ErrorUtil {
          */
         @JvmStatic
         fun createNotification(context: Context, errorInfo: ErrorInfo) {
-            var pendingIntentFlags = PendingIntent.FLAG_UPDATE_CURRENT
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                pendingIntentFlags = pendingIntentFlags or PendingIntent.FLAG_IMMUTABLE
-            }
-
             val notificationBuilder: NotificationCompat.Builder =
                 NotificationCompat.Builder(
                     context,
@@ -119,11 +114,11 @@ class ErrorUtil {
                     .setContentText(context.getString(errorInfo.messageStringId))
                     .setAutoCancel(true)
                     .setContentIntent(
-                        PendingIntent.getActivity(
+                        PendingIntentCompat.getActivity(
                             context,
                             0,
                             getErrorActivityIntent(context, errorInfo),
-                            pendingIntentFlags
+                            PendingIntent.FLAG_UPDATE_CURRENT
                         )
                     )
 

--- a/app/src/main/java/org/schabi/newpipe/local/feed/notifications/NotificationHelper.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/notifications/NotificationHelper.kt
@@ -1,7 +1,6 @@
 package org.schabi.newpipe.local.feed.notifications
 
 import android.app.NotificationManager
-import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
@@ -20,6 +19,7 @@ import org.schabi.newpipe.extractor.stream.StreamInfoItem
 import org.schabi.newpipe.local.feed.service.FeedUpdateInfo
 import org.schabi.newpipe.util.Localization
 import org.schabi.newpipe.util.NavigationHelper
+import org.schabi.newpipe.util.PendingIntentCompat
 import org.schabi.newpipe.util.PicassoHelper
 
 /**
@@ -70,16 +70,13 @@ class NotificationHelper(val context: Context) {
 
         // open the channel page when clicking on the notification
         builder.setContentIntent(
-            PendingIntent.getActivity(
+            PendingIntentCompat.getActivity(
                 context,
                 data.pseudoId,
                 NavigationHelper
                     .getChannelIntent(context, data.listInfo.serviceId, data.listInfo.url)
                     .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
-                    PendingIntent.FLAG_IMMUTABLE
-                else
-                    0
+                0
             )
         )
 

--- a/app/src/main/java/org/schabi/newpipe/local/feed/service/FeedLoadService.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/service/FeedLoadService.kt
@@ -19,7 +19,6 @@
 
 package org.schabi.newpipe.local.feed.service
 
-import android.app.PendingIntent
 import android.app.Service
 import android.content.BroadcastReceiver
 import android.content.Context
@@ -43,6 +42,7 @@ import org.schabi.newpipe.extractor.ListInfo
 import org.schabi.newpipe.extractor.stream.StreamInfoItem
 import org.schabi.newpipe.local.feed.service.FeedEventManager.Event.ErrorResultEvent
 import org.schabi.newpipe.local.feed.service.FeedEventManager.postEvent
+import org.schabi.newpipe.util.PendingIntentCompat
 import java.util.concurrent.TimeUnit
 
 class FeedLoadService : Service() {
@@ -152,12 +152,8 @@ class FeedLoadService : Service() {
     private lateinit var notificationBuilder: NotificationCompat.Builder
 
     private fun createNotification(): NotificationCompat.Builder {
-        val cancelActionIntent = PendingIntent.getBroadcast(
-            this,
-            NOTIFICATION_ID,
-            Intent(ACTION_CANCEL),
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) PendingIntent.FLAG_IMMUTABLE else 0
-        )
+        val cancelActionIntent =
+            PendingIntentCompat.getBroadcast(this, NOTIFICATION_ID, Intent(ACTION_CANCEL), 0)
 
         return NotificationCompat.Builder(this, getString(R.string.notification_channel_id))
             .setOngoing(true)

--- a/app/src/main/java/org/schabi/newpipe/player/notification/NotificationUtil.java
+++ b/app/src/main/java/org/schabi/newpipe/player/notification/NotificationUtil.java
@@ -1,7 +1,6 @@
 package org.schabi.newpipe.player.notification;
 
 import android.annotation.SuppressLint;
-import android.app.PendingIntent;
 import android.content.Intent;
 import android.content.pm.ServiceInfo;
 import android.graphics.Bitmap;
@@ -22,6 +21,7 @@ import org.schabi.newpipe.R;
 import org.schabi.newpipe.player.Player;
 import org.schabi.newpipe.player.mediasession.MediaSessionPlayerUi;
 import org.schabi.newpipe.util.NavigationHelper;
+import org.schabi.newpipe.util.PendingIntentCompat;
 
 import java.util.List;
 import java.util.Objects;
@@ -133,8 +133,8 @@ public final class NotificationUtil {
                         R.color.dark_background_color))
                 .setColorized(player.getPrefs().getBoolean(
                         player.getContext().getString(R.string.notification_colorize_key), true))
-                .setDeleteIntent(PendingIntent.getBroadcast(player.getContext(), NOTIFICATION_ID,
-                        new Intent(ACTION_CLOSE), FLAG_UPDATE_CURRENT));
+                .setDeleteIntent(PendingIntentCompat.getBroadcast(player.getContext(),
+                        NOTIFICATION_ID, new Intent(ACTION_CLOSE), FLAG_UPDATE_CURRENT));
 
         // set the initial value for the video thumbnail, updatable with updateNotificationThumbnail
         setLargeIcon(builder);
@@ -151,7 +151,7 @@ public final class NotificationUtil {
         }
 
         // also update content intent, in case the user switched players
-        notificationBuilder.setContentIntent(PendingIntent.getActivity(player.getContext(),
+        notificationBuilder.setContentIntent(PendingIntentCompat.getActivity(player.getContext(),
                 NOTIFICATION_ID, getIntentForNotification(), FLAG_UPDATE_CURRENT));
         notificationBuilder.setContentTitle(player.getVideoTitle());
         notificationBuilder.setContentText(player.getUploaderName());
@@ -334,7 +334,7 @@ public final class NotificationUtil {
                                                 @StringRes final int title,
                                                 final String intentAction) {
         return new NotificationCompat.Action(drawable, player.getContext().getString(title),
-                PendingIntent.getBroadcast(player.getContext(), NOTIFICATION_ID,
+                PendingIntentCompat.getBroadcast(player.getContext(), NOTIFICATION_ID,
                         new Intent(intentAction), FLAG_UPDATE_CURRENT));
     }
 

--- a/app/src/main/java/org/schabi/newpipe/util/PendingIntentCompat.java
+++ b/app/src/main/java/org/schabi/newpipe/util/PendingIntentCompat.java
@@ -1,0 +1,69 @@
+package org.schabi.newpipe.util;
+
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+
+import androidx.annotation.NonNull;
+
+public final class PendingIntentCompat {
+    private PendingIntentCompat() {
+    }
+
+    private static int addImmutableFlag(final int flags) {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
+                ? flags | PendingIntent.FLAG_IMMUTABLE : flags;
+    }
+
+    /**
+     * Creates a {@link PendingIntent} to start an activity. It is immutable on API level 23 and
+     * greater.
+     *
+     * @param context     The context in which the activity should be started.
+     * @param requestCode The request code
+     * @param intent      The Intent of the activity to be launched.
+     * @param flags       The flags for the intent.
+     * @return The pending intent.
+     * @see PendingIntent#getActivity(Context, int, Intent, int)
+     */
+    @NonNull
+    public static PendingIntent getActivity(@NonNull final Context context, final int requestCode,
+                                            @NonNull final Intent intent, final int flags) {
+        return PendingIntent.getActivity(context, requestCode, intent, addImmutableFlag(flags));
+    }
+
+    /**
+     * Creates a {@link PendingIntent} to start a service. It is immutable on API level 23 and
+     * greater.
+     *
+     * @param context     The context in which the service should be started.
+     * @param requestCode The request code
+     * @param intent      The Intent of the service to be launched.
+     * @param flags       The flags for the intent.
+     * @return The pending intent.
+     * @see PendingIntent#getService(Context, int, Intent, int)
+     */
+    @NonNull
+    public static PendingIntent getService(@NonNull final Context context, final int requestCode,
+                                           @NonNull final Intent intent, final int flags) {
+        return PendingIntent.getService(context, requestCode, intent, addImmutableFlag(flags));
+    }
+
+    /**
+     * Creates a {@link PendingIntent} to perform a broadcast. It is immutable on API level 23 and
+     * greater.
+     *
+     * @param context     The context in which the broadcast should be performed.
+     * @param requestCode The request code
+     * @param intent      The Intent to be broadcast.
+     * @param flags       The flags for the intent.
+     * @return The pending intent.
+     * @see PendingIntent#getBroadcast(Context, int, Intent, int)
+     */
+    @NonNull
+    public static PendingIntent getBroadcast(@NonNull final Context context, final int requestCode,
+                                             @NonNull final Intent intent, final int flags) {
+        return PendingIntent.getBroadcast(context, requestCode, intent, addImmutableFlag(flags));
+    }
+}

--- a/app/src/main/java/us/shandian/giga/service/DownloadManagerService.java
+++ b/app/src/main/java/us/shandian/giga/service/DownloadManagerService.java
@@ -47,6 +47,7 @@ import us.shandian.giga.get.MissionRecoveryInfo;
 import org.schabi.newpipe.streams.io.StoredDirectoryHelper;
 import org.schabi.newpipe.streams.io.StoredFileHelper;
 import org.schabi.newpipe.util.Localization;
+import org.schabi.newpipe.util.PendingIntentCompat;
 
 import us.shandian.giga.postprocessing.Postprocessing;
 import us.shandian.giga.service.DownloadManager.NetworkState;
@@ -142,7 +143,7 @@ public class DownloadManagerService extends Service {
         Intent openDownloadListIntent = new Intent(this, DownloadActivity.class)
                 .setAction(Intent.ACTION_MAIN);
 
-        mOpenDownloadList = PendingIntent.getActivity(this, 0,
+        mOpenDownloadList = PendingIntentCompat.getActivity(this, 0,
                 openDownloadListIntent,
                 PendingIntent.FLAG_UPDATE_CURRENT);
 
@@ -484,7 +485,8 @@ public class DownloadManagerService extends Service {
 
     private PendingIntent makePendingIntent(String action) {
         Intent intent = new Intent(this, DownloadManagerService.class).setAction(action);
-        return PendingIntent.getService(this, intent.hashCode(), intent, PendingIntent.FLAG_UPDATE_CURRENT);
+        return PendingIntentCompat.getService(this, intent.hashCode(), intent,
+                PendingIntent.FLAG_UPDATE_CURRENT);
     }
 
     private void manageLock(boolean acquire) {


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Make the `PendingIntent`s created in the app immutable on Android 6.0 and later. This prevents issues with `PendingIntent`s occurring [when targeting Android 12 and later](https://developer.android.com/about/versions/12/behavior-changes-12#pending-intent-mutability) in #9306.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
