### PR TITLE
Disable tunneling on internal Surface related Exceptions

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -1446,9 +1446,11 @@ public final class Player implements PlaybackListener, Listener {
                     trackSelector.setParameters(trackSelector.buildUponParameters()
                             .setTunnelingEnabled(false));
                     Log.d(TAG, "Disable tunneling and reload");
-                    // Reload playback on unexpected errors:
-                    setRecovery();
-                    reloadPlayQueueManager();
+                    simpleExoPlayer.seekToDefaultPosition();
+                    simpleExoPlayer.prepare();
+                    // Inform the user that we are reloading the stream by
+                    // switching to the buffering state
+                    onBuffering();
                     break;
                 } else {
                     Log.d(TAG, "Conditinns for recovery not met. Tunneling enabled?: "

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -1434,8 +1434,15 @@ public final class Player implements PlaybackListener, Listener {
                 // Try to handle tunneling related exceptions
                 final String stackTrace = Log.getStackTraceString(error.getCause());
                 Log.d(TAG, "Unexpected PlaybackException! Cause: " + stackTrace);
-                if (simpleExoPlayer.isTunnelingEnabled()
-                        && stackTrace.contains("Surface")) {
+                boolean isTunnelingEnabled = false;
+                try {
+                    isTunnelingEnabled = simpleExoPlayer.isTunnelingEnabled()
+                            || trackSelector.getParameters().tunnelingEnabled;
+                } catch (final NullPointerException e) {
+                    Log.d(TAG, "Unable to check tunneling enablement status: "
+                            + Log.getStackTraceString(e));
+                }
+                if (isTunnelingEnabled && stackTrace.contains("Surface")) {
                     trackSelector.setParameters(trackSelector.buildUponParameters()
                             .setTunnelingEnabled(false));
                     Log.d(TAG, "Disable tunneling and reload");
@@ -1445,7 +1452,7 @@ public final class Player implements PlaybackListener, Listener {
                     break;
                 } else {
                     Log.d(TAG, "Conditinns for recovery not met. Tunneling enabled?: "
-                            + simpleExoPlayer.isTunnelingEnabled()
+                            + isTunnelingEnabled
                             + ", Surface keyword found?: " + stackTrace.contains("Surface"));
                 }
                 // fall through to default

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -1434,17 +1434,18 @@ public final class Player implements PlaybackListener, Listener {
                 // Try to handle tunneling related exceptions
                 final String stackTrace = Log.getStackTraceString(error.getCause());
                 Log.d(TAG, "Unexpected PlaybackException! Cause: " + stackTrace);
-                if (trackSelector.getParameters().tunnelingEnabled
+                if (simpleExoPlayer.isTunnelingEnabled()
                         && stackTrace.contains("Surface")) {
                     trackSelector.setParameters(trackSelector.buildUponParameters()
                             .setTunnelingEnabled(false));
+                    Log.d(TAG, "Disable tunneling and reload");
                     // Reload playback on unexpected errors:
                     setRecovery();
                     reloadPlayQueueManager();
                     break;
                 } else {
                     Log.d(TAG, "Conditinns for recovery not met. Tunneling enabled?: "
-                            + trackSelector.getParameters().tunnelingEnabled
+                            + simpleExoPlayer.isTunnelingEnabled()
                             + ", Surface keyword found?: " + stackTrace.contains("Surface"));
                 }
                 // fall through to default


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [X] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This PR tries to automatically disable media tunneling on unrecoverable internal player exceptions. Analysis was possible thanks to the stack trace provided in this comment: https://github.com/TeamNewPipe/NewPipe/issues/9023#issuecomment-1321003333
In the past we tried to disable media tunneling on devices that claim to support it but fail to do so. This was not only device specific but also frustrating for users that would have to create an issue on Github to hope for help with a new version release. With the new ExoPlayer Settings page that is still a PR (#8875) we have a general approach. However most users would still first create an issue before they would learn about these settings. So an automatic recovery for at least some of the devices seems useful.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- It might be a fix for only a part of the affected devices of #9023. It requires testing on affected devices to see how effective this workaround is.

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
