### PR TITLE
Remove jsoup files from APK

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -96,6 +96,13 @@ android {
     buildFeatures {
         viewBinding true
     }
+
+    packagingOptions {
+        // remove two files which belong to jsoup
+        // no idea how they ended up in the META-INF dir...
+        exclude 'META-INF/README.md'
+        exclude 'META-INF/CHANGES'
+    }
 }
 
 ext {
@@ -313,6 +320,7 @@ static String getGitWorkingBranch() {
     }
 }
 
+// fix reproducible builds
 project.afterEvaluate {
     tasks.compileReleaseArtProfile.doLast {
         outputs.files.each { file ->


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [x] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Two jsoup files slipped into the META-INF dir of the APK for some reason. README.md and CHANGES are removed automatically now.
![image](https://user-images.githubusercontent.com/17365767/229846233-6950897c-c268-4b66-91ea-277a466dab39.png)


#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
