### PR TITLE
Made the channel-images in the grid list bigger

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/info_list/holder/ChannelInfoItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/holder/ChannelInfoItemHolder.java
@@ -1,14 +1,9 @@
 package org.schabi.newpipe.info_list.holder;
 
 import android.view.ViewGroup;
-import android.widget.TextView;
 
 import org.schabi.newpipe.R;
-import org.schabi.newpipe.extractor.InfoItem;
-import org.schabi.newpipe.extractor.channel.ChannelInfoItem;
 import org.schabi.newpipe.info_list.InfoItemBuilder;
-import org.schabi.newpipe.local.history.HistoryRecordManager;
-import org.schabi.newpipe.util.Localization;
 
 /*
  * Created by Christian Schabesberger on 12.02.17.
@@ -31,40 +26,7 @@ import org.schabi.newpipe.util.Localization;
  */
 
 public class ChannelInfoItemHolder extends ChannelMiniInfoItemHolder {
-    private final TextView itemChannelDescriptionView;
-
     public ChannelInfoItemHolder(final InfoItemBuilder infoItemBuilder, final ViewGroup parent) {
         super(infoItemBuilder, R.layout.list_channel_item, parent);
-        itemChannelDescriptionView = itemView.findViewById(R.id.itemChannelDescriptionView);
-    }
-
-    @Override
-    public void updateFromItem(final InfoItem infoItem,
-                               final HistoryRecordManager historyRecordManager) {
-        super.updateFromItem(infoItem, historyRecordManager);
-
-        if (!(infoItem instanceof ChannelInfoItem)) {
-            return;
-        }
-        final ChannelInfoItem item = (ChannelInfoItem) infoItem;
-
-        itemChannelDescriptionView.setText(item.getDescription());
-    }
-
-    @Override
-    protected String getDetailLine(final ChannelInfoItem item) {
-        String details = super.getDetailLine(item);
-
-        if (item.getStreamCount() >= 0) {
-            final String formattedVideoAmount = Localization.localizeStreamCount(
-                    itemBuilder.getContext(), item.getStreamCount());
-
-            if (!details.isEmpty()) {
-                details += " • " + formattedVideoAmount;
-            } else {
-                details = formattedVideoAmount;
-            }
-        }
-        return details;
     }
 }

--- a/app/src/main/res/layout/list_channel_grid_item.xml
+++ b/app/src/main/res/layout/list_channel_grid_item.xml
@@ -39,12 +39,24 @@
         android:id="@+id/itemAdditionalDetails"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/itemTitleView"
+        android:layout_below="@id/itemTitleView"
         android:layout_centerHorizontal="true"
         android:lines="1"
         android:textAppearance="?android:attr/textAppearanceSmall"
         android:textSize="@dimen/video_item_search_upload_date_text_size"
         tools:ignore="RtlHardcoded"
-        tools:text="10M subscribers" />
+        tools:text="10M subscribers • 100 videos" />
+
+    <TextView
+        android:id="@+id/itemChannelDescriptionView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/itemAdditionalDetails"
+        android:layout_centerHorizontal="true"
+        android:textAppearance="?android:attr/textAppearanceSmall"
+        android:textSize="@dimen/video_item_search_upload_date_text_size"
+        android:gravity="center"
+        tools:ignore="RtlHardcoded"
+        tools:text="@tools:sample/lorem/random" />
 
 </RelativeLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -30,7 +30,7 @@
     <dimen name="video_item_grid_thumbnail_image_width">164dp</dimen>
     <dimen name="video_item_grid_thumbnail_image_height">92dp</dimen>
 
-    <dimen name="channel_item_grid_thumbnail_image_size">42dp</dimen>
+    <dimen name="channel_item_grid_thumbnail_image_size">92dp</dimen>
     <dimen name="channel_item_grid_min_width">128dp</dimen>
     <!-- Calculated: 2*video_item_search_padding + video_item_search_thumbnail_image_height -->
     <dimen name="video_item_search_height">96dp</dimen>


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Made the channel-images in the grid list bigger
- Add description to channel grid items
- Detail line: display both subscriber count and video count in all channel item instances
- Make description height either 2 lines or 3 lines based on whether the detail line actually contains something or not

#### Before/After Screenshots/Screen Record
<table>
  <tr>
    <th>Before1</th>
    <th>Before2</th>
    <th>After1</th>
    <th>After2</th>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/109673982/208202962-05569fec-8b87-4888-88c3-18a824a9e1e5.png" width="200px" alt="Before1"/></td>
    <td><img src="https://user-images.githubusercontent.com/109673982/208202993-88ba7a4b-66b6-47bd-b81a-9200a2ed3377.png" width="200px" alt="Before2"/></td>
    <td><img src="https://user-images.githubusercontent.com/36421898/212534465-11867ea8-18b0-4a42-9f1f-065e9e9e5d9a.png" width="200px" alt="After1"/></td>
    <td><img src="https://user-images.githubusercontent.com/36421898/212534498-5dd3657e-f7b5-4427-a8cc-25aa9b708757.png" width="200px" alt="After2"/></td>
  </tr>
</table>

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #3291

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
