### PR TITLE
[YouTube] Improve download speed

### DIFF
--- a/app/src/main/java/us/shandian/giga/get/DownloadInitializer.java
+++ b/app/src/main/java/us/shandian/giga/get/DownloadInitializer.java
@@ -54,12 +54,12 @@ public class DownloadInitializer extends Thread {
                     long lowestSize = Long.MAX_VALUE;
 
                     for (int i = 0; i < mMission.urls.length && mMission.running; i++) {
-                        mConn = mMission.openConnection(mMission.urls[i], true, -1, -1);
+                        mConn = mMission.openConnection(mMission.urls[i], true, 0, 0);
                         mMission.establishConnection(mId, mConn);
                         dispose();
 
                         if (Thread.interrupted()) return;
-                        long length = Utility.getContentLength(mConn);
+                        long length = Utility.getTotalContentLength(mConn);
 
                         if (i == 0) {
                             httpCode = mConn.getResponseCode();
@@ -84,14 +84,14 @@ public class DownloadInitializer extends Thread {
                     }
                 } else {
                     // ask for the current resource length
-                    mConn = mMission.openConnection(true, -1, -1);
+                    mConn = mMission.openConnection(true, 0, 0);
                     mMission.establishConnection(mId, mConn);
                     dispose();
 
                     if (!mMission.running || Thread.interrupted()) return;
 
                     httpCode = mConn.getResponseCode();
-                    mMission.length = Utility.getContentLength(mConn);
+                    mMission.length = Utility.getTotalContentLength(mConn);
                 }
 
                 if (mMission.length == 0 || httpCode == 204) {

--- a/app/src/main/java/us/shandian/giga/util/Utility.java
+++ b/app/src/main/java/us/shandian/giga/util/Utility.java
@@ -1,11 +1,8 @@
 package us.shandian.giga.util;
 
-import android.content.ClipData;
-import android.content.ClipboardManager;
 import android.content.Context;
 import android.os.Build;
 import android.util.Log;
-import android.widget.Toast;
 
 import androidx.annotation.ColorInt;
 import androidx.annotation.DrawableRes;
@@ -29,8 +26,10 @@ import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.net.HttpURLConnection;
 import java.util.Locale;
+import java.util.Random;
 
 import okio.ByteString;
+import us.shandian.giga.get.DownloadMission;
 
 public class Utility {
 
@@ -225,6 +224,28 @@ public class Utility {
 
         try {
             return Long.parseLong(connection.getHeaderField("Content-Length"));
+        } catch (Exception err) {
+            // nothing to do
+        }
+
+        return -1;
+    }
+
+    /**
+     * Get the content length of the entire file even if the HTTP response is partial
+     * (response code 206).
+     * @param connection http connection
+     * @return content length
+     */
+    public static long getTotalContentLength(final HttpURLConnection connection) {
+        try {
+            if (connection.getResponseCode() == 206) {
+                final String rangeStr = connection.getHeaderField("Content-Range");
+                final String bytesStr = rangeStr.split("/", 2)[1];
+                return Long.parseLong(bytesStr);
+            } else {
+                return getContentLength(connection);
+            }
         } catch (Exception err) {
             // nothing to do
         }


### PR DESCRIPTION
#### What is it?
- [X] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
- YouTube throttles all requests to their streams if they dont have either a Range header or a `&range=n-m` URL parameter
- YouTube's throttling is triggered by HEAD requests, too. Since the downloader uses HEAD requests to determine the file size, the subsequent GET requests will be throttled, too
- I modified the downloader to use HEAD requests with a range header to determine the file size. YouTube will return a Content-Range header for these requests, e.g. (`bytes 0-0/4530953`) which can be parsed to get the total size.
- The improvement is most noticeable on small audio files. Songs download almost instantly now.
- Larger audio files still get throttled at the end of a download, I am not sure how to fix this.

#### Fixes the following issue(s)
- Fixes #8147, fixes #8619.

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [X] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).