### PR TITLE
Orientation is locked if there is no sensor for it

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
@@ -14,6 +14,7 @@ import static java.lang.annotation.RetentionPolicy.SOURCE;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.provider.Settings;
 import android.view.accessibility.CaptioningManager;
 
@@ -382,8 +383,11 @@ public final class PlayerHelper {
     public static boolean globalScreenOrientationLocked(final Context context) {
         // 1: Screen orientation changes using accelerometer
         // 0: Screen orientation is locked
+        // if the accelerometer sensor is missing completely, assume locked orientation
         return android.provider.Settings.System.getInt(
-                context.getContentResolver(), Settings.System.ACCELEROMETER_ROTATION, 0) == 0;
+                context.getContentResolver(), Settings.System.ACCELEROMETER_ROTATION, 0) == 0
+                    || !context.getPackageManager()
+                        .hasSystemFeature(PackageManager.FEATURE_SENSOR_ACCELEROMETER);
     }
 
     public static int getProgressiveLoadIntervalBytes(@NonNull final Context context) {


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [X] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This https://github.com/TeamNewPipe/NewPipe/issues/4478#issuecomment-1382828147 in the ever lasting full screen button discussion is actually valid. If a device does not feature an accelerometer (STB, Terminal, TV), the screen cannot rotate. It is more some sort of "sanity" check, as "def_accelerometer_rotation" in the SettingsProvider in AOSP is "false", which means, that after a factory reset, auto rotation of the screen should be disabled anyway. So a device manufacturer must have deliberately broken it (actually a device bug, not a bug in NewPipe) or a user must have selected screen auto rotation, even though it doesn't work. So this probably affects only a handful of users of NewPipe.

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [X] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
