### PR TITLE
Use Optional.map() instead of flatMap().

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -1887,7 +1887,7 @@ public final class VideoDetailFragment
         setupBrightness();
         if (!isPlayerAndPlayerServiceAvailable()
                 || player.UIs().get(MainPlayerUi.class).isEmpty()
-                || getRoot().flatMap(v -> Optional.ofNullable(v.getParent())).isEmpty()) {
+                || getRoot().map(View::getParent).isEmpty()) {
             return;
         }
 

--- a/app/src/main/java/org/schabi/newpipe/player/mediaitem/MediaItemTag.java
+++ b/app/src/main/java/org/schabi/newpipe/player/mediaitem/MediaItemTag.java
@@ -62,8 +62,8 @@ public interface MediaItemTag {
     @NonNull
     static Optional<MediaItemTag> from(@Nullable final MediaItem mediaItem) {
         return Optional.ofNullable(mediaItem)
-                .flatMap(item -> Optional.ofNullable(item.localConfiguration))
-                .flatMap(localConfiguration -> Optional.ofNullable(localConfiguration.tag))
+                .map(item -> item.localConfiguration)
+                .map(localConfiguration -> localConfiguration.tag)
                 .filter(MediaItemTag.class::isInstance)
                 .map(MediaItemTag.class::cast);
     }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Use `Optional`'s `map` method instead of `flatMap`, as it already handles null values returned in the lambda. This adds to the changes in #9285.

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
