### PR TITLE
Add whitelist to only retrieve supported YouTube itags/streams

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/resolver/AudioPlaybackResolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/AudioPlaybackResolver.java
@@ -1,6 +1,6 @@
 package org.schabi.newpipe.player.resolver;
 
-import static org.schabi.newpipe.util.ListHelper.getNonTorrentStreams;
+import static org.schabi.newpipe.util.ListHelper.getPlayableStreams;
 
 import android.content.Context;
 import android.util.Log;
@@ -68,12 +68,12 @@ public class AudioPlaybackResolver implements PlaybackResolver {
      */
     @Nullable
     private Stream getAudioSource(@NonNull final StreamInfo info) {
-        final List<AudioStream> audioStreams = getNonTorrentStreams(info.getAudioStreams());
+        final List<AudioStream> audioStreams = getPlayableStreams(info.getAudioStreams());
         if (!audioStreams.isEmpty()) {
             final int index = ListHelper.getDefaultAudioFormat(context, audioStreams);
             return getStreamForIndex(index, audioStreams);
         } else {
-            final List<VideoStream> videoStreams = getNonTorrentStreams(info.getVideoStreams());
+            final List<VideoStream> videoStreams = getPlayableStreams(info.getVideoStreams());
             if (!videoStreams.isEmpty()) {
                 final int index = ListHelper.getDefaultResolutionIndex(context, videoStreams);
                 return getStreamForIndex(index, videoStreams);

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/AudioPlaybackResolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/AudioPlaybackResolver.java
@@ -68,12 +68,14 @@ public class AudioPlaybackResolver implements PlaybackResolver {
      */
     @Nullable
     private Stream getAudioSource(@NonNull final StreamInfo info) {
-        final List<AudioStream> audioStreams = getPlayableStreams(info.getAudioStreams());
+        final List<AudioStream> audioStreams = getPlayableStreams(
+                info.getAudioStreams(), info.getServiceId());
         if (!audioStreams.isEmpty()) {
             final int index = ListHelper.getDefaultAudioFormat(context, audioStreams);
             return getStreamForIndex(index, audioStreams);
         } else {
-            final List<VideoStream> videoStreams = getPlayableStreams(info.getVideoStreams());
+            final List<VideoStream> videoStreams = getPlayableStreams(
+                    info.getVideoStreams(), info.getServiceId());
             if (!videoStreams.isEmpty()) {
                 final int index = ListHelper.getDefaultResolutionIndex(context, videoStreams);
                 return getStreamForIndex(index, videoStreams);

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/VideoPlaybackResolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/VideoPlaybackResolver.java
@@ -29,7 +29,7 @@ import java.util.Optional;
 
 import static com.google.android.exoplayer2.C.TIME_UNSET;
 import static org.schabi.newpipe.util.ListHelper.getUrlAndNonTorrentStreams;
-import static org.schabi.newpipe.util.ListHelper.getNonTorrentStreams;
+import static org.schabi.newpipe.util.ListHelper.getPlayableStreams;
 
 public class VideoPlaybackResolver implements PlaybackResolver {
     private static final String TAG = VideoPlaybackResolver.class.getSimpleName();
@@ -72,8 +72,8 @@ public class VideoPlaybackResolver implements PlaybackResolver {
 
         // Create video stream source
         final List<VideoStream> videoStreamsList = ListHelper.getSortedStreamVideosList(context,
-                getNonTorrentStreams(info.getVideoStreams()),
-                getNonTorrentStreams(info.getVideoOnlyStreams()), false, true);
+                getPlayableStreams(info.getVideoStreams()),
+                getPlayableStreams(info.getVideoOnlyStreams()), false, true);
         final int index;
         if (videoStreamsList.isEmpty()) {
             index = -1;
@@ -100,7 +100,7 @@ public class VideoPlaybackResolver implements PlaybackResolver {
         }
 
         // Create optional audio stream source
-        final List<AudioStream> audioStreams = getNonTorrentStreams(info.getAudioStreams());
+        final List<AudioStream> audioStreams = getPlayableStreams(info.getAudioStreams());
         final AudioStream audio = audioStreams.isEmpty() ? null : audioStreams.get(
                 ListHelper.getDefaultAudioFormat(context, audioStreams));
 

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/VideoPlaybackResolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/VideoPlaybackResolver.java
@@ -72,8 +72,8 @@ public class VideoPlaybackResolver implements PlaybackResolver {
 
         // Create video stream source
         final List<VideoStream> videoStreamsList = ListHelper.getSortedStreamVideosList(context,
-                getPlayableStreams(info.getVideoStreams()),
-                getPlayableStreams(info.getVideoOnlyStreams()), false, true);
+                getPlayableStreams(info.getVideoStreams(), info.getServiceId()),
+                getPlayableStreams(info.getVideoOnlyStreams(), info.getServiceId()), false, true);
         final int index;
         if (videoStreamsList.isEmpty()) {
             index = -1;
@@ -100,7 +100,8 @@ public class VideoPlaybackResolver implements PlaybackResolver {
         }
 
         // Create optional audio stream source
-        final List<AudioStream> audioStreams = getPlayableStreams(info.getAudioStreams());
+        final List<AudioStream> audioStreams = getPlayableStreams(
+                info.getAudioStreams(), info.getServiceId());
         final AudioStream audio = audioStreams.isEmpty() ? null : audioStreams.get(
                 ListHelper.getDefaultAudioFormat(context, audioStreams));
 

--- a/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
@@ -1,5 +1,7 @@
 package org.schabi.newpipe.util;
 
+import static org.schabi.newpipe.extractor.ServiceList.YouTube;
+
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.net.ConnectivityManager;
@@ -162,16 +164,19 @@ public final class ListHelper {
      * Some formats are not supported. For more info, see {@link #SUPPORTED_ITAG_IDS}.
      * Torrent streams are also removed, because they cannot be retrieved.
      *
-     * @param streamList the original stream list
      * @param <S>        the item type's class that extends {@link Stream}
+     * @param streamList the original stream list
+     * @param serviceId
      * @return a stream list which only contains streams that can be played the player
      */
     @NonNull
     public static <S extends Stream> List<S> getPlayableStreams(
-            @Nullable final List<S> streamList) {
+            @Nullable final List<S> streamList, final int serviceId) {
+        final int youtubeServiceId = YouTube.getServiceId();
         return getFilteredStreamList(streamList,
                 stream -> stream.getDeliveryMethod() != DeliveryMethod.TORRENT
-                        && (stream.getItagItem() == null
+                        && (serviceId != youtubeServiceId
+                        || stream.getItagItem() == null
                         || SUPPORTED_ITAG_IDS.contains(stream.getItagItem().id)));
     }
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [x] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This PR makes NewPipe compatible with the changes from https://github.com/TeamNewPipe/NewPipeExtractor/pull/488 and https://github.com/TeamNewPipe/NewPipeExtractor/pull/706

#### Relies on the following changes
https://github.com/TeamNewPipe/NewPipeExtractor/pull/488 and https://github.com/TeamNewPipe/NewPipeExtractor/pull/706 can, but do not have to be merged

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
