### PR TITLE
Set image-minimizer to specify image width ...

### DIFF
--- a/.github/workflows/image-minimizer.js
+++ b/.github/workflows/image-minimizer.js
@@ -88,7 +88,7 @@ module.exports = async ({github, context}) => {
         if (shouldModify) {
             wasMatchModified = true;
             console.log(`Modifying match '${match}'`);
-            return `<img alt="${g1}" src="${g2}" width=${(IMG_MAX_HEIGHT_PX * probeAspectRatio).toFixed(0)} />`;
+            return `<img alt="${g1}" src="${g2}" width=${Math.min(600, (IMG_MAX_HEIGHT_PX * probeAspectRatio).toFixed(0))} />`;
         }
         
         console.log(`Match '${match}' is ok/will not be modified`);

--- a/.github/workflows/image-minimizer.js
+++ b/.github/workflows/image-minimizer.js
@@ -86,7 +86,7 @@ module.exports = async ({github, context}) => {
         if (shouldModify) {
             wasMatchModified = true;
             console.log(`Modifying match '${match}'`);
-            return `<img alt="${g1}" src="${g2}" height=${IMG_MAX_HEIGHT_PX} />`;
+            return `<img alt="${g1}" src="${g2}" width=${IMG_MAX_WIDTH_PX} />`;
         }
         
         console.log(`Match '${match}' is ok/will not be modified`);

--- a/.github/workflows/image-minimizer.js
+++ b/.github/workflows/image-minimizer.js
@@ -55,6 +55,7 @@ module.exports = async ({github, context}) => {
             return match;
         }
         
+        let probeAspectRatio = 0;
         let shouldModify = false;
         try {
             console.log(`Probing ${g2}`);
@@ -76,7 +77,8 @@ module.exports = async ({github, context}) => {
             }
             console.log(`Probing resulted in ${probeResult.width}x${probeResult.height}px`);
             
-            shouldModify = probeResult.height > IMG_MAX_HEIGHT_PX && (probeResult.width / probeResult.height) < MIN_ASPECT_RATIO;
+            probeAspectRatio = probeResult.width / probeResult.height;
+            shouldModify = probeResult.height > IMG_MAX_HEIGHT_PX && probeAspectRatio < MIN_ASPECT_RATIO;
         } catch(e) {
             console.log('Probing failed:', e);
             // Immediately abort
@@ -86,7 +88,7 @@ module.exports = async ({github, context}) => {
         if (shouldModify) {
             wasMatchModified = true;
             console.log(`Modifying match '${match}'`);
-            return `<img alt="${g1}" src="${g2}" width=${((IMG_MAX_HEIGHT_PX * probeResult.width) / probeResult.height).toFixed(0)} />`;
+            return `<img alt="${g1}" src="${g2}" width=${(IMG_MAX_HEIGHT_PX * probeAspectRatio).toFixed(0)} />`;
         }
         
         console.log(`Match '${match}' is ok/will not be modified`);

--- a/.github/workflows/image-minimizer.js
+++ b/.github/workflows/image-minimizer.js
@@ -86,7 +86,7 @@ module.exports = async ({github, context}) => {
         if (shouldModify) {
             wasMatchModified = true;
             console.log(`Modifying match '${match}'`);
-            return `<img alt="${g1}" src="${g2}" width=${IMG_MAX_WIDTH_PX} />`;
+            return `<img alt="${g1}" src="${g2}" width=${((IMG_MAX_HEIGHT_PX * probeResult.width) / probeResult.height).toFixed(0)} />`;
         }
         
         console.log(`Match '${match}' is ok/will not be modified`);


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [x] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->

- set the width of the image, instead of the height
see the rationale mentioned in the linked issue

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->

- Before:

https://user-images.githubusercontent.com/19423063/204108377-dd920f3b-eadc-4d65-b567-84a8cda03270.mp4

- After:

https://user-images.githubusercontent.com/19423063/204108380-b94bb158-f5f8-43a2-b64b-bae868a8d111.mp4

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes https://github.com/TeamNewPipe/NewPipe/issues/9469 for portrait like orientations


#### Testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->

* Try adding the test images at https://github.com/yashpalgoyal1304/NewPipe/issues/1
* And for resizing the viewerport: use "Device Toolbar" in the browser's dev tools, 
* ... which in chromium is triggered by: in caret arrow notation](https://en.wikipedia.org/wiki/Caret_notation): `^↑i` > `^↑m` or say in [Emacs notation](https://www.emacswiki.org/emacs/EmacsKeyNotation): `C-I` > `C-M`

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).