### PR TITLE
Fixed bug that lead to faulty playlist thumbnail updates

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
@@ -73,6 +73,8 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
     // Save the list 10 seconds after the last change occurred
     private static final long SAVE_DEBOUNCE_MILLIS = 10000;
     private static final int MINIMUM_INITIAL_DRAG_VELOCITY = 12;
+    private static final int VIDEO_ID_NO_LONGER_IN_PLAYLIST = -1;
+
     @State
     protected Long playlistId;
     @State
@@ -472,6 +474,49 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
                         "Removing watched videos, partially watched=" + removePartiallyWatched))));
     }
 
+    /**
+     * If the current thumbnail has changed but the video is still the same, this method will update
+     * the playlist thumbnail accordingly.
+     *
+     * @param currentItems List of items currently in the playlist
+     * @param updatedItems List of items that will replace the current items in the playlist
+     */
+    private void updateCurrentThumbnail(@NonNull final List<LocalItem> currentItems,
+                                        @NonNull final List<PlaylistStreamEntry> updatedItems) {
+
+        final String playlistThumbnail = playlistManager.getPlaylistThumbnail(playlistId);
+        long streamId = VIDEO_ID_NO_LONGER_IN_PLAYLIST;
+
+        // Find the streamId of the current thumbnail video
+        for (final LocalItem item : currentItems) {
+            if (playlistThumbnail.equals(((PlaylistStreamEntry) item).getStreamEntity()
+                    .getThumbnailUrl())) {
+                streamId = ((PlaylistStreamEntry) item).getStreamId();
+            }
+        }
+
+        if (streamId == VIDEO_ID_NO_LONGER_IN_PLAYLIST) {
+            return;
+        }
+
+        // If the video has a different thumbnail now, update the playlist thumbnail accordingly
+        for (final PlaylistStreamEntry item : updatedItems) {
+
+            if (streamId == item.getStreamId()
+                    && !playlistThumbnail.equals(item.getStreamEntity().getThumbnailUrl())) {
+                final String newThumbnailUrl = item.getStreamEntity().getThumbnailUrl();
+
+                final Disposable disposable = playlistManager
+                        .changePlaylistThumbnail(playlistId, newThumbnailUrl)
+                        .observeOn(AndroidSchedulers.mainThread())
+                        .subscribe(ignored -> Log.d(TAG, "Updating current thumbnail with new"
+                                + "url=[" + newThumbnailUrl + "]"));
+                disposables.add(disposable);
+            }
+
+        }
+    }
+
     @Override
     public void handleResult(@NonNull final List<PlaylistStreamEntry> result) {
         super.handleResult(result);
@@ -479,6 +524,7 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
             return;
         }
 
+        updateCurrentThumbnail(itemListAdapter.getItemsList(), result);
         itemListAdapter.clearStreamItemList();
 
         if (result.isEmpty()) {


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [X] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
This is an attempt to fix the bug mentioned in #9458.

I found out that this bug not only happens if you play videos in the background but also if you watch them “normally”.
The problem is that there are two types of thumbnails. There is a low- and a high-resolution thumbnail for every video. So, after you start watching a video in a particular playlist, the thumbnail of the watched item changes from low to high resolution. However, this change is not detected in the playlist. Therefore, all of the following equality checks no longer work because you are comparing the low-resolution and high-resolution thumbanails, which have completely different URLs. 

I thought about adding a field that stores both versions. However, this implementation felt like a temporary hack and would most likely cause unnecessary database bloat. 
Therefore, I decided to check the "Thumbnail" video for a change of the thumbnail every time the items in the playlist are changed or replaced. This solution has another advantage as well. When the creator of a YouTube video changes the thumbnail, it should be automatically updated in NewPipe.

If there is anything I did wrong, please let me know and I will fix it. 

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #9458 

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [X] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
