### PR TITLE
Support audio only background for services only supporting video streams

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -1666,8 +1666,9 @@ public final class VideoDetailFragment
 
         binding.detailControlsDownload.setVisibility(
                 StreamTypeUtil.isLiveStream(info.getStreamType()) ? View.GONE : View.VISIBLE);
-        binding.detailControlsBackground.setVisibility(info.getAudioStreams().isEmpty()
-                ? View.GONE : View.VISIBLE);
+        binding.detailControlsBackground.setVisibility(
+                info.getAudioStreams().isEmpty() && info.getVideoStreams().isEmpty()
+                        ? View.GONE : View.VISIBLE);
 
         final boolean noVideoStreams =
                 info.getVideoStreams().isEmpty() && info.getVideoOnlyStreams().isEmpty();

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/PlaybackResolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/PlaybackResolver.java
@@ -158,6 +158,26 @@ public interface PlaybackResolver extends Resolver<StreamInfo, MediaSource> {
 
         return cacheKey.toString();
     }
+
+    /**
+     * Use common base type {@link Stream} to handle {@link AudioStream} or {@link VideoStream}
+     * transparently. For more info see {@link #cacheKeyOf(StreamInfo, AudioStream)} or
+     * {@link #cacheKeyOf(StreamInfo, VideoStream)}.
+     *
+     * @param info   the {@link StreamInfo stream info}, to distinguish between streams with
+     *               the same features but coming from different stream infos
+     * @param stream the {@link Stream} ({@link AudioStream} or {@link VideoStream})
+     *               for which the cache key should be created
+     * @return a key to be used to store the cache of the provided {@link Stream}
+     */
+    static String cacheKeyOf(final StreamInfo info, final Stream stream) {
+        if (stream instanceof AudioStream) {
+            return cacheKeyOf(info, (AudioStream) stream);
+        } else if (stream instanceof VideoStream) {
+            return cacheKeyOf(info, (VideoStream) stream);
+        }
+        throw new RuntimeException("no audio or video stream. That should never happen");
+    }
     //endregion
 
 


### PR DESCRIPTION
Some services may only have video streams and no separate audio streams available. This commit will add audio background playback support for those services. It uses the video source as audio source for background playback.

**Note** I think currently NewPipe is in no need to support this feature but maybe in the future. I use it in BraveNewPipe as some services do not support audio only streams. Would be great if it could be merged.
Thx

<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- audio playback for services that do not support audio streams.
- use audio from video stream for audio only background playback


#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
