### PR TITLE
Add boolean for BRAVIA_VH1 & disable media tunneling support

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
@@ -50,6 +50,9 @@ public final class DeviceUtils {
     // Philips QM16XE
     private static final boolean QM16XE_U = Build.VERSION.SDK_INT == 23
             && Build.DEVICE.equals("QM16XE_U");
+    // Sony Bravia
+    private static final boolean BRAVIA_VH1 = Build.VERSION.SDK_INT == 29
+            && Build.DEVICE.equals("BRAVIA_VH1");
 
     private DeviceUtils() {
     }
@@ -215,7 +218,8 @@ public final class DeviceUtils {
         return !HI3798MV200
                 && !CVT_MT5886_EU_1G
                 && !REALTEKATV
-                && !QM16XE_U;
+                && !QM16XE_U
+                && !BRAVIA_VH1;
     }
 
     public static boolean isLandscape(final Context context) {


### PR DESCRIPTION
#### What is it?
- [+] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Restores the ability to go fullscreen on Sony Bravia HV1 smart TVs from 0.24.0+. Also fixes long standing issue that results in frequent crashes between videos.

#### Fixes the following issue(s)
- Fixes #9023 (for Sony Bravia VH1 only)

#### APK testing
https://github.com/glbyers/NewPipe/raw/5447dfbdcaf1f6b8fd9e3a75bffea2a5025ac97d/app-debug.apk

#### Due diligence
- [+] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
