### PR TITLE
Place downloaded files in default folder without file permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,7 +6,6 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 

--- a/app/src/main/java/org/schabi/newpipe/streams/io/StoredDirectoryHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/streams/io/StoredDirectoryHelper.java
@@ -35,7 +35,7 @@ public class StoredDirectoryHelper {
 
     private final String tag;
 
-    public StoredDirectoryHelper(@NonNull final Context context, @NonNull final Uri path,
+    public StoredDirectoryHelper(final Context context, final Uri path,
                                  final String tag) throws IOException {
         this.tag = tag;
 
@@ -46,13 +46,20 @@ public class StoredDirectoryHelper {
 
         this.context = context;
 
+        if (!path.toString().contains(context.getExternalFilesDir("").toString())) {
+            try {
+                this.context.getContentResolver().takePersistableUriPermission(path,
+                        PERMISSION_FLAGS);
+            } catch (final Exception e) {
+                throw new IOException(e);
+            }
+        }
+
         try {
-            this.context.getContentResolver().takePersistableUriPermission(path, PERMISSION_FLAGS);
+            this.docTree = DocumentFile.fromTreeUri(context, path);
         } catch (final Exception e) {
             throw new IOException(e);
         }
-
-        this.docTree = DocumentFile.fromTreeUri(context, path);
 
         if (this.docTree == null) {
             throw new IOException("Failed to create the tree from Uri");
@@ -230,7 +237,13 @@ public class StoredDirectoryHelper {
     @NonNull
     @Override
     public String toString() {
-        return (docTree == null ? Uri.fromFile(ioTree) : docTree.getUri()).toString();
+        if (ioTree != null) {
+            return Uri.fromFile(ioTree).toString();
+        }
+        if (docTree != null) {
+            return docTree.getUri().toString();
+        }
+        return "";
     }
 
     ////////////////////

--- a/app/src/main/java/org/schabi/newpipe/streams/io/StoredFileHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/streams/io/StoredFileHelper.java
@@ -126,6 +126,7 @@ public class StoredFileHelper implements Serializable {
                             @NonNull final Uri path, final String tag) throws IOException {
         this.tag = tag;
         this.source = path.toString();
+        this.context = context;
 
         if (path.getScheme() == null
                 || path.getScheme().equalsIgnoreCase(ContentResolver.SCHEME_FILE)) {
@@ -136,8 +137,6 @@ public class StoredFileHelper implements Serializable {
             if (file == null) {
                 throw new RuntimeException("SAF not available");
             }
-
-            this.context = context;
 
             if (file.getName() == null) {
                 this.source = null;
@@ -183,6 +182,10 @@ public class StoredFileHelper implements Serializable {
         return instance;
     }
 
+    public Context getContext() {
+        return this.context;
+    }
+
     public SharpStream getStream() throws IOException {
         assertValid();
 
@@ -226,6 +229,10 @@ public class StoredFileHelper implements Serializable {
         try (SharpStream fs = getStream()) {
             fs.setLength(0);
         }
+    }
+
+    public void updatePath(final String path) {
+        ioFile = new File(path);
     }
 
     public boolean delete() {

--- a/app/src/main/java/us/shandian/giga/service/DownloadManagerService.java
+++ b/app/src/main/java/us/shandian/giga/service/DownloadManagerService.java
@@ -497,26 +497,6 @@ public class DownloadManagerService extends Service {
         mLockAcquired = acquire;
     }
 
-    private StoredDirectoryHelper loadMainStorage(@StringRes int prefKey, String tag) {
-        String path = mPrefs.getString(getString(prefKey), null);
-
-        if (path == null || path.isEmpty()) return null;
-
-        if (path.charAt(0) == File.separatorChar) {
-            Log.i(TAG, "Old save path style present: " + path);
-            path = "";
-            mPrefs.edit().putString(getString(prefKey), "").apply();
-        }
-
-        try {
-            return new StoredDirectoryHelper(this, Uri.parse(path), tag);
-        } catch (Exception e) {
-            Log.e(TAG, "Failed to load the storage of " + tag + " from " + path, e);
-            Toast.makeText(this, R.string.no_available_dir, Toast.LENGTH_LONG).show();
-        }
-
-        return null;
-    }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////
     // Wrappers for DownloadManager

--- a/app/src/main/java/us/shandian/giga/service/DownloadManagerService.java
+++ b/app/src/main/java/us/shandian/giga/service/DownloadManagerService.java
@@ -139,7 +139,7 @@ public class DownloadManagerService extends Service {
 
         mPrefs = PreferenceManager.getDefaultSharedPreferences(this);
 
-        mManager = new DownloadManager(this, mHandler, loadMainVideoStorage(), loadMainAudioStorage());
+        mManager = new DownloadManager(this, mHandler);
 
         Intent openDownloadListIntent = new Intent(this, DownloadActivity.class)
                 .setAction(Intent.ACTION_MAIN);
@@ -322,10 +322,6 @@ public class DownloadManagerService extends Service {
             mManager.mPrefMeteredDownloads = prefs.getBoolean(key, false);
         } else if (key.equals(getString(R.string.downloads_queue_limit))) {
             mManager.mPrefQueueLimit = prefs.getBoolean(key, true);
-        } else if (key.equals(getString(R.string.download_path_video_key))) {
-            mManager.mMainStorageVideo = loadMainVideoStorage();
-        } else if (key.equals(getString(R.string.download_path_audio_key))) {
-            mManager.mMainStorageAudio = loadMainAudioStorage();
         }
     }
 
@@ -501,14 +497,6 @@ public class DownloadManagerService extends Service {
         mLockAcquired = acquire;
     }
 
-    private StoredDirectoryHelper loadMainVideoStorage() {
-        return loadMainStorage(R.string.download_path_video_key, DownloadManager.TAG_VIDEO);
-    }
-
-    private StoredDirectoryHelper loadMainAudioStorage() {
-        return loadMainStorage(R.string.download_path_audio_key, DownloadManager.TAG_AUDIO);
-    }
-
     private StoredDirectoryHelper loadMainStorage(@StringRes int prefKey, String tag) {
         String path = mPrefs.getString(getString(prefKey), null);
 
@@ -537,23 +525,6 @@ public class DownloadManagerService extends Service {
     public class DownloadManagerBinder extends Binder {
         public DownloadManager getDownloadManager() {
             return mManager;
-        }
-
-        @Nullable
-        public StoredDirectoryHelper getMainStorageVideo() {
-            return mManager.mMainStorageVideo;
-        }
-
-        @Nullable
-        public StoredDirectoryHelper getMainStorageAudio() {
-            return mManager.mMainStorageAudio;
-        }
-
-        public boolean askForSavePath() {
-            return DownloadManagerService.this.mPrefs.getBoolean(
-                    DownloadManagerService.this.getString(R.string.downloads_storage_ask),
-                    false
-            );
         }
 
         public void addMissionEventListener(Callback handler) {

--- a/app/src/main/java/us/shandian/giga/ui/adapter/MissionAdapter.java
+++ b/app/src/main/java/us/shandian/giga/ui/adapter/MissionAdapter.java
@@ -649,7 +649,7 @@ public class MissionAdapter extends Adapter<ViewHolder> implements Handler.Callb
                     if (mission.isPsRunning()) {
                         mission.psContinue(true);
                     } else {
-                        mDownloadManager.tryRecover(mission);
+                        mDownloadManager.tryRecover(mContext, mission);
                         if (mission.storage.isInvalid())
                             mRecover.tryRecover(mission);
                         else


### PR DESCRIPTION
Thats how it should wok in my experience. Solid explorer has full access and the others do zero. the master does everything. they just work

i updated newpipe a year ago and downloads were crashing incomprehensibly. something was more complicated than it had to be. the old settings had not been tested and a change in the published release crashed for everyone with previous settings and certain os versions.

this beautiful method was introduced in api 19. works like magic. no clutter. no bugs. it just works. i still have apps that cling on the the legacy override and clutter my homefgolder with useless empty folders. apps lovew to make empty folders for no reason. and everyone thinks their app is the only thing the os will ever servce. most people dont car e much about your app and just want it to do no harm

the gui settings still have to be removed. i am only one man only haver so much ork. 

if the storage backup can be removed it will completely remove all traces of file pickers and permissions since api 19. and homespace horrow https://blog.codinghorror.com/dont-pollute-user-space/

i certainly store files. notes. but no browser data. i dont know why someone would collect playlists et c and guard them like a treasure. i would remove it to purge all home space pollution or traces of it