### PR TITLE
Add check for data saver

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
@@ -3,6 +3,7 @@ package org.schabi.newpipe.util;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.net.ConnectivityManager;
+import android.os.Build;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -567,7 +568,15 @@ public final class ListHelper {
     }
 
     private static boolean isLimitingDataUsage(final Context context) {
-        return getResolutionLimit(context) != null;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            final ConnectivityManager manager =
+                    ContextCompat.getSystemService(context, ConnectivityManager.class);
+            return manager.getRestrictBackgroundStatus()
+                    == manager.RESTRICT_BACKGROUND_STATUS_ENABLED
+                || getResolutionLimit(context) != null;
+        } else {
+            return getResolutionLimit(context) != null;
+        }
     }
 
     /**


### PR DESCRIPTION
This setting is called data saver for the user. (To match the equivalent setting battery saver.) I suppose anyone that use it would expect the lowest bitrate in the background. Unless i made a mistake with the logic this always use low bitrate when data saver is enabled regardless of resolutioin limit

I had no idea the resolution limit also set the background bitrate until i checked to add a setting for it. 160 or 50 kbit makes a big difference when listenting for along time.

A few comments on my use. I poersonally never use video. I will enable resolution limit now to get cheap audio. When i checked i had not enabled data saver but i enabled it now since i cant think of any reason i wouild not want it. maybe there was a reason that i forgot, like drive upl;loads not working or something. battery saver ius horrendoues but i think i like data saver fine it doesnt have any strange side effects. I would like to see more aggressive use of it like firefox not showing any ppictures for example would be perfect

