### PR TITLE
Improve ellipsising of comments and add slide open animation

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -605,13 +605,13 @@ public final class VideoDetailFragment
                 animateRotation(binding.detailToggleSecondaryControlsView,
                         VideoPlayerUi.DEFAULT_CONTROLS_DURATION, 180);
                 AnimationUtil.expand(binding.detailSecondaryControlPanel, 500,
-                        (animatedValue, initialValue, targetValue) -> updateTabLayoutVisibility());
+                        (animatedFraction, isCollapsing) -> updateTabLayoutVisibility());
             } else {
                 AnimationUtil.collapse(binding.detailVideoTitleView, 500, 1);
                 animateRotation(binding.detailToggleSecondaryControlsView,
                         VideoPlayerUi.DEFAULT_CONTROLS_DURATION, 0);
                 AnimationUtil.collapse(binding.detailSecondaryControlPanel, 500,
-                        (animatedValue, initialValue, targetValue) -> updateTabLayoutVisibility());
+                        (animatedFraction, isCollapsing) -> updateTabLayoutVisibility());
             }
         } else {
             // legacy approach

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -613,6 +613,7 @@ public final class VideoDetailFragment
                 }
                 public void onAnimationEnd(final View v, final boolean reversed,
                                            final boolean expanded) {
+                    // no impl pls
                 }
             };
             animateListener = new WeakReference<>(listener);

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -100,7 +100,6 @@ import org.schabi.newpipe.player.playqueue.SinglePlayQueue;
 import org.schabi.newpipe.player.ui.MainPlayerUi;
 import org.schabi.newpipe.player.ui.VideoPlayerUi;
 import org.schabi.newpipe.util.AnimationUtil;
-import org.schabi.newpipe.util.AnimationUtil.OnAnimateListener;
 import org.schabi.newpipe.util.Constants;
 import org.schabi.newpipe.util.DeviceUtils;
 import org.schabi.newpipe.util.ExtractorHelper;
@@ -115,7 +114,6 @@ import org.schabi.newpipe.util.external_communication.KoreUtils;
 import org.schabi.newpipe.util.external_communication.ShareUtils;
 import org.schabi.newpipe.views.NewPipeTextView;
 
-import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -600,27 +598,6 @@ public final class VideoDetailFragment
         return true;
     }
 
-    private WeakReference<OnAnimateListener> animateListener;
-
-    private OnAnimateListener getAnimateListener() {
-        if (animateListener != null && animateListener.get() != null) {
-            return animateListener.get();
-        } else {
-            final OnAnimateListener listener = new OnAnimateListener() {
-                public void onAnimate(final int animated, final int initial, final int target) {
-                    // view pager height has changed, update the tab layout
-                    updateTabLayoutVisibility();
-                }
-                public void onAnimationEnd(final View v, final boolean reversed,
-                                           final boolean expanded) {
-                    // no impl pls
-                }
-            };
-            animateListener = new WeakReference<>(listener);
-            return listener;
-        }
-    }
-
     private void toggleTitleAndSecondaryControls() {
         if (binding.detailVideoTitleView instanceof NewPipeTextView) {
             if (binding.detailSecondaryControlPanel.getVisibility() == View.GONE) {
@@ -628,13 +605,13 @@ public final class VideoDetailFragment
                 animateRotation(binding.detailToggleSecondaryControlsView,
                         VideoPlayerUi.DEFAULT_CONTROLS_DURATION, 180);
                 AnimationUtil.expand(binding.detailSecondaryControlPanel, 500,
-                        getAnimateListener());
+                        (animatedValue, initialValue, targetValue) -> updateTabLayoutVisibility());
             } else {
                 AnimationUtil.collapse(binding.detailVideoTitleView, 500, 1);
                 animateRotation(binding.detailToggleSecondaryControlsView,
                         VideoPlayerUi.DEFAULT_CONTROLS_DURATION, 0);
                 AnimationUtil.collapse(binding.detailSecondaryControlPanel, 500,
-                        getAnimateListener());
+                        (animatedValue, initialValue, targetValue) -> updateTabLayoutVisibility());
             }
         } else {
             // legacy approach

--- a/app/src/main/java/org/schabi/newpipe/info_list/holder/CommentsMiniInfoItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/holder/CommentsMiniInfoItemHolder.java
@@ -1,5 +1,7 @@
 package org.schabi.newpipe.info_list.holder;
 
+import static org.schabi.newpipe.views.NewPipeTextView.EllipsisState;
+
 import android.text.TextUtils;
 import android.text.method.LinkMovementMethod;
 import android.text.style.URLSpan;
@@ -112,7 +114,8 @@ public class CommentsMiniInfoItemHolder extends InfoItemHolder {
             itemContentView.setMaxLines(COMMENT_DEFAULT_LINES);
             itemContentView.setEllipsize(TextUtils.TruncateAt.END);
             OneShotPreDrawListener.add(itemContentView, () -> {
-                if (((NewPipeTextView) itemContentView).ellipsisState() == 1) {
+                if (((NewPipeTextView) itemContentView).ellipsisState()
+                        == EllipsisState.EXPANDABLE) {
                     denyLinkFocus();
                 } else {
                     determineLinkFocus();
@@ -123,7 +126,8 @@ public class CommentsMiniInfoItemHolder extends InfoItemHolder {
             );
             itemView.setOnClickListener(view -> {
                 if (itemContentView.getMaxLines() != COMMENT_DEFAULT_LINES
-                        || ((NewPipeTextView) itemContentView).ellipsisState() == 1) {
+                        || ((NewPipeTextView) itemContentView).ellipsisState()
+                        == EllipsisState.EXPANDABLE) {
                     ((NewPipeTextView) itemContentView)
                             .toggle(COMMENT_DEFAULT_LINES, COMMENT_EXPANDED_LINES, 500);
                 }

--- a/app/src/main/java/org/schabi/newpipe/info_list/holder/CommentsMiniInfoItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/holder/CommentsMiniInfoItemHolder.java
@@ -118,8 +118,18 @@ public class CommentsMiniInfoItemHolder extends InfoItemHolder {
                     determineLinkFocus();
                 }
             });
-            ((NewPipeTextView) itemContentView).setOnToggleListener((textView, expanded) -> {
-                determineLinkFocus();
+            ((NewPipeTextView) itemContentView).setOnToggleListener((textView, expanded) ->
+                determineLinkFocus()
+            );
+            itemView.setOnClickListener(view -> {
+                if (itemContentView.getMaxLines() != COMMENT_DEFAULT_LINES
+                        || ((NewPipeTextView) itemContentView).ellipsisState() == 1) {
+                    ((NewPipeTextView) itemContentView)
+                            .toggle(COMMENT_DEFAULT_LINES, COMMENT_EXPANDED_LINES, 500);
+                }
+                if (itemBuilder.getOnCommentsSelectedListener() != null) {
+                    itemBuilder.getOnCommentsSelectedListener().selected(item);
+                }
             });
         }
 
@@ -139,20 +149,15 @@ public class CommentsMiniInfoItemHolder extends InfoItemHolder {
             itemPublishedTime.setText(item.getTextualUploadDate());
         }
 
-        itemView.setOnClickListener(view -> {
-            if (!(itemContentView instanceof NewPipeTextView)) {
+        if (legacyEllipsize) {
+            itemView.setOnClickListener(view -> {
                 toggleEllipsize();
-            } else {
-                if (itemContentView.getMaxLines() != COMMENT_DEFAULT_LINES
-                        || ((NewPipeTextView) itemContentView).ellipsisState() == 1) {
-                    ((NewPipeTextView) itemContentView)
-                            .toggle(COMMENT_DEFAULT_LINES, COMMENT_EXPANDED_LINES, 500);
+
+                if (itemBuilder.getOnCommentsSelectedListener() != null) {
+                    itemBuilder.getOnCommentsSelectedListener().selected(item);
                 }
-            }
-            if (itemBuilder.getOnCommentsSelectedListener() != null) {
-                itemBuilder.getOnCommentsSelectedListener().selected(item);
-            }
-        });
+            });
+        }
 
 
         itemView.setOnLongClickListener(view -> {

--- a/app/src/main/java/org/schabi/newpipe/util/AnimationUtil.java
+++ b/app/src/main/java/org/schabi/newpipe/util/AnimationUtil.java
@@ -18,8 +18,7 @@ import java.util.WeakHashMap;
 
 public final class AnimationUtil {
     /* a running list of animators in flight; they will be manually removed onAnimationEnd */
-    private static WeakHashMap<View, ValueAnimator> runningAnimators =
-            new WeakHashMap<View, ValueAnimator>();
+    private static WeakHashMap<View, ValueAnimator> runningAnimators = new WeakHashMap<>();
     /* weak references to old animators post-service for opportunistic reuse before gc'ed */
     private static Set<ValueAnimator> oldAnimators = Collections.newSetFromMap(
             new WeakHashMap<ValueAnimator, Boolean>());
@@ -82,10 +81,10 @@ public final class AnimationUtil {
         toggle(v, duration, -1, -1, true);
     }
     public static void expand(final TextView v, final int duration, final int lines) {
-        toggle((View) v, duration, -1, lines, false);
+        toggle(v, duration, -1, lines, false);
     }
     public static void collapse(final TextView v, final int duration, final int lines) {
-        toggle((View) v, duration, lines, -1, true);
+        toggle(v, duration, lines, -1, true);
     }
     public static void expand(final View v, final int duration, final OnAnimateListener listener) {
         toggle(v, duration, -1, false, listener);
@@ -152,7 +151,7 @@ public final class AnimationUtil {
             v.setVisibility(View.VISIBLE);
         }
 
-       final NewPipeAnimator valueAnimator = (a instanceof NewPipeAnimator && a != null)
+       final NewPipeAnimator valueAnimator = a instanceof NewPipeAnimator // implies a not null
                 ? (NewPipeAnimator) a : new NewPipeAnimator();
 
         final AnimationParams animationParams = isTextView
@@ -193,7 +192,7 @@ public final class AnimationUtil {
             logic = animationLogic.get();
         } else {
             logic = new NewPipeAnimationLogic();
-            animationLogic = new WeakReference<NewPipeAnimationLogic>(logic);
+            animationLogic = new WeakReference<>(logic);
         }
         return logic;
     }
@@ -206,7 +205,7 @@ public final class AnimationUtil {
         }
     }
 
-    /* base logic for (de-)registering animators to/from running list and moving to recycle list */
+    /* base logic for de-/registering animators to/from running list and moving to recycle list */
     public static class BaseRecycleLogic implements Animator.AnimatorListener {
         /* helper functions */
         protected static AnimationParams getAnimationParams(final Animator animation) {
@@ -260,9 +259,11 @@ public final class AnimationUtil {
         }
         @Override
         public void onAnimationCancel(final Animator animation) {
+            // no impl pls
         }
         @Override
         public void onAnimationRepeat(final Animator animation) {
+            // no impl pls
         }
     }
 
@@ -343,7 +344,7 @@ public final class AnimationUtil {
         private boolean listenerInTarget;
 
         public void setView(final View v) {
-            target = v == null ? null : new WeakReference<View>(v);
+            target = v == null ? null : new WeakReference<>(v);
         }
         public OnAnimateListener setAnimateListener(final OnAnimateListener l) {
             if (l == listener) {

--- a/app/src/main/java/org/schabi/newpipe/util/AnimationUtil.java
+++ b/app/src/main/java/org/schabi/newpipe/util/AnimationUtil.java
@@ -83,6 +83,7 @@ public final class AnimationUtil {
 
     public interface OnAnimateListener {
         void onAnimateProgress(float animatedFraction, boolean isCollapsing);
+        default void onAnimationStart(View v, boolean isCollapsing) { }
         default void onAnimationEnd(View v, boolean reversed, boolean expanded) { }
     }
 
@@ -324,6 +325,10 @@ public final class AnimationUtil {
             }
             super.onAnimationStart(animation);
             animationStart(t, p);
+
+            if (p.getAnimateListener() != null) {
+                p.getAnimateListener().onAnimationStart(t, p.isCollapsing());
+            }
         }
     }
 

--- a/app/src/main/java/org/schabi/newpipe/util/AnimationUtil.java
+++ b/app/src/main/java/org/schabi/newpipe/util/AnimationUtil.java
@@ -82,7 +82,7 @@ public final class AnimationUtil {
     //////////////////////////////////////////////////////////////////////////*/
 
     public interface OnAnimateListener {
-        void onAnimate(int animatedValue, int initialValue, int targetValue);
+        void onAnimateProgress(float animatedFraction, boolean isCollapsing);
         default void onAnimationEnd(View v, boolean reversed, boolean expanded) { }
     }
 
@@ -227,13 +227,10 @@ public final class AnimationUtil {
             }
             return null;
         }
-        /* returns true if the animator is reversed halfway and didn't make its full course */
+        /* returns true if the animator is eg reversed halfway and not at its finishing line */
         protected static boolean abandoned(final Animator animation) {
-            if (animation instanceof NewPipeAnimator) {
-                final AnimationParams params = ((NewPipeAnimator) animation).getAnimationParams();
-                if (params != null) {
-                    return (int) ((ValueAnimator) animation).getAnimatedValue() != params.to();
-                }
+            if (animation instanceof ValueAnimator) {
+                return ((ValueAnimator) animation).getAnimatedFraction() != 1;
             }
             return false;
         }
@@ -293,8 +290,8 @@ public final class AnimationUtil {
             animate(t, p, animation);
 
             if (p.getAnimateListener() != null) {
-                p.getAnimateListener().onAnimate((int) animation.getAnimatedValue(),
-                        p.from(), p.to());
+                p.getAnimateListener().onAnimateProgress(animation.getAnimatedFraction(),
+                        p.isCollapsing());
             }
         }
 

--- a/app/src/main/java/org/schabi/newpipe/util/AnimationUtil.java
+++ b/app/src/main/java/org/schabi/newpipe/util/AnimationUtil.java
@@ -51,6 +51,7 @@ public final class AnimationUtil {
         if (it.hasNext()) {
             final ValueAnimator animator = it.next();
             it.remove();
+            return animator;
         }
         return null;
     }

--- a/app/src/main/java/org/schabi/newpipe/util/AnimationUtil.java
+++ b/app/src/main/java/org/schabi/newpipe/util/AnimationUtil.java
@@ -1,0 +1,399 @@
+package org.schabi.newpipe.util;
+
+import android.animation.Animator;
+import android.animation.ValueAnimator;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.animation.AccelerateDecelerateInterpolator;
+import android.view.animation.DecelerateInterpolator;
+import android.widget.TextView;
+
+import androidx.annotation.CallSuper;
+
+import java.lang.ref.WeakReference;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.WeakHashMap;
+
+public final class AnimationUtil {
+    /* a running list of animators in flight; they will be manually removed onAnimationEnd */
+    private static WeakHashMap<View, ValueAnimator> runningAnimators =
+            new WeakHashMap<View, ValueAnimator>();
+    /* weak references to old animators post-service for opportunistic reuse before gc'ed */
+    private static Set<ValueAnimator> oldAnimators = Collections.newSetFromMap(
+            new WeakHashMap<ValueAnimator, Boolean>());
+
+    private AnimationUtil() {
+        // no impl pls
+    }
+
+    public static void cleanup(final Animator animator) {
+        if (animator != null) {
+            if (animator instanceof ValueAnimator) {
+                ((ValueAnimator) animator).removeAllUpdateListeners();
+            }
+            animator.removeAllListeners();
+            if (animator instanceof NewPipeAnimator) {
+                ((NewPipeAnimator) animator).setAnimationParams(null);
+            }
+        }
+    }
+
+    public static void recycle(final ValueAnimator animator) {
+        if (animator != null) {
+            oldAnimators.add(animator);
+        }
+    }
+
+    public static ValueAnimator popOldAnimators() {
+        final Iterator<ValueAnimator> it = oldAnimators.iterator();
+        if (it.hasNext()) {
+            final ValueAnimator animator = it.next();
+            it.remove();
+        }
+        return null;
+    }
+
+
+    /*//////////////////////////////////////////////////////////////////////////
+    // Static functions and interfaces
+    //////////////////////////////////////////////////////////////////////////*/
+
+    public interface OnAnimateListener {
+        void onAnimate(int animatedValue, int initialValue, int targetVslue);
+        void onAnimationEnd(View v, boolean reversed, boolean expanded);
+    }
+
+    /* AnimationUtil essentially implements a closed system of NewPipeAnimators
+     * (subclass of ValueAnimator) which would be kept track of (to allow reverse(),
+     * say when the user consecutively taps on it during an animation) and reused
+     * as far as possible. These static functions allow callers to essentially
+     * 'fire and forget' and do not return the ValueAnimator to prevent clients
+     * from accidentally holding a strong reference to it */
+
+    /* shorthands to explicitly specify a direction; note that regardless of direction,
+     * the ongoing animation is still reversed if one in flight is detected */
+    public static void expand(final View v, final int duration) {
+        toggle(v, duration, -1, -1, false);
+    }
+    public static void collapse(final View v, final int duration) {
+        toggle(v, duration, -1, -1, true);
+    }
+    public static void expand(final TextView v, final int duration, final int lines) {
+        toggle((View) v, duration, -1, lines, false);
+    }
+    public static void collapse(final TextView v, final int duration, final int lines) {
+        toggle((View) v, duration, lines, -1, true);
+    }
+    public static void expand(final View v, final int duration, final OnAnimateListener listener) {
+        toggle(v, duration, -1, false, listener);
+    }
+    public static void collapse(final View v, final int duration,
+                                final OnAnimateListener listener) {
+        toggle(v, duration, -1, true, listener);
+    }
+    public static void toggle(final View v, final int duration) {
+        toggle(v, duration, -1, -1);
+    }
+
+    public static void toggle(final View v, final int duration,
+                              final int collapsedLines, final int expandedLines) {
+        toggle(v, duration, collapsedLines, expandedLines, v instanceof TextView
+                ? (((TextView) v).getMaxLines() > collapsedLines)
+                : (v.getVisibility() != View.GONE && v.getHeight() > 0));
+    }
+
+    public static void toggle(final View v, final int duration,
+                              final int collapsedLines, final int expandedLines,
+                              final boolean collapse) {
+        toggle(v, duration, v instanceof TextView
+                ? (collapse ? collapsedLines : expandedLines) : -1, collapse, null);
+    }
+
+    /* takes an OnAnimateListener if custom actions are desired */
+    public static void toggle(final View v, final int duration, final int lines,
+                              final boolean collapse, final OnAnimateListener listener) {
+        final ValueAnimator valueAnimator = runningAnimators.get(v);
+        if (valueAnimator != null) {
+            valueAnimator.reverse();
+            return;
+        }
+        expandCollapse(v, popOldAnimators(), duration, lines, collapse, listener);
+    }
+
+    public static ValueAnimator expandCollapse(final View v, final ValueAnimator a,
+                                               final int duration, final int lines,
+                                               final boolean isCollapsing,
+                                               final OnAnimateListener listener) {
+        final boolean isTextView = v instanceof TextView;
+
+        final int initialHeight = v.getHeight();
+        final int origMaxLines;
+        if (isTextView) {
+            origMaxLines = ((TextView) v).getMaxLines();
+            if (lines != -1) {
+                ((TextView) v).setMaxLines(lines);
+            }
+        } else {
+            origMaxLines = -1; // unused
+        }
+        if (isTextView || !isCollapsing) {
+            v.measure(View.MeasureSpec.makeMeasureSpec(v.getMeasuredWidth(),
+                            View.MeasureSpec.EXACTLY),
+                    View.MeasureSpec.makeMeasureSpec(View.MeasureSpec.UNSPECIFIED,
+                            View.MeasureSpec.UNSPECIFIED));
+        }
+        final int targetHeight = !isTextView && isCollapsing ? 0 : v.getMeasuredHeight();
+
+        if (!isTextView) {
+            // if the animated object is not a TextView, we assume animating to/from being visible
+            v.setVisibility(View.VISIBLE);
+        }
+
+       final NewPipeAnimator valueAnimator = (a instanceof NewPipeAnimator && a != null)
+                ? (NewPipeAnimator) a : new NewPipeAnimator();
+
+        final AnimationParams animationParams = isTextView
+                ? (AnimationParams) new TextAnimationParams() : new AnimationParams();
+        animationParams.setView(v);
+        animationParams.initialValue = initialHeight;
+        animationParams.targetValue = targetHeight;
+        animationParams.isCollapsing = isCollapsing;
+        animationParams.setAnimateListener(listener);
+        if (isTextView) {
+            ((TextAnimationParams) animationParams).oldLines = origMaxLines;
+            ((TextAnimationParams) animationParams).newLines = lines;
+        }
+        valueAnimator.setAnimationParams(animationParams);
+        setupAnimationLogic(valueAnimator);
+
+        valueAnimator.setInterpolator(isCollapsing ? new DecelerateInterpolator()
+                : new AccelerateDecelerateInterpolator());
+        valueAnimator.setDuration(duration);
+        valueAnimator.start();
+
+        return valueAnimator;
+    }
+
+
+    /*//////////////////////////////////////////////////////////////////////////
+    // Moving parts
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /* Holds a WeakReference to an AnimationLogic (we currently only have one type of them)
+     * to be shared and strongly referenced by Animators in flight (via setupAnimationLogic()).
+     * Idealistically it would be gc'ed after prolonged unuse and recreated as necessary. */
+    private static WeakReference<NewPipeAnimationLogic> animationLogic;
+
+    public static NewPipeAnimationLogic getAnimationLogic() {
+        final NewPipeAnimationLogic logic;
+        if (animationLogic != null && animationLogic.get() != null) {
+            logic = animationLogic.get();
+        } else {
+            logic = new NewPipeAnimationLogic();
+            animationLogic = new WeakReference<NewPipeAnimationLogic>(logic);
+        }
+        return logic;
+    }
+    /* an AnimationLogic implements AnimatorListener and AnimatorUpdateListener under the hook */
+    public static void setupAnimationLogic(final ValueAnimator valueAnimator) {
+        final NewPipeAnimationLogic logic = getAnimationLogic();
+        if (logic != null) {
+            valueAnimator.addUpdateListener(logic);
+            valueAnimator.addListener(logic);
+        }
+    }
+
+    /* base logic for (de-)registering animators to/from running list and moving to recycle list */
+    public static class BaseRecycleLogic implements Animator.AnimatorListener {
+        /* helper functions */
+        protected static AnimationParams getAnimationParams(final Animator animation) {
+            if (animation instanceof NewPipeAnimator) {
+                return ((NewPipeAnimator) animation).animationParams;
+            }
+            return null;
+        }
+        protected static View getView(final Animator animation) {
+            if (animation instanceof NewPipeAnimator) {
+                final AnimationParams p = getAnimationParams(animation);
+                if (p != null && p.target != null) {
+                    return p.target.get();
+                }
+            }
+            return null;
+        }
+        /* returns true if the animator is reversed halfway and didn't make its full course */
+        protected static boolean abandoned(final Animator animation) {
+            if (animation instanceof NewPipeAnimator
+                    && ((NewPipeAnimator) animation).animationParams != null) {
+                return (int) ((NewPipeAnimator) animation).getAnimatedValue()
+                        != ((NewPipeAnimator) animation).animationParams.targetValue;
+            }
+            return false;
+        }
+
+        @CallSuper
+        @Override
+        public void onAnimationEnd(final Animator animation) {
+            if (animation instanceof NewPipeAnimator) {
+                final View v = getView(animation);
+                if (v != null) {
+                    runningAnimators.remove(v);
+                }
+            }
+            // make sure to remove animator from running list first before cleanup()
+            // which would remove reference to the animated View
+            cleanup(animation);
+            if (animation instanceof ValueAnimator) {
+                recycle((ValueAnimator) animation);
+            }
+        }
+        @CallSuper
+        @Override
+        public void onAnimationStart(final Animator animation) {
+            final View v = getView(animation);
+            if (v != null && animation instanceof ValueAnimator) {
+                runningAnimators.put(v, (ValueAnimator) animation);
+            }
+        }
+        @Override
+        public void onAnimationCancel(final Animator animation) {
+        }
+        @Override
+        public void onAnimationRepeat(final Animator animation) {
+        }
+    }
+
+    /* (currently the only type of) AnimationLogic which animates the View's height
+     * for TextView: initial -> new height; everything else: gone -> new height or vice versa */
+    // ref: https://medium.com/@yuriyskul/expandable-textview-using-staticlayouts-data-f9bc9cbdf283
+    public static class NewPipeAnimationLogic extends BaseRecycleLogic
+            implements ValueAnimator.AnimatorUpdateListener {
+
+        /* implements ValueAnimator.AnimatorUpdateListener */
+        @Override
+        public void onAnimationUpdate(final ValueAnimator animation) {
+            final View t = getView(animation);
+            final AnimationParams p = getAnimationParams(animation);
+            if (t == null || p == null) {
+                animation.cancel();
+                return;
+            }
+            t.getLayoutParams().height = (int) animation.getAnimatedValue();
+            t.requestLayout();
+
+            if (p.getAnimateListener() != null) {
+                p.getAnimateListener().onAnimate((int) animation.getAnimatedValue(),
+                        p.initialValue, p.targetValue);
+            }
+        }
+
+        /* implements Animator.AnimatorListener */
+        @Override
+        public void onAnimationEnd(final Animator animation) {
+            final View t = getView(animation);
+            final AnimationParams p = getAnimationParams(animation);
+            if (t == null || p == null) {
+                super.onAnimationEnd(animation);
+                return;
+            }
+            final boolean reversed = abandoned(animation);
+            if (t instanceof TextView) {
+                if (reversed) {
+                    ((TextView) t).setMaxLines(((TextAnimationParams) p).oldLines);
+                } else if (((TextAnimationParams) p).newLines != -1) {
+                    ((TextView) t).setMaxLines(((TextAnimationParams) p).newLines);
+                }
+            } else if ((p.isCollapsing && !reversed) || (!p.isCollapsing && reversed)) {
+                t.setVisibility(View.GONE);
+            }
+            t.getLayoutParams().height = ViewGroup.LayoutParams.WRAP_CONTENT;
+
+            if (p.getAnimateListener() != null) {
+                p.getAnimateListener().onAnimationEnd(t, reversed,
+                        ((!p.isCollapsing && !reversed) || p.isCollapsing && reversed));
+            }
+            super.onAnimationEnd(animation);
+        }
+
+        @Override
+        public void onAnimationStart(final Animator animation) {
+            final View t = getView(animation);
+            final AnimationParams p = getAnimationParams(animation);
+            if (t == null || p == null) {
+                animation.cancel();
+                return;
+            }
+            super.onAnimationStart(animation);
+            if (t instanceof TextView && p.isCollapsing
+                    && ((TextAnimationParams) p).newLines != -1) {
+                ((TextView) t).setMaxLines(((TextAnimationParams) p).oldLines);
+            }
+        }
+    }
+
+    public static class AnimationParams {
+        public WeakReference<View> target;
+        public int initialValue;
+        public int targetValue;
+        public boolean isCollapsing; // FIXME: determine from targetValue < initialValue ?
+        private OnAnimateListener listener;
+        private boolean listenerInTarget;
+
+        public void setView(final View v) {
+            target = v == null ? null : new WeakReference<View>(v);
+        }
+        public OnAnimateListener setAnimateListener(final OnAnimateListener l) {
+            if (l == listener) {
+                return listener;
+            }
+            if (l != null && target != null && target.get() == l) {
+                // if the animated View itself implements the OnAnimateListener,
+                // flip the switch for WeakReference and don't keep a strong reference to it
+                listenerInTarget = true;
+                listener = null;
+                return (OnAnimateListener) target.get();
+            } else {
+                listenerInTarget = false;
+                listener = l;
+            }
+            return listener;
+        }
+        public OnAnimateListener getAnimateListener() {
+            if (listener != null) {
+                return listener;
+            } else if (listenerInTarget
+                    && target != null && target.get() instanceof OnAnimateListener) {
+                return (OnAnimateListener) target.get();
+            }
+            return null;
+        }
+    }
+    public static class TextAnimationParams extends AnimationParams {
+        public int oldLines;
+        public int newLines;
+    }
+
+    /* a subclass of ValueAnimator which comprises two components:
+     * a set of AnimationLogic (applied by setupAnimationLogic() commonly shared across instances)
+     * and an AnimationParams (per instance) which stores a weak reference to the animated View
+     * (much like a thinly provisioned ObjectAnimator) and exposes useful functions to listeners */
+    public static class NewPipeAnimator extends ValueAnimator {
+        private AnimationParams animationParams;
+
+        public void setAnimationParams(final AnimationParams params) {
+            if (params != animationParams) {
+                if (animationParams != null) {
+                    // explicitly clean up old OnAnimateListener just in case
+                    animationParams.setAnimateListener(null);
+                    animationParams.setView(null);
+                }
+                animationParams = params;
+                if (params != null) {
+                    setIntValues(animationParams.initialValue, animationParams.targetValue);
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/util/EllipsizeParams.java
+++ b/app/src/main/java/org/schabi/newpipe/util/EllipsizeParams.java
@@ -1,0 +1,1015 @@
+package org.schabi.newpipe.util;
+
+import android.graphics.Rect;
+import android.text.Layout;
+
+import androidx.annotation.IntDef;
+import androidx.annotation.IntRange;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.util.Consumer;
+
+import org.schabi.newpipe.views.NewPipeTextView;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.ref.WeakReference;
+import java.text.BreakIterator;
+
+/* our home-grown cache holding the metrics for drawing the ellipsis and/or a ellipsis mask */
+public final class EllipsizeParams {
+    public static final boolean DEBUG = android.os.Debug.isDebuggerConnected();
+
+    private EllipsizeParams() {
+        // no impl pls
+    }
+
+
+    /*//////////////////////////////////////////////////////////////////////////
+    // Ellipsizing companions
+    //////////////////////////////////////////////////////////////////////////*/
+
+    // magic numbers
+    public static final int UNSET = -1;
+
+    @Retention(RetentionPolicy.SOURCE)
+    @IntDef({ValueType.BOOLEAN, ValueType.INT, ValueType.FLOAT})
+    public @interface ValueType {
+        int BOOLEAN = 0;
+        int INT = 1;
+        int FLOAT = 2;
+    }
+
+    @Retention(RetentionPolicy.SOURCE)
+    @IntDef({Op.NORMAL, Op.ADD, Op.MINUS})
+    public @interface Op {
+        int NORMAL = 0;  // read: replace
+        int ADD = 1;
+        int MINUS = 2;
+    }
+
+    @Retention(RetentionPolicy.SOURCE)
+    @IntDef({Result.OK, Result.NOT_FOUND, Result.NOT_IN_RANGE,
+            Result.ERROR, Result.NOT_IMPLEMENTED})
+    public @interface Result {  // status codes
+        int OK = -200;
+        int NOT_FOUND = -404;
+        int NOT_IN_RANGE = -416;
+        int ERROR = -500;
+        int NOT_IMPLEMENTED = -501;
+    }
+
+    public static final int HEADER_RESERVED = 0;
+
+    @Retention(RetentionPolicy.SOURCE)
+    @IntDef({INITIALIZED, SCHEMA_1, SCHEMA_DEBUG, IS_LTR, SKIP_PREFIX_SPACE, ANIMATING})
+    public @interface Flags {
+    }
+
+    public static final int FLAGS_START = 0;
+    // booleans are stored in FLAGS
+    public static final int INITIALIZED = FLAGS_START;
+    public static final int SCHEMA_1 = 1 + FLAGS_START;
+    public static final int SCHEMA_DEBUG = 2 + FLAGS_START;
+    public static final int FALLBACK_LAYOUT = 3 + FLAGS_START;
+    // LineMetrics enums
+    public static final int IS_LTR = 4 + FLAGS_START;
+    public static final int SKIP_PREFIX_SPACE = 5 + FLAGS_START;
+    public static final int ELLIPSISING_MASK = 6 + FLAGS_START;
+    // animation enums
+    public static final int ANIMATING = 7 + FLAGS_START;
+    /* keep this to last */
+    public static final int FLAGS_END = 8 + FLAGS_START;
+
+    /* reserved a byte to 'smuggle in' crossfadeEllipsis (bits 8-15) */
+    public static final int CROSSFADE_ELLIPSIS = 8 + FLAGS_START;
+
+    public static final int FLOAT_INDEX_START = 16 + FLAGS_START; // 15 slots (bits 16-30)
+
+    // highest bit reserved for meta
+    public static final int CONTINUATION = Integer.SIZE - 1; // highest bit (31) of int
+
+
+    public static final int SCHEMA_0_START = 100;
+    // LineMetrics enums (SCHEMA 0)
+    public static final int LINEMETRICS_START = SCHEMA_0_START;
+    /* properties */
+    public static final int LINE_NO = 1 + LINEMETRICS_START;
+    /* bounds */
+    public static final int WIDTH = 2 + LINEMETRICS_START;
+    public static final int TOP = 3 + LINEMETRICS_START;
+    public static final int BOTTOM = 4 + LINEMETRICS_START;
+    /* canvas coordinates */
+    public static final int BASELINE = 5 + LINEMETRICS_START;
+    public static final int LINEMAX = 6 + LINEMETRICS_START;  // float
+    /* text offsets */
+    public static final int LINE_START = 7 + LINEMETRICS_START;
+    public static final int LINE_END = 8 + LINEMETRICS_START;
+    /* keep this to last */
+    public static final int LINEMETRICS_END = 9 + LINEMETRICS_START;
+
+    // derived LineMetrics
+    public static final int LINEMETRIC_DERIVED_START = 110;
+    public static final int LINE_LEFT = 1 + LINEMETRIC_DERIVED_START;
+    public static final int LINE_RIGHT = 2 + LINEMETRIC_DERIVED_START;
+    public static final int LINEMETRIC_DERIVED_END = 3 + LINEMETRIC_DERIVED_START;
+
+    // extended LineMetrics (computed without equivalent functions in Layout)
+    public static final int LINEMETRIC_COMPUTED_START = 120;
+    public static final int LINE_REMAINING_SPACE = 1 + LINEMETRIC_COMPUTED_START;
+    public static final int LINE_START_EDGE = 2 + LINEMETRIC_COMPUTED_START;
+    public static final int LINE_END_EDGE = 3 + LINEMETRIC_COMPUTED_START;
+    public static final int LINEMETRIC_COMPUTED_END = 4 + LINEMETRIC_COMPUTED_START;
+
+    public static final int LINEMETRICS_EXT_END = LINEMETRIC_COMPUTED_END;
+
+    public static final int SCHEMA_1_START = 200;
+    // EllipsisParams enums (SCHEMA 1)
+    public static final int ELLIPSISPARAMS_START = SCHEMA_1_START;
+    /* ellipsisBounds */
+    public static final int EB_LEFT = 1 + ELLIPSISPARAMS_START;
+    public static final int EB_RIGHT = 2 + ELLIPSISPARAMS_START;
+    public static final int EB_TOP = 3 + ELLIPSISPARAMS_START;
+    public static final int EB_BOTTOM = 4 + ELLIPSISPARAMS_START;
+    /* ellipsisBaseline */
+    public static final int EB_BASELINE = 5 + ELLIPSISPARAMS_START;
+    /* keep this to last */
+    public static final int ELLIPSISPARAMS_END = 6 + ELLIPSISPARAMS_START;
+
+    // EllipsisParamsDebug enums (SCHEMA 1-D)
+    public static final int ELLIPSISPARAMS_DEBUG_START = SCHEMA_1_START;
+    /* lastLineBounds (shared with lastLineEndBounds; overlaps LineMetrics bounds) */
+    public static final int LL_WIDTH = 2 + ELLIPSISPARAMS_DEBUG_START;
+    public static final int LL_TOP = 3 + ELLIPSISPARAMS_DEBUG_START;
+    public static final int LL_BOTTOM = 4 + ELLIPSISPARAMS_DEBUG_START;
+    /* ellipsisBaseline */
+    public static final int EB_BASELINE_D = 5 + ELLIPSISPARAMS_DEBUG_START;
+    // lastLineEndBounds */                      // overlaps LINEMAX
+    public static final int LE_EDGE = 6 + ELLIPSISPARAMS_DEBUG_START;
+    /* ellipsisBounds */
+    public static final int EB_LEFT_D = 1 + ELLIPSISPARAMS_DEBUG_START;
+    public static final int EB_RIGHT_D = 7 + ELLIPSISPARAMS_DEBUG_START;
+    public static final int EB_TOP_D = LL_TOP;
+    public static final int EB_BOTTOM_D = LL_BOTTOM;
+    /* keep this to last */
+    public static final int ELLIPSISPARAMS_DEBUG_END = 8 + ELLIPSISPARAMS_DEBUG_START;
+
+    public static int[] setupLineMetrics(@Nullable final int[] storage) {
+        int[] configStorage = storage;
+        final int size = accomodationSize();
+        final int storageSize = size + indexOffset(size);
+        if (configStorage == null || configStorage.length < storageSize) {
+            configStorage = new int[storageSize];
+        } else {
+            configStorage[0] = 0;
+        }
+        initializeIndex(configStorage, size);
+        setFlag(configStorage, INITIALIZED, true);
+        if (EllipsizeParams.DEBUG) {
+            setFlag(configStorage, SCHEMA_DEBUG, true);
+        }
+        return configStorage;
+    }
+
+    private static int accomodationSize() {
+        // finds the lowest common size that could fit the schemas into one common storage
+        return Math.max(getRawIndex(LINEMETRICS_END), getRawIndex(ELLIPSISPARAMS_DEBUG_END));
+    }
+
+    private static boolean initializeIndex(@NonNull final int[] params,
+                                           @IntRange(from = 1) final int paramsSize) {
+        final int indexSize = indexOffset(paramsSize);
+        if (indexSize < params.length) {
+            for (int i = 0; i < indexSize; i++) {
+                params[i] = params[i] | (1 << CONTINUATION);
+            }
+            return true;
+        }
+        return false;
+    }
+
+    // get the actual index in storage
+    private static int getRawIndex(@IntRange(from = FLAGS_START) final int flag) {
+        // inclusive of end bounds (<=) in case it's called to compute size
+        if (flag <= FLOAT_INDEX_START) {  // could have been FLAGS_END but to cover the use case
+            return flag - FLAGS_START;
+        } else if (flag <= LINEMETRICS_END) {
+            return flag - SCHEMA_0_START;
+        } else if (flag <= ELLIPSISPARAMS_DEBUG_END) {
+            return flag - SCHEMA_1_START;
+        }
+        return Result.NOT_IN_RANGE;
+    }
+
+    // compute the additional 'pages' (int) of FLAGS required for paramsSize
+    // ref: https://stackoverflow.com/a/20090375
+    private static int indexOffset(@IntRange(from = 1) final int paramsSize) {
+        return indexOffset(paramsSize - 1, false);
+    }
+
+    private static int indexOffset(@IntRange(from = FLAGS_START) final int enumIndex,
+                                   final boolean isFlag) {
+        final int pageSize = Integer.SIZE - 1; // minus the reserved highest bit
+        // take also into account size reserved for flags
+        final int headerSize = enumIndex + (isFlag ? 1 : getRawIndex(FLOAT_INDEX_START));
+        // minus the first 'page' already reserved at int[0]
+        return headerSize / pageSize - ((headerSize % pageSize == 0) ? 1 : 0);
+    }
+
+    // returns the additional 'pages' (int) used for FLAGS de facto, 0 if just int[0] in params
+    private static int indexOffset(@NonNull final int[] params) {
+        int extendedPages = 0;
+        for (int i = 0; i < params.length; i++) {
+            // evaluate directly here instead of calling getBit() to avoid infinite loop
+            if ((params[i] & (1 << CONTINUATION)) != 0) {
+                extendedPages++;
+            } else {
+                break;
+            }
+        }
+        return extendedPages;
+    }
+
+    // compute the 'page' no (int) of flag in params
+    private static int indexOffset(@NonNull final int[] params,
+                                   @IntRange(from = FLAGS_START) final int enumIndex) {
+        return indexOffset(enumIndex, true);
+    }
+
+    // ref: https://stackoverflow.com/a/12015619
+    private static boolean getBit(@NonNull final int[] params,
+                                  @IntRange(from = 0) final int index,
+                                  @IntRange(from = 0, to = CONTINUATION - 1) final int bit) {
+        if (index <= indexOffset(params)) {
+            return (params[index] & (1 << bit)) != 0;
+        }
+        return false;
+    }
+
+    private static boolean setBit(@NonNull final int[] params,
+                                  @IntRange(from = 0) final int index,
+                                  @IntRange(from = 0, to = CONTINUATION - 1) final int bit,
+                                  final boolean markBit) {
+        if (index <= indexOffset(params)) {
+            if (markBit) {
+                params[index] |= (1 << bit);
+            } else {
+                params[index] &= ~(1 << bit);
+            }
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean paramValid(@NonNull final int[] params, final int param) {
+        return getFlag(params, INITIALIZED) && getRawIndex(param) > HEADER_RESERVED;
+    }
+
+    private static boolean setParamInt(@NonNull final int[] params,
+                                       final int param, final int value) {
+        return paramValid(params, param)
+                && setInt(params, getRawIndex(param) + indexOffset(params), value);
+    }
+
+    private static boolean setParamFloat(@NonNull final int[] params,
+                                         final int param, final float value) {
+        return paramValid(params, param)
+                && setFloat(params, getRawIndex(param) + indexOffset(params), value);
+    }
+
+    public static float getFloat(@NonNull final int[] params, final int param) {
+        if (!paramValid(params, param)) {
+            return -1;
+        }
+        final int index = getRawIndex(param) + indexOffset(params);
+        if (index < params.length) {
+            final boolean isFloat = markedFloat(params, index);
+            if (isFloat) {
+                return Float.intBitsToFloat(params[index]);
+            } else {
+                return params[index];
+            }
+        }
+        return -1;
+    }
+
+    public static int getInt(@NonNull final int[] params, final int param) {
+        if (!paramValid(params, param)) {
+            return -1;
+        }
+        final int index = getRawIndex(param) + indexOffset(params);
+        if (index < params.length) {
+            final boolean isFloat = markedFloat(params, index);
+            if (isFloat) {
+                return (int) Float.intBitsToFloat(params[index]);
+            } else {
+                return params[index];
+            }
+        }
+        return -1;
+    }
+
+    private static boolean getParam(@NonNull final int[] params, final int param,
+                                    @NonNull final TypedValue value) {
+        return paramValid(params, param)
+                && getValue(params, getRawIndex(param) + indexOffset(params), value);
+    }
+
+    public static boolean getFlag(@NonNull final int[] params, @Flags final int flag) {
+        final int flagIndex = getRawIndex(flag);
+        return getBit(params, indexOffset(params, flagIndex), flagIndex);
+    }
+
+    public static boolean setFlag(@NonNull final int[] params, final int flag,
+                                   final boolean b) {
+        final int flagIndex = getRawIndex(flag);
+        return setBit(params, indexOffset(params, flagIndex), flagIndex, b);
+    }
+
+    // ref: https://stackoverflow.com/a/46385852
+    public static int getByte(@NonNull final int[] params, @Flags final int flag) {
+        final int flagIndex = getRawIndex(flag);
+        final int index = indexOffset(params, flagIndex);
+        if (index <= indexOffset(params)) {
+            return (params[index] >>> flagIndex) & 0xff;
+        }
+        return -1;
+    }
+
+    // ref: https://stackoverflow.com/a/27870983
+    public static boolean setByte(@NonNull final int[] params, @Flags final int flag,
+                                   @IntRange(from = 0, to = 255) final int value) {
+        final int flagIndex = getRawIndex(flag);
+        final int index = indexOffset(params, flagIndex);
+        if (index <= indexOffset(params)) {
+            params[index] &= ~(0xff << flagIndex);  // clear current bit values
+            params[index] |= ((value & 0xff) << flagIndex);
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean setValue(@NonNull final int[] params,
+                                    @IntRange(from = 0) final int index,
+                                    final int value, final boolean isFloat) {
+        if (index < params.length) {
+            params[index] = value;
+            markFloat(params, index, isFloat);
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean setInt(@NonNull final int[] params,
+                                  @IntRange(from = 0) final int index, final int value) {
+        return setValue(params, index, value, false);
+    }
+
+    private static boolean setFloat(@NonNull final int[] params,
+                                    @IntRange(from = 0) final int index, final float value) {
+        return setValue(params, index, Float.floatToRawIntBits(value), true);
+    }
+
+    private static boolean getValue(@NonNull final int[] params,
+                                    @IntRange(from = 0) final int index,
+                                    @NonNull final TypedValue value) {
+        if (index < params.length) {
+            final boolean isFloat = markedFloat(params, index);
+            if (isFloat) {
+                value.setValue(Float.intBitsToFloat(params[index]));
+            } else {
+                value.setValue(params[index]);
+            }
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean markFloat(@NonNull final int[] params,
+                                     @IntRange(from = 0) final int index,
+                                     final boolean isFloat) {
+        final int extIndex = indexOffset(params);
+        final int flagIndex = index - 1 - extIndex + getRawIndex(FLOAT_INDEX_START);
+        final int page = indexOffset(params, flagIndex);
+        if (page <= extIndex) {
+            setBit(params, page, flagIndex - page * (Integer.SIZE - 1), isFloat);
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean markedFloat(@NonNull final int[] params,
+                                       @IntRange(from = 0) final int index) {
+        final int flagIndex = getRawIndex(FLOAT_INDEX_START) + index - 1 - indexOffset(params);
+        final int page = indexOffset(params, flagIndex);
+        if (page <= indexOffset(params)) {
+            return getBit(params, page, flagIndex - page * (Integer.SIZE - 2));
+        }
+        return false;
+    }
+
+    // a convenient type-agnostic transport 'vehicle' to shuffle primitives around
+    // without worrying about its type or its type-corresponding method overloads
+    // (it's a pity that Java generics doesn't seem to work with primitives wuthout boxing
+    // so we're left with duplicating some parts of the code for primitive types overloads)
+    private static class TypedValue {
+        protected int value;
+        protected int type = UNSET;
+        protected int op = Op.NORMAL;
+
+        public void setValue(final int v) {
+            opValue(v);
+            op = Op.NORMAL;
+        }
+
+        public void setValue(final float v) {
+            opValue(v);
+            op = Op.NORMAL;
+        }
+
+        public void setValue(final boolean v) {
+            value = v ? 1 : 0;
+            type = ValueType.BOOLEAN;
+            op = Op.NORMAL;
+        }
+
+        public void opValue(final int v) {
+            switch (op) {
+                case Op.MINUS:
+                case Op.ADD:
+                    if (type == ValueType.FLOAT) {
+                        value = Float.floatToRawIntBits(asFloat() + (op == Op.MINUS ? -v : v));
+                    } else {
+                        value += (op == Op.MINUS ? -v : v);
+                        type = ValueType.INT;
+                    }
+                    break;
+                default:
+                    value = v;
+                    type = ValueType.INT;
+                    break;
+            }
+        }
+
+        public void opValue(final float v) {
+            switch (op) {
+                case Op.MINUS:
+                case Op.ADD:
+                    if (type == ValueType.FLOAT) {
+                        value = Float.floatToRawIntBits(asFloat() + (op == Op.MINUS ? -v : v));
+                    } else {
+                        value = Float.floatToRawIntBits(value + (op == Op.MINUS ? -v : v));
+                        type = ValueType.FLOAT;
+                    }
+                    break;
+                default:
+                    value = Float.floatToRawIntBits(v);
+                    type = ValueType.FLOAT;
+                    break;
+            }
+        }
+
+        public int getType() {
+            return type;
+        }
+
+        public int getRawValue() {
+            return value;
+        }
+
+        public int asInt() {
+            return type == ValueType.FLOAT ? (int) Float.intBitsToFloat(value) : value;
+        }
+
+        public float asFloat() {
+            return type == ValueType.FLOAT ? Float.intBitsToFloat(value) : (float) value;
+        }
+
+        public boolean asBoolean() {
+            return value != 0;
+        }
+    }
+
+    // acts as a temporary holder for g/seting params from/by different 'actors'
+    private static class Ticket extends TypedValue {
+        private int param = UNSET;
+        private int status = UNSET;
+
+        public Ticket setParam(final int p) {
+            param = p;
+            return this;
+        }
+
+        public int getParam() {
+            return param;
+        }
+
+        public void resolved(final boolean success) {
+            status = success ? Result.OK : Result.ERROR;
+        }
+    }
+
+    // a wrapper class around the backing config storage
+    // (since it's such a pain to directly work with the (primitive) int[] in raw)
+    protected static class LayoutTicket extends Ticket {
+        private WeakReference<Layout> layout;
+        private int[] cache;
+        private int line = UNSET;
+        private boolean cached = false;
+        private UpgradeHelper upgrade;
+        private BreakIterator wordIterator;
+
+        public void reset() {
+            layout = null;
+            cache = null;
+            line = UNSET;
+            cached = false;
+            upgrade = null;
+        }
+        private BreakIterator getWordInstance() {
+            if (wordIterator == null) {
+                wordIterator = BreakIterator.getWordInstance();
+            }
+            return wordIterator;
+        }
+
+        public static LayoutTicket from(final Layout l, final int ln) {
+            return new LayoutTicket().setLayout(l).setLine(ln);
+        }
+
+        public LayoutTicket setLayout(final Layout l) {
+            layout = new WeakReference<>(l);
+            return this;
+        }
+
+        public Layout getLayout() {
+            return layout == null ? null : layout.get();
+        }
+
+        public int[] getCache() {
+            return cache;
+        }
+
+        public LayoutTicket setLine(@IntRange(from = 0) final int ln) {
+            line = ln;
+            return this;
+        }
+
+        public int getLine() {
+            return line;
+        }
+
+        public LayoutTicket to(final int[] c) {
+            cache = c;
+            if (line != UNSET) {
+                setParamInt(c, LINE_NO, line);
+            }
+            return this;
+        }
+
+        public LayoutTicket resolve(final int... params) {
+            if (cached) {
+                resolveFromCache(this, cache, params);
+            } else {
+                resolveFromLayout(this, cache == null ? null : resolveToCache, params);
+            }
+            return this;
+        }
+
+        public LayoutTicket cached(final boolean c) {
+            cached = c;
+            return this;
+        }
+
+        public LayoutTicket get(final int param) {
+            op = Op.NORMAL;
+            return resolve(param);
+        }
+
+        public LayoutTicket andThen(@Op final int operator, final int param) {
+            op = operator;
+            return resolve(param);
+        }
+
+        // offset the value in relation to text direction, +ve to move forward, -ve backwards
+        public LayoutTicket advance(final int offset) {
+            if (cache == null) {
+                resolved(false);
+                return this;
+            }
+            op = Op.ADD;
+            opValue(getFlag(cache, IS_LTR) ? offset : -offset);
+            op = Op.NORMAL;
+            return this;
+        }
+
+        public LayoutTicket advance(final float offset) {
+            if (cache == null) {
+                resolved(false);
+                return this;
+            }
+            op = Op.ADD;
+            opValue(getFlag(cache, IS_LTR) ? offset : -offset);
+            op = Op.NORMAL;
+            return this;
+        }
+
+        public LayoutTicket set(final int param, final int value) {
+            super.setParam(param);
+            super.setValue(value);
+            resolveToCache.accept(this);
+            return this;
+        }
+
+        public LayoutTicket set(final int param, final float value) {
+            super.setParam(param);
+            super.setValue(value);
+            resolveToCache.accept(this);
+            return this;
+        }
+
+        public LayoutTicket set(final int param, final boolean value) {
+            super.setParam(param);
+            super.setValue(value);
+            resolveToCache.accept(this);
+            return this;
+        }
+
+        public UpgradeHelper upgrade() {
+            if (upgrade == null) {
+                upgrade = new UpgradeHelper().from(this).to(this);
+                if (cache != null) {
+                    setFlag(cache, SCHEMA_1, true);
+                }
+            }
+            return upgrade;
+        }
+    }
+
+    // resolver 1: from cached line metrics
+    private static void resolveFromCache(@NonNull final LayoutTicket t, final int[] cache,
+                                         final int... params) {
+        if (cache == null) {
+            t.resolved(false);
+            return;
+        }
+        for (int i = 0; i < params.length; i++) {
+            final int param = params[i];
+            t.setParam(param);
+            if (param < FLAGS_END) {
+                t.setValue(getFlag(cache, param));
+                t.resolved(true);
+            } else if (param < LINEMETRICS_END) {
+                t.resolved(getParam(cache, param, t));
+            } else {
+                final boolean isLTR = getFlag(cache, IS_LTR);
+                final boolean fallback = getFlag(cache, FALLBACK_LAYOUT);
+                switch (param) {
+                    case LINE_LEFT:
+                        if (fallback) {
+                            resolveFromLayout(t, null, param);
+                        } else {
+                            // from AOSP: mWidth - getLineMax(line)if ALIGN_RIGHT or 0
+                            if (isLTR) {
+                                t.setValue(0);
+                            } else {
+                                t.get(WIDTH).andThen(Op.MINUS, LINEMAX);
+                            }
+                        }
+                        break;
+                    case LINE_RIGHT:
+                        if (fallback) {
+                            resolveFromLayout(t, null, param);
+                        } else {
+                            // from AOSP: mWidth if ALIGN_RIGHT or getLineMax(line)
+                            getParam(cache, isLTR ? LINEMAX : WIDTH, t);
+                        }
+                        break;
+                    // extended
+                    case LINE_REMAINING_SPACE:
+                        if (isLTR) {
+                            t.get(WIDTH).andThen(Op.MINUS, LINE_RIGHT);
+                        } else {
+                            getParam(cache, LINE_LEFT, t);
+                        }
+                        break;
+                    case LINE_START_EDGE:
+                        if (isLTR) {
+                            t.setValue(0);
+                        } else {
+                            getParam(cache, WIDTH, t);
+                        }
+                        break;
+                    case LINE_END_EDGE:
+                        t.get(isLTR ? LINE_RIGHT : LINE_LEFT);
+                        break;
+                    default:
+                        t.resolved(false);
+                        continue;
+                }
+                t.resolved(true);
+            }
+        }
+    }
+
+    // resolver 2 (fallback): directly from source (by calling respective Layout functions)
+    private static void resolveFromLayout(@NonNull final LayoutTicket t,
+                                          @Nullable final Consumer<LayoutTicket> resolveTo,
+                                          final int... params) {
+        final Layout layout = t.getLayout();
+        final int line = t.getLine();
+        if (layout == null) {
+            t.resolved(false);
+            return;
+        }
+        Rect bounds = null;
+        for (int i = 0; i < params.length; i++) {
+            t.setParam(params[i]);
+            switch (t.getParam()) {
+                case BASELINE:
+                    if (bounds == null) {
+                        bounds = new Rect();
+                    }
+                    t.setValue(layout.getLineBounds(line, bounds));
+                    break;
+                case WIDTH:
+                    if (bounds != null) {
+                        t.setValue(bounds.right);
+                    } else {
+                        t.setValue(layout.getWidth());
+                    }
+                    break;
+                case TOP:
+                    if (bounds != null) {
+                        t.setValue(bounds.top);
+                    } else {
+                        t.setValue(layout.getLineTop(line));
+                    }
+                    break;
+                case BOTTOM:
+                    if (bounds != null) {
+                        t.setValue(bounds.bottom);
+                    } else {
+                        t.setValue(layout.getLineBottom(line));
+                    }
+                    break;
+                case LINEMAX:
+                    t.setValue(layout.getLineMax(line));
+                    break;
+                case LINE_START:
+                    t.setValue(layout.getLineStart(line));
+                    break;
+                case LINE_END:
+                    t.setValue(layout.getLineEnd(line));
+                    break;
+                case IS_LTR:
+                    t.setValue(layout.getParagraphDirection(line) == Layout.DIR_LEFT_TO_RIGHT);
+                    break;
+                default:
+                    t.resolved(false);
+                    continue;
+            }
+            t.resolved(true);
+            if (resolveTo != null) {
+                resolveTo.accept(t);
+            }
+        }
+    }
+
+    // writer to save line metrics to cache
+    private static Consumer<LayoutTicket> resolveToCache = t -> {
+        final int[] cache = t.getCache();
+        if (cache == null) {
+            t.resolved(false);
+            return;
+        }
+        switch (t.getType()) {
+            case ValueType.FLOAT:
+                setParamFloat(cache, t.getParam(), t.asFloat());
+                break;
+            case ValueType.INT:
+                setParamInt(cache, t.getParam(), t.asInt());
+                break;
+            case ValueType.BOOLEAN:
+                setFlag(cache, t.getParam(), t.asBoolean());
+                break;
+            default:
+                t.resolved(false);
+                return;
+        }
+        t.resolved(true);
+    };
+
+    // highly experimental: might not be put into use after all
+    private static class UpgradeHelper {
+        private int[] tmpStorage;
+        private LayoutTicket storage;
+        private boolean inPlace = false;
+        private int[] reservedIndex;
+
+        public UpgradeHelper from(final LayoutTicket src) {
+            storage = src;
+            return this;
+        }
+
+        public UpgradeHelper to(final LayoutTicket dst) {
+            if (dst == storage) {
+                inPlace = true;
+            } else {
+                // not (yet) implemented
+                throw new RuntimeException(-Result.NOT_IMPLEMENTED + ": Not Implemented");
+            }
+            return this;
+        }
+
+        private void initializeReservedIndex(final int size) {
+            final int storageSize = size + indexOffset(size);
+            if (reservedIndex == null || reservedIndex.length < storageSize) {
+                reservedIndex = new int[storageSize];
+            } else {
+                reservedIndex[0] = 0;
+            }
+            initializeIndex(reservedIndex, size);
+            setFlag(reservedIndex, INITIALIZED, true);
+        }
+
+        public UpgradeHelper defaultTo(final int ellipsisParam, final int lineMetric) {
+            if (!inPlace) {
+                // not (yet) implemented
+                throw new RuntimeException(-Result.NOT_IMPLEMENTED + ": Not Implemented");
+            }
+            final int srcPos = getRawIndex(lineMetric);
+            final int dstPos = getRawIndex(ellipsisParam);
+            if (dstPos >= getRawIndex(LINEMETRICS_END)) {
+                // we can safely write the value since there's no overlap
+                // just copy from old position to new position since we're upgrading in-place
+                storage.getCache()[dstPos] = storage.getCache()[srcPos];
+            }
+            if (srcPos == dstPos) {
+                markReserved(srcPos, true);
+            }
+            return this;
+        }
+
+        private void markReserved(final int pos, final boolean b) {
+            if (b && reservedIndex == null) {
+                initializeReservedIndex(getRawIndex(LINEMETRICS_END));
+            }
+            if (reservedIndex != null) {
+                setBit(reservedIndex, indexOffset(reservedIndex, pos), pos, b);
+            }
+        }
+
+        public UpgradeHelper set(final int ellipsisParam, final int v) {
+            final int dstPos = getRawIndex(ellipsisParam);
+            markReserved(dstPos, false);
+            storage.set(ellipsisParam, v);
+            return this;
+        }
+
+        public UpgradeHelper set(final int ellipsisParam, final float v) {
+            final int dstPos = getRawIndex(ellipsisParam);
+            markReserved(dstPos, false);
+            storage.set(ellipsisParam, v);
+            return this;
+        }
+    }
+
+    private static LayoutTicket warmUpLineMetrics(@IntRange(from = 0) final int line,
+                                           @NonNull final Layout layout,
+                                           @NonNull final int[] metrics) {
+        return LayoutTicket.from(layout, line).to(metrics)
+                .resolve(BASELINE, WIDTH, TOP, BOTTOM, LINEMAX, LINE_START, LINE_END, IS_LTR)
+                .cached(true);
+    }
+
+    // non-breaking space, ellipsis, non-breaking space
+    // we surround nbsp at both ends so that we can just offset ELLIPSIS_LEN by 1 for RTL
+    public static final char[] ELLIPSIS_CHARS = {'\u00a0', '\u2026', '\u00a0'};
+    public static final int ELLIPSIS_LEN = 2;
+
+    /* Our custom ellipsizing strategy implemented as follows: where lines of text don't fit,
+     * - append the ellipsis to the end of the last line displayed, if screen estate fits; else
+     * - crunch the last bit (word) of the last line to make room for the ellipsis.
+     * It's been longstanding (bug) in Android's TextView the internal ellipsizing doesn't work
+     * with BufferType.SPANNABLE (necessitated by setMovementMethod() other than null) at all
+     * (so we're bound to roll our own). A feature over TextView's internal implementation
+     * is that we crunch by word rather than characters (so the user won't be caught by surprise
+     * when 'app...' was meant to mean 'approach' upon expanding the text, just as an example).
+     * (We defer to BreakIterator for the last 'word' since not every language delimits words
+     * by a space (and there we have emojis too).) */
+    public static int[] initialize(@NonNull final NewPipeTextView textView,
+                               @Nullable final int[] storage) {
+        final Layout layout = textView.getLayout();
+        if (layout == null) {
+            return storage;
+        }
+        //layoutReference = new WeakReference<>(layout);
+        int ellipsisLine = textView.getDisplayLines() - 1;
+        final int[] configStorage = setupLineMetrics(storage);
+        final LayoutTicket lastLine = warmUpLineMetrics(ellipsisLine, layout, configStorage);
+
+        if (layout.getParagraphAlignment(textView.getDisplayLines() - 1)
+                != Layout.Alignment.ALIGN_NORMAL) {
+            // short-circuits are unimplemented for Alignment other than ALIGN_NORMAL
+            // as there is simply no use case, fall back gracefully to Layout just in case
+            setFlag(configStorage, FALLBACK_LAYOUT, true);
+        }
+
+        // determine screen estate the ellipsis takes
+        final float ellipsisWidth = layout.getPaint().measureText(ELLIPSIS_CHARS,
+                lastLine.get(IS_LTR).asBoolean() ? 0
+                        : ELLIPSIS_CHARS.length - ELLIPSIS_LEN, ELLIPSIS_LEN);
+        final float shortfall = ellipsisWidth - lastLine.get(LINE_REMAINING_SPACE).asFloat();
+        int lastChar = lastLine.get(LINE_END).asInt();
+        // this would be the reference point to determine if the clipping mask
+        // would eventually kick in at the end of the evaluations
+        final int origLastChar = lastChar;
+        if (shortfall > 0) {
+            // find the closest text offset where the ellipsis fits in
+            lastChar = layout.getOffsetForHorizontal(ellipsisLine,
+                    lastLine.get(LINE_END_EDGE).advance(-shortfall).asFloat());
+        }
+        // we're safe to assume by now the ellipsis fits in the last line up to lastChar
+        // but we go further to crunch by word and do some cleanup / nitpicks
+        final int origLineStart = lastLine.get(LINE_START).asInt();
+        final BreakIterator wb = lastLine.getWordInstance();
+        boolean trailingWhitespacesOnly = lastChar == origLastChar;
+
+        wb.setText(textView.getText().toString());
+        int last = wb.preceding(lastChar);
+        if (!wb.isBoundary(lastChar) && last != BreakIterator.DONE) {
+            lastChar = last;
+            trailingWhitespacesOnly = false;
+            last = wb.preceding(lastChar);
+        }
+        // strip whitespaces: the last line might well end with a space and a line return
+        // be greedy since we're always prefixing the ellipsis to be drawn with a space
+        // and we won't want there to end up having more than one
+        while (last != BreakIterator.DONE && Character.isWhitespace(
+                Character.codePointAt(textView.getText(), last))) {
+            lastChar = last;
+            last = wb.preceding(lastChar);
+        }
+
+        // our clipping mask to be, which also positions the ellipsis to be drawn
+        // default to zero width bounds to cloak nothing of the text drawn by super.onDraw(),
+        // say if we're simply drawing an ellipsis above it when screen estate fits
+        final float initialPos = lastLine.get(LINE_END_EDGE).asFloat();
+        final boolean debug = lastLine.get(SCHEMA_DEBUG).asBoolean();
+        // prepare to write the finalised ellipsis params
+        if (debug) {
+            lastLine.upgrade().set(LE_EDGE, initialPos)
+                    .defaultTo(LL_WIDTH, WIDTH)
+                    .defaultTo(LL_TOP, TOP)
+                    .defaultTo(LL_BOTTOM, BOTTOM)
+                    .defaultTo(EB_BASELINE_D, BASELINE)
+                    .defaultTo(EB_TOP_D, TOP)
+                    .defaultTo(EB_BOTTOM_D, BOTTOM);
+        } else {
+            lastLine.upgrade().defaultTo(EB_BASELINE, BASELINE)
+                    .defaultTo(EB_TOP, TOP)
+                    .defaultTo(EB_BOTTOM, BOTTOM);
+        }
+        if (lastChar != origLastChar) {
+            // whitespaces stripped above also include line break characters (hard returns)
+            // opportunistically wrap the ellipsis to the second last line if screen estate fits
+            if (lastChar < origLineStart && ellipsisLine > 0) {
+                if (layout.getLineMax(ellipsisLine - 1) + ellipsisWidth
+                        // assuming width consistent across lines
+                        <= lastLine.get(WIDTH).asInt()) {
+                    ellipsisLine -= 1; // nil shortfall
+                    lastLine.set(debug ? EB_BASELINE_D : EB_BASELINE,
+                                    layout.getLineBaseline(ellipsisLine))
+                            .set(IS_LTR, layout.getParagraphDirection(ellipsisLine)
+                                    == Layout.DIR_LEFT_TO_RIGHT);
+                } else {
+                    // we're not crunching anything above the last line, so never mind
+                    // just let the ellipsis start on its own right in the last line
+                    lastChar = origLineStart;
+                }
+            }
+            // finally setting the extent of the clipping mask, we need one after all
+            final float ellipsisPos = layout.getPrimaryHorizontal(lastChar);
+            if (trailingWhitespacesOnly && lastChar >= origLineStart) {
+                // optimization: we won't need a mask just for whitespaces on the same last line
+                lastLine.set(debug ? EB_LEFT_D : EB_LEFT, ellipsisPos)
+                        .set(debug ? EB_RIGHT_D : EB_RIGHT, ellipsisPos);
+            } else {
+                lastLine.set(debug ? EB_LEFT_D : EB_LEFT,
+                                lastLine.get(IS_LTR).asBoolean() ? ellipsisPos : initialPos)
+                        .set(debug ? EB_RIGHT_D : EB_RIGHT,
+                                lastLine.get(IS_LTR).asBoolean() ? initialPos : ellipsisPos);
+            }
+        } else {
+            lastLine.set(debug ? EB_LEFT_D : EB_LEFT, initialPos)
+                    .set(debug ? EB_RIGHT_D : EB_RIGHT, initialPos);
+        }
+        // nitpick: omit the prefixed space if ellipsis starts on its own line
+        if (lastChar == origLineStart) {
+            lastLine.set(SKIP_PREFIX_SPACE, true);
+        }
+
+        return configStorage;
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/util/EllipsizeParams.java
+++ b/app/src/main/java/org/schabi/newpipe/util/EllipsizeParams.java
@@ -440,7 +440,7 @@ public final class EllipsizeParams {
 
     // a convenient type-agnostic transport 'vehicle' to shuffle primitives around
     // without worrying about its type or its type-corresponding method overloads
-    // (it's a pity that Java generics doesn't seem to work with primitives wuthout boxing
+    // (it's a pity that Java generics doesn't seem to work with primitives without boxing
     // so we're left with duplicating some parts of the code for primitive types overloads)
     private static class TypedValue {
         protected int value;
@@ -566,11 +566,6 @@ public final class EllipsizeParams {
                 wordIterator = BreakIterator.getWordInstance();
             }
             return wordIterator;
-        }
-
-        public static LayoutTicket from(final Layout l, final int ln) {
-            final LayoutTicket ticket = popOldLayoutTickets();
-            return (ticket != null ? ticket : new LayoutTicket()).setLayout(l).setLine(ln);
         }
 
         public LayoutTicket setLayout(final Layout l) {
@@ -710,7 +705,7 @@ public final class EllipsizeParams {
                         if (fallback) {
                             resolveFromLayout(t, null, param);
                         } else {
-                            // from AOSP: mWidth - getLineMax(line)if ALIGN_RIGHT or 0
+                            // from AOSP: mWidth - getLineMax(line) if ALIGN_RIGHT or 0
                             if (isLTR) {
                                 t.setValue(0);
                             } else {
@@ -928,10 +923,11 @@ public final class EllipsizeParams {
         return layout.getParagraphAlignment(line) != Layout.Alignment.ALIGN_NORMAL;
     }
 
-    private static LayoutTicket warmUpLineMetrics(@IntRange(from = 0) final int line,
-                                           @NonNull final Layout layout,
-                                           @NonNull final int[] metrics) {
-        return LayoutTicket.from(layout, line).to(metrics)
+    private static LayoutTicket warmUpLineMetrics(@NonNull final LayoutTicket ticket,
+                                                  @IntRange(from = 0) final int line,
+                                                  @NonNull final Layout layout,
+                                                  @NonNull final int[] metrics) {
+        return ticket.setLayout(layout).setLine(line).to(metrics)
                 .set(FALLBACK_LAYOUT, shortCircuitsUnsupported(line, layout))
                 .resolve(BASELINE, WIDTH, TOP, BOTTOM, LINEMAX, LINE_START, LINE_END, IS_LTR)
                 .cached(true);
@@ -960,7 +956,9 @@ public final class EllipsizeParams {
         }
         int ellipsisLine = textView.getDisplayLines() - 1;
         final int[] configStorage = setupLineMetrics(storage);
-        try (LayoutTicket lastLine = warmUpLineMetrics(ellipsisLine, layout, configStorage)) {
+        final LayoutTicket ticket = popOldLayoutTickets();
+        try (LayoutTicket lastLine = warmUpLineMetrics(ticket != null ? ticket : new LayoutTicket(),
+                ellipsisLine, layout, configStorage)) {
 
             // determine screen estate the ellipsis takes
             final float ellipsisWidth = layout.getPaint().measureText(ELLIPSIS_CHARS,

--- a/app/src/main/java/org/schabi/newpipe/util/EllipsizeParams.java
+++ b/app/src/main/java/org/schabi/newpipe/util/EllipsizeParams.java
@@ -37,11 +37,13 @@ public final class EllipsizeParams {
 
     @Nullable
     public static LayoutTicket popOldLayoutTickets() {
-        final Iterator<LayoutTicket> it = oldLayoutTickets.iterator();
-        if (it.hasNext()) {
-            final LayoutTicket ticket = it.next();
-            it.remove();
-            return ticket;
+        if (!oldLayoutTickets.isEmpty()) {
+            final Iterator<LayoutTicket> it = oldLayoutTickets.iterator();
+            if (it.hasNext()) {
+                final LayoutTicket ticket = it.next();
+                it.remove();
+                return ticket;
+            }
         }
         return null;
     }
@@ -64,48 +66,32 @@ public final class EllipsizeParams {
     @IntDef({ValueType.BOOLEAN, ValueType.INT, ValueType.FLOAT})
     public @interface ValueType {
         int BOOLEAN = 0;
-        int INT = 1;
-        int FLOAT = 2;
+        int INT     = 1;
+        int FLOAT   = 2;
     }
 
     @Retention(RetentionPolicy.SOURCE)
     @IntDef({Op.NORMAL, Op.ADD, Op.MINUS})
     public @interface Op {
-        int NORMAL = 0;  // read: replace
-        int ADD = 1;
-        int MINUS = 2;
-    }
-
-    @Retention(RetentionPolicy.SOURCE)
-    @IntDef({Result.OK, Result.NOT_FOUND, Result.NOT_IN_RANGE,
-            Result.ERROR, Result.NOT_IMPLEMENTED})
-    public @interface Result {  // status codes
-        int OK = -200;
-        int NOT_FOUND = -404;
-        int NOT_IN_RANGE = -416;
-        int ERROR = -500;
-        int NOT_IMPLEMENTED = -501;
+        int NORMAL  = 0;  // read: replace
+        int ADD     = 1;
+        int MINUS   = 2;
     }
 
     public static final int HEADER_RESERVED = 0;
 
-    @Retention(RetentionPolicy.SOURCE)
-    @IntDef({INITIALIZED, SCHEMA_1, SCHEMA_DEBUG, IS_LTR, SKIP_PREFIX_SPACE, ANIMATING})
-    public @interface Flags {
-    }
-
     public static final int FLAGS_START = 0;
     // booleans are stored in FLAGS
-    public static final int INITIALIZED = FLAGS_START;
-    public static final int SCHEMA_1 = 1 + FLAGS_START;
-    public static final int SCHEMA_DEBUG = 2 + FLAGS_START;
-    public static final int FALLBACK_LAYOUT = 3 + FLAGS_START;
+    public static final int INITIALIZED        = FLAGS_START;
+    public static final int SCHEMA_1           = 1 + FLAGS_START;
+    public static final int SCHEMA_DEBUG       = 2 + FLAGS_START;
+    public static final int FALLBACK_LAYOUT    = 3 + FLAGS_START;
     // LineMetrics enums
-    public static final int IS_LTR = 4 + FLAGS_START;
-    public static final int SKIP_PREFIX_SPACE = 5 + FLAGS_START;
-    public static final int ELLIPSISING_MASK = 6 + FLAGS_START;
+    public static final int IS_LTR             = 4 + FLAGS_START;
+    public static final int SKIP_PREFIX_SPACE  = 5 + FLAGS_START;
+    public static final int ELLIPSISING_MASK   = 6 + FLAGS_START;
     // animation enums
-    public static final int ANIMATING = 7 + FLAGS_START;
+    public static final int ANIMATING          = 7 + FLAGS_START;
     /* keep this to last */
     public static final int FLAGS_END = 8 + FLAGS_START;
 
@@ -122,31 +108,31 @@ public final class EllipsizeParams {
     // LineMetrics enums (SCHEMA 0)
     public static final int LINEMETRICS_START = SCHEMA_0_START;
     /* properties */
-    public static final int LINE_NO = 1 + LINEMETRICS_START;
+    public static final int LINE_NO            = 1 + LINEMETRICS_START;
     /* bounds */
-    public static final int WIDTH = 2 + LINEMETRICS_START;
-    public static final int TOP = 3 + LINEMETRICS_START;
-    public static final int BOTTOM = 4 + LINEMETRICS_START;
+    public static final int WIDTH              = 2 + LINEMETRICS_START;
+    public static final int TOP                = 3 + LINEMETRICS_START;
+    public static final int BOTTOM             = 4 + LINEMETRICS_START;
     /* canvas coordinates */
-    public static final int BASELINE = 5 + LINEMETRICS_START;
-    public static final int LINEMAX = 6 + LINEMETRICS_START;  // float
+    public static final int BASELINE           = 5 + LINEMETRICS_START;
+    public static final int LINEMAX            = 6 + LINEMETRICS_START;  // float
     /* text offsets */
-    public static final int LINE_START = 7 + LINEMETRICS_START;
-    public static final int LINE_END = 8 + LINEMETRICS_START;
+    public static final int LINE_START         = 7 + LINEMETRICS_START;
+    public static final int LINE_END           = 8 + LINEMETRICS_START;
     /* keep this to last */
     public static final int LINEMETRICS_END = 9 + LINEMETRICS_START;
 
     // derived LineMetrics
     public static final int LINEMETRIC_DERIVED_START = 110;
-    public static final int LINE_LEFT = 1 + LINEMETRIC_DERIVED_START;
+    public static final int LINE_LEFT  = 1 + LINEMETRIC_DERIVED_START;
     public static final int LINE_RIGHT = 2 + LINEMETRIC_DERIVED_START;
     public static final int LINEMETRIC_DERIVED_END = 3 + LINEMETRIC_DERIVED_START;
 
     // extended LineMetrics (computed without equivalent functions in Layout)
     public static final int LINEMETRIC_COMPUTED_START = 120;
     public static final int LINE_REMAINING_SPACE = 1 + LINEMETRIC_COMPUTED_START;
-    public static final int LINE_START_EDGE = 2 + LINEMETRIC_COMPUTED_START;
-    public static final int LINE_END_EDGE = 3 + LINEMETRIC_COMPUTED_START;
+    public static final int LINE_START_EDGE      = 2 + LINEMETRIC_COMPUTED_START;
+    public static final int LINE_END_EDGE        = 3 + LINEMETRIC_COMPUTED_START;
     public static final int LINEMETRIC_COMPUTED_END = 4 + LINEMETRIC_COMPUTED_START;
 
     public static final int LINEMETRICS_EXT_END = LINEMETRIC_COMPUTED_END;
@@ -155,30 +141,30 @@ public final class EllipsizeParams {
     // EllipsisParams enums (SCHEMA 1)
     public static final int ELLIPSISPARAMS_START = SCHEMA_1_START;
     /* ellipsisBounds */
-    public static final int EB_LEFT = 1 + ELLIPSISPARAMS_START;
-    public static final int EB_RIGHT = 2 + ELLIPSISPARAMS_START;
-    public static final int EB_TOP = 3 + ELLIPSISPARAMS_START;
-    public static final int EB_BOTTOM = 4 + ELLIPSISPARAMS_START;
+    public static final int EB_LEFT            = 1 + ELLIPSISPARAMS_START;
+    public static final int EB_RIGHT           = 2 + ELLIPSISPARAMS_START;
+    public static final int EB_TOP             = 3 + ELLIPSISPARAMS_START;
+    public static final int EB_BOTTOM          = 4 + ELLIPSISPARAMS_START;
     /* ellipsisBaseline */
-    public static final int EB_BASELINE = 5 + ELLIPSISPARAMS_START;
+    public static final int EB_BASELINE        = 5 + ELLIPSISPARAMS_START;
     /* keep this to last */
     public static final int ELLIPSISPARAMS_END = 6 + ELLIPSISPARAMS_START;
 
     // EllipsisParamsDebug enums (SCHEMA 1-D)
     public static final int ELLIPSISPARAMS_DEBUG_START = SCHEMA_1_START;
     /* lastLineBounds (shared with lastLineEndBounds; overlaps LineMetrics bounds) */
-    public static final int LL_WIDTH = 2 + ELLIPSISPARAMS_DEBUG_START;
-    public static final int LL_TOP = 3 + ELLIPSISPARAMS_DEBUG_START;
-    public static final int LL_BOTTOM = 4 + ELLIPSISPARAMS_DEBUG_START;
+    public static final int LL_WIDTH           = 2 + ELLIPSISPARAMS_DEBUG_START;
+    public static final int LL_TOP             = 3 + ELLIPSISPARAMS_DEBUG_START;
+    public static final int LL_BOTTOM          = 4 + ELLIPSISPARAMS_DEBUG_START;
     /* ellipsisBaseline */
-    public static final int EB_BASELINE_D = 5 + ELLIPSISPARAMS_DEBUG_START;
+    public static final int EB_BASELINE_D      = 5 + ELLIPSISPARAMS_DEBUG_START;
     // lastLineEndBounds */                      // overlaps LINEMAX
-    public static final int LE_EDGE = 6 + ELLIPSISPARAMS_DEBUG_START;
+    public static final int LE_EDGE            = 6 + ELLIPSISPARAMS_DEBUG_START;
     /* ellipsisBounds */
-    public static final int EB_LEFT_D = 1 + ELLIPSISPARAMS_DEBUG_START;
-    public static final int EB_RIGHT_D = 7 + ELLIPSISPARAMS_DEBUG_START;
-    public static final int EB_TOP_D = LL_TOP;
-    public static final int EB_BOTTOM_D = LL_BOTTOM;
+    public static final int EB_LEFT_D          = 1 + ELLIPSISPARAMS_DEBUG_START;
+    public static final int EB_RIGHT_D         = 7 + ELLIPSISPARAMS_DEBUG_START;
+    public static final int EB_TOP_D           = LL_TOP;
+    public static final int EB_BOTTOM_D        = LL_BOTTOM;
     /* keep this to last */
     public static final int ELLIPSISPARAMS_DEBUG_END = 8 + ELLIPSISPARAMS_DEBUG_START;
 
@@ -243,7 +229,7 @@ public final class EllipsizeParams {
         } else if (flag <= ELLIPSISPARAMS_DEBUG_END) {
             return flag - SCHEMA_1_START;
         }
-        return Result.NOT_IN_RANGE;
+        return UNSET;
     }
 
     // compute the additional 'pages' (int) of FLAGS required for paramsSize
@@ -282,8 +268,7 @@ public final class EllipsizeParams {
     }
 
     // ref: https://stackoverflow.com/a/12015619
-    private static boolean getBit(@NonNull final int[] params,
-                                  @IntRange(from = 0) final int index,
+    private static boolean getBit(@NonNull final int[] params, @IntRange(from = 0) final int index,
                                   @IntRange(from = 0, to = CONTINUATION - 1) final int bit) {
         if (index <= extHeader(params)) {
             return (params[index] & (1 << bit)) != 0;
@@ -291,8 +276,7 @@ public final class EllipsizeParams {
         return false;
     }
 
-    private static boolean setBit(@NonNull final int[] params,
-                                  @IntRange(from = 0) final int index,
+    private static boolean setBit(@NonNull final int[] params, @IntRange(from = 0) final int index,
                                   @IntRange(from = 0, to = CONTINUATION - 1) final int bit,
                                   final boolean markBit) {
         if (index <= extHeader(params)) {
@@ -360,19 +344,18 @@ public final class EllipsizeParams {
                 && getValue(params, getRawIndex(param) + extHeader(params), value);
     }
 
-    public static boolean getFlag(@NonNull final int[] params, @Flags final int flag) {
+    public static boolean getFlag(@NonNull final int[] params, final int flag) {
         final int flagIndex = getRawIndex(flag);
         return getBit(params, indexPage(params, flagIndex), flagIndex);
     }
 
-    public static boolean setFlag(@NonNull final int[] params, final int flag,
-                                   final boolean b) {
+    public static boolean setFlag(@NonNull final int[] params, final int flag, final boolean b) {
         final int flagIndex = getRawIndex(flag);
         return setBit(params, indexPage(params, flagIndex), flagIndex, b);
     }
 
     // ref: https://stackoverflow.com/a/46385852
-    public static int getByte(@NonNull final int[] params, @Flags final int flag) {
+    public static int getByte(@NonNull final int[] params, final int flag) {
         final int flagIndex = getRawIndex(flag);
         final int index = indexPage(params, flagIndex);
         if (index <= extHeader(params)) {
@@ -382,8 +365,8 @@ public final class EllipsizeParams {
     }
 
     // ref: https://stackoverflow.com/a/27870983
-    public static boolean setByte(@NonNull final int[] params, @Flags final int flag,
-                                   @IntRange(from = 0, to = 255) final int value) {
+    public static boolean setByte(@NonNull final int[] params, final int flag,
+                                  @IntRange(from = 0, to = 255) final int value) {
         final int flagIndex = getRawIndex(flag);
         final int index = indexPage(params, flagIndex);
         if (index <= extHeader(params)) {
@@ -543,7 +526,6 @@ public final class EllipsizeParams {
     // acts as a temporary holder for g/seting params from/by different 'actors'
     private static class Ticket extends TypedValue {
         private int param = UNSET;
-        private int status = UNSET;
 
         public Ticket setParam(final int p) {
             param = p;
@@ -552,10 +534,6 @@ public final class EllipsizeParams {
 
         public int getParam() {
             return param;
-        }
-
-        public void resolved(final boolean success) {
-            status = success ? Result.OK : Result.ERROR;
         }
     }
 
@@ -566,7 +544,6 @@ public final class EllipsizeParams {
         private int[] cache;
         private int line = UNSET;
         private boolean cached = false;
-        private UpgradeHelper upgrade;
         private BreakIterator wordIterator;
 
         public void reset() {
@@ -574,7 +551,6 @@ public final class EllipsizeParams {
             cache = null;
             line = UNSET;
             cached = false;
-            upgrade = null;
         }
         @Override
         public void close() {
@@ -645,7 +621,6 @@ public final class EllipsizeParams {
         // offset the value in relation to text direction, +ve to move forward, -ve backwards
         public LayoutTicket advance(final int offset) {
             if (cache == null) {
-                resolved(false);
                 return this;
             }
             op = getFlag(cache, IS_LTR) ? Op.ADD : Op.MINUS;
@@ -656,7 +631,6 @@ public final class EllipsizeParams {
 
         public LayoutTicket advance(final float offset) {
             if (cache == null) {
-                resolved(false);
                 return this;
             }
             op = getFlag(cache, IS_LTR) ? Op.ADD : Op.MINUS;
@@ -686,14 +660,23 @@ public final class EllipsizeParams {
             return this;
         }
 
-        public UpgradeHelper upgrade() {
-            if (upgrade == null) {
-                upgrade = new UpgradeHelper().from(this).to(this);
-                if (cache != null) {
-                    setFlag(cache, SCHEMA_1, true);
+        public LayoutTicket upgrade() {
+            if (cache != null) {
+                setFlag(cache, SCHEMA_1, true);
+            }
+            return this;
+        }
+
+        public LayoutTicket defaultTo(final int ellipsisParam, final int lineMetric) {
+            if (cache != null) {
+                final int srcPos = getRawIndex(lineMetric);
+                final int dstPos = getRawIndex(ellipsisParam);
+                if (srcPos != dstPos) {
+                    // just copy from old position to new position since we're upgrading in-place
+                    cache[dstPos] = cache[srcPos];
                 }
             }
-            return upgrade;
+            return this;
         }
     }
 
@@ -706,7 +689,6 @@ public final class EllipsizeParams {
     private static void resolveFromCache(@NonNull final LayoutTicket t, final int[] cache,
                                          final int... params) {
         if (cache == null) {
-            t.resolved(false);
             return;
         }
         for (int i = 0; i < params.length; i++) {
@@ -714,9 +696,8 @@ public final class EllipsizeParams {
             t.setParam(param);
             if (param < FLAGS_END) {
                 t.setValue(getFlag(cache, param));
-                t.resolved(true);
             } else if (param < LINEMETRICS_END) {
-                t.resolved(getParam(cache, param, t));
+                getParam(cache, param, t);
             } else {
                 final boolean isLTR = getFlag(cache, IS_LTR);
                 final boolean fallback = getFlag(cache, FALLBACK_LAYOUT);
@@ -760,10 +741,8 @@ public final class EllipsizeParams {
                         t.get(isLTR ? LINE_RIGHT : LINE_LEFT);
                         break;
                     default:
-                        t.resolved(false);
-                        continue;
+                        break;
                 }
-                t.resolved(true);
             }
         }
     }
@@ -775,7 +754,6 @@ public final class EllipsizeParams {
         final Layout layout = t.getLayout();
         final int line = t.getLine();
         if (layout == null) {
-            t.resolved(false);
             return;
         }
         Rect bounds = null;
@@ -822,10 +800,8 @@ public final class EllipsizeParams {
                     t.setValue(layout.getParagraphDirection(line) == Layout.DIR_LEFT_TO_RIGHT);
                     break;
                 default:
-                    t.resolved(false);
                     continue;
             }
-            t.resolved(true);
             if (resolveTo != null) {
                 resolveTo.accept(t);
             }
@@ -836,7 +812,6 @@ public final class EllipsizeParams {
     private static Consumer<LayoutTicket> resolveToCache = t -> {
         final int[] cache = t.getCache();
         if (cache == null) {
-            t.resolved(false);
             return;
         }
         switch (t.getType()) {
@@ -850,86 +825,9 @@ public final class EllipsizeParams {
                 setFlag(cache, t.getParam(), t.asBoolean());
                 break;
             default:
-                t.resolved(false);
-                return;
+                break;
         }
-        t.resolved(true);
     };
-
-    // highly experimental: might not be put into use after all
-    private static class UpgradeHelper {
-        private int[] tmpStorage;
-        private LayoutTicket storage;
-        private boolean inPlace = false;
-        private int[] reservedIndex;
-
-        public UpgradeHelper from(final LayoutTicket src) {
-            storage = src;
-            return this;
-        }
-
-        public UpgradeHelper to(final LayoutTicket dst) {
-            if (dst == storage) {
-                inPlace = true;
-            } else {
-                // not (yet) implemented
-                throw new RuntimeException(-Result.NOT_IMPLEMENTED + ": Not Implemented");
-            }
-            return this;
-        }
-
-        private void initializeReservedIndex(final int size) {
-            final int storageSize = size + extendedPages(size);
-            if (reservedIndex == null || reservedIndex.length < storageSize) {
-                reservedIndex = new int[storageSize];
-            } else {
-                reservedIndex[0] = 0;
-            }
-            initializeIndex(reservedIndex, size);
-            setFlag(reservedIndex, INITIALIZED, true);
-        }
-
-        public UpgradeHelper defaultTo(final int ellipsisParam, final int lineMetric) {
-            if (!inPlace) {
-                // not (yet) implemented
-                throw new RuntimeException(-Result.NOT_IMPLEMENTED + ": Not Implemented");
-            }
-            final int srcPos = getRawIndex(lineMetric);
-            final int dstPos = getRawIndex(ellipsisParam);
-            if (dstPos >= getRawIndex(LINEMETRICS_END)) {
-                // we can safely write the value since there's no overlap
-                // just copy from old position to new position since we're upgrading in-place
-                storage.getCache()[dstPos] = storage.getCache()[srcPos];
-            }
-            if (srcPos == dstPos) {
-                markReserved(srcPos, true);
-            }
-            return this;
-        }
-
-        private void markReserved(final int pos, final boolean b) {
-            if (b && reservedIndex == null) {
-                initializeReservedIndex(getRawIndex(LINEMETRICS_END));
-            }
-            if (reservedIndex != null) {
-                setBit(reservedIndex, indexPage(reservedIndex, pos), pos, b);
-            }
-        }
-
-        public UpgradeHelper set(final int ellipsisParam, final int v) {
-            final int dstPos = getRawIndex(ellipsisParam);
-            markReserved(dstPos, false);
-            storage.set(ellipsisParam, v);
-            return this;
-        }
-
-        public UpgradeHelper set(final int ellipsisParam, final float v) {
-            final int dstPos = getRawIndex(ellipsisParam);
-            markReserved(dstPos, false);
-            storage.set(ellipsisParam, v);
-            return this;
-        }
-    }
 
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -1022,6 +920,13 @@ public final class EllipsizeParams {
             final float initialPos = lastLine.get(LINE_END_EDGE).asFloat();
             final boolean debug = lastLine.get(SCHEMA_DEBUG).asBoolean();
             // prepare to write the finalised ellipsis params
+            // nb: hereafter the line metrics (Schema 0 metrics) may be 'taped over'
+            // by ellipsizing params (Schema 1 params) during the in-place 'upgrade'
+            // since they share the same storage space (poor man's all in one briefcase).
+            // Take care not to call lastLine.get([metrics]) hereafter or ensure it hasn't collided
+            // with a (different) ellipsizing param set at the same 'address' space, or otherwise
+            // store it in a local variable beforehand, or postpone 'upgrade' until the overlapping
+            // line metrics are ready to be relinquished (In short: exercise designer's diligence).
             if (debug) {
                 lastLine.upgrade().set(LE_EDGE, initialPos)
                         .defaultTo(LL_WIDTH, WIDTH)

--- a/app/src/main/java/org/schabi/newpipe/views/NewPipeTextView.java
+++ b/app/src/main/java/org/schabi/newpipe/views/NewPipeTextView.java
@@ -1,12 +1,22 @@
 package org.schabi.newpipe.views;
 
 import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.Rect;
+import android.graphics.RectF;
+import android.os.Build;
+import android.text.Layout;
 import android.util.AttributeSet;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.AppCompatTextView;
 
+import java.text.BreakIterator;
+import java.lang.ref.WeakReference;
+
+import org.schabi.newpipe.util.AnimationUtil;
 import org.schabi.newpipe.util.NewPipeTextViewHelper;
 import org.schabi.newpipe.util.external_communication.ShareUtils;
 
@@ -41,5 +51,510 @@ public class NewPipeTextView extends AppCompatTextView {
             return true;
         }
         return super.onTextContextMenuItem(id);
+    }
+
+
+    /*//////////////////////////////////////////////////////////////////////////
+    // Methods and interfaces
+    //////////////////////////////////////////////////////////////////////////*/
+
+    private static final boolean DEBUG = android.os.Debug.isDebuggerConnected();
+
+    public int getDisplayLines() {
+        return getMaxLines() == -1 ? getLineCount() : Math.min(getMaxLines(), getLineCount());
+    }
+
+    /* the transient ellipsizing state: returns -1 if undetermined (usually before
+     * the layout is first drawn), 1 if we determine the text is shown in part and thus expandable,
+     * 2 if TextView reports the text is ellipsized (by it), 0 otherwise if text is in full view */
+    public int ellipsisState() {
+        if (getLayout() == null) {
+            return -1;
+        } else {
+            return getLayout().getLineEnd(getDisplayLines() - 1) != getText().length() ? 1
+                    : (getLayout().getEllipsisCount(getDisplayLines() - 1) > 0 ? 2 : 0);
+        }
+    }
+
+    public interface OnToggleListener {
+        void onToggle(NewPipeTextView textView, boolean expanded);
+    }
+
+    private OnToggleListener onToggleListener;
+
+    public void setOnToggleListener(final OnToggleListener listener) {
+        onToggleListener = listener;
+    }
+
+
+    /*//////////////////////////////////////////////////////////////////////////
+    // Animations stuff
+    //////////////////////////////////////////////////////////////////////////*/
+
+    public void toggle(final int collapsedLines, final int expandedLines, final int duration) {
+        toggle(collapsedLines, expandedLines, duration, duration);
+    }
+
+    public void toggle(final int collapsedLines, final int expandedLines,
+                       final int collapseDuration, final int expandDuration) {
+        if ((ellipsisState() == 1 && getMaxLines() < expandedLines)
+                || getMaxLines() > collapsedLines) {
+
+            final int initialHeight = getHeight();
+            final boolean isCollapsing = getMaxLines() > collapsedLines;
+            AnimationUtil.toggle(this,
+                    isCollapsing ? collapseDuration : expandDuration,
+                    isCollapsing ? collapsedLines : expandedLines,
+                    isCollapsing, this);
+        }
+    }
+    /* implements AnimationUtil.OnAnimateListener */
+    @Override
+    public void onAnimate(final int animated, final int initial, final int target) {
+        // determine position of the sliding window for the ellipsis during animation
+        crossfadeEllipsis = target > initial
+                ? 1 - (float) (animated - initial) / (float) (target - initial)
+                : (float) (initial - animated) / (float) (initial - target);
+    }
+    @Override
+    public void onAnimationEnd(final View v, final boolean reversed, final boolean expanded) {
+        crossfadeEllipsis = -1;
+        if (!reversed && onToggleListener != null) {
+            onToggleListener.onToggle(this, expanded);
+        }
+    }
+
+
+    /*//////////////////////////////////////////////////////////////////////////
+    // Static heloer functions
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /* Bounds related static helper functions for EllipsizeParams */
+    private static void setStartEdge(final RectF bounds, final float pos, final boolean isLTR) {
+        setBoundsEdge(bounds, pos, isLTR, true, 0);
+    }
+    private static void setEndEdge(final RectF bounds, final float pos, final boolean isLTR) {
+        setBoundsEdge(bounds, pos, isLTR, false, 0);
+    }
+    private static void offsetStartEdge(final RectF bounds, final boolean isLTR,
+                                        final float offset) {
+        setBoundsEdge(bounds, getStartEdge(bounds, isLTR), isLTR, true, offset);
+    }
+    private static void offsetEndEdge(final RectF bounds, final boolean isLTR, final float offset) {
+        setBoundsEdge(bounds, getEndEdge(bounds, isLTR), isLTR, false, offset);
+    }
+    private static void setBoundsEdge(final RectF bounds, final float pos, final boolean isLTR,
+                                      final boolean startEdge, final float offset) {
+        if ((isLTR && startEdge) || (!isLTR && !startEdge)) {
+            bounds.left = isLTR ? pos + offset : pos - offset;
+        } else {
+            bounds.right = isLTR ? pos + offset : pos - offset;
+        }
+    }
+    private static float getStartEdge(final RectF bounds, final boolean isLTR) {
+        return isLTR ? bounds.left : bounds.right;
+    }
+    private static float getEndEdge(final RectF bounds, final boolean isLTR) {
+        return isLTR ? bounds.right : bounds.left;
+    }
+    private static boolean sameStartEdge(final RectF bounds, final Rect lineBounds,
+                                         final boolean isLTR) {
+        return isLTR ? (bounds.left == lineBounds.left) : (bounds.right == lineBounds.right);
+    }
+
+
+    /*//////////////////////////////////////////////////////////////////////////
+    // Ellipsizing companions
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /* our home-grown cache holding the metrics for drawing the ellipsis and/or a ellipsis mask */
+    private static class EllipsizeParams {
+        public WeakReference<Layout> layoutReference;
+        public String ellipsisString;
+        public int ellipsisLine;
+        public RectF ellipsisBounds;
+        public int ellipsisBaseline;
+        public boolean ellipsisLTR;
+
+        /* a cache which holds metrics for a single line; namely the last line temporarily inside
+         * EllipsizeParams.initialize() because the calls to Layout appear to be expensive */
+        protected static class LineMetrics {
+            /* properties */
+            public int line; // zero based line number
+            public boolean isLTR;
+            /* bounds */
+            public int width;
+            public int top;
+            public int bottom;
+            /* canvas coordinates */
+            public int baseline;
+            public float lineMax;
+            /* text offsets */
+            public int lineStart;
+            public int lineEnd;
+        }
+
+        private LineMetrics warmUpLineMetrics(final int line, final Layout layout) {
+            final LineMetrics metrics = new LineMetrics();
+            metrics.line = line;
+            final Rect bounds = new Rect();
+            // from AOSP: bounds = 0, getLineTop(line), mWidth, getLineTop(line + 1)
+            metrics.baseline = layout.getLineBounds(line, bounds);
+            metrics.width = bounds.right;
+            metrics.top = bounds.top;
+            metrics.bottom = bounds.bottom;
+
+            metrics.isLTR = (layout.getParagraphDirection(line) == Layout.DIR_LEFT_TO_RIGHT);
+            metrics.lineMax = layout.getLineMax(line);
+            metrics.lineStart = layout.getLineStart(line);
+            metrics.lineEnd = layout.getLineEnd(line);
+            return metrics;
+        }
+
+        public Layout getLayout() {
+            return layoutReference != null && layoutReference.get() != null
+                    ? layoutReference.get() : null;
+        }
+
+        /* Equivalent helper functions to avoid hitting Layout.getLineExtend() which seems expensive
+         * These short-circuits blissfully ignore getParagraphAlignment() and assume ALIGN_NORMAL */
+        protected float getLineLeft(final LineMetrics metrics) {
+            // from AOSP: mWidth - getLineMax(line)if ALIGN_RIGHT or 0
+            return metrics.isLTR ? 0 : metrics.width - metrics.lineMax;
+        }
+        protected float getLineRight(final LineMetrics metrics) {
+            // from AOSP: mWidth if ALIGN_RIGHT or getLineMax(line)
+            return metrics.isLTR ? metrics.lineMax : metrics.width;
+        }
+
+        /* helper functions which fetch from the warmed up cache */
+        private int getLineBaseLine(final LineMetrics metrics) {
+            return metrics.baseline;
+        }
+        private int getLineWidth(final LineMetrics metrics) {
+            return metrics.width;
+        }
+        private int getLineStart(final LineMetrics metrics) {
+            return metrics.lineStart;
+        }
+        private int getLineEnd(final LineMetrics metrics) {
+            return metrics.lineEnd;
+        }
+        private float getLineRemainingWidth(final LineMetrics metrics) {
+            return metrics.isLTR ? metrics.width - getLineRight(metrics) : getLineLeft(metrics);
+        }
+
+        /* debug helpers */
+        protected RectF getLineRemainderBounds(final LineMetrics metrics) {
+            if (metrics.isLTR) {
+                return new RectF(getLineRight(metrics), metrics.top, metrics.width, metrics.bottom);
+            } else {
+                return new RectF(0, metrics.top, getLineLeft(metrics), metrics.bottom);
+            }
+        }
+        protected Rect getLineBounds(final LineMetrics metrics) {
+            return new Rect(0, metrics.top, metrics.width, metrics.bottom);
+        }
+        private float getLineEndEdge(final LineMetrics metrics, final float offset) {
+            return metrics.isLTR ? getLineRight(metrics) + offset : getLineLeft(metrics) - offset;
+        }
+
+        EllipsizeParams() {
+            // just an empty default no-arg ctor for subclass to initialize
+        }
+
+        EllipsizeParams(final NewPipeTextView textView) {
+            initialize(textView);
+        }
+
+        public static EllipsizeParams newInstance(final NewPipeTextView textView) {
+            final Layout layout = textView.getLayout();
+            if (layout == null) {
+                return null;
+            }
+            // short-circuits are unimplemented for Alignment other than ALIGN_NORMAL
+            // for the simple reason that there is currently no use case
+            if (layout.getParagraphAlignment(textView.getDisplayLines() - 1)
+                    != Layout.Alignment.ALIGN_NORMAL) {
+                // fall back gracefully to a relay subclass just in case
+                return new EllipsizeParamsLayout(textView);
+            }
+            if (DEBUG) {
+                return new EllipsizeParamsDebug(textView);
+            } else {
+                return new EllipsizeParams(textView);
+            }
+        }
+
+        /* Our custom ellipsizing strategy implemented as follows: where lines of text don't fit,
+         * - append the ellipsis to the end of the last line displayed, if screen estate fits; else
+         * - crunch the last bit (word) of the last line to make room for the ellipsis.
+         * It's been longstanding (bug) in Android's TextView the internal ellipsizing doesn't work
+         * with BufferType.SPANNABLE (necessitated by setMovementMethod() other than null) at all
+         * (so we're bound to roll our own). A feature over TextView's internal implementation
+         * is that we crunch by word rather than characters (so the user won't be caught by surprise
+         * when 'app...' was meant to mean 'approach' upon expanding the text, just as an example).
+         * (We defer to BreakIterator for the last 'word' since not every language delimits words
+         * by a space.) */
+        protected LineMetrics initialize(final NewPipeTextView textView) {
+            layoutReference = new WeakReference<>(textView.getLayout());
+            final Layout layout = textView.getLayout();
+            final LineMetrics lastLine = warmUpLineMetrics(textView.getDisplayLines() - 1, layout);
+            final Rect lastLineBounds = getLineBounds(lastLine);
+
+            if (lastLine.isLTR) {
+                ellipsisString = "\u00a0\u2026"; // non-breaking space, ellipsis
+            } else {
+                ellipsisString = "\u2026\u00a0"; // reversed
+            }
+            // determine screen estate the ellipsis takes
+            final float ellipsisWidth = layout.getPaint().measureText(ellipsisString);
+            final float shortfall = ellipsisWidth - getLineRemainingWidth(lastLine);
+            int lastChar = getLineEnd(lastLine);
+            // this would be the reference point to determine if the clipping mask
+            // would eventually kick in at the end of the evaluations
+            final int origLastChar = lastChar;
+            if (shortfall > 0) {
+                // find the closest text offset where the ellipsis fits in
+                lastChar = layout.getOffsetForHorizontal(lastLine.line,
+                        getLineEndEdge(lastLine, -shortfall));
+            }
+            // we're safe to assume by now the ellipsis fits in the last line up to lastChar
+            // but we go further to crunch by word and do some cleanup / nitpicks
+            final int origLineStart = getLineStart(lastLine);
+            final BreakIterator wb = textView.getWordInstance();
+            boolean trailingWhitespacesOnly = lastChar == origLastChar;
+            try {
+                wb.setText(textView.getText().toString());
+                int last = wb.preceding(lastChar);
+                if (!wb.isBoundary(lastChar) && last != BreakIterator.DONE) {
+                    lastChar = last;
+                    trailingWhitespacesOnly = false;
+                    last = wb.preceding(lastChar);
+                }
+                // strip whitespaces: the last line might well end with a space and a line return;
+                // be greedy since we're always prefixing the ellipsis to be drawn with a space
+                // and we won't want there to end up having more than one
+                while (last != BreakIterator.DONE && Character.isWhitespace(
+                        Character.codePointAt(textView.getText(), last))) {
+                    lastChar = last;
+                    last = wb.preceding(lastChar);
+                }
+            } finally {
+                textView.recycle(wb);
+            }
+            ellipsisLine = lastLine.line;
+            ellipsisBaseline = lastLine.baseline;
+            ellipsisLTR = lastLine.isLTR;
+            // our clipping mask to be, which also positions the ellipsis to be drawn
+            // default to zero width bounds to cloak nothing of the text drawn by super.onDraw(),
+            // say if we're simply drawing an ellipsis above it when screen estate fits
+            final float initialPos = getLineEndEdge(lastLine, 0);
+            ellipsisBounds = new RectF(initialPos, lastLine.top, initialPos, lastLine.bottom);
+            if (lastChar != origLastChar) {
+                // whitespaces stripped above also include line break characters (hard returns)
+                // opportunistically wrap the ellipsis to the second last line if screen estate fits
+                if (lastChar < origLineStart && lastLine.line > 0) {
+                    if (layout.getLineMax(lastLine.line - 1) + ellipsisWidth
+                            <= getLineWidth(lastLine)) { // assuming width consistent across lines
+                        ellipsisLine -= 1; // shortfall = 0;
+                        ellipsisBaseline = layout.getLineBaseline(ellipsisLine);
+                        ellipsisLTR = (layout.getParagraphDirection(ellipsisLine)
+                                == Layout.DIR_LEFT_TO_RIGHT);
+                    } else {
+                        // we're not crunching anything above the last line, so never mind
+                        // just let the ellipsis start on its own right in the last line
+                        lastChar = origLineStart;
+                    }
+                }
+                // finally setting the extent of the clipping mask, we need one after all
+                final float ellipsisPos = layout.getPrimaryHorizontal(lastChar);
+                setStartEdge(ellipsisBounds, ellipsisPos, ellipsisLTR);
+                // optimization: we won't need a mask just for whitespaces on the same last line
+                if (trailingWhitespacesOnly && lastChar >= origLineStart) {
+                    setEndEdge(ellipsisBounds, ellipsisPos, ellipsisLTR);
+                }
+            }
+            // nitpick: omit the prefixed space if ellipsis starts on its own line
+            if (sameStartEdge(ellipsisBounds, lastLineBounds, ellipsisLTR)) {
+                if (ellipsisLTR) {
+                    ellipsisString = ellipsisString.substring(1);
+                } else {
+                    ellipsisString = ellipsisString.substring(0, ellipsisString.length() - 1);
+                }
+            }
+
+            return lastLine;
+        }
+    }
+
+    /* just a subclass with additional bounds info for debug purposes */
+    private static class EllipsizeParamsDebug extends EllipsizeParams {
+        public Rect lastLineBounds;
+        public RectF lastLineEndBounds;
+
+        EllipsizeParamsDebug(final NewPipeTextView textView) {
+            final LineMetrics lastLine = initialize(textView);
+            lastLineBounds = getLineBounds(lastLine);
+            lastLineEndBounds = getLineRemainderBounds(lastLine);
+        }
+    }
+
+    /* subclass which proxies functions back to Layout where short-circuits are unimplemented */
+    private static class EllipsizeParamsLayout extends EllipsizeParams {
+        EllipsizeParamsLayout(final NewPipeTextView textView) {
+            initialize(textView);
+        }
+        @Override
+        protected float getLineLeft(final LineMetrics metrics) {
+            return getLayout() != null ? getLayout().getLineLeft(metrics.line)
+                    : super.getLineLeft(metrics);
+        }
+        @Override
+        protected float getLineRight(final LineMetrics metrics) {
+            return getLayout() != null ? getLayout().getLineRight(metrics.line)
+                    : super.getLineRight(metrics);
+        }
+    }
+
+
+    /*//////////////////////////////////////////////////////////////////////////
+    // Word breaker utility
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /* tries to do some recycle magic here */
+    protected BreakIterator getWordInstance() {
+        if (oldWordIterator == null || oldWordIterator.get() == null) {
+            return BreakIterator.getWordInstance();
+        } else {
+            return oldWordIterator.get();
+        }
+    }
+    protected void recycle(final BreakIterator wordIterator) {
+        if (wordIterator != null) {
+            oldWordIterator = new WeakReference<>(wordIterator);
+        }
+    }
+
+
+    /*//////////////////////////////////////////////////////////////////////////
+    // TextView stuff
+    //////////////////////////////////////////////////////////////////////////*/
+
+    private EllipsizeParams ellipsizeParams;
+    private WeakReference<BreakIterator> oldWordIterator;
+
+    /* used in expanding/collapsing animation; 0 for ellipsis to be invisible, 1 fully visible */
+    private float crossfadeEllipsis = -1; // not in use (not animating)
+
+    private static void clipOutRectCompat(final Canvas canvas, final RectF rect) {
+        if (Build.VERSION.SDK_INT >= 26) {
+            canvas.clipOutRect(rect);
+        } else {
+            canvas.clipRect(rect, android.graphics.Region.Op.DIFFERENCE);
+        }
+    }
+
+    /* The bone of this override is to carry out our custom ellipsizing which comprises
+     * two components: a clipping mask and an ellipsis, backed by an EllipsizeParams
+     * (a super-lazy initialized home-grown cache which stores the necessary metrics).
+     * Much like a magician's trick, the mask cloaks part of the ellipisized text
+     * while the ellipsis is drawn above it, as necessary. */
+    @Override
+    protected void onDraw(final Canvas canvas) {
+        final Layout layout = getLayout();
+        if ((layout == null || getMaxLines() == -1 || getLineCount() == 0 || ellipsisState() != 1)
+                && crossfadeEllipsis == -1) {
+            super.onDraw(canvas);
+            return;
+        }
+
+        // invalidate cache if text layout changed;
+        // except when animation is in flight: we actually reuse the last cached ellipsizeParams
+        if (ellipsizeParams != null && crossfadeEllipsis == -1) {
+            // There doesn't seem to be a good way to detect (the internal) text layout changes
+            // eg layout change listeners are only fired upon external (size) changes but not, say,
+            // an internal text reflow (invalidated internally by setText() and other functions).
+            // We cheated a bit by keeping a WeakReference to the TextView's internal Layout
+            // at the time EllipsizeParams is created and computed leveraging the fact that
+            // getLayout() returns the instance rather than a copy of it.
+            if (ellipsizeParams.getLayout() != getLayout()) {
+                ellipsizeParams = null;
+                if (DEBUG) {
+                    canvas.drawColor(0x22222222);
+                }
+            }
+        }
+        // super lazy initialize our ellipsizeParams cache
+        if (ellipsizeParams == null) {
+            if (crossfadeEllipsis == -1) { // ie we're not drawing amidst an animation
+                // We're not left with much better place to do computations:
+                // we'll be fiddling with setMaxLines() to measure() the final bounds post-animation
+                // so tapping into onMeasure() might incur extra computation cycles when we're not
+                // really drawing (given our limitation in listening to text layout changes above).
+                // Computations in onDraw() is generally a bad idea after all;
+                // so we roll our home-grown cache as part of the remedy.
+                ellipsizeParams = EllipsizeParams.newInstance(this);
+            } else {
+                // we're in flight an animation but without the previously cached ellipsizeParams
+                // ah well, never mind - not animating the ellipsis change this time
+                super.onDraw(canvas);
+                return;
+            }
+        }
+        canvas.save();
+        final Paint p = new Paint(layout.getPaint());
+        final int offsetX = getTotalPaddingLeft();
+        final int offsetY = getTotalPaddingTop();
+        canvas.translate(offsetX, offsetY);
+        try {
+            if (DEBUG && ellipsizeParams instanceof EllipsizeParamsDebug
+                    && crossfadeEllipsis == -1) {
+                final EllipsizeParamsDebug debugParams = (EllipsizeParamsDebug) ellipsizeParams;
+                p.setARGB(100, 255, 0, 0);
+                canvas.drawRect(debugParams.lastLineBounds, p);
+
+                p.setARGB(100, 0, 255, 0);
+                canvas.drawRect(debugParams.lastLineEndBounds, p);
+            }
+
+            if (DEBUG && ellipsizeParams.ellipsisBounds.width() > 0) {
+                p.setARGB(100, 0, 0, 255);
+                canvas.drawRect(ellipsizeParams.ellipsisBounds, p);
+            }
+
+            if (crossfadeEllipsis > 0 || ellipsisState() == 1) {
+                RectF clipOutBounds = null;
+
+                p.setColor(getCurrentTextColor());
+                if (crossfadeEllipsis != -1) { // animation stuff
+                    // simulate sliding window to the end of thd ellipsized last line
+                    clipOutBounds = new RectF(ellipsizeParams.ellipsisBounds);
+                    offsetEndEdge(clipOutBounds, ellipsizeParams.ellipsisLTR,
+                            -clipOutBounds.width() * crossfadeEllipsis);
+                    canvas.save();
+                    clipOutRectCompat(canvas, clipOutBounds);
+                    p.setAlpha((int) ((float) 255 * crossfadeEllipsis));
+                }
+                p.setTextAlign(ellipsizeParams.ellipsisLTR ? Paint.Align.LEFT : Paint.Align.RIGHT);
+                canvas.drawText(ellipsizeParams.ellipsisString,
+                        getStartEdge(ellipsizeParams.ellipsisBounds, ellipsizeParams.ellipsisLTR),
+                        (float) (getTotalPaddingTop() + ellipsizeParams.ellipsisBaseline), p);
+                if (clipOutBounds != null) {
+                    canvas.restore();
+                    clipOutBounds = new RectF(ellipsizeParams.ellipsisBounds);
+                    offsetStartEdge(clipOutBounds, ellipsizeParams.ellipsisLTR,
+                            clipOutBounds.width() * (1 - crossfadeEllipsis));
+                    clipOutRectCompat(canvas, clipOutBounds);
+                } else if (ellipsizeParams.ellipsisBounds.width() > 0) {
+                    clipOutRectCompat(canvas, ellipsizeParams.ellipsisBounds);
+                }
+            }
+
+        } finally {
+            canvas.translate(-offsetX, -offsetY);
+        }
+        super.onDraw(canvas);
+        canvas.restore();
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/views/NewPipeTextView.java
+++ b/app/src/main/java/org/schabi/newpipe/views/NewPipeTextView.java
@@ -3,7 +3,6 @@ package org.schabi.newpipe.views;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Paint;
-import android.os.Build;
 import android.text.Layout;
 import android.util.AttributeSet;
 import android.view.View;
@@ -161,28 +160,6 @@ public class NewPipeTextView extends AppCompatTextView implements AnimationUtil.
     // poor man's all in one briefcase
     private int[] ellipsizeParams;
 
-    @SuppressWarnings("deprecation")
-    private static void clipOutRectCompat(@NonNull final Canvas canvas, final float left,
-                                          final float top, final float right, final float bottom) {
-        if (Build.VERSION.SDK_INT >= 26) {
-            canvas.clipOutRect(left, top, right, bottom);
-        } else {
-            canvas.clipRect(left, top, right, bottom, android.graphics.Region.Op.DIFFERENCE);
-        }
-    }
-    // shorthands to fetch ellipsising params from config storage
-    private boolean getConfigFlag(final int flag) {
-        return EllipsizeParams.getFlag(ellipsizeParams, flag);
-    }
-    private int getConfigByte(final int param) {
-        return EllipsizeParams.getByte(ellipsizeParams, param);
-    }
-    private int getConfigInt(final int param) {
-        return EllipsizeParams.getInt(ellipsizeParams, param);
-    }
-    private float getConfigFloat(final int param) {
-        return EllipsizeParams.getFloat(ellipsizeParams, param);
-    }
     private boolean textLayoutChanged() {
         // There doesn't seem to be a good way to detect (the internal) text layout changes
         // eg layout change listeners only fire upon external (size) changes but not say, an
@@ -206,7 +183,7 @@ public class NewPipeTextView extends AppCompatTextView implements AnimationUtil.
     protected void onDraw(final Canvas canvas) {
         final Layout layout = getLayout();
         final boolean animating = ellipsizeParams != null
-                && getConfigFlag(EllipsizeParams.ANIMATING);
+                && EllipsizeParams.getFlag(ellipsizeParams, EllipsizeParams.ANIMATING);
         if (layout == null || getLineCount() == 0
                 || (ellipsisState() != EllipsisState.EXPANDABLE && !animating)) {
             super.onDraw(canvas);
@@ -217,12 +194,13 @@ public class NewPipeTextView extends AppCompatTextView implements AnimationUtil.
         // except when animation is in flight: we actually reuse the last cached ellipsizeParams
         if (ellipsizeParams != null && !animating && textLayoutChanged()) {
             EllipsizeParams.setFlag(ellipsizeParams, EllipsizeParams.INITIALIZED, false);
-            if (getConfigFlag(EllipsizeParams.SCHEMA_DEBUG)) {
+            if (EllipsizeParams.getFlag(ellipsizeParams, EllipsizeParams.SCHEMA_DEBUG)) {
                 canvas.drawColor(0x22222222);
             }
         }
         // super lazy initialize our ellipsizeParams cache
-        if (ellipsizeParams == null || !getConfigFlag(EllipsizeParams.INITIALIZED)) {
+        if (ellipsizeParams == null
+                || !EllipsizeParams.getFlag(ellipsizeParams, EllipsizeParams.INITIALIZED)) {
             if (!animating) {
                 // We're not left with much better place to do computations:
                 // we'll be fiddling with setMaxLines() to measure() the final bounds post-animation
@@ -247,73 +225,7 @@ public class NewPipeTextView extends AppCompatTextView implements AnimationUtil.
         final int offsetY = getTotalPaddingTop();
         canvas.translate(offsetX, offsetY);
 
-        final boolean debug = getConfigFlag(EllipsizeParams.SCHEMA_DEBUG);
-        final boolean isLTR = getConfigFlag(EllipsizeParams.IS_LTR);
-        if (debug && !animating) {
-            // draw lastLineBounds
-            p.setARGB(100, 255, 0, 0);
-            canvas.drawRect(0, getConfigInt(EllipsizeParams.LL_TOP),
-                    getConfigInt(EllipsizeParams.LL_WIDTH),
-                    getConfigInt(EllipsizeParams.LL_BOTTOM), p);
-            // draw lastLineEndBounds
-            p.setARGB(100, 0, 255, 0);
-            canvas.drawRect(isLTR ? getConfigFloat(EllipsizeParams.LE_EDGE) : 0,
-                    getConfigInt(EllipsizeParams.LL_TOP),
-                    getConfigFloat(isLTR ? EllipsizeParams.LL_WIDTH : EllipsizeParams.LE_EDGE),
-                    getConfigInt(EllipsizeParams.LL_BOTTOM), p);
-        }
-
-        if (debug && (getConfigFloat(EllipsizeParams.EB_RIGHT_D)
-                - getConfigFloat(EllipsizeParams.EB_LEFT_D)) > 0) {
-            p.setARGB(100, 0, 0, 255);
-            canvas.drawRect(getConfigFloat(EllipsizeParams.EB_LEFT_D),
-                    getConfigFloat(EllipsizeParams.EB_TOP_D),
-                    getConfigFloat(EllipsizeParams.EB_RIGHT_D),
-                    getConfigFloat(EllipsizeParams.EB_BOTTOM_D), p);
-        }
-
-        if (animating || ellipsisState() == EllipsisState.EXPANDABLE) {
-            final int crossfadeEllipsis = getConfigByte(EllipsizeParams.CROSSFADE_ELLIPSIS);
-            float splitPt = -1;
-            final float clipOutBoundsL = getConfigFloat(
-                    debug ? EllipsizeParams.EB_LEFT_D : EllipsizeParams.EB_LEFT);
-            final float clipOutBoundsT = getConfigFloat(
-                    debug ? EllipsizeParams.EB_TOP_D : EllipsizeParams.EB_TOP);
-            final float clipOutBoundsR = getConfigFloat(
-                    debug ? EllipsizeParams.EB_RIGHT_D : EllipsizeParams.EB_RIGHT);
-            final float clipOutBoundsB = getConfigFloat(
-                    debug ? EllipsizeParams.EB_BOTTOM_D : EllipsizeParams.EB_BOTTOM);
-
-            p.setColor(getCurrentTextColor());
-            if (animating) { // animation stuff
-                // simulate sliding window to the end of the ellipsized last line
-                splitPt = (clipOutBoundsR - clipOutBoundsL) * crossfadeEllipsis / 255;
-                canvas.save();
-                // pass in the four corners as parameters to avoid boxing an intermediate RectF
-                clipOutRectCompat(canvas,
-                        isLTR ? clipOutBoundsL : clipOutBoundsL + splitPt, clipOutBoundsT,
-                        isLTR ? clipOutBoundsR - splitPt : clipOutBoundsR, clipOutBoundsB);
-                p.setAlpha(crossfadeEllipsis);
-            }
-            final Paint.Align origAlign = p.getTextAlign();
-            p.setTextAlign(isLTR ? Paint.Align.LEFT : Paint.Align.RIGHT);
-            final boolean skipSpace = getConfigFlag(EllipsizeParams.SKIP_PREFIX_SPACE);
-            canvas.drawText(EllipsizeParams.ELLIPSIS_CHARS, isLTR && !skipSpace ? 0 : 1,
-                    skipSpace ? EllipsizeParams.ELLIPSIS_LEN - 1 : EllipsizeParams.ELLIPSIS_LEN,
-                    isLTR ? clipOutBoundsL : clipOutBoundsR,
-                    getTotalPaddingTop() + getConfigFloat(debug
-                            ? EllipsizeParams.EB_BASELINE_D : EllipsizeParams.EB_BASELINE), p);
-            p.setTextAlign(origAlign);
-            if (animating) {
-                canvas.restore();
-                clipOutRectCompat(canvas,
-                        isLTR ? clipOutBoundsR - splitPt : clipOutBoundsL, clipOutBoundsT,
-                        isLTR ? clipOutBoundsR : clipOutBoundsL + splitPt, clipOutBoundsB);
-            } else if (clipOutBoundsR - clipOutBoundsL > 0) {
-                clipOutRectCompat(canvas,
-                        clipOutBoundsL, clipOutBoundsT, clipOutBoundsR, clipOutBoundsB);
-            }
-        }
+        EllipsizeParams.onDraw(canvas, p, ellipsizeParams, ellipsisState(), getCurrentTextColor());
 
         canvas.translate(-offsetX, -offsetY);
         super.onDraw(canvas);

--- a/app/src/main/java/org/schabi/newpipe/views/NewPipeTextView.java
+++ b/app/src/main/java/org/schabi/newpipe/views/NewPipeTextView.java
@@ -8,6 +8,7 @@ import android.graphics.RectF;
 import android.os.Build;
 import android.text.Layout;
 import android.util.AttributeSet;
+import android.view.View;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;

--- a/app/src/main/java/org/schabi/newpipe/views/NewPipeTextView.java
+++ b/app/src/main/java/org/schabi/newpipe/views/NewPipeTextView.java
@@ -464,8 +464,8 @@ public class NewPipeTextView extends AppCompatTextView implements AnimationUtil.
     @Override
     protected void onDraw(final Canvas canvas) {
         final Layout layout = getLayout();
-        if ((layout == null || getMaxLines() == -1 || getLineCount() == 0 || ellipsisState() != 1)
-                && crossfadeEllipsis == -1) {
+        if (layout == null || getLineCount() == 0
+                || (ellipsisState() != 1 && crossfadeEllipsis == -1)) {
             super.onDraw(canvas);
             return;
         }

--- a/app/src/main/java/org/schabi/newpipe/views/NewPipeTextView.java
+++ b/app/src/main/java/org/schabi/newpipe/views/NewPipeTextView.java
@@ -71,9 +71,11 @@ public class NewPipeTextView extends AppCompatTextView implements AnimationUtil.
     public int ellipsisState() {
         if (getLayout() == null) {
             return -1;
+        }
+        if (getLayout().getLineEnd(getDisplayLines() - 1) != getText().length()) {
+            return 1;
         } else {
-            return getLayout().getLineEnd(getDisplayLines() - 1) != getText().length() ? 1
-                    : (getLayout().getEllipsisCount(getDisplayLines() - 1) > 0 ? 2 : 0);
+            return getLayout().getEllipsisCount(getDisplayLines() - 1) > 0 ? 2 : 0;
         }
     }
 
@@ -101,7 +103,6 @@ public class NewPipeTextView extends AppCompatTextView implements AnimationUtil.
         if ((ellipsisState() == 1 && getMaxLines() < expandedLines)
                 || getMaxLines() > collapsedLines) {
 
-            final int initialHeight = getHeight();
             final boolean isCollapsing = getMaxLines() > collapsedLines;
             AnimationUtil.toggle(this,
                     isCollapsing ? collapseDuration : expandDuration,
@@ -333,7 +334,7 @@ public class NewPipeTextView extends AppCompatTextView implements AnimationUtil.
                     trailingWhitespacesOnly = false;
                     last = wb.preceding(lastChar);
                 }
-                // strip whitespaces: the last line might well end with a space and a line return;
+                // strip whitespaces: the last line might well end with a space and a line return
                 // be greedy since we're always prefixing the ellipsis to be drawn with a space
                 // and we won't want there to end up having more than one
                 while (last != BreakIterator.DONE && Character.isWhitespace(
@@ -358,7 +359,7 @@ public class NewPipeTextView extends AppCompatTextView implements AnimationUtil.
                 if (lastChar < origLineStart && lastLine.line > 0) {
                     if (layout.getLineMax(lastLine.line - 1) + ellipsisWidth
                             <= getLineWidth(lastLine)) { // assuming width consistent across lines
-                        ellipsisLine -= 1; // shortfall = 0;
+                        ellipsisLine -= 1; // nil shortfall
                         ellipsisBaseline = layout.getLineBaseline(ellipsisLine);
                         ellipsisLTR = (layout.getParagraphDirection(ellipsisLine)
                                 == Layout.DIR_LEFT_TO_RIGHT);
@@ -470,20 +471,19 @@ public class NewPipeTextView extends AppCompatTextView implements AnimationUtil.
             return;
         }
 
-        // invalidate cache if text layout changed;
+        // invalidate cache if text layout changed
         // except when animation is in flight: we actually reuse the last cached ellipsizeParams
-        if (ellipsizeParams != null && crossfadeEllipsis == -1) {
-            // There doesn't seem to be a good way to detect (the internal) text layout changes
-            // eg layout change listeners are only fired upon external (size) changes but not, say,
-            // an internal text reflow (invalidated internally by setText() and other functions).
-            // We cheated a bit by keeping a WeakReference to the TextView's internal Layout
-            // at the time EllipsizeParams is created and computed leveraging the fact that
-            // getLayout() returns the instance rather than a copy of it.
-            if (ellipsizeParams.getLayout() != getLayout()) {
-                ellipsizeParams = null;
-                if (DEBUG) {
-                    canvas.drawColor(0x22222222);
-                }
+        if (ellipsizeParams != null && crossfadeEllipsis == -1
+                // There doesn't seem to be a good way to detect (the internal) text layout changes
+                // eg layout change listeners only fire upon external (size) changes but not say, an
+                // internal text reflow (invalidated internally by setText() and other functions).
+                // We cheated a bit by keeping a WeakReference to the TextView's internal Layout
+                // at the time EllipsizeParams is created and computed leveraging the fact that
+                // getLayout() returns the instance rather than a copy of it.
+                && ellipsizeParams.getLayout() != getLayout()) {
+            ellipsizeParams = null;
+            if (DEBUG) {
+                canvas.drawColor(0x22222222);
             }
         }
         // super lazy initialize our ellipsizeParams cache
@@ -493,7 +493,7 @@ public class NewPipeTextView extends AppCompatTextView implements AnimationUtil.
                 // we'll be fiddling with setMaxLines() to measure() the final bounds post-animation
                 // so tapping into onMeasure() might incur extra computation cycles when we're not
                 // really drawing (given our limitation in listening to text layout changes above).
-                // Computations in onDraw() is generally a bad idea after all;
+                // Computations in onDraw() is generally a bad idea after all,
                 // so we roll our home-grown cache as part of the remedy.
                 ellipsizeParams = EllipsizeParams.newInstance(this);
             } else {
@@ -529,13 +529,13 @@ public class NewPipeTextView extends AppCompatTextView implements AnimationUtil.
 
                 p.setColor(getCurrentTextColor());
                 if (crossfadeEllipsis != -1) { // animation stuff
-                    // simulate sliding window to the end of thd ellipsized last line
+                    // simulate sliding window to the end of the ellipsized last line
                     clipOutBounds = new RectF(ellipsizeParams.ellipsisBounds);
                     offsetEndEdge(clipOutBounds, ellipsizeParams.ellipsisLTR,
                             -clipOutBounds.width() * crossfadeEllipsis);
                     canvas.save();
                     clipOutRectCompat(canvas, clipOutBounds);
-                    p.setAlpha((int) ((float) 255 * crossfadeEllipsis));
+                    p.setAlpha((int) (255 * crossfadeEllipsis));
                 }
                 p.setTextAlign(ellipsizeParams.ellipsisLTR ? Paint.Align.LEFT : Paint.Align.RIGHT);
                 canvas.drawText(ellipsizeParams.ellipsisString,

--- a/app/src/main/java/org/schabi/newpipe/views/NewPipeTextView.java
+++ b/app/src/main/java/org/schabi/newpipe/views/NewPipeTextView.java
@@ -12,7 +12,6 @@ import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.AppCompatTextView;
-import androidx.core.util.Consumer;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/app/src/main/java/org/schabi/newpipe/views/NewPipeTextView.java
+++ b/app/src/main/java/org/schabi/newpipe/views/NewPipeTextView.java
@@ -3,14 +3,12 @@ package org.schabi.newpipe.views;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Paint;
-import android.graphics.Rect;
 import android.os.Build;
 import android.text.Layout;
 import android.util.AttributeSet;
 import android.view.View;
 
 import androidx.annotation.IntDef;
-import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.AppCompatTextView;
@@ -18,10 +16,10 @@ import androidx.core.util.Consumer;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-import java.text.BreakIterator;
 import java.lang.ref.WeakReference;
 
 import org.schabi.newpipe.util.AnimationUtil;
+import org.schabi.newpipe.util.EllipsizeParams;
 import org.schabi.newpipe.util.NewPipeTextViewHelper;
 import org.schabi.newpipe.util.external_communication.ShareUtils;
 
@@ -62,8 +60,6 @@ public class NewPipeTextView extends AppCompatTextView implements AnimationUtil.
     /*//////////////////////////////////////////////////////////////////////////
     // Methods and interfaces
     //////////////////////////////////////////////////////////////////////////*/
-
-    private static final boolean DEBUG = android.os.Debug.isDebuggerConnected();
 
     public int getDisplayLines() {
         return getMaxLines() == -1 ? getLineCount() : Math.min(getMaxLines(), getLineCount());
@@ -118,24 +114,22 @@ public class NewPipeTextView extends AppCompatTextView implements AnimationUtil.
     @Override
     public void onAnimateProgress(final float animatedFraction, final boolean isCollapsing) {
         // determine position of the sliding window for the ellipsis during animation
-        if (ellipsizeParams != null && ellipsizeParams.configStorage != null) {
+        if (ellipsizeParams != null) {
             // afford to lose some precision and smuggle it into 8 bits (0 - 255) for storage
-            EllipsizeParams.setByte(ellipsizeParams.configStorage,
-                    EllipsizeParams.CROSSFADE_ELLIPSIS,
+            EllipsizeParams.setByte(ellipsizeParams, EllipsizeParams.CROSSFADE_ELLIPSIS,
                     (int) (255 * (isCollapsing ? animatedFraction : 1 - animatedFraction)));
         }
     }
     @Override
     public void onAnimationStart(final View v, final boolean isCollapsing) {
-        if (ellipsizeParams != null && ellipsizeParams.configStorage != null) {
-            EllipsizeParams.setFlag(ellipsizeParams.configStorage, EllipsizeParams.ANIMATING, true);
+        if (ellipsizeParams != null) {
+            EllipsizeParams.setFlag(ellipsizeParams, EllipsizeParams.ANIMATING, true);
         }
     }
     @Override
     public void onAnimationEnd(final View v, final boolean reversed, final boolean expanded) {
-        if (ellipsizeParams != null && ellipsizeParams.configStorage != null) {
-            EllipsizeParams.setFlag(ellipsizeParams.configStorage,
-                    EllipsizeParams.ANIMATING, false);
+        if (ellipsizeParams != null) {
+            EllipsizeParams.setFlag(ellipsizeParams, EllipsizeParams.ANIMATING, false);
         }
         if (!reversed && onToggleListener != null) {
             onToggleListener.onToggle(this, expanded);
@@ -159,962 +153,14 @@ public class NewPipeTextView extends AppCompatTextView implements AnimationUtil.
 
 
     /*//////////////////////////////////////////////////////////////////////////
-    // Ellipsizing companions
-    //////////////////////////////////////////////////////////////////////////*/
-
-    /* our home-grown cache holding the metrics for drawing the ellipsis and/or a ellipsis mask */
-    private static class EllipsizeParams {
-        private WeakReference<Layout> layoutReference;
-
-        // magic numbers
-        public static final int UNSET   = -1;
-
-        @Retention(RetentionPolicy.SOURCE)
-        @IntDef({ValueType.BOOLEAN, ValueType.INT, ValueType.FLOAT})
-        public @interface ValueType {
-            int BOOLEAN = 0;
-            int INT     = 1;
-            int FLOAT   = 2;
-        }
-
-        @Retention(RetentionPolicy.SOURCE)
-        @IntDef({Op.NORMAL, Op.ADD, Op.MINUS})
-        public @interface Op {
-            int NORMAL  = 0;  // read: replace
-            int ADD     = 1;
-            int MINUS   = 2;
-        }
-
-        @Retention(RetentionPolicy.SOURCE)
-        @IntDef({Result.OK, Result.NOT_FOUND, Result.NOT_IN_RANGE,
-                Result.ERROR, Result.NOT_IMPLEMENTED})
-        public @interface Result {  // status codes
-            int OK                = -200;
-            int NOT_FOUND         = -404;
-            int NOT_IN_RANGE      = -416;
-            int ERROR             = -500;
-            int NOT_IMPLEMENTED   = -501;
-        }
-
-        public static final int HEADER_RESERVED = 0;
-
-        @Retention(RetentionPolicy.SOURCE)
-        @IntDef({INITIALIZED, SCHEMA_1, SCHEMA_DEBUG, IS_LTR, SKIP_PREFIX_SPACE, ANIMATING})
-        public @interface Flags { }
-
-        public static final int FLAGS_START = 0;
-        // booleans are stored in FLAGS
-        public static final int INITIALIZED       = FLAGS_START;
-        public static final int SCHEMA_1          = 1 + FLAGS_START;
-        public static final int SCHEMA_DEBUG      = 2 + FLAGS_START;
-        public static final int FALLBACK_LAYOUT   = 3 + FLAGS_START;
-        // LineMetrics enums
-        public static final int IS_LTR            = 4 + FLAGS_START;
-        public static final int SKIP_PREFIX_SPACE = 5 + FLAGS_START;
-        public static final int ELLIPSISING_MASK  = 6 + FLAGS_START;
-        // animation enums
-        public static final int ANIMATING         = 7 + FLAGS_START;
-        /* keep this to last */
-        public static final int FLAGS_END   = 8 + FLAGS_START;
-
-        /* reserved a byte to 'smuggle in' crossfadeEllipsis (bits 8-15) */
-        public static final int CROSSFADE_ELLIPSIS = 8 + FLAGS_START;
-
-        public static final int FLOAT_INDEX_START = 16 + FLAGS_START; // 15 slots (bits 16-30)
-
-        // highest bit reserved for meta
-        public static final int CONTINUATION = Integer.SIZE - 1; // highest bit (31) of int
-
-
-        public static final int SCHEMA_0_START = 100;
-        // LineMetrics enums (SCHEMA 0)
-        public static final int LINEMETRICS_START = SCHEMA_0_START;
-        /* properties */
-        public static final int LINE_NO    = 1 + LINEMETRICS_START;
-        /* bounds */
-        public static final int WIDTH      = 2 + LINEMETRICS_START;
-        public static final int TOP        = 3 + LINEMETRICS_START;
-        public static final int BOTTOM     = 4 + LINEMETRICS_START;
-        /* canvas coordinates */
-        public static final int BASELINE   = 5 + LINEMETRICS_START;
-        public static final int LINEMAX    = 6 + LINEMETRICS_START;  // float
-        /* text offsets */
-        public static final int LINE_START = 7 + LINEMETRICS_START;
-        public static final int LINE_END   = 8 + LINEMETRICS_START;
-        /* keep this to last */
-        public static final int LINEMETRICS_END = 9 + LINEMETRICS_START;
-
-        // derived LineMetrics
-        public static final int LINEMETRIC_DERIVED_START = 110;
-        public static final int LINE_LEFT  = 1 + LINEMETRIC_DERIVED_START;
-        public static final int LINE_RIGHT = 2 + LINEMETRIC_DERIVED_START;
-        public static final int LINEMETRIC_DERIVED_END = 3 + LINEMETRIC_DERIVED_START;
-
-        // extended LineMetrics (computed without equivalent functions in Layout)
-        public static final int LINEMETRIC_COMPUTED_START = 120;
-        public static final int LINE_REMAINING_SPACE  = 1 + LINEMETRIC_COMPUTED_START;
-        public static final int LINE_START_EDGE       = 2 + LINEMETRIC_COMPUTED_START;
-        public static final int LINE_END_EDGE         = 3 + LINEMETRIC_COMPUTED_START;
-        public static final int LINEMETRIC_COMPUTED_END = 4 + LINEMETRIC_COMPUTED_START;
-
-        public static final int LINEMETRICS_EXT_END = LINEMETRIC_COMPUTED_END;
-
-        public static final int SCHEMA_1_START     = 200;
-        // EllipsisParams enums (SCHEMA 1)
-        public static final int ELLIPSISPARAMS_START = SCHEMA_1_START;
-        /* ellipsisBounds */
-        public static final int EB_LEFT            = 1 + ELLIPSISPARAMS_START;
-        public static final int EB_RIGHT           = 2 + ELLIPSISPARAMS_START;
-        public static final int EB_TOP             = 3 + ELLIPSISPARAMS_START;
-        public static final int EB_BOTTOM          = 4 + ELLIPSISPARAMS_START;
-        /* ellipsisBaseline */
-        public static final int EB_BASELINE        = 5 + ELLIPSISPARAMS_START;
-        /* keep this to last */
-        public static final int ELLIPSISPARAMS_END = 6 + ELLIPSISPARAMS_START;
-
-        // EllipsisParamsDebug enums (SCHEMA 1-D)
-        public static final int ELLIPSISPARAMS_DEBUG_START = SCHEMA_1_START;
-        /* lastLineBounds (shared with lastLineEndBounds; overlaps LineMetrics bounds) */
-        public static final int LL_WIDTH           = 2 + ELLIPSISPARAMS_DEBUG_START;
-        public static final int LL_TOP             = 3 + ELLIPSISPARAMS_DEBUG_START;
-        public static final int LL_BOTTOM          = 4 + ELLIPSISPARAMS_DEBUG_START;
-        /* ellipsisBaseline */
-        public static final int EB_BASELINE_D      = 5 + ELLIPSISPARAMS_DEBUG_START;
-        // lastLineEndBounds */                      // overlaps LINEMAX
-        public static final int LE_EDGE            = 6 + ELLIPSISPARAMS_DEBUG_START;
-        /* ellipsisBounds */
-        public static final int EB_LEFT_D          = 1 + ELLIPSISPARAMS_DEBUG_START;
-        public static final int EB_RIGHT_D         = 7 + ELLIPSISPARAMS_DEBUG_START;
-        public static final int EB_TOP_D           = LL_TOP;
-        public static final int EB_BOTTOM_D        = LL_BOTTOM;
-        /* keep this to last */
-        public static final int ELLIPSISPARAMS_DEBUG_END = 8 + ELLIPSISPARAMS_DEBUG_START;
-
-        // poor man's all in one briefcase
-        private int[] configStorage;
-
-        private int[] setupLineMetrics() {
-            final int size = accomodationSize();
-            final int storageSize = size + indexOffset(size);
-            if (configStorage == null || configStorage.length < storageSize) {
-                configStorage = new int[storageSize];
-            } else {
-                configStorage[0] = 0;
-            }
-            initializeIndex(configStorage, size);
-            setFlag(configStorage, INITIALIZED, true);
-            if (DEBUG) {
-                setFlag(configStorage, SCHEMA_DEBUG, true);
-            }
-            return configStorage;
-        }
-        private static int accomodationSize() {
-            // finds the lowest common size that could fit the schemas into one common storage
-            return Math.max(getRawIndex(LINEMETRICS_END), getRawIndex(ELLIPSISPARAMS_DEBUG_END));
-        }
-        private static boolean initializeIndex(@NonNull final int[] params,
-                                               @IntRange(from = 1) final int paramsSize) {
-            final int indexSize = indexOffset(paramsSize);
-            if (indexSize < params.length) {
-                for (int i = 0; i < indexSize; i++) {
-                    params[i] = params[i] | (1 << CONTINUATION);
-                }
-                return true;
-            }
-            return false;
-        }
-        // get the actual index in storage
-        private static int getRawIndex(@IntRange(from = FLAGS_START) final int flag) {
-            // inclusive of end bounds (<=) in case it's called to compute size
-            if (flag <= FLOAT_INDEX_START) {  // could have been FLAGS_END but to cover the use case
-                return flag - FLAGS_START;
-            } else if (flag <= LINEMETRICS_END) {
-                return flag - SCHEMA_0_START;
-            } else if (flag <= ELLIPSISPARAMS_DEBUG_END) {
-                return flag - SCHEMA_1_START;
-            }
-            return Result.NOT_IN_RANGE;
-        }
-        // compute the additional 'pages' (int) of FLAGS required for paramsSize
-        // ref: https://stackoverflow.com/a/20090375
-        private static int indexOffset(@IntRange(from = 1) final int paramsSize) {
-            return indexOffset(paramsSize - 1, false);
-        }
-        private static int indexOffset(@IntRange(from = FLAGS_START) final int enumIndex,
-                                       final boolean isFlag) {
-            final int pageSize = Integer.SIZE - 1; // minus the reserved highest bit
-            // take also into account size reserved for flags
-            final int headerSize = enumIndex + (isFlag ? 1 : getRawIndex(FLOAT_INDEX_START));
-            // minus the first 'page' already reserved at int[0]
-            return headerSize / pageSize - ((headerSize % pageSize == 0) ? 1 : 0);
-        }
-        // returns the additional 'pages' (int) used for FLAGS de facto, 0 if just int[0] in params
-        private static int indexOffset(@NonNull final int[] params) {
-            int extendedPages = 0;
-            for (int i = 0; i < params.length; i++) {
-                // evaluate directly here instead of calling getBit() to avoid infinite loop
-                if ((params[i] & (1 << CONTINUATION)) != 0) {
-                    extendedPages++;
-                } else {
-                    break;
-                }
-            }
-            return extendedPages;
-        }
-        // compute the 'page' no (int) of flag in params
-        private static int indexOffset(@NonNull final int[] params,
-                                       @IntRange(from = FLAGS_START) final int enumIndex) {
-            return indexOffset(enumIndex, true);
-        }
-        // ref: https://stackoverflow.com/a/12015619
-        private static boolean getBit(@NonNull final int[] params,
-                                      @IntRange(from = 0) final int index,
-                                      @IntRange(from = 0, to = CONTINUATION - 1) final int bit) {
-            if (index <= indexOffset(params)) {
-                return (params[index] & (1 << bit)) != 0;
-            }
-            return false;
-        }
-        private static boolean setBit(@NonNull final int[] params,
-                                      @IntRange(from = 0) final int index,
-                                      @IntRange(from = 0, to = CONTINUATION - 1) final int bit,
-                                      final boolean markBit) {
-            if (index <= indexOffset(params)) {
-                if (markBit) {
-                    params[index] |= (1 << bit);
-                } else {
-                    params[index] &= ~(1 << bit);
-                }
-                return true;
-            }
-            return false;
-        }
-        private static boolean paramValid(@NonNull final int[] params, final int param) {
-            return getFlag(params, INITIALIZED) && getRawIndex(param) > HEADER_RESERVED;
-        }
-        private static boolean setParamInt(@NonNull final int[] params,
-                                           final int param, final int value) {
-            return paramValid(params, param)
-                    && setInt(params, getRawIndex(param) + indexOffset(params), value);
-        }
-        private static boolean setParamFloat(@NonNull final int[] params,
-                                             final int param, final float value) {
-            return paramValid(params, param)
-                    && setFloat(params, getRawIndex(param) + indexOffset(params), value);
-        }
-        private static float getFloat(@NonNull final int[] params, final int param) {
-            if (!paramValid(params, param)) {
-                return -1;
-            }
-            final int index = getRawIndex(param) + indexOffset(params);
-            if (index < params.length) {
-                final boolean isFloat = markedFloat(params, index);
-                if (isFloat) {
-                    return Float.intBitsToFloat(params[index]);
-                } else {
-                    return params[index];
-                }
-            }
-            return -1;
-        }
-        private static int getInt(@NonNull final int[] params, final int param) {
-            if (!paramValid(params, param)) {
-                return -1;
-            }
-            final int index = getRawIndex(param) + indexOffset(params);
-            if (index < params.length) {
-                final boolean isFloat = markedFloat(params, index);
-                if (isFloat) {
-                    return (int) Float.intBitsToFloat(params[index]);
-                } else {
-                    return params[index];
-                }
-            }
-            return -1;
-        }
-        private static boolean getParam(@NonNull final int[] params, final int param,
-                                        @NonNull final TypedValue value) {
-            return paramValid(params, param)
-                    && getValue(params, getRawIndex(param) + indexOffset(params), value);
-        }
-        private static boolean getFlag(@NonNull final int[] params, @Flags final int flag) {
-            final int flagIndex = getRawIndex(flag);
-            return getBit(params, indexOffset(params, flagIndex), flagIndex);
-        }
-        private static boolean setFlag(@NonNull final int[] params, final int flag,
-                                       final boolean b) {
-            final int flagIndex = getRawIndex(flag);
-            return setBit(params, indexOffset(params, flagIndex), flagIndex, b);
-        }
-        // ref: https://stackoverflow.com/a/46385852
-        private static int getByte(@NonNull final int[] params, @Flags final int flag) {
-            final int flagIndex = getRawIndex(flag);
-            final int index = indexOffset(params, flagIndex);
-            if (index <= indexOffset(params)) {
-                return (params[index] >>> flagIndex) & 0xff;
-            }
-            return -1;
-        }
-        // ref: https://stackoverflow.com/a/27870983
-        private static boolean setByte(@NonNull final int[] params, @Flags final int flag,
-                                       @IntRange(from = 0, to = 255) final int value) {
-            final int flagIndex = getRawIndex(flag);
-            final int index = indexOffset(params, flagIndex);
-            if (index <= indexOffset(params)) {
-                params[index] &= ~(0xff << flagIndex);  // clear current bit values
-                params[index] |= ((value & 0xff) << flagIndex);
-                return true;
-            }
-            return false;
-        }
-        private static boolean setValue(@NonNull final int[] params,
-                                        @IntRange(from = 0) final int index,
-                                        final int value, final boolean isFloat) {
-            if (index < params.length) {
-                params[index] = value;
-                markFloat(params, index, isFloat);
-                return true;
-            }
-            return false;
-        }
-        private static boolean setInt(@NonNull final int[] params,
-                                      @IntRange(from = 0) final int index, final int value) {
-            return setValue(params, index, value, false);
-        }
-        private static boolean setFloat(@NonNull final int[] params,
-                                        @IntRange(from = 0) final int index, final float value) {
-            return setValue(params, index, Float.floatToRawIntBits(value), true);
-        }
-        private static boolean getValue(@NonNull final int[] params,
-                                        @IntRange(from = 0) final int index,
-                                        @NonNull final TypedValue value) {
-            if (index < params.length) {
-                final boolean isFloat = markedFloat(params, index);
-                if (isFloat) {
-                    value.setValue(Float.intBitsToFloat(params[index]));
-                } else {
-                    value.setValue(params[index]);
-                }
-                return true;
-            }
-            return false;
-        }
-        private static boolean markFloat(@NonNull final int[] params,
-                                         @IntRange(from = 0) final int index,
-                                         final boolean isFloat) {
-            final int extIndex = indexOffset(params);
-            final int flagIndex = index - 1 - extIndex + getRawIndex(FLOAT_INDEX_START);
-            final int page = indexOffset(params, flagIndex);
-            if (page <= extIndex) {
-                setBit(params, page, flagIndex - page * (Integer.SIZE - 1), isFloat);
-                return true;
-            }
-            return false;
-        }
-        private static boolean markedFloat(@NonNull final int[] params,
-                                           @IntRange(from = 0) final int index) {
-            final int flagIndex = getRawIndex(FLOAT_INDEX_START) + index - 1 - indexOffset(params);
-            final int page = indexOffset(params, flagIndex);
-            if (page <= indexOffset(params)) {
-                return getBit(params, page, flagIndex - page * (Integer.SIZE - 2));
-            }
-            return false;
-        }
-
-        // a convenient type-agnostic transport 'vehicle' to shuffle primitives around
-        // without worrying about its type or its type-corresponding method overloads
-        // (it's a pity that Java generics doesn't seem to work with primitives wuthout boxing
-        // so we're left with duplicating some parts of the code for primitive types overloads)
-        private static class TypedValue {
-            protected int value;
-            protected int type = UNSET;
-            protected int op = Op.NORMAL;
-            public void setValue(final int v) {
-                opValue(v);
-                op = Op.NORMAL;
-            }
-            public void setValue(final float v) {
-                opValue(v);
-                op = Op.NORMAL;
-            }
-            public void setValue(final boolean v) {
-                value = v ? 1 : 0;
-                type = ValueType.BOOLEAN;
-                op = Op.NORMAL;
-            }
-            public void opValue(final int v) {
-                switch (op) {
-                    case Op.MINUS:
-                    case Op.ADD:
-                        if (type == ValueType.FLOAT) {
-                            value = Float.floatToRawIntBits(asFloat() + (op == Op.MINUS ? -v : v));
-                        } else {
-                            value += (op == Op.MINUS ? -v : v);
-                            type = ValueType.INT;
-                        }
-                        break;
-                    default:
-                        value = v;
-                        type = ValueType.INT;
-                        break;
-                }
-            }
-            public void opValue(final float v) {
-                switch (op) {
-                    case Op.MINUS:
-                    case Op.ADD:
-                        if (type == ValueType.FLOAT) {
-                            value = Float.floatToRawIntBits(asFloat() + (op == Op.MINUS ? -v : v));
-                        } else {
-                            value = Float.floatToRawIntBits(value + (op == Op.MINUS ? -v : v));
-                            type = ValueType.FLOAT;
-                        }
-                        break;
-                    default:
-                        value = Float.floatToRawIntBits(v);
-                        type = ValueType.FLOAT;
-                        break;
-                }
-            }
-            public int getType() {
-                return type;
-            }
-            public int getRawValue() {
-                return value;
-            }
-            public int asInt() {
-                return type == ValueType.FLOAT ? (int) Float.intBitsToFloat(value) : value;
-            }
-            public float asFloat() {
-                return type == ValueType.FLOAT ? Float.intBitsToFloat(value) : (float) value;
-            }
-            public boolean asBoolean() {
-                return value != 0;
-            }
-        }
-
-        // acts as a temporary holder for g/seting params from/by different 'actors'
-        private static class Ticket extends TypedValue {
-            private int param = UNSET;
-            private int status = UNSET;
-            public Ticket setParam(final int p) {
-                param = p;
-                return this;
-            }
-            public int getParam() {
-                return param;
-            }
-            public void resolved(final boolean success) {
-                status = success ? Result.OK : Result.ERROR;
-            }
-        }
-
-        // a wrapper class around the backing config storage
-        // (since it's such a pain to directly work with the (primitive) int[] in raw)
-        protected static class LayoutTicket extends Ticket {
-            private WeakReference<Layout> layout;
-            private int[] cache;
-            private int line = UNSET;
-            private boolean cached = false;
-            private UpgradeHelper upgrade;
-            public static LayoutTicket from(final Layout l, final int ln) {
-                return new LayoutTicket().setLayout(l).setLine(ln);
-            }
-            public LayoutTicket setLayout(final Layout l) {
-                layout = new WeakReference<>(l);
-                return this;
-            }
-            public Layout getLayout() {
-                return layout == null ? null : layout.get();
-            }
-            public int[] getCache() {
-                return cache;
-            }
-            public LayoutTicket setLine(@IntRange(from = 0) final int ln) {
-                line = ln;
-                return this;
-            }
-            public int getLine() {
-                return line;
-            }
-            public LayoutTicket to(final int[] c) {
-                cache = c;
-                if (line != UNSET) {
-                    setParamInt(c, LINE_NO, line);
-                }
-                return this;
-            }
-            public LayoutTicket resolve(final int... params) {
-                if (cached) {
-                    resolveFromCache(this, cache, params);
-                } else {
-                    resolveFromLayout(this, cache == null ? null : resolveToCache, params);
-                }
-                return this;
-            }
-            public LayoutTicket cached(final boolean c) {
-                cached = c;
-                return this;
-            }
-            public LayoutTicket get(final int param) {
-                op = Op.NORMAL;
-                return resolve(param);
-            }
-            public LayoutTicket andThen(@Op final int operator, final int param) {
-                op = operator;
-                return resolve(param);
-            }
-            // offset the value in relation to text direction, +ve to move forward, -ve backwards
-            public LayoutTicket advance(final int offset) {
-                if (cache == null) {
-                    resolved(false);
-                    return this;
-                }
-                op = Op.ADD;
-                opValue(getFlag(cache, IS_LTR) ? offset : -offset);
-                op = Op.NORMAL;
-                return this;
-            }
-            public LayoutTicket advance(final float offset) {
-                if (cache == null) {
-                    resolved(false);
-                    return this;
-                }
-                op = Op.ADD;
-                opValue(getFlag(cache, IS_LTR) ? offset : -offset);
-                op = Op.NORMAL;
-                return this;
-            }
-            public LayoutTicket set(final int param, final int value) {
-                super.setParam(param);
-                super.setValue(value);
-                resolveToCache.accept(this);
-                return this;
-            }
-            public LayoutTicket set(final int param, final float value) {
-                super.setParam(param);
-                super.setValue(value);
-                resolveToCache.accept(this);
-                return this;
-            }
-            public LayoutTicket set(final int param, final boolean value) {
-                super.setParam(param);
-                super.setValue(value);
-                resolveToCache.accept(this);
-                return this;
-            }
-            public UpgradeHelper upgrade() {
-                if (upgrade == null) {
-                    upgrade = new UpgradeHelper().from(this).to(this);
-                    if (cache != null) {
-                        setFlag(cache, SCHEMA_1, true);
-                    }
-                }
-                return upgrade;
-            }
-        }
-
-        // resolver 1: from cached line metrics
-        private static void resolveFromCache(@NonNull final LayoutTicket t, final int[] cache,
-                                             final int... params) {
-            if (cache == null) {
-                t.resolved(false);
-                return;
-            }
-            for (int i = 0; i < params.length; i++) {
-                final int param = params[i];
-                t.setParam(param);
-                if (param < FLAGS_END) {
-                    t.setValue(getFlag(cache, param));
-                    t.resolved(true);
-                } else if (param < LINEMETRICS_END) {
-                    t.resolved(getParam(cache, param, t));
-                } else {
-                    final boolean isLTR = getFlag(cache, IS_LTR);
-                    final boolean fallback = getFlag(cache, FALLBACK_LAYOUT);
-                    switch (param) {
-                        case LINE_LEFT:
-                            if (fallback) {
-                                resolveFromLayout(t, null, param);
-                            } else {
-                                // from AOSP: mWidth - getLineMax(line)if ALIGN_RIGHT or 0
-                                if (isLTR) {
-                                    t.setValue(0);
-                                } else {
-                                    t.get(WIDTH).andThen(Op.MINUS, LINEMAX);
-                                }
-                            }
-                            break;
-                        case LINE_RIGHT:
-                            if (fallback) {
-                                resolveFromLayout(t, null, param);
-                            } else {
-                                // from AOSP: mWidth if ALIGN_RIGHT or getLineMax(line)
-                                getParam(cache, isLTR ? LINEMAX : WIDTH, t);
-                            }
-                            break;
-                        // extended
-                        case LINE_REMAINING_SPACE:
-                            if (isLTR) {
-                                t.get(WIDTH).andThen(Op.MINUS, LINE_RIGHT);
-                            } else {
-                                getParam(cache, LINE_LEFT, t);
-                            }
-                            break;
-                        case LINE_START_EDGE:
-                            if (isLTR) {
-                                t.setValue(0);
-                            } else {
-                                getParam(cache, WIDTH, t);
-                            }
-                            break;
-                        case LINE_END_EDGE:
-                            t.get(isLTR ? LINE_RIGHT : LINE_LEFT);
-                            break;
-                        default:
-                            t.resolved(false);
-                            continue;
-                    }
-                    t.resolved(true);
-                }
-            }
-        }
-        // resolver 2 (fallback): directly from source (by calling respective Layout functions)
-        private static void resolveFromLayout(@NonNull final LayoutTicket t,
-                                              @Nullable final Consumer<LayoutTicket> resolveTo,
-                                              final int... params) {
-            final Layout layout = t.getLayout();
-            final int line = t.getLine();
-            if (layout == null) {
-                t.resolved(false);
-                return;
-            }
-            Rect bounds = null;
-            for (int i = 0; i < params.length; i++) {
-                t.setParam(params[i]);
-                switch (t.getParam()) {
-                    case BASELINE:
-                        if (bounds == null) {
-                            bounds = new Rect();
-                        }
-                        t.setValue(layout.getLineBounds(line, bounds));
-                        break;
-                    case WIDTH:
-                        if (bounds != null) {
-                            t.setValue(bounds.right);
-                        } else {
-                            t.setValue(layout.getWidth());
-                        }
-                        break;
-                    case TOP:
-                        if (bounds != null) {
-                            t.setValue(bounds.top);
-                        } else {
-                            t.setValue(layout.getLineTop(line));
-                        }
-                        break;
-                    case BOTTOM:
-                        if (bounds != null) {
-                            t.setValue(bounds.bottom);
-                        } else {
-                            t.setValue(layout.getLineBottom(line));
-                        }
-                        break;
-                    case LINEMAX:
-                        t.setValue(layout.getLineMax(line));
-                        break;
-                    case LINE_START:
-                        t.setValue(layout.getLineStart(line));
-                        break;
-                    case LINE_END:
-                        t.setValue(layout.getLineEnd(line));
-                        break;
-                    case IS_LTR:
-                        t.setValue(layout.getParagraphDirection(line) == Layout.DIR_LEFT_TO_RIGHT);
-                        break;
-                    default:
-                        t.resolved(false);
-                        continue;
-                }
-                t.resolved(true);
-                if (resolveTo != null) {
-                    resolveTo.accept(t);
-                }
-            }
-        }
-        // writer to save line metrics to cache
-        private static Consumer<LayoutTicket> resolveToCache = t -> {
-            final int[] cache = t.getCache();
-            if (cache == null) {
-                t.resolved(false);
-                return;
-            }
-            switch (t.getType()) {
-                case ValueType.FLOAT:
-                    setParamFloat(cache, t.getParam(), t.asFloat());
-                    break;
-                case ValueType.INT:
-                    setParamInt(cache, t.getParam(), t.asInt());
-                    break;
-                case ValueType.BOOLEAN:
-                    setFlag(cache, t.getParam(), t.asBoolean());
-                    break;
-                default:
-                    t.resolved(false);
-                    return;
-            }
-            t.resolved(true);
-        };
-        // highly experimental: might not be put into use after all
-        private static class UpgradeHelper {
-            private int[] tmpStorage;
-            private LayoutTicket storage;
-            private boolean inPlace = false;
-            private int[] reservedIndex;
-            public UpgradeHelper from(final LayoutTicket src) {
-                storage = src;
-                return this;
-            }
-            public UpgradeHelper to(final LayoutTicket dst) {
-                if (dst == storage) {
-                    inPlace = true;
-                } else {
-                    // not (yet) implemented
-                    throw new RuntimeException(-Result.NOT_IMPLEMENTED + ": Not Implemented");
-                }
-                return this;
-            }
-            private void initializeReservedIndex(final int size) {
-                final int storageSize = size + indexOffset(size);
-                if (reservedIndex == null || reservedIndex.length < storageSize) {
-                    reservedIndex = new int[storageSize];
-                } else {
-                    reservedIndex[0] = 0;
-                }
-                initializeIndex(reservedIndex, size);
-                setFlag(reservedIndex, INITIALIZED, true);
-            }
-            public UpgradeHelper defaultTo(final int ellipsisParam, final int lineMetric) {
-                if (!inPlace) {
-                    // not (yet) implemented
-                    throw new RuntimeException(-Result.NOT_IMPLEMENTED + ": Not Implemented");
-                }
-                final int srcPos = getRawIndex(lineMetric);
-                final int dstPos = getRawIndex(ellipsisParam);
-                if (dstPos >= getRawIndex(LINEMETRICS_END)) {
-                    // we can safely write the value since there's no overlap
-                    // just copy from old position to new position since we're upgrading in-place
-                    storage.getCache()[dstPos] = storage.getCache()[srcPos];
-                }
-                if (srcPos == dstPos) {
-                    markReserved(srcPos, true);
-                }
-                return this;
-            }
-            private void markReserved(final int pos, final boolean b) {
-                if (b && reservedIndex == null) {
-                    initializeReservedIndex(getRawIndex(LINEMETRICS_END));
-                }
-                if (reservedIndex != null) {
-                    setBit(reservedIndex, indexOffset(reservedIndex, pos), pos, b);
-                }
-            }
-            public UpgradeHelper set(final int ellipsisParam, final int v) {
-                final int dstPos = getRawIndex(ellipsisParam);
-                markReserved(dstPos, false);
-                storage.set(ellipsisParam, v);
-                return this;
-            }
-            public UpgradeHelper set(final int ellipsisParam, final float v) {
-                final int dstPos = getRawIndex(ellipsisParam);
-                markReserved(dstPos, false);
-                storage.set(ellipsisParam, v);
-                return this;
-            }
-        }
-
-        private LayoutTicket warmUpLineMetrics(@IntRange(from = 0) final int line,
-                                               @NonNull final Layout layout) {
-            final int[] metrics = setupLineMetrics();
-            return LayoutTicket.from(layout, line).to(metrics)
-                    .resolve(BASELINE, WIDTH, TOP, BOTTOM, LINEMAX, LINE_START, LINE_END, IS_LTR)
-                    .cached(true);
-        }
-
-        public Layout getLayout() {
-            return layoutReference != null && layoutReference.get() != null
-                    ? layoutReference.get() : null;
-        }
-
-        EllipsizeParams(final NewPipeTextView textView) {
-            initialize(textView);
-        }
-
-        public static EllipsizeParams newInstance(final NewPipeTextView textView) {
-            final Layout layout = textView.getLayout();
-            if (layout == null) {
-                return null;
-            }
-            return new EllipsizeParams(textView);
-        }
-
-        // non-breaking space, ellipsis, non-breaking space
-        // we surround nbsp at both ends so that we can just offset ELLIPSIS_LEN by 1 for RTL
-        private static final char[] ELLIPSIS_CHARS = {'\u00a0', '\u2026', '\u00a0'};
-        private static final int ELLIPSIS_LEN = 2;
-
-        /* Our custom ellipsizing strategy implemented as follows: where lines of text don't fit,
-         * - append the ellipsis to the end of the last line displayed, if screen estate fits; else
-         * - crunch the last bit (word) of the last line to make room for the ellipsis.
-         * It's been longstanding (bug) in Android's TextView the internal ellipsizing doesn't work
-         * with BufferType.SPANNABLE (necessitated by setMovementMethod() other than null) at all
-         * (so we're bound to roll our own). A feature over TextView's internal implementation
-         * is that we crunch by word rather than characters (so the user won't be caught by surprise
-         * when 'app...' was meant to mean 'approach' upon expanding the text, just as an example).
-         * (We defer to BreakIterator for the last 'word' since not every language delimits words
-         * by a space (and there we have emojis too).) */
-        protected LayoutTicket initialize(@NonNull final NewPipeTextView textView) {
-            final Layout layout = textView.getLayout();
-            if (layout == null) {
-                return null;
-            }
-            layoutReference = new WeakReference<>(layout);
-            int ellipsisLine = textView.getDisplayLines() - 1;
-            final LayoutTicket lastLine = warmUpLineMetrics(ellipsisLine, layout);
-
-            if (layout.getParagraphAlignment(textView.getDisplayLines() - 1)
-                    != Layout.Alignment.ALIGN_NORMAL) {
-                // short-circuits are unimplemented for Alignment other than ALIGN_NORMAL
-                // as there is simply no use case, fall back gracefully to Layout just in case
-                setFlag(configStorage, FALLBACK_LAYOUT, true);
-            }
-
-            // determine screen estate the ellipsis takes
-            final float ellipsisWidth = layout.getPaint().measureText(ELLIPSIS_CHARS,
-                    lastLine.get(IS_LTR).asBoolean() ? 0
-                            : ELLIPSIS_CHARS.length - ELLIPSIS_LEN, ELLIPSIS_LEN);
-            final float shortfall = ellipsisWidth - lastLine.get(LINE_REMAINING_SPACE).asFloat();
-            int lastChar = lastLine.get(LINE_END).asInt();
-            // this would be the reference point to determine if the clipping mask
-            // would eventually kick in at the end of the evaluations
-            final int origLastChar = lastChar;
-            if (shortfall > 0) {
-                // find the closest text offset where the ellipsis fits in
-                lastChar = layout.getOffsetForHorizontal(ellipsisLine,
-                        lastLine.get(LINE_END_EDGE).advance(-shortfall).asFloat());
-            }
-            // we're safe to assume by now the ellipsis fits in the last line up to lastChar
-            // but we go further to crunch by word and do some cleanup / nitpicks
-            final int origLineStart = lastLine.get(LINE_START).asInt();
-            final BreakIterator wb = textView.getWordInstance();
-            boolean trailingWhitespacesOnly = lastChar == origLastChar;
-            try {
-                wb.setText(textView.getText().toString());
-                int last = wb.preceding(lastChar);
-                if (!wb.isBoundary(lastChar) && last != BreakIterator.DONE) {
-                    lastChar = last;
-                    trailingWhitespacesOnly = false;
-                    last = wb.preceding(lastChar);
-                }
-                // strip whitespaces: the last line might well end with a space and a line return
-                // be greedy since we're always prefixing the ellipsis to be drawn with a space
-                // and we won't want there to end up having more than one
-                while (last != BreakIterator.DONE && Character.isWhitespace(
-                        Character.codePointAt(textView.getText(), last))) {
-                    lastChar = last;
-                    last = wb.preceding(lastChar);
-                }
-            } finally {
-                textView.recycle(wb);
-            }
-            // our clipping mask to be, which also positions the ellipsis to be drawn
-            // default to zero width bounds to cloak nothing of the text drawn by super.onDraw(),
-            // say if we're simply drawing an ellipsis above it when screen estate fits
-            final float initialPos = lastLine.get(LINE_END_EDGE).asFloat();
-            final boolean debug = lastLine.get(SCHEMA_DEBUG).asBoolean();
-            // prepare to write the finalised ellipsis params
-            if (debug) {
-                lastLine.upgrade().set(LE_EDGE, initialPos)
-                        .defaultTo(LL_WIDTH, WIDTH)
-                        .defaultTo(LL_TOP, TOP)
-                        .defaultTo(LL_BOTTOM, BOTTOM)
-                        .defaultTo(EB_BASELINE_D, BASELINE)
-                        .defaultTo(EB_TOP_D, TOP)
-                        .defaultTo(EB_BOTTOM_D, BOTTOM);
-            } else {
-                lastLine.upgrade().defaultTo(EB_BASELINE, BASELINE)
-                        .defaultTo(EB_TOP, TOP)
-                        .defaultTo(EB_BOTTOM, BOTTOM);
-            }
-            if (lastChar != origLastChar) {
-                // whitespaces stripped above also include line break characters (hard returns)
-                // opportunistically wrap the ellipsis to the second last line if screen estate fits
-                if (lastChar < origLineStart && ellipsisLine > 0) {
-                    if (layout.getLineMax(ellipsisLine - 1) + ellipsisWidth
-                            // assuming width consistent across lines
-                            <= lastLine.get(WIDTH).asInt()) {
-                        ellipsisLine -= 1; // nil shortfall
-                        lastLine.set(debug ? EB_BASELINE_D : EB_BASELINE,
-                                        layout.getLineBaseline(ellipsisLine))
-                                .set(IS_LTR, layout.getParagraphDirection(ellipsisLine)
-                                        == Layout.DIR_LEFT_TO_RIGHT);
-                    } else {
-                        // we're not crunching anything above the last line, so never mind
-                        // just let the ellipsis start on its own right in the last line
-                        lastChar = origLineStart;
-                    }
-                }
-                // finally setting the extent of the clipping mask, we need one after all
-                final float ellipsisPos = layout.getPrimaryHorizontal(lastChar);
-                if (trailingWhitespacesOnly && lastChar >= origLineStart) {
-                    // optimization: we won't need a mask just for whitespaces on the same last line
-                    lastLine.set(debug ? EB_LEFT_D : EB_LEFT, ellipsisPos)
-                            .set(debug ? EB_RIGHT_D : EB_RIGHT, ellipsisPos);
-                } else {
-                    lastLine.set(debug ? EB_LEFT_D : EB_LEFT,
-                                    lastLine.get(IS_LTR).asBoolean() ? ellipsisPos : initialPos)
-                            .set(debug ? EB_RIGHT_D : EB_RIGHT,
-                                    lastLine.get(IS_LTR).asBoolean() ? initialPos : ellipsisPos);
-                }
-            } else {
-                lastLine.set(debug ? EB_LEFT_D : EB_LEFT, initialPos)
-                        .set(debug ? EB_RIGHT_D : EB_RIGHT, initialPos);
-            }
-            // nitpick: omit the prefixed space if ellipsis starts on its own line
-            if (lastChar == origLineStart) {
-                lastLine.set(SKIP_PREFIX_SPACE, true);
-            }
-
-            return lastLine;
-        }
-    }
-
-
-    /*//////////////////////////////////////////////////////////////////////////
-    // Word breaker utility
-    //////////////////////////////////////////////////////////////////////////*/
-
-    /* tries to do some recycle magic here */
-    protected BreakIterator getWordInstance() {
-        if (oldWordIterator == null || oldWordIterator.get() == null) {
-            return BreakIterator.getWordInstance();
-        } else {
-            return oldWordIterator.get();
-        }
-    }
-    protected void recycle(final BreakIterator wordIterator) {
-        if (wordIterator != null) {
-            oldWordIterator = new WeakReference<>(wordIterator);
-        }
-    }
-
-
-    /*//////////////////////////////////////////////////////////////////////////
     // TextView stuff
     //////////////////////////////////////////////////////////////////////////*/
 
-    private EllipsizeParams ellipsizeParams;
-    private WeakReference<BreakIterator> oldWordIterator;
+    // weak reference to the Layout upon which ellipsizeParams were drawn up
+    private WeakReference<Layout> ellipsizeLayout;
+
+    // poor man's all in one briefcase
+    private int[] ellipsizeParams;
 
     @SuppressWarnings("deprecation")
     private static void clipOutRectCompat(@NonNull final Canvas canvas, final float left,
@@ -1127,16 +173,29 @@ public class NewPipeTextView extends AppCompatTextView implements AnimationUtil.
     }
     // shorthands to fetch ellipsising params from config storage
     private boolean getConfigFlag(final int flag) {
-        return EllipsizeParams.getFlag(ellipsizeParams.configStorage, flag);
+        return EllipsizeParams.getFlag(ellipsizeParams, flag);
     }
     private int getConfigByte(final int param) {
-        return EllipsizeParams.getByte(ellipsizeParams.configStorage, param);
+        return EllipsizeParams.getByte(ellipsizeParams, param);
     }
     private int getConfigInt(final int param) {
-        return EllipsizeParams.getInt(ellipsizeParams.configStorage, param);
+        return EllipsizeParams.getInt(ellipsizeParams, param);
     }
     private float getConfigFloat(final int param) {
-        return EllipsizeParams.getFloat(ellipsizeParams.configStorage, param);
+        return EllipsizeParams.getFloat(ellipsizeParams, param);
+    }
+    private boolean textLayoutChanged() {
+        // There doesn't seem to be a good way to detect (the internal) text layout changes
+        // eg layout change listeners only fire upon external (size) changes but not say, an
+        // internal text reflow (invalidated internally by setText() and other functions).
+        // We cheated a bit by keeping a WeakReference to the TextView's internal Layout
+        // at the time EllipsizeParams is created and computed leveraging the fact that
+        // getLayout() returns the instance rather than a copy of it.
+        return ellipsizeLayout != null && ellipsizeLayout.get() != getLayout();
+    }
+    private void initializeEllipsizeParams() {
+        ellipsizeLayout = new WeakReference<>(getLayout());
+        ellipsizeParams = EllipsizeParams.initialize(this, ellipsizeParams);
     }
 
     /* The bone of this override is to carry out our custom ellipsizing which comprises
@@ -1147,7 +206,7 @@ public class NewPipeTextView extends AppCompatTextView implements AnimationUtil.
     @Override
     protected void onDraw(final Canvas canvas) {
         final Layout layout = getLayout();
-        final boolean animating = ellipsizeParams != null && ellipsizeParams.configStorage != null
+        final boolean animating = ellipsizeParams != null
                 && getConfigFlag(EllipsizeParams.ANIMATING);
         if (layout == null || getLineCount() == 0
                 || (ellipsisState() != EllipsisState.EXPANDABLE && !animating)) {
@@ -1157,21 +216,14 @@ public class NewPipeTextView extends AppCompatTextView implements AnimationUtil.
 
         // invalidate cache if text layout changed
         // except when animation is in flight: we actually reuse the last cached ellipsizeParams
-        if (ellipsizeParams != null && !animating
-                // There doesn't seem to be a good way to detect (the internal) text layout changes
-                // eg layout change listeners only fire upon external (size) changes but not say, an
-                // internal text reflow (invalidated internally by setText() and other functions).
-                // We cheated a bit by keeping a WeakReference to the TextView's internal Layout
-                // at the time EllipsizeParams is created and computed leveraging the fact that
-                // getLayout() returns the instance rather than a copy of it.
-                && ellipsizeParams.getLayout() != getLayout()) {
-            ellipsizeParams = null;
-            if (DEBUG) {
+        if (ellipsizeParams != null && !animating && textLayoutChanged()) {
+            EllipsizeParams.setFlag(ellipsizeParams, EllipsizeParams.INITIALIZED, false);
+            if (getConfigFlag(EllipsizeParams.SCHEMA_DEBUG)) {
                 canvas.drawColor(0x22222222);
             }
         }
         // super lazy initialize our ellipsizeParams cache
-        if (ellipsizeParams == null) {
+        if (ellipsizeParams == null || !getConfigFlag(EllipsizeParams.INITIALIZED)) {
             if (!animating) {
                 // We're not left with much better place to do computations:
                 // we'll be fiddling with setMaxLines() to measure() the final bounds post-animation
@@ -1179,7 +231,7 @@ public class NewPipeTextView extends AppCompatTextView implements AnimationUtil.
                 // really drawing (given our limitation in listening to text layout changes above).
                 // Computations in onDraw() is generally a bad idea after all,
                 // so we roll our home-grown cache as part of the remedy.
-                ellipsizeParams = EllipsizeParams.newInstance(this);
+                initializeEllipsizeParams();
             } else {
                 // we're in flight an animation but without the previously cached ellipsizeParams
                 // ah well, never mind - not animating the ellipsis change this time
@@ -1195,78 +247,76 @@ public class NewPipeTextView extends AppCompatTextView implements AnimationUtil.
         final int offsetX = getTotalPaddingLeft();
         final int offsetY = getTotalPaddingTop();
         canvas.translate(offsetX, offsetY);
-        try {
-            final boolean debug = getConfigFlag(EllipsizeParams.SCHEMA_DEBUG);
-            final boolean isLTR = getConfigFlag(EllipsizeParams.IS_LTR);
-            if (debug && !animating) {
-                // draw lastLineBounds
-                p.setARGB(100, 255, 0, 0);
-                canvas.drawRect(0, getConfigInt(EllipsizeParams.LL_TOP),
-                        getConfigInt(EllipsizeParams.LL_WIDTH),
-                        getConfigInt(EllipsizeParams.LL_BOTTOM), p);
-                // draw lastLineEndBounds
-                p.setARGB(100, 0, 255, 0);
-                canvas.drawRect(isLTR ? getConfigFloat(EllipsizeParams.LE_EDGE) : 0,
-                        getConfigInt(EllipsizeParams.LL_TOP),
-                        getConfigFloat(isLTR ? EllipsizeParams.LL_WIDTH : EllipsizeParams.LE_EDGE),
-                        getConfigInt(EllipsizeParams.LL_BOTTOM), p);
-            }
 
-            if (debug && (getConfigFloat(EllipsizeParams.EB_RIGHT_D)
-                    - getConfigFloat(EllipsizeParams.EB_LEFT_D)) > 0) {
-                p.setARGB(100, 0, 0, 255);
-                canvas.drawRect(getConfigFloat(EllipsizeParams.EB_LEFT_D),
-                        getConfigFloat(EllipsizeParams.EB_TOP_D),
-                        getConfigFloat(EllipsizeParams.EB_RIGHT_D),
-                        getConfigFloat(EllipsizeParams.EB_BOTTOM_D), p);
-            }
-
-            if (animating || ellipsisState() == EllipsisState.EXPANDABLE) {
-                final int crossfadeEllipsis = getConfigByte(EllipsizeParams.CROSSFADE_ELLIPSIS);
-                float splitPt = -1;
-                final float clipOutBoundsL = getConfigFloat(
-                        debug ? EllipsizeParams.EB_LEFT_D : EllipsizeParams.EB_LEFT);
-                final float clipOutBoundsT = getConfigFloat(
-                        debug ? EllipsizeParams.EB_TOP_D : EllipsizeParams.EB_TOP);
-                final float clipOutBoundsR = getConfigFloat(
-                        debug ? EllipsizeParams.EB_RIGHT_D : EllipsizeParams.EB_RIGHT);
-                final float clipOutBoundsB = getConfigFloat(
-                        debug ? EllipsizeParams.EB_BOTTOM_D : EllipsizeParams.EB_BOTTOM);
-
-                p.setColor(getCurrentTextColor());
-                if (animating) { // animation stuff
-                    // simulate sliding window to the end of the ellipsized last line
-                    splitPt = (clipOutBoundsR - clipOutBoundsL) * (float) crossfadeEllipsis / 255;
-                    canvas.save();
-                    // pass in the four corners as parameters to avoid boxing an intermediate RectF
-                    clipOutRectCompat(canvas,
-                            isLTR ? clipOutBoundsL : clipOutBoundsL + splitPt, clipOutBoundsT,
-                            isLTR ? clipOutBoundsR - splitPt : clipOutBoundsR, clipOutBoundsB);
-                    p.setAlpha(crossfadeEllipsis);
-                }
-                final Paint.Align origAlign = p.getTextAlign();
-                p.setTextAlign(isLTR ? Paint.Align.LEFT : Paint.Align.RIGHT);
-                final boolean skipSpace = getConfigFlag(EllipsizeParams.SKIP_PREFIX_SPACE);
-                canvas.drawText(EllipsizeParams.ELLIPSIS_CHARS, isLTR && !skipSpace ? 0 : 1,
-                        skipSpace ? EllipsizeParams.ELLIPSIS_LEN - 1 : EllipsizeParams.ELLIPSIS_LEN,
-                        isLTR ? clipOutBoundsL : clipOutBoundsR,
-                        (float) getTotalPaddingTop() + getConfigFloat(debug
-                                ? EllipsizeParams.EB_BASELINE_D : EllipsizeParams.EB_BASELINE), p);
-                p.setTextAlign(origAlign);
-                if (animating) {
-                    canvas.restore();
-                    clipOutRectCompat(canvas,
-                            isLTR ? clipOutBoundsR - splitPt : clipOutBoundsL, clipOutBoundsT,
-                            isLTR ? clipOutBoundsR : clipOutBoundsL + splitPt, clipOutBoundsB);
-                } else if (clipOutBoundsR - clipOutBoundsL > 0) {
-                    clipOutRectCompat(canvas,
-                            clipOutBoundsL, clipOutBoundsT, clipOutBoundsR, clipOutBoundsB);
-                }
-            }
-
-        } finally {
-            canvas.translate(-offsetX, -offsetY);
+        final boolean debug = getConfigFlag(EllipsizeParams.SCHEMA_DEBUG);
+        final boolean isLTR = getConfigFlag(EllipsizeParams.IS_LTR);
+        if (debug && !animating) {
+            // draw lastLineBounds
+            p.setARGB(100, 255, 0, 0);
+            canvas.drawRect(0, getConfigInt(EllipsizeParams.LL_TOP),
+                    getConfigInt(EllipsizeParams.LL_WIDTH),
+                    getConfigInt(EllipsizeParams.LL_BOTTOM), p);
+            // draw lastLineEndBounds
+            p.setARGB(100, 0, 255, 0);
+            canvas.drawRect(isLTR ? getConfigFloat(EllipsizeParams.LE_EDGE) : 0,
+                    getConfigInt(EllipsizeParams.LL_TOP),
+                    getConfigFloat(isLTR ? EllipsizeParams.LL_WIDTH : EllipsizeParams.LE_EDGE),
+                    getConfigInt(EllipsizeParams.LL_BOTTOM), p);
         }
+
+        if (debug && (getConfigFloat(EllipsizeParams.EB_RIGHT_D)
+                - getConfigFloat(EllipsizeParams.EB_LEFT_D)) > 0) {
+            p.setARGB(100, 0, 0, 255);
+            canvas.drawRect(getConfigFloat(EllipsizeParams.EB_LEFT_D),
+                    getConfigFloat(EllipsizeParams.EB_TOP_D),
+                    getConfigFloat(EllipsizeParams.EB_RIGHT_D),
+                    getConfigFloat(EllipsizeParams.EB_BOTTOM_D), p);
+        }
+
+        if (animating || ellipsisState() == EllipsisState.EXPANDABLE) {
+            final int crossfadeEllipsis = getConfigByte(EllipsizeParams.CROSSFADE_ELLIPSIS);
+            float splitPt = -1;
+            final float clipOutBoundsL = getConfigFloat(
+                    debug ? EllipsizeParams.EB_LEFT_D : EllipsizeParams.EB_LEFT);
+            final float clipOutBoundsT = getConfigFloat(
+                    debug ? EllipsizeParams.EB_TOP_D : EllipsizeParams.EB_TOP);
+            final float clipOutBoundsR = getConfigFloat(
+                    debug ? EllipsizeParams.EB_RIGHT_D : EllipsizeParams.EB_RIGHT);
+            final float clipOutBoundsB = getConfigFloat(
+                    debug ? EllipsizeParams.EB_BOTTOM_D : EllipsizeParams.EB_BOTTOM);
+
+            p.setColor(getCurrentTextColor());
+            if (animating) { // animation stuff
+                // simulate sliding window to the end of the ellipsized last line
+                splitPt = (clipOutBoundsR - clipOutBoundsL) * crossfadeEllipsis / 255;
+                canvas.save();
+                // pass in the four corners as parameters to avoid boxing an intermediate RectF
+                clipOutRectCompat(canvas,
+                        isLTR ? clipOutBoundsL : clipOutBoundsL + splitPt, clipOutBoundsT,
+                        isLTR ? clipOutBoundsR - splitPt : clipOutBoundsR, clipOutBoundsB);
+                p.setAlpha(crossfadeEllipsis);
+            }
+            final Paint.Align origAlign = p.getTextAlign();
+            p.setTextAlign(isLTR ? Paint.Align.LEFT : Paint.Align.RIGHT);
+            final boolean skipSpace = getConfigFlag(EllipsizeParams.SKIP_PREFIX_SPACE);
+            canvas.drawText(EllipsizeParams.ELLIPSIS_CHARS, isLTR && !skipSpace ? 0 : 1,
+                    skipSpace ? EllipsizeParams.ELLIPSIS_LEN - 1 : EllipsizeParams.ELLIPSIS_LEN,
+                    isLTR ? clipOutBoundsL : clipOutBoundsR,
+                    getTotalPaddingTop() + getConfigFloat(debug
+                            ? EllipsizeParams.EB_BASELINE_D : EllipsizeParams.EB_BASELINE), p);
+            p.setTextAlign(origAlign);
+            if (animating) {
+                canvas.restore();
+                clipOutRectCompat(canvas,
+                        isLTR ? clipOutBoundsR - splitPt : clipOutBoundsL, clipOutBoundsT,
+                        isLTR ? clipOutBoundsR : clipOutBoundsL + splitPt, clipOutBoundsB);
+            } else if (clipOutBoundsR - clipOutBoundsL > 0) {
+                clipOutRectCompat(canvas,
+                        clipOutBoundsL, clipOutBoundsT, clipOutBoundsR, clipOutBoundsB);
+            }
+        }
+
+        canvas.translate(-offsetX, -offsetY);
         super.onDraw(canvas);
         canvas.restore();
     }

--- a/app/src/main/java/org/schabi/newpipe/views/NewPipeTextView.java
+++ b/app/src/main/java/org/schabi/newpipe/views/NewPipeTextView.java
@@ -112,11 +112,9 @@ public class NewPipeTextView extends AppCompatTextView implements AnimationUtil.
     }
     /* implements AnimationUtil.OnAnimateListener */
     @Override
-    public void onAnimate(final int animated, final int initial, final int target) {
+    public void onAnimateProgress(final float animatedFraction, final boolean isCollapsing) {
         // determine position of the sliding window for the ellipsis during animation
-        crossfadeEllipsis = target > initial
-                ? 1 - (float) (animated - initial) / (float) (target - initial)
-                : (float) (initial - animated) / (float) (initial - target);
+        crossfadeEllipsis = isCollapsing ? animatedFraction : 1 - animatedFraction;
     }
     @Override
     public void onAnimationEnd(final View v, final boolean reversed, final boolean expanded) {

--- a/app/src/main/java/org/schabi/newpipe/views/NewPipeTextView.java
+++ b/app/src/main/java/org/schabi/newpipe/views/NewPipeTextView.java
@@ -173,7 +173,6 @@ public class NewPipeTextView extends AppCompatTextView implements AnimationUtil.
     private static class EllipsizeParams {
         public WeakReference<Layout> layoutReference;
         public String ellipsisString;
-        public int ellipsisLine;
         public RectF ellipsisBounds;
         public int ellipsisBaseline;
         public boolean ellipsisLTR;
@@ -345,7 +344,7 @@ public class NewPipeTextView extends AppCompatTextView implements AnimationUtil.
             } finally {
                 textView.recycle(wb);
             }
-            ellipsisLine = lastLine.line;
+            int ellipsisLine = lastLine.line;
             ellipsisBaseline = lastLine.baseline;
             ellipsisLTR = lastLine.isLTR;
             // our clipping mask to be, which also positions the ellipsis to be drawn
@@ -443,8 +442,8 @@ public class NewPipeTextView extends AppCompatTextView implements AnimationUtil.
     // TextView stuff
     //////////////////////////////////////////////////////////////////////////*/
 
-    private EllipsizeParams ellipsizeParams;
-    private WeakReference<BreakIterator> oldWordIterator;
+    private transient EllipsizeParams ellipsizeParams;
+    private transient WeakReference<BreakIterator> oldWordIterator;
 
     /* used in expanding/collapsing animation; 0 for ellipsis to be invisible, 1 fully visible */
     private float crossfadeEllipsis = -1; // not in use (not animating)

--- a/app/src/main/java/org/schabi/newpipe/views/NewPipeTextView.java
+++ b/app/src/main/java/org/schabi/newpipe/views/NewPipeTextView.java
@@ -29,7 +29,7 @@ import org.schabi.newpipe.util.external_communication.ShareUtils;
  * from {@link AppCompatTextView} on EMUI devices.
  * </p>
  */
-public class NewPipeTextView extends AppCompatTextView {
+public class NewPipeTextView extends AppCompatTextView implements AnimationUtil.OnAnimateListener {
 
     public NewPipeTextView(@NonNull final Context context) {
         super(context);


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

<!-- #### Description of the changes in your PR -->
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
<!-- - record videos
- create clones
- take over the world -->

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
<!-- - Before:
- After: -->
|         Before          |       After         |
| ------------------- | --------------- |
| ![20221214_215803](https://user-images.githubusercontent.com/10971704/207617007-bb40b445-fe95-4fb0-ad3e-a63d8cdbc9ed.gif) | ![20221214_215913](https://user-images.githubusercontent.com/10971704/207617265-add39dd6-bd6b-46b3-9721-0edd7f5607b4.gif) |

(The majority of changes go to `NewPipeTextView` (our sub-classed `TextView`) at widget level; while I'm at it, I've also conveniently applied an animation to the Secondary controls panel in `VideoDetailFragment`)

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #3610
- Fixes #4009
- Fixes #7334

<!-- #### Relies on the following changes -->
<!-- Delete this if it doesn't apply to your PR. -->
_p.s._ I just realize afterwards that there used to be an `AnimationUtil` class which was ported to Kotlin extensions a while ago (by one of our great developers), the 'revival' of `AnimationUtil` was a pure coincidence and with all due respect unintended (but it also does a couple of things extra like keeping a list of running and trying to reuse old animators); probably need to ponder how to better integrate with the existing `animate(...)()` ktx's, but I'll just leave it as is in draft for now

_p.s.(2)_ I saw there're a couple of brilliant PRs in flight which also touch upon `NewPipeTextView`; I'll rebase this PR after they're merged (which I guess would be pretty soon)

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
