### PR TITLE
Made the content restriction toggles dependent on each other

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
@@ -130,22 +130,14 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
             } else {
                 Log.w(TAG, "onPreferenceTreeClick: null context");
             }
-            if (restrictedMode.isChecked()) {
-                findPreference(getString(R.string.show_age_restricted_content)).setEnabled(false);
-            } else {
-                findPreference(getString(R.string.show_age_restricted_content)).setEnabled(true);
-            }
+            findPreference(getString(R.string.show_age_restricted_content))
+                    .setEnabled(!restrictedMode.isChecked());
         }
         if (preference.getKey().equals(getString(R.string.show_age_restricted_content))) {
             final SwitchPreferenceCompat showRestrictedContent =
                     (SwitchPreferenceCompat) preference;
-            if (showRestrictedContent.isChecked()) {
-                findPreference(getString(R.string.youtube_restricted_mode_enabled))
-                        .setEnabled(false);
-            } else {
-                findPreference(getString(R.string.youtube_restricted_mode_enabled))
-                        .setEnabled(true);
-            }
+            findPreference(getString(R.string.youtube_restricted_mode_enabled))
+                    .setEnabled(!showRestrictedContent.isChecked());
         }
 
         return super.onPreferenceTreeClick(preference);

--- a/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
@@ -19,6 +19,7 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.core.content.ContextCompat;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceManager;
+import androidx.preference.SwitchPreferenceCompat;
 
 import org.schabi.newpipe.DownloaderImpl;
 import org.schabi.newpipe.NewPipeDatabase;
@@ -123,10 +124,27 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
     public boolean onPreferenceTreeClick(final Preference preference) {
         if (preference.getKey().equals(youtubeRestrictedModeEnabledKey)) {
             final Context context = getContext();
+            final SwitchPreferenceCompat restrictedMode = (SwitchPreferenceCompat) preference;
             if (context != null) {
                 DownloaderImpl.getInstance().updateYoutubeRestrictedModeCookies(context);
             } else {
                 Log.w(TAG, "onPreferenceTreeClick: null context");
+            }
+            if (restrictedMode.isChecked()) {
+                findPreference(getString(R.string.show_age_restricted_content)).setEnabled(false);
+            } else {
+                findPreference(getString(R.string.show_age_restricted_content)).setEnabled(true);
+            }
+        }
+        if (preference.getKey().equals(getString(R.string.show_age_restricted_content))) {
+            final SwitchPreferenceCompat showRestrictedContent =
+                    (SwitchPreferenceCompat) preference;
+            if (showRestrictedContent.isChecked()) {
+                findPreference(getString(R.string.youtube_restricted_mode_enabled))
+                        .setEnabled(false);
+            } else {
+                findPreference(getString(R.string.youtube_restricted_mode_enabled))
+                        .setEnabled(true);
             }
         }
 


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
- Made the  content restriction toggles dependent of each other
- When you click on one toggle the other toggle is disabled

#### Before/After Screenshots/Screen Record
- Before:

https://user-images.githubusercontent.com/109673982/205660719-88478d83-f58a-42f2-a7c2-0589f8e566bd.mp4


- After:

https://user-images.githubusercontent.com/109673982/205659949-0ef3a250-f017-40ba-8dc4-f58581268a6c.mp4


#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #9354 

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
