### PR TITLE
Fix popup enablement toast crash on API 33

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/RouterActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/RouterActivity.java
@@ -631,8 +631,7 @@ public class RouterActivity extends AppCompatActivity {
         }
 
         if (selectedChoiceKey.equals(getString(R.string.popup_player_key))
-                && !PermissionHelper.isPopupEnabled(this)) {
-            PermissionHelper.showPopupEnablementToast(this);
+                && !PermissionHelper.isPopupEnabledElseAsk(this)) {
             finish();
             return;
         }

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -1066,8 +1066,7 @@ public final class VideoDetailFragment
     }
 
     private void openPopupPlayer(final boolean append) {
-        if (!PermissionHelper.isPopupEnabled(activity)) {
-            PermissionHelper.showPopupEnablementToast(activity);
+        if (!PermissionHelper.isPopupEnabledElseAsk(activity)) {
             return;
         }
 

--- a/app/src/main/java/org/schabi/newpipe/player/PlayQueueActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayQueueActivity.java
@@ -143,11 +143,9 @@ public final class PlayQueueActivity extends AppCompatActivity
                 NavigationHelper.playOnMainPlayer(this, player.getPlayQueue(), true);
                 return true;
             case R.id.action_switch_popup:
-                if (PermissionHelper.isPopupEnabled(this)) {
+                if (PermissionHelper.isPopupEnabledElseAsk(this)) {
                     this.player.setRecovery();
                     NavigationHelper.playOnPopupPlayer(this, player.getPlayQueue(), true);
-                } else {
-                    PermissionHelper.showPopupEnablementToast(this);
                 }
                 return true;
             case R.id.action_switch_background:

--- a/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
@@ -156,8 +156,7 @@ public final class NavigationHelper {
     public static void playOnPopupPlayer(final Context context,
                                          final PlayQueue queue,
                                          final boolean resumePlayback) {
-        if (!PermissionHelper.isPopupEnabled(context)) {
-            PermissionHelper.showPopupEnablementToast(context);
+        if (!PermissionHelper.isPopupEnabledElseAsk(context)) {
             return;
         }
 
@@ -183,8 +182,7 @@ public final class NavigationHelper {
     public static void enqueueOnPlayer(final Context context,
                                        final PlayQueue queue,
                                        final PlayerType playerType) {
-        if ((playerType == PlayerType.POPUP) && !PermissionHelper.isPopupEnabled(context)) {
-            PermissionHelper.showPopupEnablementToast(context);
+        if (playerType == PlayerType.POPUP && !PermissionHelper.isPopupEnabledElseAsk(context)) {
             return;
         }
 

--- a/app/src/main/java/org/schabi/newpipe/util/PermissionHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/PermissionHelper.java
@@ -9,8 +9,6 @@ import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Build;
 import android.provider.Settings;
-import android.view.Gravity;
-import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.RequiresApi;
@@ -128,18 +126,21 @@ public final class PermissionHelper {
         }
     }
 
-    public static boolean isPopupEnabled(final Context context) {
-        return Build.VERSION.SDK_INT < Build.VERSION_CODES.M
-                || checkSystemAlertWindowPermission(context);
-    }
-
-    public static void showPopupEnablementToast(final Context context) {
-        final Toast toast =
-                Toast.makeText(context, R.string.msg_popup_permission, Toast.LENGTH_LONG);
-        final TextView messageView = toast.getView().findViewById(android.R.id.message);
-        if (messageView != null) {
-            messageView.setGravity(Gravity.CENTER);
+    /**
+     * Determines whether the popup is enabled, and if it is not, starts the system activity to
+     * request the permission with {@link #checkSystemAlertWindowPermission(Context)} and shows a
+     * toast to the user explaining why the permission is needed.
+     *
+     * @param context the Android context
+     * @return whether the popup is enabled
+     */
+    public static boolean isPopupEnabledElseAsk(final Context context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M
+                || checkSystemAlertWindowPermission(context)) {
+            return true;
+        } else {
+            Toast.makeText(context, R.string.msg_popup_permission, Toast.LENGTH_LONG).show();
+            return false;
         }
-        toast.show();
     }
 }


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Calling `getView()` is forbidden (returns `null`) on API 33. That method was used to center the text in the toast, but I think that was not useful anyway so I just removed the centering completely and now the popup enablement toast shows normally.
I also simplified some duplicate code, since each time the popup permission was checked, the toast would also be shown, so I merged those.
Related to #9306.

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
