### PR TITLE
Fix opening links on Android 12+

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/util/external_communication/ShareUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/external_communication/ShareUtils.java
@@ -90,19 +90,16 @@ public final class ShareUtils {
             // No browser set as default (doesn't work on some devices)
             openAppChooser(context, intent, true);
         } else {
-            if (defaultPackageName.isEmpty()) {
-                // No app installed to open a web url
-                Toast.makeText(context, R.string.no_app_to_open_intent, Toast.LENGTH_LONG).show();
-                return false;
-            } else {
-                try {
+            try {
+                // will be empty on Android 12+
+                if (!defaultPackageName.isEmpty()) {
                     intent.setPackage(defaultPackageName);
-                    context.startActivity(intent);
-                } catch (final ActivityNotFoundException e) {
-                    // Not a browser but an app chooser because of OEMs changes
-                    intent.setPackage(null);
-                    openAppChooser(context, intent, true);
                 }
+                context.startActivity(intent);
+            } catch (final ActivityNotFoundException e) {
+                // Not a browser but an app chooser because of OEMs changes
+                intent.setPackage(null);
+                openAppChooser(context, intent, true);
             }
         }
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
#9726 wasn't enough. Android 12+ seems to return null to calls to `resolveActivity`, so the previous code would have said "No app can open this". Now instead, we try to open the activity in any case, even when we don't have a resolved package to set. I will take care of removing the now unused string if this PR is considered correct.
@AudricV do you think this is ok?

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- See https://github.com/TeamNewPipe/NewPipe/issues/9712#issuecomment-1400843696

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
