### PR TITLE
Fixed a bug that incorrectly removed videos from a playlist when using the "Remove Viewed" dialog

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
@@ -404,7 +404,7 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
                 .firstElement()
                 .zipWith(historyIdsMaybe, (playlist, historyStreamIds) -> {
                     // Remove Watched, Functionality data
-                    final List<PlaylistStreamEntry> notWatchedItems = new ArrayList<>();
+                    final List<PlaylistStreamEntry> itemsToKeep = new ArrayList<>();
                     final boolean isThumbnailPermanent = playlistManager
                             .getIsPlaylistThumbnailPermanent(playlistId);
                     boolean thumbnailVideoRemoved = false;
@@ -415,7 +415,7 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
                                     playlistItem.getStreamId());
 
                             if (indexInHistory < 0) {
-                                notWatchedItems.add(playlistItem);
+                                itemsToKeep.add(playlistItem);
                             } else if (!isThumbnailPermanent && !thumbnailVideoRemoved
                                     && playlistManager.getPlaylistThumbnail(playlistId)
                                     .equals(playlistItem.getStreamEntity().getThumbnailUrl())) {
@@ -436,7 +436,7 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
 
                             if (indexInHistory < 0 || (streamStateEntity != null
                                     && !streamStateEntity.isFinished(duration))) {
-                                notWatchedItems.add(playlistItem);
+                                itemsToKeep.add(playlistItem);
                             } else if (!isThumbnailPermanent && !thumbnailVideoRemoved
                                     && playlistManager.getPlaylistThumbnail(playlistId)
                                     .equals(playlistItem.getStreamEntity().getThumbnailUrl())) {
@@ -445,17 +445,17 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
                         }
                     }
 
-                    return new Pair<>(notWatchedItems, thumbnailVideoRemoved);
+                    return new Pair<>(itemsToKeep, thumbnailVideoRemoved);
                 });
 
         disposables.add(streamsMaybe.subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(flow -> {
-                    final List<PlaylistStreamEntry> notWatchedItems = flow.first;
+                    final List<PlaylistStreamEntry> itemsToKeep = flow.first;
                     final boolean thumbnailVideoRemoved = flow.second;
 
                     itemListAdapter.clearStreamItemList();
-                    itemListAdapter.addItems(notWatchedItems);
+                    itemListAdapter.addItems(itemsToKeep);
                     saveChanges();
 
                     if (thumbnailVideoRemoved) {


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [X] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
After a lot of troubleshooting, I found out that this bug is bigger than I initially thought, as I encountered another issue: If you manually remove videos from your playlist and then use the "Removed Watched Videos" feature, the manually deleted videos reappear. 
The reason why these bugs occur is that the streamStateTable is not up-to-date when you remove the watched videos. However, updating the playlist/streamStateTable beforehand doesn't work either, as we only save the state of an entity if it has been viewed for more than 5 seconds (maybe you want to use this feature directly after starting to watch a video). I wouldn't recommend lowering this number, as it would cause accidentally clicked videos to be counted as viewed as well.  
Therefore, I decided to slightly change the way we remove these videos. Instead of clearing the entire playlist and reinserting all the “not watched videos”, I decided to collect the “watched videos” and remove them from the playlist. This approach is IMO the best option.
This will be my first bug fix for NewPipe, so if there is anything I did wrong, please let me know and I will fix it. 

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #9122 

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [X] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
