### PR TITLE
Revert PR #9553 "Update ExoPlayer to 2.18.2"

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -102,7 +102,7 @@ ext {
     androidxWorkVersion = '2.7.1'
 
     icepickVersion = '3.2.0'
-    exoPlayerVersion = '2.18.2'
+    exoPlayerVersion = '2.18.1'
     googleAutoServiceVersion = '1.0.1'
     groupieVersion = '2.10.1'
     markwonVersion = '4.6.2'

--- a/app/src/main/java/org/schabi/newpipe/player/mediasource/LoadedMediaSource.java
+++ b/app/src/main/java/org/schabi/newpipe/player/mediasource/LoadedMediaSource.java
@@ -1,21 +1,27 @@
 package org.schabi.newpipe.player.mediasource;
 
-import androidx.annotation.NonNull;
-
 import com.google.android.exoplayer2.MediaItem;
+import com.google.android.exoplayer2.Timeline;
+import com.google.android.exoplayer2.source.CompositeMediaSource;
+import com.google.android.exoplayer2.source.MediaPeriod;
 import com.google.android.exoplayer2.source.MediaSource;
-import com.google.android.exoplayer2.source.WrappingMediaSource;
+import com.google.android.exoplayer2.upstream.Allocator;
+import com.google.android.exoplayer2.upstream.TransferListener;
 
 import org.schabi.newpipe.player.mediaitem.MediaItemTag;
 import org.schabi.newpipe.player.playqueue.PlayQueueItem;
 
-public class LoadedMediaSource extends WrappingMediaSource implements ManagedMediaSource {
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public class LoadedMediaSource extends CompositeMediaSource<Integer> implements ManagedMediaSource {
+    private final MediaSource source;
     private final PlayQueueItem stream;
     private final MediaItem mediaItem;
     private final long expireTimestamp;
 
     /**
-     * Uses a {@link WrappingMediaSource} to wrap one child {@link MediaSource}
+     * Uses a {@link CompositeMediaSource} to wrap one or more child {@link MediaSource}s
      * containing actual media. This wrapper {@link LoadedMediaSource} holds the expiration
      * timestamp as a {@link ManagedMediaSource} to allow explicit playlist management under
      * {@link ManagedMediaSourcePlaylist}.
@@ -30,7 +36,7 @@ public class LoadedMediaSource extends WrappingMediaSource implements ManagedMed
                              @NonNull final MediaItemTag tag,
                              @NonNull final PlayQueueItem stream,
                              final long expireTimestamp) {
-        super(source);
+        this.source = source;
         this.stream = stream;
         this.expireTimestamp = expireTimestamp;
 
@@ -43,6 +49,51 @@ public class LoadedMediaSource extends WrappingMediaSource implements ManagedMed
 
     private boolean isExpired() {
         return System.currentTimeMillis() >= expireTimestamp;
+    }
+
+    /**
+     * Delegates the preparation of child {@link MediaSource}s to the
+     * {@link CompositeMediaSource} wrapper. Since all {@link LoadedMediaSource}s use only
+     * a single child media, the child id of 0 is always used (sonar doesn't like null as id here).
+     *
+     * @param mediaTransferListener A data transfer listener that will be registered by the
+     *                              {@link CompositeMediaSource} for child source preparation.
+     */
+    @Override
+    protected void prepareSourceInternal(@Nullable final TransferListener mediaTransferListener) {
+        super.prepareSourceInternal(mediaTransferListener);
+        prepareChildSource(0, source);
+    }
+
+    /**
+     * When any child {@link MediaSource} is prepared, the refreshed {@link Timeline} can
+     * be listened to here. But since {@link LoadedMediaSource} has only a single child source,
+     * this method is called only once until {@link #releaseSourceInternal()} is called.
+     * <br><br>
+     * On refresh, the {@link CompositeMediaSource} delegate will be notified with the
+     * new {@link Timeline}, otherwise {@link #createPeriod(MediaPeriodId, Allocator, long)}
+     * will not be called and playback may be stalled.
+     *
+     * @param id            The unique id used to prepare the child source.
+     * @param mediaSource   The child source whose source info has been refreshed.
+     * @param timeline      The new timeline of the child source.
+     */
+    @Override
+    protected void onChildSourceInfoRefreshed(final Integer id,
+                                              final MediaSource mediaSource,
+                                              final Timeline timeline) {
+        refreshSourceInfo(timeline);
+    }
+
+    @Override
+    public MediaPeriod createPeriod(final MediaPeriodId id, final Allocator allocator,
+                                    final long startPositionUs) {
+        return source.createPeriod(id, allocator, startPositionUs);
+    }
+
+    @Override
+    public void releasePeriod(final MediaPeriod mediaPeriod) {
+        source.releasePeriod(mediaPeriod);
     }
 
     @NonNull


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This commit reverts #9553 / 1bb166a and downgrades ExoPlayer to 2.18.1.
There is a bug in ExoPlayer 2.18.2 which leads to crashes (e.g. see https://github.com/TeamNewPipe/NewPipe/pull/9553#issuecomment-1398217296) which is going to be fixed in an upcoming version.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes https://github.com/TeamNewPipe/NewPipe/pull/9553#issuecomment-1398217296

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
