### PR TITLE
Include a high-resolution option in the default resolution settings.

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/settings/VideoAudioSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/VideoAudioSettingsFragment.java
@@ -13,6 +13,7 @@ import androidx.preference.ListPreference;
 import com.google.android.material.snackbar.Snackbar;
 
 import org.schabi.newpipe.R;
+import org.schabi.newpipe.util.ListHelper;
 import org.schabi.newpipe.util.PermissionHelper;
 
 import java.util.LinkedList;
@@ -26,7 +27,7 @@ public class VideoAudioSettingsFragment extends BasePreferenceFragment {
         addPreferencesFromResourceRegistry();
 
         updateSeekOptions();
-
+        updateResolutionOptions();
         listener = (sharedPreferences, key) -> {
 
             // on M and above, if user chooses to minimise to popup player on exit
@@ -48,8 +49,70 @@ public class VideoAudioSettingsFragment extends BasePreferenceFragment {
                 }
             } else if (getString(R.string.use_inexact_seek_key).equals(key)) {
                 updateSeekOptions();
+            } else if (getString(R.string.show_higher_resolutions_key).equals(key)) {
+                updateResolutionOptions();
             }
         };
+    }
+
+    /**
+     * Update default resolution, default popup resolution & mobile data resolution options.
+     * show high resolution when "Show higher resolution" option enabled.
+     */
+    private void updateResolutionOptions() {
+        final ListPreference defaultResolution = findPreference(
+                getString(R.string.default_resolution_key));
+        final ListPreference defaultPopupResolution = findPreference(
+                getString(R.string.default_popup_resolution_key));
+        final ListPreference mobileDataResolution = findPreference(
+                getString(R.string.limit_mobile_data_usage_key));
+        final Resources resources = getResources();
+        final boolean showHigherResolutions =  getPreferenceManager().getSharedPreferences()
+                .getBoolean(resources.getString(R.string.show_higher_resolutions_key), false);
+        final List<String> resolutionListDescriptions = ListHelper.getSortedResolutionList(
+                resources,
+                R.array.resolution_list_description,
+                R.array.high_resolution_list_descriptions,
+                showHigherResolutions);
+        final List<String> resolutionListValues = ListHelper.getSortedResolutionList(
+                resources,
+                R.array.resolution_list_values,
+                R.array.high_resolution_list_values,
+                showHigherResolutions);
+        final List<String> limitDataUsageResolutionValues = ListHelper.getSortedResolutionList(
+                resources,
+                R.array.limit_data_usage_values_list,
+                R.array.high_resolution_limit_data_usage_values_list,
+                showHigherResolutions);
+        final List<String> limitDataUsageResolutionDescriptions = ListHelper
+                .getSortedResolutionList(resources,
+                R.array.limit_data_usage_description_list,
+                R.array.high_resolution_list_descriptions,
+                showHigherResolutions);
+        defaultResolution.setEntries(resolutionListDescriptions.toArray(new String[0]));
+        defaultResolution.setEntryValues(resolutionListValues.toArray(new String[0]));
+        defaultPopupResolution.setEntries(resolutionListDescriptions.toArray(new String[0]));
+        defaultPopupResolution.setEntryValues(resolutionListValues.toArray(new String[0]));
+        mobileDataResolution.setEntries(
+                limitDataUsageResolutionDescriptions.toArray(new String[0]));
+        mobileDataResolution.setEntryValues(limitDataUsageResolutionValues.toArray(new String[0]));
+        if (!showHigherResolutions) {
+            if (ListHelper.isHighResolutionSelected(defaultResolution.getValue(),
+                    R.array.high_resolution_list_values,
+                    resources)) {
+                defaultResolution.setValueIndex(0);
+            }
+            if (ListHelper.isHighResolutionSelected(defaultPopupResolution.getValue(),
+                    R.array.high_resolution_list_values,
+                    resources)) {
+                defaultPopupResolution.setValueIndex(0);
+            }
+            if (ListHelper.isHighResolutionSelected(mobileDataResolution.getValue(),
+                    R.array.high_resolution_limit_data_usage_values_list,
+                    resources)) {
+                mobileDataResolution.setValueIndex(0);
+            }
+        }
     }
 
     /**

--- a/app/src/main/java/org/schabi/newpipe/settings/VideoAudioSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/VideoAudioSettingsFragment.java
@@ -57,18 +57,17 @@ public class VideoAudioSettingsFragment extends BasePreferenceFragment {
 
     /**
      * Update default resolution, default popup resolution & mobile data resolution options.
-     * show high resolution when "Show higher resolution" option enabled.
+     * <br />
+     * Show high resolutions when "Show higher resolution" option is enabled.
+     * Set default resolution to "best resolution" when "Show higher resolution" option
+     * is disabled.
      */
     private void updateResolutionOptions() {
-        final ListPreference defaultResolution = findPreference(
-                getString(R.string.default_resolution_key));
-        final ListPreference defaultPopupResolution = findPreference(
-                getString(R.string.default_popup_resolution_key));
-        final ListPreference mobileDataResolution = findPreference(
-                getString(R.string.limit_mobile_data_usage_key));
         final Resources resources = getResources();
         final boolean showHigherResolutions =  getPreferenceManager().getSharedPreferences()
                 .getBoolean(resources.getString(R.string.show_higher_resolutions_key), false);
+
+        // get sorted resolution lists
         final List<String> resolutionListDescriptions = ListHelper.getSortedResolutionList(
                 resources,
                 R.array.resolution_list_description,
@@ -89,6 +88,16 @@ public class VideoAudioSettingsFragment extends BasePreferenceFragment {
                 R.array.limit_data_usage_description_list,
                 R.array.high_resolution_list_descriptions,
                 showHigherResolutions);
+
+        // get resolution preferences
+        final ListPreference defaultResolution = findPreference(
+                getString(R.string.default_resolution_key));
+        final ListPreference defaultPopupResolution = findPreference(
+                getString(R.string.default_popup_resolution_key));
+        final ListPreference mobileDataResolution = findPreference(
+                getString(R.string.limit_mobile_data_usage_key));
+
+        // update resolution preferences with new resolutions, entries & values for each
         defaultResolution.setEntries(resolutionListDescriptions.toArray(new String[0]));
         defaultResolution.setEntryValues(resolutionListValues.toArray(new String[0]));
         defaultPopupResolution.setEntries(resolutionListDescriptions.toArray(new String[0]));
@@ -96,6 +105,9 @@ public class VideoAudioSettingsFragment extends BasePreferenceFragment {
         mobileDataResolution.setEntries(
                 limitDataUsageResolutionDescriptions.toArray(new String[0]));
         mobileDataResolution.setEntryValues(limitDataUsageResolutionValues.toArray(new String[0]));
+
+        // if "Show higher resolution" option is disabled,
+        // set default resolution to "best resolution"
         if (!showHigherResolutions) {
             if (ListHelper.isHighResolutionSelected(defaultResolution.getValue(),
                     R.array.high_resolution_list_values,

--- a/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
@@ -4,6 +4,7 @@ import static org.schabi.newpipe.extractor.ServiceList.YouTube;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.res.Resources;
 import android.net.ConnectivityManager;
 
 import androidx.annotation.NonNull;
@@ -237,6 +238,30 @@ public final class ListHelper {
 
         return getSortedStreamVideosList(defaultFormat, showHigherResolutions, videoStreams,
                 videoOnlyStreams, ascendingOrder, preferVideoOnlyStreams);
+    }
+
+    public static List<String> getSortedResolutionList(
+            final Resources resources,
+            final int defaultResolutionKey,
+            final int additionalResolutionKey,
+            final boolean showHigherResolutions) {
+        final List<String> defaultResolution = new ArrayList<String>(Arrays.asList(
+                resources.getStringArray(defaultResolutionKey)));
+        if (!showHigherResolutions) {
+            return defaultResolution;
+        }
+        final List<String> additionalResolutions = Arrays.asList(
+                resources.getStringArray(additionalResolutionKey));
+        defaultResolution.addAll(1, additionalResolutions);
+        return defaultResolution;
+    }
+
+    public static boolean isHighResolutionSelected(final String selectedResolution,
+                                             final int additionalResolutionKey,
+                                             final Resources resources) {
+        return Arrays.asList(resources.getStringArray(
+                        additionalResolutionKey))
+                .contains(selectedResolution);
     }
 
     /**

--- a/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
@@ -240,20 +240,31 @@ public final class ListHelper {
                 videoOnlyStreams, ascendingOrder, preferVideoOnlyStreams);
     }
 
+    /**
+     * Get a sorted list containing a set of default resolution info
+     * and additional resolution info if showHigherResolutions is true.
+     *
+     * @param resources the resources to get the resolutions from
+     * @param defaultResolutionKey the settings key of the default resolution
+     * @param additionalResolutionKey the settings key of the additional resolutions
+     * @param showHigherResolutions if higher resolutions should be included in the sorted list
+     * @return a sorted list containing the default and maybe additional resolutions
+     */
     public static List<String> getSortedResolutionList(
             final Resources resources,
             final int defaultResolutionKey,
             final int additionalResolutionKey,
             final boolean showHigherResolutions) {
-        final List<String> defaultResolution = new ArrayList<String>(Arrays.asList(
+        final List<String> resolutions = new ArrayList<>(Arrays.asList(
                 resources.getStringArray(defaultResolutionKey)));
         if (!showHigherResolutions) {
-            return defaultResolution;
+            return resolutions;
         }
         final List<String> additionalResolutions = Arrays.asList(
                 resources.getStringArray(additionalResolutionKey));
-        defaultResolution.addAll(1, additionalResolutions);
-        return defaultResolution;
+        // keep "best resolution" at the top
+        resolutions.addAll(1, additionalResolutions);
+        return resolutions;
     }
 
     public static boolean isHighResolutionSelected(final String selectedResolution,

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -124,6 +124,16 @@
     <string name="default_popup_resolution_value">480p</string>
     <string name="best_resolution_key">best_resolution</string>
 
+    <string-array name="high_resolution_list_values">
+        <item>2160p</item>
+        <item>1440p</item>
+    </string-array>
+
+    <string-array name="high_resolution_list_descriptions">
+        <item>2160p</item>
+        <item>1440p</item>
+    </string-array>
+
     <string-array name="resolution_list_values">
         <item>@string/best_resolution_key</item>
         <item>1080p60</item>
@@ -1299,6 +1309,11 @@
         <item>360p</item>
         <item>240p</item>
         <item>144p</item>
+    </string-array>
+
+    <string-array name="high_resolution_limit_data_usage_values_list">
+        <item>2160p</item>
+        <item>1440p</item>
     </string-array>
 
     <string name="list_view_mode_key">list_view_mode</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -543,6 +543,10 @@
         <item>240p</item>
         <item>144p</item>
     </string-array>
+    <string-array name="high_resolution_limit_data_usage_description_list">
+        <item>2160p</item>
+        <item>1440p</item>
+    </string-array>
     <!-- Notifications settings -->
     <string name="enable_streams_notifications_title">New streams notifications</string>
     <string name="enable_streams_notifications_summary">Notify about new streams from subscriptions</string>


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
- When "Show higher resolution" option is enabled,  add 1440p and 2160p option to "Default resolution", "Default popup resolution" and "Limit resolution when using mobile data"
- switch to "Best resolution" and "No limit" when "Show higher resolution" is disabled and 1440p or 2160p is iselected

#### Before/After Screenshots/Screen Record
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/70268484/228861656-1da80cdc-a1c7-42e6-9757-2777b5d331ff.jpg" width="200px" alt="Before"/></td>
    <td><img src="https://user-images.githubusercontent.com/70268484/228861708-f2f5879e-ac10-4f11-8351-a6b49ab980ad.jpg" width="200px" alt="After"/></td>
  </tr>
</table>

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #2941 


#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
