### PR TITLE
Fix ktlint formatter after upgrade to Java 17

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -164,6 +164,7 @@ task runKtlint(type: JavaExec) {
     getMainClass().set("com.pinterest.ktlint.Main")
     classpath = configurations.ktlint
     args "src/**/*.kt"
+    jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")
 }
 
 task formatKtlint(type: JavaExec) {
@@ -172,6 +173,7 @@ task formatKtlint(type: JavaExec) {
     getMainClass().set("com.pinterest.ktlint.Main")
     classpath = configurations.ktlint
     args "-F", "src/**/*.kt"
+    jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")
 }
 
 afterEvaluate {


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR

When the ktlint formatter needed to make some changes to kotlin files, it failed with the following exception, see https://github.com/pinterest/ktlint/issues/1195:
```
java.lang.reflect.InaccessibleObjectException: Unable to make field private transient java.lang.Object java.lang.Throwable.backtrace accessible: module java.base does not "opens java.lang" to unnamed module @...
```

Although this should have been fixed in the latest version of ktlint, upgrading from 0.45.2 to 0.49.0, didn't really solve the issue as I then got a different error, see https://github.com/ScoopInstaller/Extras/issues/10313:
```
java.lang.NoClassDefFoundError: Could not initialize class org.jetbrains.kotlin.com.intellij.openapi.util.objectTree.ThrowableInterner
```

The solution provided in both issues was just to add a specific `jvmArgs` as I did. Note that this change is similar, but unrelated, to 78e1e0508eae3a60869bda1a4f0ff2095c1dabde

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
