### PR TITLE
Check availability of Samsung DeX only on Samsung devices

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
@@ -1,5 +1,7 @@
 package org.schabi.newpipe.util;
 
+import static android.content.Context.INPUT_SERVICE;
+
 import android.annotation.SuppressLint;
 import android.app.UiModeManager;
 import android.content.Context;
@@ -27,11 +29,10 @@ import org.schabi.newpipe.R;
 
 import java.lang.reflect.Method;
 
-import static android.content.Context.INPUT_SERVICE;
-
 public final class DeviceUtils {
 
     private static final String AMAZON_FEATURE_FIRE_TV = "amazon.hardware.fire_tv";
+    private static final boolean SAMSUNG = Build.MANUFACTURER.equals("samsung");
     private static Boolean isTV = null;
     private static Boolean isFireTV = null;
 
@@ -120,6 +121,10 @@ public final class DeviceUtils {
             return true;
         }
 
+        if (!SAMSUNG) {
+            return false;
+            // DeX is Samsung-specific, skip the checks below on non-Samsung devices
+        }
         // DeX check for standalone and multi-window mode, from:
         // https://developer.samsung.com/samsung-dex/modify-optimizing.html
         try {


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [X] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
Samsung DeX is a feature of Samsung devices. There is no reason to assume it is on other devices. This disables the reflection calls on all devices that aren't manufactured by Samsung.

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [X] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
