### PR TITLE
Allow selecting image quality among multiple images

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -197,7 +197,7 @@ dependencies {
     // name and the commit hash with the commit hash of the (pushed) commit you want to test
     // This works thanks to JitPack: https://jitpack.io/
     implementation 'com.github.TeamNewPipe:nanojson:1d9e1aea9049fc9f85e68b43ba39fe7be1c1f751'
-    implementation 'com.github.TeamNewPipe:NewPipeExtractor:95a3cc0a173bba28c179f9f9503b1010ec6bff21'
+    implementation 'com.github.TeamNewPipe:NewPipeExtractor:3be76a6406d59f1fd8eedf5fab6552e6c2a3da76'
     implementation 'com.github.TeamNewPipe:NoNonsense-FilePicker:5.0.0'
 
 /** Checkstyle **/

--- a/app/src/main/java/org/schabi/newpipe/App.java
+++ b/app/src/main/java/org/schabi/newpipe/App.java
@@ -20,9 +20,10 @@ import org.schabi.newpipe.extractor.downloader.Downloader;
 import org.schabi.newpipe.ktx.ExceptionUtils;
 import org.schabi.newpipe.settings.NewPipeSettings;
 import org.schabi.newpipe.util.Localization;
-import org.schabi.newpipe.util.PicassoHelper;
+import org.schabi.newpipe.util.image.PicassoHelper;
 import org.schabi.newpipe.util.ServiceHelper;
 import org.schabi.newpipe.util.StateSaver;
+import org.schabi.newpipe.util.image.PreferredImageQuality;
 
 import java.io.IOException;
 import java.io.InterruptedIOException;
@@ -99,8 +100,9 @@ public class App extends Application {
         // Initialize image loader
         final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
         PicassoHelper.init(this);
-        PicassoHelper.setShouldLoadImages(
-                prefs.getBoolean(getString(R.string.download_thumbnail_key), true));
+        PicassoHelper.setPreferredImageQuality(PreferredImageQuality.fromPreferenceKey(this,
+                prefs.getString(getString(R.string.image_quality_key),
+                        getString(R.string.image_quality_default))));
         PicassoHelper.setIndicatorsEnabled(MainActivity.DEBUG
                 && prefs.getBoolean(getString(R.string.show_image_indicators_key), false));
 

--- a/app/src/main/java/org/schabi/newpipe/App.java
+++ b/app/src/main/java/org/schabi/newpipe/App.java
@@ -20,6 +20,7 @@ import org.schabi.newpipe.extractor.downloader.Downloader;
 import org.schabi.newpipe.ktx.ExceptionUtils;
 import org.schabi.newpipe.settings.NewPipeSettings;
 import org.schabi.newpipe.util.Localization;
+import org.schabi.newpipe.util.image.ImageStrategy;
 import org.schabi.newpipe.util.image.PicassoHelper;
 import org.schabi.newpipe.util.ServiceHelper;
 import org.schabi.newpipe.util.StateSaver;
@@ -100,7 +101,7 @@ public class App extends Application {
         // Initialize image loader
         final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
         PicassoHelper.init(this);
-        PicassoHelper.setPreferredImageQuality(PreferredImageQuality.fromPreferenceKey(this,
+        ImageStrategy.setPreferredImageQuality(PreferredImageQuality.fromPreferenceKey(this,
                 prefs.getString(getString(R.string.image_quality_key),
                         getString(R.string.image_quality_default))));
         PicassoHelper.setIndicatorsEnabled(MainActivity.DEBUG

--- a/app/src/main/java/org/schabi/newpipe/QueueItemMenuUtil.java
+++ b/app/src/main/java/org/schabi/newpipe/QueueItemMenuUtil.java
@@ -75,7 +75,7 @@ public final class QueueItemMenuUtil {
                     return true;
                 case R.id.menu_item_share:
                     shareText(context, item.getTitle(), item.getUrl(),
-                            item.getThumbnailUrl());
+                            item.getThumbnails());
                     return true;
                 case R.id.menu_item_download:
                     fetchStreamInfoAndSaveToDatabase(context, item.getServiceId(), item.getUrl(),

--- a/app/src/main/java/org/schabi/newpipe/database/playlist/PlaylistStreamEntry.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/playlist/PlaylistStreamEntry.kt
@@ -29,7 +29,7 @@ data class PlaylistStreamEntry(
         item.duration = streamEntity.duration
         item.uploaderName = streamEntity.uploader
         item.uploaderUrl = streamEntity.uploaderUrl
-        item.thumbnails = ImageStrategy.urlToImageList(streamEntity.thumbnailUrl)
+        item.thumbnails = ImageStrategy.dbUrlToImageList(streamEntity.thumbnailUrl)
 
         return item
     }

--- a/app/src/main/java/org/schabi/newpipe/database/playlist/PlaylistStreamEntry.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/playlist/PlaylistStreamEntry.kt
@@ -7,7 +7,7 @@ import org.schabi.newpipe.database.playlist.model.PlaylistStreamEntity
 import org.schabi.newpipe.database.stream.model.StreamEntity
 import org.schabi.newpipe.database.stream.model.StreamStateEntity
 import org.schabi.newpipe.extractor.stream.StreamInfoItem
-import org.schabi.newpipe.util.PicassoHelper
+import org.schabi.newpipe.util.image.PicassoHelper
 
 data class PlaylistStreamEntry(
     @Embedded

--- a/app/src/main/java/org/schabi/newpipe/database/playlist/PlaylistStreamEntry.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/playlist/PlaylistStreamEntry.kt
@@ -7,7 +7,7 @@ import org.schabi.newpipe.database.playlist.model.PlaylistStreamEntity
 import org.schabi.newpipe.database.stream.model.StreamEntity
 import org.schabi.newpipe.database.stream.model.StreamStateEntity
 import org.schabi.newpipe.extractor.stream.StreamInfoItem
-import org.schabi.newpipe.util.image.PicassoHelper
+import org.schabi.newpipe.util.image.ImageStrategy
 
 data class PlaylistStreamEntry(
     @Embedded
@@ -29,7 +29,7 @@ data class PlaylistStreamEntry(
         item.duration = streamEntity.duration
         item.uploaderName = streamEntity.uploader
         item.uploaderUrl = streamEntity.uploaderUrl
-        item.thumbnails = PicassoHelper.urlToImageList(streamEntity.thumbnailUrl)
+        item.thumbnails = ImageStrategy.urlToImageList(streamEntity.thumbnailUrl)
 
         return item
     }

--- a/app/src/main/java/org/schabi/newpipe/database/playlist/PlaylistStreamEntry.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/playlist/PlaylistStreamEntry.kt
@@ -7,6 +7,7 @@ import org.schabi.newpipe.database.playlist.model.PlaylistStreamEntity
 import org.schabi.newpipe.database.stream.model.StreamEntity
 import org.schabi.newpipe.database.stream.model.StreamStateEntity
 import org.schabi.newpipe.extractor.stream.StreamInfoItem
+import org.schabi.newpipe.util.PicassoHelper
 
 data class PlaylistStreamEntry(
     @Embedded
@@ -28,7 +29,7 @@ data class PlaylistStreamEntry(
         item.duration = streamEntity.duration
         item.uploaderName = streamEntity.uploader
         item.uploaderUrl = streamEntity.uploaderUrl
-        item.thumbnailUrl = streamEntity.thumbnailUrl
+        item.thumbnails = PicassoHelper.urlToImageList(streamEntity.thumbnailUrl)
 
         return item
     }

--- a/app/src/main/java/org/schabi/newpipe/database/playlist/model/PlaylistRemoteEntity.java
+++ b/app/src/main/java/org/schabi/newpipe/database/playlist/model/PlaylistRemoteEntity.java
@@ -11,7 +11,7 @@ import androidx.room.PrimaryKey;
 import org.schabi.newpipe.database.playlist.PlaylistLocalItem;
 import org.schabi.newpipe.extractor.playlist.PlaylistInfo;
 import org.schabi.newpipe.util.Constants;
-import org.schabi.newpipe.util.image.PicassoHelper;
+import org.schabi.newpipe.util.image.ImageStrategy;
 
 import static org.schabi.newpipe.database.LocalItem.LocalItemType.PLAYLIST_REMOTE_ITEM;
 import static org.schabi.newpipe.database.playlist.model.PlaylistRemoteEntity.REMOTE_PLAYLIST_NAME;
@@ -70,7 +70,7 @@ public class PlaylistRemoteEntity implements PlaylistLocalItem {
     @Ignore
     public PlaylistRemoteEntity(final PlaylistInfo info) {
         this(info.getServiceId(), info.getName(), info.getUrl(),
-                PicassoHelper.choosePreferredImage(info.getThumbnails()),
+                ImageStrategy.choosePreferredImage(info.getThumbnails()),
                 info.getUploaderName(), info.getStreamCount());
     }
 
@@ -85,7 +85,7 @@ public class PlaylistRemoteEntity implements PlaylistLocalItem {
                 && TextUtils.equals(getName(), info.getName())
                 && TextUtils.equals(getUrl(), info.getUrl())
                 && TextUtils.equals(getThumbnailUrl(),
-                PicassoHelper.choosePreferredImage(info.getThumbnails()))
+                ImageStrategy.choosePreferredImage(info.getThumbnails()))
                 && TextUtils.equals(getUploader(), info.getUploaderName());
     }
 

--- a/app/src/main/java/org/schabi/newpipe/database/playlist/model/PlaylistRemoteEntity.java
+++ b/app/src/main/java/org/schabi/newpipe/database/playlist/model/PlaylistRemoteEntity.java
@@ -11,7 +11,7 @@ import androidx.room.PrimaryKey;
 import org.schabi.newpipe.database.playlist.PlaylistLocalItem;
 import org.schabi.newpipe.extractor.playlist.PlaylistInfo;
 import org.schabi.newpipe.util.Constants;
-import org.schabi.newpipe.util.PicassoHelper;
+import org.schabi.newpipe.util.image.PicassoHelper;
 
 import static org.schabi.newpipe.database.LocalItem.LocalItemType.PLAYLIST_REMOTE_ITEM;
 import static org.schabi.newpipe.database.playlist.model.PlaylistRemoteEntity.REMOTE_PLAYLIST_NAME;

--- a/app/src/main/java/org/schabi/newpipe/database/playlist/model/PlaylistRemoteEntity.java
+++ b/app/src/main/java/org/schabi/newpipe/database/playlist/model/PlaylistRemoteEntity.java
@@ -70,7 +70,9 @@ public class PlaylistRemoteEntity implements PlaylistLocalItem {
     @Ignore
     public PlaylistRemoteEntity(final PlaylistInfo info) {
         this(info.getServiceId(), info.getName(), info.getUrl(),
-                ImageStrategy.choosePreferredImage(info.getThumbnails()),
+                // use uploader avatar when no thumbnail is available
+                ImageStrategy.choosePreferredImage(info.getThumbnails().isEmpty()
+                        ? info.getUploaderAvatars() : info.getThumbnails()),
                 info.getUploaderName(), info.getStreamCount());
     }
 
@@ -84,6 +86,8 @@ public class PlaylistRemoteEntity implements PlaylistLocalItem {
                 && getStreamCount() == info.getStreamCount()
                 && TextUtils.equals(getName(), info.getName())
                 && TextUtils.equals(getUrl(), info.getUrl())
+                // we want to update the local playlist data even when either the remote thumbnail
+                // URL changes, or the preferred image quality setting is changed by the user
                 && TextUtils.equals(getThumbnailUrl(),
                 ImageStrategy.choosePreferredImage(info.getThumbnails()))
                 && TextUtils.equals(getUploader(), info.getUploaderName());

--- a/app/src/main/java/org/schabi/newpipe/database/playlist/model/PlaylistRemoteEntity.java
+++ b/app/src/main/java/org/schabi/newpipe/database/playlist/model/PlaylistRemoteEntity.java
@@ -71,7 +71,7 @@ public class PlaylistRemoteEntity implements PlaylistLocalItem {
     public PlaylistRemoteEntity(final PlaylistInfo info) {
         this(info.getServiceId(), info.getName(), info.getUrl(),
                 // use uploader avatar when no thumbnail is available
-                ImageStrategy.choosePreferredImage(info.getThumbnails().isEmpty()
+                ImageStrategy.imageListToDbUrl(info.getThumbnails().isEmpty()
                         ? info.getUploaderAvatars() : info.getThumbnails()),
                 info.getUploaderName(), info.getStreamCount());
     }
@@ -89,7 +89,7 @@ public class PlaylistRemoteEntity implements PlaylistLocalItem {
                 // we want to update the local playlist data even when either the remote thumbnail
                 // URL changes, or the preferred image quality setting is changed by the user
                 && TextUtils.equals(getThumbnailUrl(),
-                ImageStrategy.choosePreferredImage(info.getThumbnails()))
+                ImageStrategy.imageListToDbUrl(info.getThumbnails()))
                 && TextUtils.equals(getUploader(), info.getUploaderName());
     }
 

--- a/app/src/main/java/org/schabi/newpipe/database/playlist/model/PlaylistRemoteEntity.java
+++ b/app/src/main/java/org/schabi/newpipe/database/playlist/model/PlaylistRemoteEntity.java
@@ -11,6 +11,7 @@ import androidx.room.PrimaryKey;
 import org.schabi.newpipe.database.playlist.PlaylistLocalItem;
 import org.schabi.newpipe.extractor.playlist.PlaylistInfo;
 import org.schabi.newpipe.util.Constants;
+import org.schabi.newpipe.util.PicassoHelper;
 
 import static org.schabi.newpipe.database.LocalItem.LocalItemType.PLAYLIST_REMOTE_ITEM;
 import static org.schabi.newpipe.database.playlist.model.PlaylistRemoteEntity.REMOTE_PLAYLIST_NAME;
@@ -69,8 +70,7 @@ public class PlaylistRemoteEntity implements PlaylistLocalItem {
     @Ignore
     public PlaylistRemoteEntity(final PlaylistInfo info) {
         this(info.getServiceId(), info.getName(), info.getUrl(),
-                info.getThumbnailUrl() == null
-                        ? info.getUploaderAvatarUrl() : info.getThumbnailUrl(),
+                PicassoHelper.choosePreferredImage(info.getThumbnails()),
                 info.getUploaderName(), info.getStreamCount());
     }
 
@@ -84,7 +84,8 @@ public class PlaylistRemoteEntity implements PlaylistLocalItem {
                 && getStreamCount() == info.getStreamCount()
                 && TextUtils.equals(getName(), info.getName())
                 && TextUtils.equals(getUrl(), info.getUrl())
-                && TextUtils.equals(getThumbnailUrl(), info.getThumbnailUrl())
+                && TextUtils.equals(getThumbnailUrl(),
+                PicassoHelper.choosePreferredImage(info.getThumbnails()))
                 && TextUtils.equals(getUploader(), info.getUploaderName());
     }
 

--- a/app/src/main/java/org/schabi/newpipe/database/stream/StreamStatisticsEntry.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/stream/StreamStatisticsEntry.kt
@@ -7,6 +7,7 @@ import org.schabi.newpipe.database.history.model.StreamHistoryEntity
 import org.schabi.newpipe.database.stream.model.StreamEntity
 import org.schabi.newpipe.database.stream.model.StreamStateEntity.STREAM_PROGRESS_MILLIS
 import org.schabi.newpipe.extractor.stream.StreamInfoItem
+import org.schabi.newpipe.util.PicassoHelper
 import java.time.OffsetDateTime
 
 class StreamStatisticsEntry(
@@ -30,7 +31,7 @@ class StreamStatisticsEntry(
         item.duration = streamEntity.duration
         item.uploaderName = streamEntity.uploader
         item.uploaderUrl = streamEntity.uploaderUrl
-        item.thumbnailUrl = streamEntity.thumbnailUrl
+        item.thumbnails = PicassoHelper.urlToImageList(streamEntity.thumbnailUrl)
 
         return item
     }

--- a/app/src/main/java/org/schabi/newpipe/database/stream/StreamStatisticsEntry.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/stream/StreamStatisticsEntry.kt
@@ -7,7 +7,7 @@ import org.schabi.newpipe.database.history.model.StreamHistoryEntity
 import org.schabi.newpipe.database.stream.model.StreamEntity
 import org.schabi.newpipe.database.stream.model.StreamStateEntity.STREAM_PROGRESS_MILLIS
 import org.schabi.newpipe.extractor.stream.StreamInfoItem
-import org.schabi.newpipe.util.image.PicassoHelper
+import org.schabi.newpipe.util.image.ImageStrategy
 import java.time.OffsetDateTime
 
 class StreamStatisticsEntry(
@@ -31,7 +31,7 @@ class StreamStatisticsEntry(
         item.duration = streamEntity.duration
         item.uploaderName = streamEntity.uploader
         item.uploaderUrl = streamEntity.uploaderUrl
-        item.thumbnails = PicassoHelper.urlToImageList(streamEntity.thumbnailUrl)
+        item.thumbnails = ImageStrategy.urlToImageList(streamEntity.thumbnailUrl)
 
         return item
     }

--- a/app/src/main/java/org/schabi/newpipe/database/stream/StreamStatisticsEntry.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/stream/StreamStatisticsEntry.kt
@@ -31,7 +31,7 @@ class StreamStatisticsEntry(
         item.duration = streamEntity.duration
         item.uploaderName = streamEntity.uploader
         item.uploaderUrl = streamEntity.uploaderUrl
-        item.thumbnails = ImageStrategy.urlToImageList(streamEntity.thumbnailUrl)
+        item.thumbnails = ImageStrategy.dbUrlToImageList(streamEntity.thumbnailUrl)
 
         return item
     }

--- a/app/src/main/java/org/schabi/newpipe/database/stream/StreamStatisticsEntry.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/stream/StreamStatisticsEntry.kt
@@ -7,7 +7,7 @@ import org.schabi.newpipe.database.history.model.StreamHistoryEntity
 import org.schabi.newpipe.database.stream.model.StreamEntity
 import org.schabi.newpipe.database.stream.model.StreamStateEntity.STREAM_PROGRESS_MILLIS
 import org.schabi.newpipe.extractor.stream.StreamInfoItem
-import org.schabi.newpipe.util.PicassoHelper
+import org.schabi.newpipe.util.image.PicassoHelper
 import java.time.OffsetDateTime
 
 class StreamStatisticsEntry(

--- a/app/src/main/java/org/schabi/newpipe/database/stream/model/StreamEntity.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/stream/model/StreamEntity.kt
@@ -13,7 +13,7 @@ import org.schabi.newpipe.extractor.stream.StreamInfo
 import org.schabi.newpipe.extractor.stream.StreamInfoItem
 import org.schabi.newpipe.extractor.stream.StreamType
 import org.schabi.newpipe.player.playqueue.PlayQueueItem
-import org.schabi.newpipe.util.PicassoHelper
+import org.schabi.newpipe.util.image.PicassoHelper
 import java.io.Serializable
 import java.time.OffsetDateTime
 

--- a/app/src/main/java/org/schabi/newpipe/database/stream/model/StreamEntity.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/stream/model/StreamEntity.kt
@@ -68,7 +68,8 @@ data class StreamEntity(
     constructor(item: StreamInfoItem) : this(
         serviceId = item.serviceId, url = item.url, title = item.name,
         streamType = item.streamType, duration = item.duration, uploader = item.uploaderName,
-        uploaderUrl = item.uploaderUrl, thumbnailUrl = ImageStrategy.choosePreferredImage(item.thumbnails), viewCount = item.viewCount,
+        uploaderUrl = item.uploaderUrl,
+        thumbnailUrl = ImageStrategy.imageListToDbUrl(item.thumbnails), viewCount = item.viewCount,
         textualUploadDate = item.textualUploadDate, uploadDate = item.uploadDate?.offsetDateTime(),
         isUploadDateApproximation = item.uploadDate?.isApproximation
     )
@@ -77,7 +78,8 @@ data class StreamEntity(
     constructor(info: StreamInfo) : this(
         serviceId = info.serviceId, url = info.url, title = info.name,
         streamType = info.streamType, duration = info.duration, uploader = info.uploaderName,
-        uploaderUrl = info.uploaderUrl, thumbnailUrl = ImageStrategy.choosePreferredImage(info.thumbnails), viewCount = info.viewCount,
+        uploaderUrl = info.uploaderUrl,
+        thumbnailUrl = ImageStrategy.imageListToDbUrl(info.thumbnails), viewCount = info.viewCount,
         textualUploadDate = info.textualUploadDate, uploadDate = info.uploadDate?.offsetDateTime(),
         isUploadDateApproximation = info.uploadDate?.isApproximation
     )
@@ -87,7 +89,7 @@ data class StreamEntity(
         serviceId = item.serviceId, url = item.url, title = item.title,
         streamType = item.streamType, duration = item.duration, uploader = item.uploader,
         uploaderUrl = item.uploaderUrl,
-        thumbnailUrl = ImageStrategy.choosePreferredImage(item.thumbnails)
+        thumbnailUrl = ImageStrategy.imageListToDbUrl(item.thumbnails)
     )
 
     fun toStreamInfoItem(): StreamInfoItem {
@@ -95,7 +97,7 @@ data class StreamEntity(
         item.duration = duration
         item.uploaderName = uploader
         item.uploaderUrl = uploaderUrl
-        item.thumbnails = ImageStrategy.urlToImageList(thumbnailUrl)
+        item.thumbnails = ImageStrategy.dbUrlToImageList(thumbnailUrl)
 
         if (viewCount != null) item.viewCount = viewCount as Long
         item.textualUploadDate = textualUploadDate

--- a/app/src/main/java/org/schabi/newpipe/database/stream/model/StreamEntity.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/stream/model/StreamEntity.kt
@@ -13,7 +13,7 @@ import org.schabi.newpipe.extractor.stream.StreamInfo
 import org.schabi.newpipe.extractor.stream.StreamInfoItem
 import org.schabi.newpipe.extractor.stream.StreamType
 import org.schabi.newpipe.player.playqueue.PlayQueueItem
-import org.schabi.newpipe.util.image.PicassoHelper
+import org.schabi.newpipe.util.image.ImageStrategy
 import java.io.Serializable
 import java.time.OffsetDateTime
 
@@ -68,7 +68,7 @@ data class StreamEntity(
     constructor(item: StreamInfoItem) : this(
         serviceId = item.serviceId, url = item.url, title = item.name,
         streamType = item.streamType, duration = item.duration, uploader = item.uploaderName,
-        uploaderUrl = item.uploaderUrl, thumbnailUrl = PicassoHelper.choosePreferredImage(item.thumbnails), viewCount = item.viewCount,
+        uploaderUrl = item.uploaderUrl, thumbnailUrl = ImageStrategy.choosePreferredImage(item.thumbnails), viewCount = item.viewCount,
         textualUploadDate = item.textualUploadDate, uploadDate = item.uploadDate?.offsetDateTime(),
         isUploadDateApproximation = item.uploadDate?.isApproximation
     )
@@ -77,7 +77,7 @@ data class StreamEntity(
     constructor(info: StreamInfo) : this(
         serviceId = info.serviceId, url = info.url, title = info.name,
         streamType = info.streamType, duration = info.duration, uploader = info.uploaderName,
-        uploaderUrl = info.uploaderUrl, thumbnailUrl = PicassoHelper.choosePreferredImage(info.thumbnails), viewCount = info.viewCount,
+        uploaderUrl = info.uploaderUrl, thumbnailUrl = ImageStrategy.choosePreferredImage(info.thumbnails), viewCount = info.viewCount,
         textualUploadDate = info.textualUploadDate, uploadDate = info.uploadDate?.offsetDateTime(),
         isUploadDateApproximation = info.uploadDate?.isApproximation
     )
@@ -87,7 +87,7 @@ data class StreamEntity(
         serviceId = item.serviceId, url = item.url, title = item.title,
         streamType = item.streamType, duration = item.duration, uploader = item.uploader,
         uploaderUrl = item.uploaderUrl,
-        thumbnailUrl = PicassoHelper.choosePreferredImage(item.thumbnails)
+        thumbnailUrl = ImageStrategy.choosePreferredImage(item.thumbnails)
     )
 
     fun toStreamInfoItem(): StreamInfoItem {
@@ -95,7 +95,7 @@ data class StreamEntity(
         item.duration = duration
         item.uploaderName = uploader
         item.uploaderUrl = uploaderUrl
-        item.thumbnails = PicassoHelper.urlToImageList(thumbnailUrl)
+        item.thumbnails = ImageStrategy.urlToImageList(thumbnailUrl)
 
         if (viewCount != null) item.viewCount = viewCount as Long
         item.textualUploadDate = textualUploadDate

--- a/app/src/main/java/org/schabi/newpipe/database/stream/model/StreamEntity.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/stream/model/StreamEntity.kt
@@ -13,6 +13,7 @@ import org.schabi.newpipe.extractor.stream.StreamInfo
 import org.schabi.newpipe.extractor.stream.StreamInfoItem
 import org.schabi.newpipe.extractor.stream.StreamType
 import org.schabi.newpipe.player.playqueue.PlayQueueItem
+import org.schabi.newpipe.util.PicassoHelper
 import java.io.Serializable
 import java.time.OffsetDateTime
 
@@ -67,7 +68,7 @@ data class StreamEntity(
     constructor(item: StreamInfoItem) : this(
         serviceId = item.serviceId, url = item.url, title = item.name,
         streamType = item.streamType, duration = item.duration, uploader = item.uploaderName,
-        uploaderUrl = item.uploaderUrl, thumbnailUrl = item.thumbnailUrl, viewCount = item.viewCount,
+        uploaderUrl = item.uploaderUrl, thumbnailUrl = PicassoHelper.choosePreferredImage(item.thumbnails), viewCount = item.viewCount,
         textualUploadDate = item.textualUploadDate, uploadDate = item.uploadDate?.offsetDateTime(),
         isUploadDateApproximation = item.uploadDate?.isApproximation
     )
@@ -76,7 +77,7 @@ data class StreamEntity(
     constructor(info: StreamInfo) : this(
         serviceId = info.serviceId, url = info.url, title = info.name,
         streamType = info.streamType, duration = info.duration, uploader = info.uploaderName,
-        uploaderUrl = info.uploaderUrl, thumbnailUrl = info.thumbnailUrl, viewCount = info.viewCount,
+        uploaderUrl = info.uploaderUrl, thumbnailUrl = PicassoHelper.choosePreferredImage(info.thumbnails), viewCount = info.viewCount,
         textualUploadDate = info.textualUploadDate, uploadDate = info.uploadDate?.offsetDateTime(),
         isUploadDateApproximation = info.uploadDate?.isApproximation
     )
@@ -85,7 +86,8 @@ data class StreamEntity(
     constructor(item: PlayQueueItem) : this(
         serviceId = item.serviceId, url = item.url, title = item.title,
         streamType = item.streamType, duration = item.duration, uploader = item.uploader,
-        uploaderUrl = item.uploaderUrl, thumbnailUrl = item.thumbnailUrl
+        uploaderUrl = item.uploaderUrl,
+        thumbnailUrl = PicassoHelper.choosePreferredImage(item.thumbnails)
     )
 
     fun toStreamInfoItem(): StreamInfoItem {
@@ -93,7 +95,7 @@ data class StreamEntity(
         item.duration = duration
         item.uploaderName = uploader
         item.uploaderUrl = uploaderUrl
-        item.thumbnailUrl = thumbnailUrl
+        item.thumbnails = PicassoHelper.urlToImageList(thumbnailUrl)
 
         if (viewCount != null) item.viewCount = viewCount as Long
         item.textualUploadDate = textualUploadDate

--- a/app/src/main/java/org/schabi/newpipe/database/subscription/SubscriptionEntity.java
+++ b/app/src/main/java/org/schabi/newpipe/database/subscription/SubscriptionEntity.java
@@ -10,7 +10,7 @@ import androidx.room.PrimaryKey;
 import org.schabi.newpipe.extractor.channel.ChannelInfo;
 import org.schabi.newpipe.extractor.channel.ChannelInfoItem;
 import org.schabi.newpipe.util.Constants;
-import org.schabi.newpipe.util.PicassoHelper;
+import org.schabi.newpipe.util.image.PicassoHelper;
 
 import static org.schabi.newpipe.database.subscription.SubscriptionEntity.SUBSCRIPTION_SERVICE_ID;
 import static org.schabi.newpipe.database.subscription.SubscriptionEntity.SUBSCRIPTION_TABLE;

--- a/app/src/main/java/org/schabi/newpipe/database/subscription/SubscriptionEntity.java
+++ b/app/src/main/java/org/schabi/newpipe/database/subscription/SubscriptionEntity.java
@@ -58,7 +58,7 @@ public class SubscriptionEntity {
         final SubscriptionEntity result = new SubscriptionEntity();
         result.setServiceId(info.getServiceId());
         result.setUrl(info.getUrl());
-        result.setData(info.getName(), ImageStrategy.choosePreferredImage(info.getAvatars()),
+        result.setData(info.getName(), ImageStrategy.imageListToDbUrl(info.getAvatars()),
                 info.getDescription(), info.getSubscriberCount());
         return result;
     }
@@ -139,7 +139,7 @@ public class SubscriptionEntity {
     @Ignore
     public ChannelInfoItem toChannelInfoItem() {
         final ChannelInfoItem item = new ChannelInfoItem(getServiceId(), getUrl(), getName());
-        item.setThumbnails(ImageStrategy.urlToImageList(getAvatarUrl()));
+        item.setThumbnails(ImageStrategy.dbUrlToImageList(getAvatarUrl()));
         item.setSubscriberCount(getSubscriberCount());
         item.setDescription(getDescription());
         return item;

--- a/app/src/main/java/org/schabi/newpipe/database/subscription/SubscriptionEntity.java
+++ b/app/src/main/java/org/schabi/newpipe/database/subscription/SubscriptionEntity.java
@@ -10,6 +10,7 @@ import androidx.room.PrimaryKey;
 import org.schabi.newpipe.extractor.channel.ChannelInfo;
 import org.schabi.newpipe.extractor.channel.ChannelInfoItem;
 import org.schabi.newpipe.util.Constants;
+import org.schabi.newpipe.util.PicassoHelper;
 
 import static org.schabi.newpipe.database.subscription.SubscriptionEntity.SUBSCRIPTION_SERVICE_ID;
 import static org.schabi.newpipe.database.subscription.SubscriptionEntity.SUBSCRIPTION_TABLE;
@@ -57,8 +58,8 @@ public class SubscriptionEntity {
         final SubscriptionEntity result = new SubscriptionEntity();
         result.setServiceId(info.getServiceId());
         result.setUrl(info.getUrl());
-        result.setData(info.getName(), info.getAvatarUrl(), info.getDescription(),
-                info.getSubscriberCount());
+        result.setData(info.getName(), PicassoHelper.choosePreferredImage(info.getAvatars()),
+                info.getDescription(), info.getSubscriberCount());
         return result;
     }
 
@@ -138,7 +139,7 @@ public class SubscriptionEntity {
     @Ignore
     public ChannelInfoItem toChannelInfoItem() {
         final ChannelInfoItem item = new ChannelInfoItem(getServiceId(), getUrl(), getName());
-        item.setThumbnailUrl(getAvatarUrl());
+        item.setThumbnails(PicassoHelper.urlToImageList(getAvatarUrl()));
         item.setSubscriberCount(getSubscriberCount());
         item.setDescription(getDescription());
         return item;

--- a/app/src/main/java/org/schabi/newpipe/database/subscription/SubscriptionEntity.java
+++ b/app/src/main/java/org/schabi/newpipe/database/subscription/SubscriptionEntity.java
@@ -10,7 +10,7 @@ import androidx.room.PrimaryKey;
 import org.schabi.newpipe.extractor.channel.ChannelInfo;
 import org.schabi.newpipe.extractor.channel.ChannelInfoItem;
 import org.schabi.newpipe.util.Constants;
-import org.schabi.newpipe.util.image.PicassoHelper;
+import org.schabi.newpipe.util.image.ImageStrategy;
 
 import static org.schabi.newpipe.database.subscription.SubscriptionEntity.SUBSCRIPTION_SERVICE_ID;
 import static org.schabi.newpipe.database.subscription.SubscriptionEntity.SUBSCRIPTION_TABLE;
@@ -58,7 +58,7 @@ public class SubscriptionEntity {
         final SubscriptionEntity result = new SubscriptionEntity();
         result.setServiceId(info.getServiceId());
         result.setUrl(info.getUrl());
-        result.setData(info.getName(), PicassoHelper.choosePreferredImage(info.getAvatars()),
+        result.setData(info.getName(), ImageStrategy.choosePreferredImage(info.getAvatars()),
                 info.getDescription(), info.getSubscriberCount());
         return result;
     }
@@ -139,7 +139,7 @@ public class SubscriptionEntity {
     @Ignore
     public ChannelInfoItem toChannelInfoItem() {
         final ChannelInfoItem item = new ChannelInfoItem(getServiceId(), getUrl(), getName());
-        item.setThumbnails(PicassoHelper.urlToImageList(getAvatarUrl()));
+        item.setThumbnails(ImageStrategy.urlToImageList(getAvatarUrl()));
         item.setSubscriberCount(getSubscriberCount());
         item.setDescription(getDescription());
         return item;

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/BaseDescriptionFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/BaseDescriptionFragment.java
@@ -224,6 +224,7 @@ public abstract class BaseDescriptionFragment extends BaseFragment {
                     case LOW:
                         urls.append(getString(R.string.image_quality_low));
                         break;
+                    default: // unreachable, Image.ResolutionLevel.UNKNOWN is already filtered out
                     case MEDIUM:
                         urls.append(getString(R.string.image_quality_medium));
                         break;

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/BaseDescriptionFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/BaseDescriptionFragment.java
@@ -4,7 +4,13 @@ import static android.text.TextUtils.isEmpty;
 import static org.schabi.newpipe.extractor.utils.Utils.isBlank;
 import static org.schabi.newpipe.util.text.TextLinkifier.SET_LINK_MOVEMENT_METHOD;
 
+import android.graphics.Typeface;
 import android.os.Bundle;
+import android.text.SpannableStringBuilder;
+import android.text.Spanned;
+import android.text.method.LinkMovementMethod;
+import android.text.style.ClickableSpan;
+import android.text.style.StyleSpan;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -23,10 +29,12 @@ import org.schabi.newpipe.R;
 import org.schabi.newpipe.databinding.FragmentDescriptionBinding;
 import org.schabi.newpipe.databinding.ItemMetadataBinding;
 import org.schabi.newpipe.databinding.ItemMetadataTagsBinding;
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.stream.Description;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.external_communication.ShareUtils;
+import org.schabi.newpipe.util.image.ImageStrategy;
 import org.schabi.newpipe.util.text.TextLinkifier;
 
 import java.util.List;
@@ -173,6 +181,73 @@ public abstract class BaseDescriptionFragment extends BaseFragment {
 
         itemBinding.metadataContentView.setClickable(true);
 
+        layout.addView(itemBinding.getRoot());
+    }
+
+    private String imageSizeToText(final int heightOrWidth) {
+        if (heightOrWidth < 0) {
+            return "?";
+        } else {
+            return String.valueOf(heightOrWidth);
+        }
+    }
+
+    protected void addImagesMetadataItem(final LayoutInflater inflater,
+                                         final LinearLayout layout,
+                                         @StringRes final int type,
+                                         final List<Image> images) {
+        final String preferredImageUrl = ImageStrategy.choosePreferredImage(images);
+        if (preferredImageUrl == null) {
+            return; // null will be returned in case there is no image
+        }
+
+        final ItemMetadataBinding itemBinding =
+                ItemMetadataBinding.inflate(inflater, layout, false);
+        itemBinding.metadataTypeView.setText(type);
+
+        final SpannableStringBuilder urls = new SpannableStringBuilder();
+        for (final Image image : images) {
+            if (urls.length() != 0) {
+                urls.append(", ");
+            }
+            final int entryBegin = urls.length();
+
+            if (image.getHeight() != Image.HEIGHT_UNKNOWN
+                    || image.getWidth() != Image.WIDTH_UNKNOWN
+                    // if even the resolution level is unknown, ?x? will be shown
+                    || image.getEstimatedResolutionLevel() == Image.ResolutionLevel.UNKNOWN) {
+                urls.append(imageSizeToText(image.getHeight()));
+                urls.append('x');
+                urls.append(imageSizeToText(image.getWidth()));
+            } else {
+                switch (image.getEstimatedResolutionLevel()) {
+                    case LOW:
+                        urls.append(getString(R.string.image_quality_low));
+                        break;
+                    case MEDIUM:
+                        urls.append(getString(R.string.image_quality_medium));
+                        break;
+                    case HIGH:
+                        urls.append(getString(R.string.image_quality_high));
+                        break;
+                }
+            }
+
+            urls.setSpan(new ClickableSpan() {
+                @Override
+                public void onClick(@NonNull final View widget) {
+                    ShareUtils.openUrlInBrowser(requireContext(), image.getUrl());
+                }
+            }, entryBegin, urls.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+
+            if (preferredImageUrl.equals(image.getUrl())) {
+                urls.setSpan(new StyleSpan(Typeface.BOLD), entryBegin, urls.length(),
+                        Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+            }
+        }
+
+        itemBinding.metadataContentView.setText(urls);
+        itemBinding.metadataContentView.setMovementMethod(LinkMovementMethod.getInstance());
         layout.addView(itemBinding.getRoot());
     }
 

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/BaseDescriptionFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/BaseDescriptionFragment.java
@@ -186,7 +186,7 @@ public abstract class BaseDescriptionFragment extends BaseFragment {
 
     private String imageSizeToText(final int heightOrWidth) {
         if (heightOrWidth < 0) {
-            return "?";
+            return getString(R.string.question_mark);
         } else {
             return String.valueOf(heightOrWidth);
         }

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/DescriptionFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/DescriptionFragment.java
@@ -17,6 +17,7 @@ import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.util.Localization;
 
 import java.util.List;
+import org.schabi.newpipe.util.PicassoHelper;
 
 import icepick.State;
 
@@ -113,7 +114,7 @@ public class DescriptionFragment extends BaseDescriptionFragment {
         addMetadataItem(inflater, layout, true, R.string.metadata_host,
                 streamInfo.getHost());
         addMetadataItem(inflater, layout, true, R.string.metadata_thumbnail_url,
-                streamInfo.getThumbnailUrl());
+                PicassoHelper.choosePreferredImage(streamInfo.getThumbnails()));
     }
 
     private void addPrivacyMetadataItem(final LayoutInflater inflater, final LinearLayout layout) {

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/DescriptionFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/DescriptionFragment.java
@@ -17,7 +17,6 @@ import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.util.Localization;
 
 import java.util.List;
-import org.schabi.newpipe.util.image.ImageStrategy;
 
 import icepick.State;
 
@@ -113,8 +112,13 @@ public class DescriptionFragment extends BaseDescriptionFragment {
                 streamInfo.getSupportInfo());
         addMetadataItem(inflater, layout, true, R.string.metadata_host,
                 streamInfo.getHost());
-        addMetadataItem(inflater, layout, true, R.string.metadata_thumbnail_url,
-                ImageStrategy.choosePreferredImage(streamInfo.getThumbnails()));
+
+        addImagesMetadataItem(inflater, layout, R.string.metadata_thumbnails,
+                streamInfo.getThumbnails());
+        addImagesMetadataItem(inflater, layout, R.string.metadata_uploader_avatars,
+                streamInfo.getUploaderAvatars());
+        addImagesMetadataItem(inflater, layout, R.string.metadata_subchannel_avatars,
+                streamInfo.getSubChannelAvatars());
     }
 
     private void addPrivacyMetadataItem(final LayoutInflater inflater, final LinearLayout layout) {

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/DescriptionFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/DescriptionFragment.java
@@ -17,7 +17,7 @@ import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.util.Localization;
 
 import java.util.List;
-import org.schabi.newpipe.util.image.PicassoHelper;
+import org.schabi.newpipe.util.image.ImageStrategy;
 
 import icepick.State;
 
@@ -114,7 +114,7 @@ public class DescriptionFragment extends BaseDescriptionFragment {
         addMetadataItem(inflater, layout, true, R.string.metadata_host,
                 streamInfo.getHost());
         addMetadataItem(inflater, layout, true, R.string.metadata_thumbnail_url,
-                PicassoHelper.choosePreferredImage(streamInfo.getThumbnails()));
+                ImageStrategy.choosePreferredImage(streamInfo.getThumbnails()));
     }
 
     private void addPrivacyMetadataItem(final LayoutInflater inflater, final LinearLayout layout) {

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/DescriptionFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/DescriptionFragment.java
@@ -17,7 +17,7 @@ import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.util.Localization;
 
 import java.util.List;
-import org.schabi.newpipe.util.PicassoHelper;
+import org.schabi.newpipe.util.image.PicassoHelper;
 
 import icepick.State;
 

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -108,7 +108,7 @@ import org.schabi.newpipe.util.ListHelper;
 import org.schabi.newpipe.util.Localization;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.PermissionHelper;
-import org.schabi.newpipe.util.PicassoHelper;
+import org.schabi.newpipe.util.image.PicassoHelper;
 import org.schabi.newpipe.util.StreamTypeUtil;
 import org.schabi.newpipe.util.ThemeHelper;
 import org.schabi.newpipe.util.external_communication.KoreUtils;

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -71,6 +71,7 @@ import org.schabi.newpipe.error.ErrorInfo;
 import org.schabi.newpipe.error.ErrorUtil;
 import org.schabi.newpipe.error.ReCaptchaActivity;
 import org.schabi.newpipe.error.UserAction;
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.exceptions.ContentNotSupportedException;
@@ -483,7 +484,7 @@ public final class VideoDetailFragment
         });
         binding.detailControlsShare.setOnClickListener(makeOnClickListener(info ->
                 ShareUtils.shareText(requireContext(), info.getName(), info.getUrl(),
-                        info.getThumbnailUrl())));
+                        info.getThumbnails())));
         binding.detailControlsOpenInBrowser.setOnClickListener(makeOnClickListener(info ->
                 ShareUtils.openUrlInBrowser(requireContext(), info.getUrl())));
         binding.detailControlsPlayWithKodi.setOnClickListener(makeOnClickListener(info ->
@@ -723,7 +724,7 @@ public final class VideoDetailFragment
         final boolean isPlayerStopped = !isPlayerAvailable() || player.isStopped();
         if (playQueueItem != null && isPlayerStopped) {
             updateOverlayData(playQueueItem.getTitle(),
-                    playQueueItem.getUploader(), playQueueItem.getThumbnailUrl());
+                    playQueueItem.getUploader(), playQueueItem.getThumbnails());
         }
     }
 
@@ -1536,13 +1537,13 @@ public final class VideoDetailFragment
         binding.detailSecondaryControlPanel.setVisibility(View.GONE);
 
         checkUpdateProgressInfo(info);
-        PicassoHelper.loadDetailsThumbnail(info.getThumbnailUrl()).tag(PICASSO_VIDEO_DETAILS_TAG)
+        PicassoHelper.loadDetailsThumbnail(info.getThumbnails()).tag(PICASSO_VIDEO_DETAILS_TAG)
                 .into(binding.detailThumbnailImageView);
         showMetaInfoInTextView(info.getMetaInfo(), binding.detailMetaInfoTextView,
                 binding.detailMetaInfoSeparator, disposables);
 
         if (!isPlayerAvailable() || player.isStopped()) {
-            updateOverlayData(info.getName(), info.getUploaderName(), info.getThumbnailUrl());
+            updateOverlayData(info.getName(), info.getUploaderName(), info.getThumbnails());
         }
 
         if (!info.getErrors().isEmpty()) {
@@ -1587,7 +1588,7 @@ public final class VideoDetailFragment
             binding.detailUploaderTextView.setVisibility(View.GONE);
         }
 
-        PicassoHelper.loadAvatar(info.getUploaderAvatarUrl()).tag(PICASSO_VIDEO_DETAILS_TAG)
+        PicassoHelper.loadAvatar(info.getUploaderAvatars()).tag(PICASSO_VIDEO_DETAILS_TAG)
                 .into(binding.detailSubChannelThumbnailView);
         binding.detailSubChannelThumbnailView.setVisibility(View.VISIBLE);
         binding.detailUploaderThumbnailView.setVisibility(View.GONE);
@@ -1619,10 +1620,10 @@ public final class VideoDetailFragment
             binding.detailUploaderTextView.setVisibility(View.GONE);
         }
 
-        PicassoHelper.loadAvatar(info.getSubChannelAvatarUrl()).tag(PICASSO_VIDEO_DETAILS_TAG)
+        PicassoHelper.loadAvatar(info.getSubChannelAvatars()).tag(PICASSO_VIDEO_DETAILS_TAG)
                 .into(binding.detailSubChannelThumbnailView);
         binding.detailSubChannelThumbnailView.setVisibility(View.VISIBLE);
-        PicassoHelper.loadAvatar(info.getUploaderAvatarUrl()).tag(PICASSO_VIDEO_DETAILS_TAG)
+        PicassoHelper.loadAvatar(info.getUploaderAvatars()).tag(PICASSO_VIDEO_DETAILS_TAG)
                 .into(binding.detailUploaderThumbnailView);
         binding.detailUploaderThumbnailView.setVisibility(View.VISIBLE);
     }
@@ -1797,7 +1798,7 @@ public final class VideoDetailFragment
             return;
         }
 
-        updateOverlayData(info.getName(), info.getUploaderName(), info.getThumbnailUrl());
+        updateOverlayData(info.getName(), info.getUploaderName(), info.getThumbnails());
         if (currentInfo != null && info.getUrl().equals(currentInfo.getUrl())) {
             return;
         }
@@ -1826,7 +1827,7 @@ public final class VideoDetailFragment
         if (currentInfo != null) {
             updateOverlayData(currentInfo.getName(),
                     currentInfo.getUploaderName(),
-                    currentInfo.getThumbnailUrl());
+                    currentInfo.getThumbnails());
         }
         updateOverlayPlayQueueButtonVisibility();
     }
@@ -2191,7 +2192,7 @@ public final class VideoDetailFragment
         playerHolder.stopService();
         setInitialData(0, null, "", null);
         currentInfo = null;
-        updateOverlayData(null, null, null);
+        updateOverlayData(null, null, List.of());
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -2373,11 +2374,11 @@ public final class VideoDetailFragment
 
     private void updateOverlayData(@Nullable final String overlayTitle,
                                    @Nullable final String uploader,
-                                   @Nullable final String thumbnailUrl) {
+                                   @NonNull final List<Image> thumbnails) {
         binding.overlayTitleTextView.setText(isEmpty(overlayTitle) ? "" : overlayTitle);
         binding.overlayChannelTextView.setText(isEmpty(uploader) ? "" : uploader);
         binding.overlayThumbnail.setImageDrawable(null);
-        PicassoHelper.loadDetailsThumbnail(thumbnailUrl).tag(PICASSO_VIDEO_DETAILS_TAG)
+        PicassoHelper.loadDetailsThumbnail(thumbnails).tag(PICASSO_VIDEO_DETAILS_TAG)
                 .into(binding.overlayThumbnail);
     }
 

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelAboutFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelAboutFragment.java
@@ -17,7 +17,6 @@ import org.schabi.newpipe.extractor.stream.Description;
 import org.schabi.newpipe.fragments.detail.BaseDescriptionFragment;
 import org.schabi.newpipe.util.DeviceUtils;
 import org.schabi.newpipe.util.Localization;
-import org.schabi.newpipe.util.image.ImageStrategy;
 
 import java.util.List;
 
@@ -100,9 +99,9 @@ public class ChannelAboutFragment extends BaseDescriptionFragment {
                     Localization.localizeNumber(context, channelInfo.getSubscriberCount()));
         }
 
-        addMetadataItem(inflater, layout, true, R.string.metadata_avatar_url,
-                ImageStrategy.choosePreferredImage(channelInfo.getAvatars()));
-        addMetadataItem(inflater, layout, true, R.string.metadata_banner_url,
-                ImageStrategy.choosePreferredImage(channelInfo.getBanners()));
+        addImagesMetadataItem(inflater, layout, R.string.metadata_avatars,
+                channelInfo.getAvatars());
+        addImagesMetadataItem(inflater, layout, R.string.metadata_banners,
+                channelInfo.getBanners());
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelAboutFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelAboutFragment.java
@@ -17,7 +17,7 @@ import org.schabi.newpipe.extractor.stream.Description;
 import org.schabi.newpipe.fragments.detail.BaseDescriptionFragment;
 import org.schabi.newpipe.util.DeviceUtils;
 import org.schabi.newpipe.util.Localization;
-import org.schabi.newpipe.util.PicassoHelper;
+import org.schabi.newpipe.util.image.PicassoHelper;
 
 import java.util.List;
 

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelAboutFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelAboutFragment.java
@@ -17,7 +17,7 @@ import org.schabi.newpipe.extractor.stream.Description;
 import org.schabi.newpipe.fragments.detail.BaseDescriptionFragment;
 import org.schabi.newpipe.util.DeviceUtils;
 import org.schabi.newpipe.util.Localization;
-import org.schabi.newpipe.util.image.PicassoHelper;
+import org.schabi.newpipe.util.image.ImageStrategy;
 
 import java.util.List;
 
@@ -101,8 +101,8 @@ public class ChannelAboutFragment extends BaseDescriptionFragment {
         }
 
         addMetadataItem(inflater, layout, true, R.string.metadata_avatar_url,
-                PicassoHelper.choosePreferredImage(channelInfo.getAvatars()));
+                ImageStrategy.choosePreferredImage(channelInfo.getAvatars()));
         addMetadataItem(inflater, layout, true, R.string.metadata_banner_url,
-                PicassoHelper.choosePreferredImage(channelInfo.getBanners()));
+                ImageStrategy.choosePreferredImage(channelInfo.getBanners()));
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelAboutFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelAboutFragment.java
@@ -17,6 +17,7 @@ import org.schabi.newpipe.extractor.stream.Description;
 import org.schabi.newpipe.fragments.detail.BaseDescriptionFragment;
 import org.schabi.newpipe.util.DeviceUtils;
 import org.schabi.newpipe.util.Localization;
+import org.schabi.newpipe.util.PicassoHelper;
 
 import java.util.List;
 
@@ -100,8 +101,8 @@ public class ChannelAboutFragment extends BaseDescriptionFragment {
         }
 
         addMetadataItem(inflater, layout, true, R.string.metadata_avatar_url,
-                channelInfo.getAvatarUrl());
+                PicassoHelper.choosePreferredImage(channelInfo.getAvatars()));
         addMetadataItem(inflater, layout, true, R.string.metadata_banner_url,
-                channelInfo.getBannerUrl());
+                PicassoHelper.choosePreferredImage(channelInfo.getBanners()));
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
@@ -48,8 +48,8 @@ import org.schabi.newpipe.util.Constants;
 import org.schabi.newpipe.util.ExtractorHelper;
 import org.schabi.newpipe.util.Localization;
 import org.schabi.newpipe.util.NavigationHelper;
-import org.schabi.newpipe.util.PicassoHelper;
 import org.schabi.newpipe.util.StateSaver;
+import org.schabi.newpipe.util.image.PicassoHelper;
 import org.schabi.newpipe.util.ThemeHelper;
 import org.schabi.newpipe.util.external_communication.ShareUtils;
 
@@ -147,7 +147,7 @@ public class ChannelFragment extends BaseStateFragment<ChannelInfo>
 
         setTitle(name);
         binding.channelTitleView.setText(name);
-        if (!PicassoHelper.getShouldLoadImages()) {
+        if (!PicassoHelper.shouldLoadImages()) {
             // do not waste space for the banner if it is not going to be loaded
             binding.channelBannerImage.setImageDrawable(null);
         }
@@ -578,7 +578,7 @@ public class ChannelFragment extends BaseStateFragment<ChannelInfo>
         currentInfo = result;
         setInitialData(result.getServiceId(), result.getOriginalUrl(), result.getName());
 
-        if (PicassoHelper.getShouldLoadImages() && !result.getBanners().isEmpty()) {
+        if (PicassoHelper.shouldLoadImages() && !result.getBanners().isEmpty()) {
             PicassoHelper.loadBanner(result.getBanners()).tag(PICASSO_CHANNEL_TAG)
                     .into(binding.channelBannerImage);
         } else {

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
@@ -355,7 +355,7 @@ public class ChannelFragment extends BaseStateFragment<ChannelInfo>
                 channel.setServiceId(info.getServiceId());
                 channel.setUrl(info.getUrl());
                 channel.setData(info.getName(),
-                        ImageStrategy.choosePreferredImage(info.getAvatars()),
+                        ImageStrategy.imageListToDbUrl(info.getAvatars()),
                         info.getDescription(),
                         info.getSubscriberCount());
                 channelSubscription = null;

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
@@ -49,6 +49,7 @@ import org.schabi.newpipe.util.ExtractorHelper;
 import org.schabi.newpipe.util.Localization;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.StateSaver;
+import org.schabi.newpipe.util.image.ImageStrategy;
 import org.schabi.newpipe.util.image.PicassoHelper;
 import org.schabi.newpipe.util.ThemeHelper;
 import org.schabi.newpipe.util.external_communication.ShareUtils;
@@ -147,7 +148,7 @@ public class ChannelFragment extends BaseStateFragment<ChannelInfo>
 
         setTitle(name);
         binding.channelTitleView.setText(name);
-        if (!PicassoHelper.shouldLoadImages()) {
+        if (!ImageStrategy.shouldLoadImages()) {
             // do not waste space for the banner if it is not going to be loaded
             binding.channelBannerImage.setImageDrawable(null);
         }
@@ -354,7 +355,7 @@ public class ChannelFragment extends BaseStateFragment<ChannelInfo>
                 channel.setServiceId(info.getServiceId());
                 channel.setUrl(info.getUrl());
                 channel.setData(info.getName(),
-                        PicassoHelper.choosePreferredImage(info.getAvatars()),
+                        ImageStrategy.choosePreferredImage(info.getAvatars()),
                         info.getDescription(),
                         info.getSubscriberCount());
                 channelSubscription = null;
@@ -578,7 +579,7 @@ public class ChannelFragment extends BaseStateFragment<ChannelInfo>
         currentInfo = result;
         setInitialData(result.getServiceId(), result.getOriginalUrl(), result.getName());
 
-        if (PicassoHelper.shouldLoadImages() && !result.getBanners().isEmpty()) {
+        if (ImageStrategy.shouldLoadImages() && !result.getBanners().isEmpty()) {
             PicassoHelper.loadBanner(result.getBanners()).tag(PICASSO_CHANNEL_TAG)
                     .into(binding.channelBannerImage);
         } else {

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
@@ -1,6 +1,5 @@
 package org.schabi.newpipe.fragments.list.channel;
 
-import static org.schabi.newpipe.extractor.utils.Utils.isBlank;
 import static org.schabi.newpipe.ktx.TextViewUtils.animateTextColor;
 import static org.schabi.newpipe.ktx.ViewUtils.animate;
 import static org.schabi.newpipe.ktx.ViewUtils.animateBackgroundColor;
@@ -234,7 +233,7 @@ public class ChannelFragment extends BaseStateFragment<ChannelInfo>
             case R.id.menu_item_share:
                 if (currentInfo != null) {
                     ShareUtils.shareText(requireContext(), name, currentInfo.getOriginalUrl(),
-                            currentInfo.getAvatarUrl());
+                            currentInfo.getAvatars());
                 }
                 break;
             default:
@@ -355,7 +354,7 @@ public class ChannelFragment extends BaseStateFragment<ChannelInfo>
                 channel.setServiceId(info.getServiceId());
                 channel.setUrl(info.getUrl());
                 channel.setData(info.getName(),
-                        info.getAvatarUrl(),
+                        PicassoHelper.choosePreferredImage(info.getAvatars()),
                         info.getDescription(),
                         info.getSubscriberCount());
                 channelSubscription = null;
@@ -579,17 +578,17 @@ public class ChannelFragment extends BaseStateFragment<ChannelInfo>
         currentInfo = result;
         setInitialData(result.getServiceId(), result.getOriginalUrl(), result.getName());
 
-        if (PicassoHelper.getShouldLoadImages() && !isBlank(result.getBannerUrl())) {
-            PicassoHelper.loadBanner(result.getBannerUrl()).tag(PICASSO_CHANNEL_TAG)
+        if (PicassoHelper.getShouldLoadImages() && !result.getBanners().isEmpty()) {
+            PicassoHelper.loadBanner(result.getBanners()).tag(PICASSO_CHANNEL_TAG)
                     .into(binding.channelBannerImage);
         } else {
             // do not waste space for the banner, if the user disabled images or there is not one
             binding.channelBannerImage.setImageDrawable(null);
         }
 
-        PicassoHelper.loadAvatar(result.getAvatarUrl()).tag(PICASSO_CHANNEL_TAG)
+        PicassoHelper.loadAvatar(result.getAvatars()).tag(PICASSO_CHANNEL_TAG)
                 .into(binding.channelAvatarView);
-        PicassoHelper.loadAvatar(result.getParentChannelAvatarUrl()).tag(PICASSO_CHANNEL_TAG)
+        PicassoHelper.loadAvatar(result.getParentChannelAvatars()).tag(PICASSO_CHANNEL_TAG)
                 .into(binding.subChannelAvatarView);
 
         binding.channelTitleView.setText(result.getName());

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
@@ -48,7 +48,7 @@ import org.schabi.newpipe.player.playqueue.PlaylistPlayQueue;
 import org.schabi.newpipe.util.ExtractorHelper;
 import org.schabi.newpipe.util.Localization;
 import org.schabi.newpipe.util.NavigationHelper;
-import org.schabi.newpipe.util.PicassoHelper;
+import org.schabi.newpipe.util.image.PicassoHelper;
 import org.schabi.newpipe.util.external_communication.ShareUtils;
 import org.schabi.newpipe.util.PlayButtonHelper;
 

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
@@ -234,7 +234,7 @@ public class PlaylistFragment extends BaseListInfoFragment<StreamInfoItem, Playl
                 break;
             case R.id.menu_item_share:
                 ShareUtils.shareText(requireContext(), name, url,
-                        currentInfo == null ? null : currentInfo.getThumbnailUrl());
+                        currentInfo == null ? List.of() : currentInfo.getThumbnails());
                 break;
             case R.id.menu_item_bookmark:
                 onBookmarkClicked();
@@ -299,7 +299,6 @@ public class PlaylistFragment extends BaseListInfoFragment<StreamInfoItem, Playl
 
         playlistControlBinding.getRoot().setVisibility(View.VISIBLE);
 
-        final String avatarUrl = result.getUploaderAvatarUrl();
         if (result.getServiceId() == ServiceList.YouTube.getServiceId()
                 && (YoutubeParsingHelper.isYoutubeMixId(result.getId())
                 || YoutubeParsingHelper.isYoutubeMusicMixId(result.getId()))) {
@@ -315,7 +314,7 @@ public class PlaylistFragment extends BaseListInfoFragment<StreamInfoItem, Playl
                     R.drawable.ic_radio)
             );
         } else {
-            PicassoHelper.loadAvatar(avatarUrl).tag(PICASSO_PLAYLIST_TAG)
+            PicassoHelper.loadAvatar(result.getUploaderAvatars()).tag(PICASSO_PLAYLIST_TAG)
                     .into(headerBinding.uploaderAvatarView);
         }
 

--- a/app/src/main/java/org/schabi/newpipe/info_list/StreamSegmentItem.kt
+++ b/app/src/main/java/org/schabi/newpipe/info_list/StreamSegmentItem.kt
@@ -8,7 +8,7 @@ import com.xwray.groupie.Item
 import org.schabi.newpipe.R
 import org.schabi.newpipe.extractor.stream.StreamSegment
 import org.schabi.newpipe.util.Localization
-import org.schabi.newpipe.util.PicassoHelper
+import org.schabi.newpipe.util.image.PicassoHelper
 
 class StreamSegmentItem(
     private val item: StreamSegment,

--- a/app/src/main/java/org/schabi/newpipe/info_list/dialog/StreamDialogDefaultEntry.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/dialog/StreamDialogDefaultEntry.java
@@ -104,7 +104,7 @@ public enum StreamDialogDefaultEntry {
 
     SHARE(R.string.share, (fragment, item) ->
             ShareUtils.shareText(fragment.requireContext(), item.getName(), item.getUrl(),
-                    item.getThumbnailUrl())),
+                    item.getThumbnails())),
 
     /**
      * Opens a {@link DownloadDialog} after fetching some stream info.

--- a/app/src/main/java/org/schabi/newpipe/info_list/holder/ChannelMiniInfoItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/holder/ChannelMiniInfoItemHolder.java
@@ -13,7 +13,7 @@ import org.schabi.newpipe.extractor.channel.ChannelInfoItem;
 import org.schabi.newpipe.extractor.utils.Utils;
 import org.schabi.newpipe.info_list.InfoItemBuilder;
 import org.schabi.newpipe.local.history.HistoryRecordManager;
-import org.schabi.newpipe.util.PicassoHelper;
+import org.schabi.newpipe.util.image.PicassoHelper;
 import org.schabi.newpipe.util.Localization;
 
 public class ChannelMiniInfoItemHolder extends InfoItemHolder {

--- a/app/src/main/java/org/schabi/newpipe/info_list/holder/ChannelMiniInfoItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/holder/ChannelMiniInfoItemHolder.java
@@ -56,7 +56,7 @@ public class ChannelMiniInfoItemHolder extends InfoItemHolder {
             itemAdditionalDetailView.setText(getDetailLine(item));
         }
 
-        PicassoHelper.loadAvatar(item.getThumbnailUrl()).into(itemThumbnailView);
+        PicassoHelper.loadAvatar(item.getThumbnails()).into(itemThumbnailView);
 
         itemView.setOnClickListener(view -> {
             if (itemBuilder.getOnChannelSelectedListener() != null) {

--- a/app/src/main/java/org/schabi/newpipe/info_list/holder/CommentsMiniInfoItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/holder/CommentsMiniInfoItemHolder.java
@@ -31,6 +31,7 @@ import org.schabi.newpipe.local.history.HistoryRecordManager;
 import org.schabi.newpipe.util.DeviceUtils;
 import org.schabi.newpipe.util.Localization;
 import org.schabi.newpipe.util.NavigationHelper;
+import org.schabi.newpipe.util.image.ImageStrategy;
 import org.schabi.newpipe.util.image.PicassoHelper;
 import org.schabi.newpipe.util.external_communication.ShareUtils;
 import org.schabi.newpipe.util.text.CommentTextOnTouchListener;
@@ -98,7 +99,7 @@ public class CommentsMiniInfoItemHolder extends InfoItemHolder {
         final CommentsInfoItem item = (CommentsInfoItem) infoItem;
 
         PicassoHelper.loadAvatar(item.getUploaderAvatars()).into(itemThumbnailView);
-        if (PicassoHelper.shouldLoadImages()) {
+        if (ImageStrategy.shouldLoadImages()) {
             itemThumbnailView.setVisibility(View.VISIBLE);
             itemRoot.setPadding(commentVerticalPadding, commentVerticalPadding,
                     commentVerticalPadding, commentVerticalPadding);

--- a/app/src/main/java/org/schabi/newpipe/info_list/holder/CommentsMiniInfoItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/holder/CommentsMiniInfoItemHolder.java
@@ -97,7 +97,7 @@ public class CommentsMiniInfoItemHolder extends InfoItemHolder {
         }
         final CommentsInfoItem item = (CommentsInfoItem) infoItem;
 
-        PicassoHelper.loadAvatar(item.getUploaderAvatarUrl()).into(itemThumbnailView);
+        PicassoHelper.loadAvatar(item.getUploaderAvatars()).into(itemThumbnailView);
         if (PicassoHelper.getShouldLoadImages()) {
             itemThumbnailView.setVisibility(View.VISIBLE);
             itemRoot.setPadding(commentVerticalPadding, commentVerticalPadding,

--- a/app/src/main/java/org/schabi/newpipe/info_list/holder/CommentsMiniInfoItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/holder/CommentsMiniInfoItemHolder.java
@@ -31,7 +31,7 @@ import org.schabi.newpipe.local.history.HistoryRecordManager;
 import org.schabi.newpipe.util.DeviceUtils;
 import org.schabi.newpipe.util.Localization;
 import org.schabi.newpipe.util.NavigationHelper;
-import org.schabi.newpipe.util.PicassoHelper;
+import org.schabi.newpipe.util.image.PicassoHelper;
 import org.schabi.newpipe.util.external_communication.ShareUtils;
 import org.schabi.newpipe.util.text.CommentTextOnTouchListener;
 import org.schabi.newpipe.util.text.TextLinkifier;
@@ -98,7 +98,7 @@ public class CommentsMiniInfoItemHolder extends InfoItemHolder {
         final CommentsInfoItem item = (CommentsInfoItem) infoItem;
 
         PicassoHelper.loadAvatar(item.getUploaderAvatars()).into(itemThumbnailView);
-        if (PicassoHelper.getShouldLoadImages()) {
+        if (PicassoHelper.shouldLoadImages()) {
             itemThumbnailView.setVisibility(View.VISIBLE);
             itemRoot.setPadding(commentVerticalPadding, commentVerticalPadding,
                     commentVerticalPadding, commentVerticalPadding);

--- a/app/src/main/java/org/schabi/newpipe/info_list/holder/PlaylistMiniInfoItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/holder/PlaylistMiniInfoItemHolder.java
@@ -46,7 +46,7 @@ public class PlaylistMiniInfoItemHolder extends InfoItemHolder {
                 .localizeStreamCountMini(itemStreamCountView.getContext(), item.getStreamCount()));
         itemUploaderView.setText(item.getUploaderName());
 
-        PicassoHelper.loadPlaylistThumbnail(item.getThumbnailUrl()).into(itemThumbnailView);
+        PicassoHelper.loadPlaylistThumbnail(item.getThumbnails()).into(itemThumbnailView);
 
         itemView.setOnClickListener(view -> {
             if (itemBuilder.getOnPlaylistSelectedListener() != null) {

--- a/app/src/main/java/org/schabi/newpipe/info_list/holder/PlaylistMiniInfoItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/holder/PlaylistMiniInfoItemHolder.java
@@ -9,7 +9,7 @@ import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.playlist.PlaylistInfoItem;
 import org.schabi.newpipe.info_list.InfoItemBuilder;
 import org.schabi.newpipe.local.history.HistoryRecordManager;
-import org.schabi.newpipe.util.PicassoHelper;
+import org.schabi.newpipe.util.image.PicassoHelper;
 import org.schabi.newpipe.util.Localization;
 
 public class PlaylistMiniInfoItemHolder extends InfoItemHolder {

--- a/app/src/main/java/org/schabi/newpipe/info_list/holder/StreamMiniInfoItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/holder/StreamMiniInfoItemHolder.java
@@ -16,7 +16,7 @@ import org.schabi.newpipe.ktx.ViewUtils;
 import org.schabi.newpipe.local.history.HistoryRecordManager;
 import org.schabi.newpipe.util.DependentPreferenceHelper;
 import org.schabi.newpipe.util.Localization;
-import org.schabi.newpipe.util.PicassoHelper;
+import org.schabi.newpipe.util.image.PicassoHelper;
 import org.schabi.newpipe.util.StreamTypeUtil;
 import org.schabi.newpipe.views.AnimatedProgressBar;
 

--- a/app/src/main/java/org/schabi/newpipe/info_list/holder/StreamMiniInfoItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/holder/StreamMiniInfoItemHolder.java
@@ -87,7 +87,7 @@ public class StreamMiniInfoItemHolder extends InfoItemHolder {
         }
 
         // Default thumbnail is shown on error, while loading and if the url is empty
-        PicassoHelper.loadThumbnail(item.getThumbnailUrl()).into(itemThumbnailView);
+        PicassoHelper.loadThumbnail(item.getThumbnails()).into(itemThumbnailView);
 
         itemView.setOnClickListener(view -> {
             if (itemBuilder.getOnStreamSelectedListener() != null) {

--- a/app/src/main/java/org/schabi/newpipe/local/feed/item/StreamItem.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/item/StreamItem.kt
@@ -18,8 +18,8 @@ import org.schabi.newpipe.extractor.stream.StreamType.POST_LIVE_AUDIO_STREAM
 import org.schabi.newpipe.extractor.stream.StreamType.POST_LIVE_STREAM
 import org.schabi.newpipe.extractor.stream.StreamType.VIDEO_STREAM
 import org.schabi.newpipe.util.Localization
-import org.schabi.newpipe.util.PicassoHelper
 import org.schabi.newpipe.util.StreamTypeUtil
+import org.schabi.newpipe.util.image.PicassoHelper
 import java.util.concurrent.TimeUnit
 import java.util.function.Consumer
 

--- a/app/src/main/java/org/schabi/newpipe/local/feed/notifications/NotificationHelper.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/notifications/NotificationHelper.kt
@@ -22,7 +22,7 @@ import org.schabi.newpipe.R
 import org.schabi.newpipe.extractor.stream.StreamInfoItem
 import org.schabi.newpipe.local.feed.service.FeedUpdateInfo
 import org.schabi.newpipe.util.NavigationHelper
-import org.schabi.newpipe.util.PicassoHelper
+import org.schabi.newpipe.util.image.PicassoHelper
 
 /**
  * Helper for everything related to show notifications about new streams to the user.

--- a/app/src/main/java/org/schabi/newpipe/local/holder/LocalPlaylistItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/local/holder/LocalPlaylistItemHolder.java
@@ -8,7 +8,7 @@ import org.schabi.newpipe.database.playlist.PlaylistDuplicatesEntry;
 import org.schabi.newpipe.database.playlist.PlaylistMetadataEntry;
 import org.schabi.newpipe.local.LocalItemBuilder;
 import org.schabi.newpipe.local.history.HistoryRecordManager;
-import org.schabi.newpipe.util.PicassoHelper;
+import org.schabi.newpipe.util.image.PicassoHelper;
 import org.schabi.newpipe.util.Localization;
 
 import java.time.format.DateTimeFormatter;

--- a/app/src/main/java/org/schabi/newpipe/local/holder/LocalPlaylistStreamItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/local/holder/LocalPlaylistStreamItemHolder.java
@@ -16,7 +16,7 @@ import org.schabi.newpipe.local.LocalItemBuilder;
 import org.schabi.newpipe.local.history.HistoryRecordManager;
 import org.schabi.newpipe.util.DependentPreferenceHelper;
 import org.schabi.newpipe.util.Localization;
-import org.schabi.newpipe.util.PicassoHelper;
+import org.schabi.newpipe.util.image.PicassoHelper;
 import org.schabi.newpipe.util.ServiceHelper;
 import org.schabi.newpipe.views.AnimatedProgressBar;
 

--- a/app/src/main/java/org/schabi/newpipe/local/holder/LocalStatisticStreamItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/local/holder/LocalStatisticStreamItemHolder.java
@@ -16,7 +16,7 @@ import org.schabi.newpipe.local.LocalItemBuilder;
 import org.schabi.newpipe.local.history.HistoryRecordManager;
 import org.schabi.newpipe.util.DependentPreferenceHelper;
 import org.schabi.newpipe.util.Localization;
-import org.schabi.newpipe.util.PicassoHelper;
+import org.schabi.newpipe.util.image.PicassoHelper;
 import org.schabi.newpipe.util.ServiceHelper;
 import org.schabi.newpipe.views.AnimatedProgressBar;
 

--- a/app/src/main/java/org/schabi/newpipe/local/holder/RemotePlaylistItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/local/holder/RemotePlaylistItemHolder.java
@@ -8,7 +8,7 @@ import org.schabi.newpipe.database.playlist.model.PlaylistRemoteEntity;
 import org.schabi.newpipe.local.LocalItemBuilder;
 import org.schabi.newpipe.local.history.HistoryRecordManager;
 import org.schabi.newpipe.util.Localization;
-import org.schabi.newpipe.util.PicassoHelper;
+import org.schabi.newpipe.util.image.PicassoHelper;
 import org.schabi.newpipe.util.ServiceHelper;
 
 import java.time.format.DateTimeFormatter;

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
@@ -58,6 +58,7 @@ import org.schabi.newpipe.streams.io.NoFileManagerSafeGuard
 import org.schabi.newpipe.streams.io.StoredFileHelper
 import org.schabi.newpipe.util.NavigationHelper
 import org.schabi.newpipe.util.OnClickGesture
+import org.schabi.newpipe.util.PicassoHelper
 import org.schabi.newpipe.util.ServiceHelper
 import org.schabi.newpipe.util.ThemeHelper.getGridSpanCountChannels
 import org.schabi.newpipe.util.external_communication.ShareUtils
@@ -342,7 +343,7 @@ class SubscriptionFragment : BaseStateFragment<SubscriptionState>() {
             when (i) {
                 0 -> ShareUtils.shareText(
                     requireContext(), selectedItem.name, selectedItem.url,
-                    selectedItem.thumbnailUrl
+                    PicassoHelper.choosePreferredImage(selectedItem.thumbnails)
                 )
                 1 -> ShareUtils.openUrlInBrowser(requireContext(), selectedItem.url)
                 2 -> deleteChannel(selectedItem)

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
@@ -58,10 +58,10 @@ import org.schabi.newpipe.streams.io.NoFileManagerSafeGuard
 import org.schabi.newpipe.streams.io.StoredFileHelper
 import org.schabi.newpipe.util.NavigationHelper
 import org.schabi.newpipe.util.OnClickGesture
-import org.schabi.newpipe.util.PicassoHelper
 import org.schabi.newpipe.util.ServiceHelper
 import org.schabi.newpipe.util.ThemeHelper.getGridSpanCountChannels
 import org.schabi.newpipe.util.external_communication.ShareUtils
+import org.schabi.newpipe.util.image.PicassoHelper
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
@@ -61,7 +61,6 @@ import org.schabi.newpipe.util.OnClickGesture
 import org.schabi.newpipe.util.ServiceHelper
 import org.schabi.newpipe.util.ThemeHelper.getGridSpanCountChannels
 import org.schabi.newpipe.util.external_communication.ShareUtils
-import org.schabi.newpipe.util.image.ImageStrategy
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -342,8 +341,7 @@ class SubscriptionFragment : BaseStateFragment<SubscriptionState>() {
         val actions = DialogInterface.OnClickListener { _, i ->
             when (i) {
                 0 -> ShareUtils.shareText(
-                    requireContext(), selectedItem.name, selectedItem.url,
-                    ImageStrategy.choosePreferredImage(selectedItem.thumbnails)
+                    requireContext(), selectedItem.name, selectedItem.url, selectedItem.thumbnails
                 )
                 1 -> ShareUtils.openUrlInBrowser(requireContext(), selectedItem.url)
                 2 -> deleteChannel(selectedItem)

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionFragment.kt
@@ -61,7 +61,7 @@ import org.schabi.newpipe.util.OnClickGesture
 import org.schabi.newpipe.util.ServiceHelper
 import org.schabi.newpipe.util.ThemeHelper.getGridSpanCountChannels
 import org.schabi.newpipe.util.external_communication.ShareUtils
-import org.schabi.newpipe.util.image.PicassoHelper
+import org.schabi.newpipe.util.image.ImageStrategy
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -343,7 +343,7 @@ class SubscriptionFragment : BaseStateFragment<SubscriptionState>() {
             when (i) {
                 0 -> ShareUtils.shareText(
                     requireContext(), selectedItem.name, selectedItem.url,
-                    PicassoHelper.choosePreferredImage(selectedItem.thumbnails)
+                    ImageStrategy.choosePreferredImage(selectedItem.thumbnails)
                 )
                 1 -> ShareUtils.openUrlInBrowser(requireContext(), selectedItem.url)
                 2 -> deleteChannel(selectedItem)

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionManager.kt
@@ -19,7 +19,7 @@ import org.schabi.newpipe.extractor.feed.FeedInfo
 import org.schabi.newpipe.extractor.stream.StreamInfoItem
 import org.schabi.newpipe.local.feed.FeedDatabaseManager
 import org.schabi.newpipe.util.ExtractorHelper
-import org.schabi.newpipe.util.image.PicassoHelper
+import org.schabi.newpipe.util.image.ImageStrategy
 
 class SubscriptionManager(context: Context) {
     private val database = NewPipeDatabase.getInstance(context)
@@ -74,7 +74,7 @@ class SubscriptionManager(context: Context) {
                 Completable.fromRunnable {
                     it.setData(
                         info.name,
-                        PicassoHelper.choosePreferredImage(info.avatars),
+                        ImageStrategy.choosePreferredImage(info.avatars),
                         info.description,
                         info.subscriberCount
                     )
@@ -105,7 +105,7 @@ class SubscriptionManager(context: Context) {
         } else if (info is ChannelInfo) {
             subscriptionEntity.setData(
                 info.name,
-                PicassoHelper.choosePreferredImage(info.avatars),
+                ImageStrategy.choosePreferredImage(info.avatars),
                 info.description,
                 info.subscriberCount
             )

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionManager.kt
@@ -19,6 +19,7 @@ import org.schabi.newpipe.extractor.feed.FeedInfo
 import org.schabi.newpipe.extractor.stream.StreamInfoItem
 import org.schabi.newpipe.local.feed.FeedDatabaseManager
 import org.schabi.newpipe.util.ExtractorHelper
+import org.schabi.newpipe.util.PicassoHelper
 
 class SubscriptionManager(context: Context) {
     private val database = NewPipeDatabase.getInstance(context)
@@ -71,7 +72,12 @@ class SubscriptionManager(context: Context) {
         subscriptionTable.getSubscription(info.serviceId, info.url)
             .flatMapCompletable {
                 Completable.fromRunnable {
-                    it.setData(info.name, info.avatarUrl, info.description, info.subscriberCount)
+                    it.setData(
+                        info.name,
+                        PicassoHelper.choosePreferredImage(info.avatars),
+                        info.description,
+                        info.subscriberCount
+                    )
                     subscriptionTable.update(it)
                 }
             }
@@ -99,7 +105,7 @@ class SubscriptionManager(context: Context) {
         } else if (info is ChannelInfo) {
             subscriptionEntity.setData(
                 info.name,
-                info.avatarUrl,
+                PicassoHelper.choosePreferredImage(info.avatars),
                 info.description,
                 info.subscriberCount
             )

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionManager.kt
@@ -74,7 +74,7 @@ class SubscriptionManager(context: Context) {
                 Completable.fromRunnable {
                     it.setData(
                         info.name,
-                        ImageStrategy.choosePreferredImage(info.avatars),
+                        ImageStrategy.imageListToDbUrl(info.avatars),
                         info.description,
                         info.subscriberCount
                     )
@@ -105,7 +105,7 @@ class SubscriptionManager(context: Context) {
         } else if (info is ChannelInfo) {
             subscriptionEntity.setData(
                 info.name,
-                ImageStrategy.choosePreferredImage(info.avatars),
+                ImageStrategy.imageListToDbUrl(info.avatars),
                 info.description,
                 info.subscriberCount
             )

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionManager.kt
@@ -19,7 +19,7 @@ import org.schabi.newpipe.extractor.feed.FeedInfo
 import org.schabi.newpipe.extractor.stream.StreamInfoItem
 import org.schabi.newpipe.local.feed.FeedDatabaseManager
 import org.schabi.newpipe.util.ExtractorHelper
-import org.schabi.newpipe.util.PicassoHelper
+import org.schabi.newpipe.util.image.PicassoHelper
 
 class SubscriptionManager(context: Context) {
     private val database = NewPipeDatabase.getInstance(context)

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/item/ChannelItem.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/item/ChannelItem.kt
@@ -9,7 +9,7 @@ import org.schabi.newpipe.R
 import org.schabi.newpipe.extractor.channel.ChannelInfoItem
 import org.schabi.newpipe.util.Localization
 import org.schabi.newpipe.util.OnClickGesture
-import org.schabi.newpipe.util.PicassoHelper
+import org.schabi.newpipe.util.image.PicassoHelper
 
 class ChannelItem(
     private val infoItem: ChannelInfoItem,

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/item/ChannelItem.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/item/ChannelItem.kt
@@ -39,7 +39,7 @@ class ChannelItem(
             itemChannelDescriptionView.text = infoItem.description
         }
 
-        PicassoHelper.loadAvatar(infoItem.thumbnailUrl).into(itemThumbnailView)
+        PicassoHelper.loadAvatar(infoItem.thumbnails).into(itemThumbnailView)
 
         gesturesListener?.run {
             viewHolder.root.setOnClickListener { selected(infoItem) }

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/item/PickerSubscriptionItem.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/item/PickerSubscriptionItem.kt
@@ -10,7 +10,7 @@ import org.schabi.newpipe.database.subscription.SubscriptionEntity
 import org.schabi.newpipe.databinding.PickerSubscriptionItemBinding
 import org.schabi.newpipe.ktx.AnimationType
 import org.schabi.newpipe.ktx.animate
-import org.schabi.newpipe.util.PicassoHelper
+import org.schabi.newpipe.util.image.PicassoHelper
 
 data class PickerSubscriptionItem(
     val subscriptionEntity: SubscriptionEntity,

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -87,6 +87,7 @@ import org.schabi.newpipe.error.ErrorInfo;
 import org.schabi.newpipe.error.ErrorUtil;
 import org.schabi.newpipe.error.UserAction;
 import org.schabi.newpipe.extractor.stream.AudioStream;
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.extractor.stream.StreamType;
 import org.schabi.newpipe.extractor.stream.VideoStream;
@@ -805,10 +806,10 @@ public final class Player implements PlaybackListener, Listener {
         };
     }
 
-    private void loadCurrentThumbnail(final String url) {
+    private void loadCurrentThumbnail(final List<Image> thumbnails) {
         if (DEBUG) {
-            Log.d(TAG, "Thumbnail - loadCurrentThumbnail() called with url = ["
-                    + (url == null ? "null" : url) + "]");
+            Log.d(TAG, "Thumbnail - loadCurrentThumbnail() called with thumbnails = ["
+                    + thumbnails.size() + "]");
         }
 
         // first cancel any previous loading
@@ -817,12 +818,12 @@ public final class Player implements PlaybackListener, Listener {
         // Unset currentThumbnail, since it is now outdated. This ensures it is not used in media
         // session metadata while the new thumbnail is being loaded by Picasso.
         onThumbnailLoaded(null);
-        if (isNullOrEmpty(url)) {
+        if (thumbnails.isEmpty()) {
             return;
         }
 
         // scale down the notification thumbnail for performance
-        PicassoHelper.loadScaledDownThumbnail(context, url)
+        PicassoHelper.loadScaledDownThumbnail(context, thumbnails)
                 .tag(PICASSO_PLAYER_THUMBNAIL_TAG)
                 .into(currentThumbnailTarget);
     }
@@ -1792,7 +1793,7 @@ public final class Player implements PlaybackListener, Listener {
 
         maybeAutoQueueNextStream(info);
 
-        loadCurrentThumbnail(info.getThumbnailUrl());
+        loadCurrentThumbnail(info.getThumbnails());
         registerStreamViewed();
 
         notifyMetadataUpdateToListeners();

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -118,7 +118,7 @@ import org.schabi.newpipe.player.ui.VideoPlayerUi;
 import org.schabi.newpipe.util.DependentPreferenceHelper;
 import org.schabi.newpipe.util.ListHelper;
 import org.schabi.newpipe.util.NavigationHelper;
-import org.schabi.newpipe.util.PicassoHelper;
+import org.schabi.newpipe.util.image.PicassoHelper;
 import org.schabi.newpipe.util.SerializedCache;
 import org.schabi.newpipe.util.StreamTypeUtil;
 

--- a/app/src/main/java/org/schabi/newpipe/player/mediaitem/ExceptionTag.java
+++ b/app/src/main/java/org/schabi/newpipe/player/mediaitem/ExceptionTag.java
@@ -3,6 +3,7 @@ package org.schabi.newpipe.player.mediaitem;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.extractor.stream.StreamType;
 import org.schabi.newpipe.player.playqueue.PlayQueueItem;
+import org.schabi.newpipe.util.PicassoHelper;
 
 import java.util.List;
 import java.util.Optional;
@@ -74,7 +75,7 @@ public final class ExceptionTag implements MediaItemTag {
 
     @Override
     public String getThumbnailUrl() {
-        return item.getThumbnailUrl();
+        return PicassoHelper.choosePreferredImage(item.getThumbnails());
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/player/mediaitem/ExceptionTag.java
+++ b/app/src/main/java/org/schabi/newpipe/player/mediaitem/ExceptionTag.java
@@ -3,7 +3,7 @@ package org.schabi.newpipe.player.mediaitem;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.extractor.stream.StreamType;
 import org.schabi.newpipe.player.playqueue.PlayQueueItem;
-import org.schabi.newpipe.util.image.PicassoHelper;
+import org.schabi.newpipe.util.image.ImageStrategy;
 
 import java.util.List;
 import java.util.Optional;
@@ -75,7 +75,7 @@ public final class ExceptionTag implements MediaItemTag {
 
     @Override
     public String getThumbnailUrl() {
-        return PicassoHelper.choosePreferredImage(item.getThumbnails());
+        return ImageStrategy.choosePreferredImage(item.getThumbnails());
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/player/mediaitem/ExceptionTag.java
+++ b/app/src/main/java/org/schabi/newpipe/player/mediaitem/ExceptionTag.java
@@ -3,7 +3,7 @@ package org.schabi.newpipe.player.mediaitem;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.extractor.stream.StreamType;
 import org.schabi.newpipe.player.playqueue.PlayQueueItem;
-import org.schabi.newpipe.util.PicassoHelper;
+import org.schabi.newpipe.util.image.PicassoHelper;
 
 import java.util.List;
 import java.util.Optional;

--- a/app/src/main/java/org/schabi/newpipe/player/mediaitem/StreamInfoTag.java
+++ b/app/src/main/java/org/schabi/newpipe/player/mediaitem/StreamInfoTag.java
@@ -6,6 +6,7 @@ import org.schabi.newpipe.extractor.stream.AudioStream;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.extractor.stream.StreamType;
 import org.schabi.newpipe.extractor.stream.VideoStream;
+import org.schabi.newpipe.util.PicassoHelper;
 
 import java.util.Collections;
 import java.util.List;
@@ -95,7 +96,7 @@ public final class StreamInfoTag implements MediaItemTag {
 
     @Override
     public String getThumbnailUrl() {
-        return streamInfo.getThumbnailUrl();
+        return PicassoHelper.choosePreferredImage(streamInfo.getThumbnails());
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/player/mediaitem/StreamInfoTag.java
+++ b/app/src/main/java/org/schabi/newpipe/player/mediaitem/StreamInfoTag.java
@@ -6,7 +6,7 @@ import org.schabi.newpipe.extractor.stream.AudioStream;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.extractor.stream.StreamType;
 import org.schabi.newpipe.extractor.stream.VideoStream;
-import org.schabi.newpipe.util.PicassoHelper;
+import org.schabi.newpipe.util.image.PicassoHelper;
 
 import java.util.Collections;
 import java.util.List;

--- a/app/src/main/java/org/schabi/newpipe/player/mediaitem/StreamInfoTag.java
+++ b/app/src/main/java/org/schabi/newpipe/player/mediaitem/StreamInfoTag.java
@@ -6,7 +6,7 @@ import org.schabi.newpipe.extractor.stream.AudioStream;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.extractor.stream.StreamType;
 import org.schabi.newpipe.extractor.stream.VideoStream;
-import org.schabi.newpipe.util.image.PicassoHelper;
+import org.schabi.newpipe.util.image.ImageStrategy;
 
 import java.util.Collections;
 import java.util.List;
@@ -96,7 +96,7 @@ public final class StreamInfoTag implements MediaItemTag {
 
     @Override
     public String getThumbnailUrl() {
-        return PicassoHelper.choosePreferredImage(streamInfo.getThumbnails());
+        return ImageStrategy.choosePreferredImage(streamInfo.getThumbnails());
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/player/mediasession/PlayQueueNavigator.java
+++ b/app/src/main/java/org/schabi/newpipe/player/mediasession/PlayQueueNavigator.java
@@ -20,7 +20,7 @@ import com.google.android.exoplayer2.util.Util;
 import org.schabi.newpipe.player.Player;
 import org.schabi.newpipe.player.playqueue.PlayQueue;
 import org.schabi.newpipe.player.playqueue.PlayQueueItem;
-import org.schabi.newpipe.util.image.PicassoHelper;
+import org.schabi.newpipe.util.image.ImageStrategy;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -139,7 +139,7 @@ public class PlayQueueNavigator implements MediaSessionConnector.QueueNavigator 
         descBuilder.setExtras(additionalMetadata);
 
         final Uri thumbnailUri = Uri.parse(
-                PicassoHelper.choosePreferredImage(item.getThumbnails()));
+                ImageStrategy.choosePreferredImage(item.getThumbnails()));
         if (thumbnailUri != null) {
             descBuilder.setIconUri(thumbnailUri);
         }

--- a/app/src/main/java/org/schabi/newpipe/player/mediasession/PlayQueueNavigator.java
+++ b/app/src/main/java/org/schabi/newpipe/player/mediasession/PlayQueueNavigator.java
@@ -20,6 +20,7 @@ import com.google.android.exoplayer2.util.Util;
 import org.schabi.newpipe.player.Player;
 import org.schabi.newpipe.player.playqueue.PlayQueue;
 import org.schabi.newpipe.player.playqueue.PlayQueueItem;
+import org.schabi.newpipe.util.PicassoHelper;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -137,7 +138,8 @@ public class PlayQueueNavigator implements MediaSessionConnector.QueueNavigator 
                 .putLong(MediaMetadataCompat.METADATA_KEY_NUM_TRACKS, player.getPlayQueue().size());
         descBuilder.setExtras(additionalMetadata);
 
-        final Uri thumbnailUri = Uri.parse(item.getThumbnailUrl());
+        final Uri thumbnailUri = Uri.parse(
+                PicassoHelper.choosePreferredImage(item.getThumbnails()));
         if (thumbnailUri != null) {
             descBuilder.setIconUri(thumbnailUri);
         }

--- a/app/src/main/java/org/schabi/newpipe/player/mediasession/PlayQueueNavigator.java
+++ b/app/src/main/java/org/schabi/newpipe/player/mediasession/PlayQueueNavigator.java
@@ -20,7 +20,7 @@ import com.google.android.exoplayer2.util.Util;
 import org.schabi.newpipe.player.Player;
 import org.schabi.newpipe.player.playqueue.PlayQueue;
 import org.schabi.newpipe.player.playqueue.PlayQueueItem;
-import org.schabi.newpipe.util.PicassoHelper;
+import org.schabi.newpipe.util.image.PicassoHelper;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/app/src/main/java/org/schabi/newpipe/player/mediasession/PlayQueueNavigator.java
+++ b/app/src/main/java/org/schabi/newpipe/player/mediasession/PlayQueueNavigator.java
@@ -138,10 +138,12 @@ public class PlayQueueNavigator implements MediaSessionConnector.QueueNavigator 
                 .putLong(MediaMetadataCompat.METADATA_KEY_NUM_TRACKS, player.getPlayQueue().size());
         descBuilder.setExtras(additionalMetadata);
 
-        final Uri thumbnailUri = Uri.parse(
-                ImageStrategy.choosePreferredImage(item.getThumbnails()));
-        if (thumbnailUri != null) {
-            descBuilder.setIconUri(thumbnailUri);
+        try {
+            descBuilder.setIconUri(Uri.parse(
+                    ImageStrategy.choosePreferredImage(item.getThumbnails())));
+        } catch (final Throwable e) {
+            // no thumbnail available at all, or the user disabled image loading,
+            // or the obtained url is not a valid `Uri`
         }
 
         return descBuilder.build();

--- a/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueueItem.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueueItem.java
@@ -3,12 +3,14 @@ package org.schabi.newpipe.player.playqueue;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.extractor.stream.StreamType;
 import org.schabi.newpipe.util.ExtractorHelper;
 
 import java.io.Serializable;
+import java.util.List;
 
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.schedulers.Schedulers;
@@ -24,7 +26,7 @@ public class PlayQueueItem implements Serializable {
     private final int serviceId;
     private final long duration;
     @NonNull
-    private final String thumbnailUrl;
+    private final List<Image> thumbnails;
     @NonNull
     private final String uploader;
     private final String uploaderUrl;
@@ -38,7 +40,7 @@ public class PlayQueueItem implements Serializable {
 
     PlayQueueItem(@NonNull final StreamInfo info) {
         this(info.getName(), info.getUrl(), info.getServiceId(), info.getDuration(),
-                info.getThumbnailUrl(), info.getUploaderName(),
+                info.getThumbnails(), info.getUploaderName(),
                 info.getUploaderUrl(), info.getStreamType());
 
         if (info.getStartPosition() > 0) {
@@ -48,20 +50,20 @@ public class PlayQueueItem implements Serializable {
 
     PlayQueueItem(@NonNull final StreamInfoItem item) {
         this(item.getName(), item.getUrl(), item.getServiceId(), item.getDuration(),
-                item.getThumbnailUrl(), item.getUploaderName(),
+                item.getThumbnails(), item.getUploaderName(),
                 item.getUploaderUrl(), item.getStreamType());
     }
 
     @SuppressWarnings("ParameterNumber")
     private PlayQueueItem(@Nullable final String name, @Nullable final String url,
                           final int serviceId, final long duration,
-                          @Nullable final String thumbnailUrl, @Nullable final String uploader,
+                          final List<Image> thumbnails, @Nullable final String uploader,
                           final String uploaderUrl, @NonNull final StreamType streamType) {
         this.title = name != null ? name : EMPTY_STRING;
         this.url = url != null ? url : EMPTY_STRING;
         this.serviceId = serviceId;
         this.duration = duration;
-        this.thumbnailUrl = thumbnailUrl != null ? thumbnailUrl : EMPTY_STRING;
+        this.thumbnails = thumbnails;
         this.uploader = uploader != null ? uploader : EMPTY_STRING;
         this.uploaderUrl = uploaderUrl;
         this.streamType = streamType;
@@ -88,8 +90,8 @@ public class PlayQueueItem implements Serializable {
     }
 
     @NonNull
-    public String getThumbnailUrl() {
-        return thumbnailUrl;
+    public List<Image> getThumbnails() {
+        return thumbnails;
     }
 
     @NonNull

--- a/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueueItemBuilder.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueueItemBuilder.java
@@ -6,7 +6,7 @@ import android.view.MotionEvent;
 import android.view.View;
 
 import org.schabi.newpipe.util.Localization;
-import org.schabi.newpipe.util.PicassoHelper;
+import org.schabi.newpipe.util.image.PicassoHelper;
 import org.schabi.newpipe.util.ServiceHelper;
 
 public class PlayQueueItemBuilder {

--- a/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueueItemBuilder.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueueItemBuilder.java
@@ -33,7 +33,7 @@ public class PlayQueueItemBuilder {
             holder.itemDurationView.setVisibility(View.GONE);
         }
 
-        PicassoHelper.loadThumbnail(item.getThumbnailUrl()).into(holder.itemThumbnailView);
+        PicassoHelper.loadThumbnail(item.getThumbnails()).into(holder.itemThumbnailView);
 
         holder.itemRoot.setOnClickListener(view -> {
             if (onItemClickListener != null) {

--- a/app/src/main/java/org/schabi/newpipe/player/seekbarpreview/SeekbarPreviewThumbnailHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/player/seekbarpreview/SeekbarPreviewThumbnailHolder.java
@@ -14,7 +14,7 @@ import androidx.collection.SparseArrayCompat;
 import com.google.common.base.Stopwatch;
 
 import org.schabi.newpipe.extractor.stream.Frameset;
-import org.schabi.newpipe.util.PicassoHelper;
+import org.schabi.newpipe.util.image.PicassoHelper;
 
 import java.util.Comparator;
 import java.util.List;

--- a/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
@@ -740,7 +740,7 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
                     String videoUrl = player.getVideoUrl();
                     videoUrl += ("&t=" + seconds);
                     ShareUtils.shareText(context, currentItem.getTitle(),
-                            videoUrl, currentItem.getThumbnailUrl());
+                            videoUrl, currentItem.getThumbnails());
                 }
             }
         };

--- a/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
@@ -226,7 +226,7 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
             final PlayQueueItem currentItem = player.getCurrentItem();
             if (currentItem != null) {
                 ShareUtils.shareText(context, currentItem.getTitle(),
-                        player.getVideoUrlAtCurrentTime(), currentItem.getThumbnailUrl());
+                        player.getVideoUrlAtCurrentTime(), currentItem.getThumbnails());
             }
         }));
         binding.share.setOnLongClickListener(v -> {

--- a/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
@@ -31,6 +31,7 @@ import org.schabi.newpipe.extractor.localization.Localization;
 import org.schabi.newpipe.streams.io.NoFileManagerSafeGuard;
 import org.schabi.newpipe.streams.io.StoredFileHelper;
 import org.schabi.newpipe.util.NavigationHelper;
+import org.schabi.newpipe.util.image.ImageStrategy;
 import org.schabi.newpipe.util.image.PicassoHelper;
 import org.schabi.newpipe.util.ZipHelper;
 import org.schabi.newpipe.util.image.PreferredImageQuality;
@@ -109,7 +110,7 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
         final Preference imageQualityPreference = requirePreference(R.string.image_quality_key);
         imageQualityPreference.setOnPreferenceChangeListener(
                 (preference, newValue) -> {
-                    PicassoHelper.setPreferredImageQuality(PreferredImageQuality
+                    ImageStrategy.setPreferredImageQuality(PreferredImageQuality
                             .fromPreferenceKey(requireContext(), (String) newValue));
                     try {
                         PicassoHelper.clearCache(preference.getContext());

--- a/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
@@ -31,8 +31,9 @@ import org.schabi.newpipe.extractor.localization.Localization;
 import org.schabi.newpipe.streams.io.NoFileManagerSafeGuard;
 import org.schabi.newpipe.streams.io.StoredFileHelper;
 import org.schabi.newpipe.util.NavigationHelper;
-import org.schabi.newpipe.util.PicassoHelper;
+import org.schabi.newpipe.util.image.PicassoHelper;
 import org.schabi.newpipe.util.ZipHelper;
+import org.schabi.newpipe.util.image.PreferredImageQuality;
 
 import java.io.File;
 import java.io.IOException;
@@ -105,9 +106,11 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
                 .getPreferredContentCountry(requireContext());
         initialLanguage = defaultPreferences.getString(getString(R.string.app_language_key), "en");
 
-        findPreference(getString(R.string.download_thumbnail_key)).setOnPreferenceChangeListener(
+        final Preference imageQualityPreference = requirePreference(R.string.image_quality_key);
+        imageQualityPreference.setOnPreferenceChangeListener(
                 (preference, newValue) -> {
-                    PicassoHelper.setShouldLoadImages((Boolean) newValue);
+                    PicassoHelper.setPreferredImageQuality(PreferredImageQuality
+                            .fromPreferenceKey(requireContext(), (String) newValue));
                     try {
                         PicassoHelper.clearCache(preference.getContext());
                         Toast.makeText(preference.getContext(),

--- a/app/src/main/java/org/schabi/newpipe/settings/DebugSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/DebugSettingsFragment.java
@@ -10,7 +10,7 @@ import org.schabi.newpipe.error.ErrorInfo;
 import org.schabi.newpipe.error.ErrorUtil;
 import org.schabi.newpipe.error.UserAction;
 import org.schabi.newpipe.local.feed.notifications.NotificationWorker;
-import org.schabi.newpipe.util.PicassoHelper;
+import org.schabi.newpipe.util.image.PicassoHelper;
 
 import java.util.Optional;
 

--- a/app/src/main/java/org/schabi/newpipe/settings/SelectChannelFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/SelectChannelFragment.java
@@ -19,7 +19,7 @@ import org.schabi.newpipe.R;
 import org.schabi.newpipe.database.subscription.SubscriptionEntity;
 import org.schabi.newpipe.error.ErrorUtil;
 import org.schabi.newpipe.local.subscription.SubscriptionManager;
-import org.schabi.newpipe.util.PicassoHelper;
+import org.schabi.newpipe.util.image.PicassoHelper;
 import org.schabi.newpipe.util.ThemeHelper;
 
 import java.util.List;

--- a/app/src/main/java/org/schabi/newpipe/settings/SelectPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/SelectPlaylistFragment.java
@@ -25,7 +25,7 @@ import org.schabi.newpipe.error.ErrorUtil;
 import org.schabi.newpipe.error.UserAction;
 import org.schabi.newpipe.local.playlist.LocalPlaylistManager;
 import org.schabi.newpipe.local.playlist.RemotePlaylistManager;
-import org.schabi.newpipe.util.PicassoHelper;
+import org.schabi.newpipe.util.image.PicassoHelper;
 
 import java.util.List;
 import java.util.Vector;

--- a/app/src/main/java/org/schabi/newpipe/settings/SettingMigrations.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/SettingMigrations.java
@@ -128,6 +128,20 @@ public final class SettingMigrations {
         }
     };
 
+    public static final Migration MIGRATION_5_6 = new Migration(5, 6) {
+        @Override
+        protected void migrate(@NonNull final Context context) {
+            final boolean loadImages = sp.getBoolean("download_thumbnail_key", true);
+
+            sp.edit()
+                    .putString(context.getString(R.string.image_quality_key),
+                            context.getString(loadImages
+                                    ? R.string.image_quality_default
+                                    : R.string.image_quality_none_key))
+                    .apply();
+        }
+    };
+
     /**
      * List of all implemented migrations.
      * <p>
@@ -140,12 +154,13 @@ public final class SettingMigrations {
             MIGRATION_2_3,
             MIGRATION_3_4,
             MIGRATION_4_5,
+            MIGRATION_5_6,
     };
 
     /**
      * Version number for preferences. Must be incremented every time a migration is necessary.
      */
-    private static final int VERSION = 5;
+    private static final int VERSION = 6;
 
 
     public static void runMigrationsIfNeeded(@NonNull final Context context,

--- a/app/src/main/java/org/schabi/newpipe/util/external_communication/ShareUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/external_communication/ShareUtils.java
@@ -269,8 +269,8 @@ public final class ShareUtils {
      *
      * <p>
      * For Android 10+ users, a content preview is shown, which includes the title of the shared
-     * content and an image preview the content, if its URL is not null or empty and its
-     * corresponding image is in the image cache.
+     * content and an image preview the content, if the preferred image chosen by {@link
+     * ImageStrategy#choosePreferredImage(List)} is in the image cache.
      * </p>
      *
      * @param context the context to use

--- a/app/src/main/java/org/schabi/newpipe/util/external_communication/ShareUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/external_communication/ShareUtils.java
@@ -24,6 +24,7 @@ import androidx.core.content.FileProvider;
 import org.schabi.newpipe.BuildConfig;
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.extractor.Image;
+import org.schabi.newpipe.util.image.ImageStrategy;
 import org.schabi.newpipe.util.image.PicassoHelper;
 
 import java.io.File;
@@ -251,7 +252,7 @@ public final class ShareUtils {
         // If loading of images has been disabled, don't try to generate a content preview
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
                 && !TextUtils.isEmpty(imagePreviewUrl)
-                && PicassoHelper.shouldLoadImages()) {
+                && ImageStrategy.shouldLoadImages()) {
 
             final ClipData clipData = generateClipDataForImagePreview(context, imagePreviewUrl);
             if (clipData != null) {
@@ -276,14 +277,14 @@ public final class ShareUtils {
      * @param title   the title of the content
      * @param content the content to share
      * @param images  a set of possible {@link Image}s of the subject, among which to choose with
-     *                {@link PicassoHelper#choosePreferredImage(List)} since that's likely to
+     *                {@link ImageStrategy#choosePreferredImage(List)} since that's likely to
      *                provide an image that is in Picasso's cache
      */
     public static void shareText(@NonNull final Context context,
                                  @NonNull final String title,
                                  final String content,
                                  final List<Image> images) {
-        shareText(context, title, content, PicassoHelper.choosePreferredImage(images));
+        shareText(context, title, content, ImageStrategy.choosePreferredImage(images));
     }
 
     /**

--- a/app/src/main/java/org/schabi/newpipe/util/external_communication/ShareUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/external_communication/ShareUtils.java
@@ -23,10 +23,12 @@ import androidx.core.content.FileProvider;
 
 import org.schabi.newpipe.BuildConfig;
 import org.schabi.newpipe.R;
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.util.PicassoHelper;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.util.List;
 
 public final class ShareUtils {
     private static final String TAG = ShareUtils.class.getSimpleName();
@@ -259,6 +261,29 @@ public final class ShareUtils {
         }
 
         openAppChooser(context, shareIntent, false);
+    }
+
+    /**
+     * Open the android share sheet to share a content.
+     *
+     * <p>
+     * For Android 10+ users, a content preview is shown, which includes the title of the shared
+     * content and an image preview the content, if its URL is not null or empty and its
+     * corresponding image is in the image cache.
+     * </p>
+     *
+     * @param context the context to use
+     * @param title   the title of the content
+     * @param content the content to share
+     * @param images  a set of possible {@link Image}s of the subject, among which to choose with
+     *                {@link PicassoHelper#choosePreferredImage(List)} since that's likely to
+     *                provide an image that is in Picasso's cache
+     */
+    public static void shareText(@NonNull final Context context,
+                                 @NonNull final String title,
+                                 final String content,
+                                 final List<Image> images) {
+        shareText(context, title, content, PicassoHelper.choosePreferredImage(images));
     }
 
     /**

--- a/app/src/main/java/org/schabi/newpipe/util/external_communication/ShareUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/external_communication/ShareUtils.java
@@ -24,7 +24,7 @@ import androidx.core.content.FileProvider;
 import org.schabi.newpipe.BuildConfig;
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.extractor.Image;
-import org.schabi.newpipe.util.PicassoHelper;
+import org.schabi.newpipe.util.image.PicassoHelper;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -251,7 +251,7 @@ public final class ShareUtils {
         // If loading of images has been disabled, don't try to generate a content preview
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
                 && !TextUtils.isEmpty(imagePreviewUrl)
-                && PicassoHelper.getShouldLoadImages()) {
+                && PicassoHelper.shouldLoadImages()) {
 
             final ClipData clipData = generateClipDataForImagePreview(context, imagePreviewUrl);
             if (clipData != null) {

--- a/app/src/main/java/org/schabi/newpipe/util/image/ImageStrategy.java
+++ b/app/src/main/java/org/schabi/newpipe/util/image/ImageStrategy.java
@@ -49,30 +49,16 @@ public final class ImageStrategy {
     }
 
     /**
-     * Chooses an image amongst the provided list based on the user preference previously set with
-     * {@link #setPreferredImageQuality(PreferredImageQuality)}. {@code null} will be returned in
-     * case the list is empty or the user preference is to not show images.
-     * <br>
-     * These properties will be preferred, from most to least important:
-     * <ol>
-     *     <li>The image's {@link Image#getEstimatedResolutionLevel()} is not unknown and is close
-     *     to {@link #preferredImageQuality}</li>
-     *     <li>At least one of the image's width or height are known</li>
-     *     <li>The highest resolution image is finally chosen if the user's preference is {@link
-     *     PreferredImageQuality#HIGH}, otherwise the chosen image is the one that has the closest
-     *     height to {@link #BEST_LOW_H} or {@link #BEST_MEDIUM_H}</li>
-     * </ol>
+     * {@link #choosePreferredImage(List)} contains the description for this function's logic.
      *
-     * @param images the images from which to choose
-     * @return the chosen preferred image, or {@link null} if the list is empty or the user disabled
-     *         images
+     * @param images         the images from which to choose
+     * @param nonNoneQuality the preferred quality (must NOT be {@link PreferredImageQuality#NONE})
+     * @return the chosen preferred image, or {@link null} if the list is empty
+     * @see #choosePreferredImage(List)
      */
     @Nullable
-    public static String choosePreferredImage(@NonNull final List<Image> images) {
-        if (preferredImageQuality == PreferredImageQuality.NONE) {
-            return null; // do not load images
-        }
-
+    static String choosePreferredImage(@NonNull final List<Image> images,
+                                       final PreferredImageQuality nonNoneQuality) {
         // this will be used to estimate the pixel count for images where only one of height or
         // width are known
         final double widthOverHeight = images.stream()
@@ -82,7 +68,7 @@ public final class ImageStrategy {
                 .findFirst()
                 .orElse(1.0);
 
-        final Image.ResolutionLevel preferredLevel = preferredImageQuality.toResolutionLevel();
+        final Image.ResolutionLevel preferredLevel = nonNoneQuality.toResolutionLevel();
         final Comparator<Image> initialComparator = Comparator
                 // the first step splits the images into groups of resolution levels
                 .<Image>comparingInt(i -> {
@@ -105,7 +91,7 @@ public final class ImageStrategy {
         // on how close its size is to BEST_LOW_H or BEST_MEDIUM_H (with proper units). Subgroups
         // without known image size will be left untouched since estimatePixelCount always returns
         // the same number for those.
-        final Comparator<Image> finalComparator = switch (preferredImageQuality) {
+        final Comparator<Image> finalComparator = switch (nonNoneQuality) {
             case NONE -> initialComparator; // unreachable
             case LOW -> initialComparator.thenComparingDouble(image -> {
                 final double pixelCount = estimatePixelCount(image, widthOverHeight);
@@ -128,8 +114,78 @@ public final class ImageStrategy {
                 .orElse(null);
     }
 
+    /**
+     * Chooses an image amongst the provided list based on the user preference previously set with
+     * {@link #setPreferredImageQuality(PreferredImageQuality)}. {@code null} will be returned in
+     * case the list is empty or the user preference is to not show images.
+     * <br>
+     * These properties will be preferred, from most to least important:
+     * <ol>
+     *     <li>The image's {@link Image#getEstimatedResolutionLevel()} is not unknown and is close
+     *     to {@link #preferredImageQuality}</li>
+     *     <li>At least one of the image's width or height are known</li>
+     *     <li>The highest resolution image is finally chosen if the user's preference is {@link
+     *     PreferredImageQuality#HIGH}, otherwise the chosen image is the one that has the height
+     *     closest to {@link #BEST_LOW_H} or {@link #BEST_MEDIUM_H}</li>
+     * </ol>
+     * <br>
+     * Use {@link #imageListToDbUrl(List)} if the URL is going to be saved to the database, to avoid
+     * saving nothing in case at the moment of saving the user preference is to not show images.
+     *
+     * @param images the images from which to choose
+     * @return the chosen preferred image, or {@link null} if the list is empty or the user disabled
+     *         images
+     * @see #imageListToDbUrl(List)
+     */
+    @Nullable
+    public static String choosePreferredImage(@NonNull final List<Image> images) {
+        if (preferredImageQuality == PreferredImageQuality.NONE) {
+            return null; // do not load images
+        }
+
+        return choosePreferredImage(images, preferredImageQuality);
+    }
+
+    /**
+     * Like {@link #choosePreferredImage(List)}, except that if {@link #preferredImageQuality} is
+     * {@link PreferredImageQuality#NONE} an image will be chosen anyway (with preferred quality
+     * {@link PreferredImageQuality#MEDIUM}.
+     * <br>
+     * To go back to a list of images (obviously with just the one chosen image) from a URL saved in
+     * the database use {@link #dbUrlToImageList(String)}.
+     *
+     * @param images the images from which to choose
+     * @return the chosen preferred image, or {@link null} if the list is empty
+     * @see #choosePreferredImage(List)
+     * @see #dbUrlToImageList(String)
+     */
+    @Nullable
+    public static String imageListToDbUrl(@NonNull final List<Image> images) {
+        final PreferredImageQuality quality;
+        if (preferredImageQuality == PreferredImageQuality.NONE) {
+            quality = PreferredImageQuality.MEDIUM;
+        } else {
+            quality = preferredImageQuality;
+        }
+
+        return choosePreferredImage(images, quality);
+    }
+
+    /**
+     * Wraps the URL (coming from the database) in a {@code List<Image>} so that it is usable
+     * seamlessly in all of the places where the extractor would return a list of images, including
+     * allowing to build info objects based on database objects.
+     * <br>
+     * To obtain a url to save to the database from a list of images use {@link
+     * #imageListToDbUrl(List)}.
+     *
+     * @param url the URL to wrap coming from the database, or {@code null} to get an empty list
+     * @return a list containing just one {@link Image} wrapping the provided URL, with unknown
+     *         image size fields, or an empty list if the URL is {@code null}
+     * @see #imageListToDbUrl(List)
+     */
     @NonNull
-    public static List<Image> urlToImageList(@Nullable final String url) {
+    public static List<Image> dbUrlToImageList(@Nullable final String url) {
         if (url == null) {
             return List.of();
         } else {

--- a/app/src/main/java/org/schabi/newpipe/util/image/ImageStrategy.java
+++ b/app/src/main/java/org/schabi/newpipe/util/image/ImageStrategy.java
@@ -38,19 +38,35 @@ public final class ImageStrategy {
                 // images whose size is completely unknown will be in their own subgroups, so
                 // any one of them will do, hence returning the same value for all of them
                 return 0;
-
             } else {
                 return image.getWidth() * image.getWidth() / widthOverHeight;
             }
-
         } else if (image.getWidth() == WIDTH_UNKNOWN) {
             return image.getHeight() * image.getHeight() * widthOverHeight;
-
         } else {
             return image.getHeight() * image.getWidth();
         }
     }
 
+    /**
+     * Chooses an image amongst the provided list based on the user preference previously set with
+     * {@link #setPreferredImageQuality(PreferredImageQuality)}. {@code null} will be returned in
+     * case the list is empty or the user preference is to not show images.
+     * <br>
+     * These properties will be preferred, from most to least important:
+     * <ol>
+     *     <li>The image's {@link Image#getEstimatedResolutionLevel()} is not unknown and is close
+     *     to {@link #preferredImageQuality}</li>
+     *     <li>At least one of the image's width or height are known</li>
+     *     <li>The highest resolution image is finally chosen if the user's preference is {@link
+     *     PreferredImageQuality#HIGH}, otherwise the chosen image is the one that has the closest
+     *     height to {@link #BEST_LOW_H} or {@link #BEST_MEDIUM_H}</li>
+     * </ol>
+     *
+     * @param images the images from which to choose
+     * @return the chosen preferred image, or {@link null} if the list is empty or the user disabled
+     *         images
+     */
     @Nullable
     public static String choosePreferredImage(@NonNull final List<Image> images) {
         if (preferredImageQuality == PreferredImageQuality.NONE) {

--- a/app/src/main/java/org/schabi/newpipe/util/image/ImageStrategy.java
+++ b/app/src/main/java/org/schabi/newpipe/util/image/ImageStrategy.java
@@ -1,0 +1,115 @@
+package org.schabi.newpipe.util.image;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.schabi.newpipe.extractor.Image;
+
+import java.util.Comparator;
+import java.util.List;
+
+public final class ImageStrategy {
+
+    // the height thresholds also used by the extractor (TODO move them to the extractor)
+    private static final int LOW_MEDIUM = 175;
+    private static final int MEDIUM_HIGH = 720;
+
+    private static PreferredImageQuality preferredImageQuality = PreferredImageQuality.MEDIUM;
+
+    private ImageStrategy() {
+    }
+
+    public static void setPreferredImageQuality(final PreferredImageQuality preferredImageQuality) {
+        ImageStrategy.preferredImageQuality = preferredImageQuality;
+    }
+
+    public static boolean shouldLoadImages() {
+        return preferredImageQuality != PreferredImageQuality.NONE;
+    }
+
+
+    private static double estimatePixelCount(final Image image,
+                                             final double widthOverHeight,
+                                             final boolean unknownsLast) {
+        if (image.getHeight() == Image.HEIGHT_UNKNOWN) {
+            if (image.getWidth() == Image.WIDTH_UNKNOWN) {
+                switch (image.getEstimatedResolutionLevel()) {
+                    case LOW:
+                        return unknownsLast
+                                ? (LOW_MEDIUM - 1) * (LOW_MEDIUM - 1) * widthOverHeight
+                                : 0;
+                    case MEDIUM:
+                        return unknownsLast
+                                ? (MEDIUM_HIGH - 1) * (MEDIUM_HIGH - 1) * widthOverHeight
+                                : LOW_MEDIUM * LOW_MEDIUM * widthOverHeight;
+                    case HIGH:
+                        return unknownsLast
+                                ? 1e20 // less than 1e21 to prefer over fully unknown image sizes
+                                : MEDIUM_HIGH * MEDIUM_HIGH * widthOverHeight;
+                    default:
+                    case UNKNOWN:
+                        // images whose size is completely unknown will be avoided when possible
+                        return unknownsLast ? 1e21 : -1;
+                }
+
+            } else {
+                return image.getWidth() * image.getWidth() / widthOverHeight;
+            }
+
+        } else if (image.getWidth() == Image.WIDTH_UNKNOWN) {
+            return image.getHeight() * image.getHeight() * widthOverHeight;
+
+        } else {
+            return image.getHeight() * image.getWidth();
+        }
+    }
+
+    @Nullable
+    public static String choosePreferredImage(@NonNull final List<Image> images) {
+        if (preferredImageQuality == PreferredImageQuality.NONE) {
+            return null; // do not load images
+        }
+
+        final double widthOverHeight = images.stream()
+                .filter(image -> image.getHeight() != Image.HEIGHT_UNKNOWN
+                        && image.getWidth() != Image.WIDTH_UNKNOWN)
+                .mapToDouble(image -> ((double) image.getWidth()) / image.getHeight())
+                .findFirst()
+                .orElse(1.0);
+
+        final Comparator<Image> comparator;
+        switch (preferredImageQuality) {
+            case LOW:
+                comparator = Comparator.comparingDouble(
+                        image -> estimatePixelCount(image, widthOverHeight, true));
+                break;
+            default:
+            case MEDIUM:
+                comparator = Comparator.comparingDouble(image -> {
+                    final double pixelCount = estimatePixelCount(image, widthOverHeight, true);
+                    final double mediumHeight = (LOW_MEDIUM + MEDIUM_HIGH) / 2.0;
+                    return Math.abs(pixelCount - mediumHeight * mediumHeight * widthOverHeight);
+                });
+                break;
+            case HIGH:
+                comparator = Comparator.<Image>comparingDouble(
+                        image -> estimatePixelCount(image, widthOverHeight, false))
+                        .reversed();
+                break;
+        }
+
+        return images.stream()
+                .min(comparator)
+                .map(Image::getUrl)
+                .orElse(null);
+    }
+
+    @NonNull
+    public static List<Image> urlToImageList(@Nullable final String url) {
+        if (url == null) {
+            return List.of();
+        } else {
+            return List.of(new Image(url, -1, -1, Image.ResolutionLevel.UNKNOWN));
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/util/image/PicassoHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/image/PicassoHelper.java
@@ -9,6 +9,7 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.util.Log;
 
+import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.graphics.BitmapCompat;
@@ -190,17 +191,17 @@ public final class PicassoHelper {
 
 
     private static RequestCreator loadImageDefault(@NonNull final List<Image> images,
-                                                   final int placeholderResId) {
+                                                   @DrawableRes final int placeholderResId) {
         return loadImageDefault(choosePreferredImage(images), placeholderResId);
     }
 
     private static RequestCreator loadImageDefault(@Nullable final String url,
-                                                   final int placeholderResId) {
+                                                   @DrawableRes final int placeholderResId) {
         return loadImageDefault(url, placeholderResId, true);
     }
 
     private static RequestCreator loadImageDefault(@Nullable final String url,
-                                                   final int placeholderResId,
+                                                   @DrawableRes final int placeholderResId,
                                                    final boolean showPlaceholderWhileLoading) {
         // if the URL was chosen with `choosePreferredImage` it will be null, but check again
         // `shouldLoadImages` in case the URL was chosen with `imageListToDbUrl` (which is the case

--- a/app/src/main/java/org/schabi/newpipe/util/image/PicassoHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/image/PicassoHelper.java
@@ -202,7 +202,10 @@ public final class PicassoHelper {
     private static RequestCreator loadImageDefault(@Nullable final String url,
                                                    final int placeholderResId,
                                                    final boolean showPlaceholderWhileLoading) {
-        if (isNullOrEmpty(url)) {
+        // if the URL was chosen with `choosePreferredImage` it will be null, but check again
+        // `shouldLoadImages` in case the URL was chosen with `imageListToDbUrl` (which is the case
+        // for URLs stored in the database)
+        if (isNullOrEmpty(url) || !ImageStrategy.shouldLoadImages()) {
             return picassoInstance
                     .load((String) null)
                     .placeholder(placeholderResId) // show placeholder when no image should load

--- a/app/src/main/java/org/schabi/newpipe/util/image/PicassoHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/image/PicassoHelper.java
@@ -2,13 +2,13 @@ package org.schabi.newpipe.util.image;
 
 import static org.schabi.newpipe.MainActivity.DEBUG;
 import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
+import static org.schabi.newpipe.util.image.ImageStrategy.choosePreferredImage;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.util.Log;
 
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.graphics.BitmapCompat;
 
@@ -21,11 +21,9 @@ import com.squareup.picasso.Transformation;
 
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.extractor.Image;
-import org.schabi.newpipe.extractor.Image.ResolutionLevel;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -46,7 +44,6 @@ public final class PicassoHelper {
     @SuppressLint("StaticFieldLeak")
     private static Picasso picassoInstance;
 
-    private static PreferredImageQuality preferredImageQuality = PreferredImageQuality.MEDIUM;
 
     public static void init(final Context context) {
         picassoCache = new LruCache(10 * 1024 * 1024);
@@ -90,14 +87,6 @@ public final class PicassoHelper {
 
     public static void setIndicatorsEnabled(final boolean enabled) {
         picassoInstance.setIndicatorsEnabled(enabled); // useful for debugging
-    }
-
-    public static void setPreferredImageQuality(final PreferredImageQuality preferredImageQuality) {
-        PicassoHelper.preferredImageQuality = preferredImageQuality;
-    }
-
-    public static boolean shouldLoadImages() {
-        return preferredImageQuality != PreferredImageQuality.NONE;
     }
 
 
@@ -225,43 +214,6 @@ public final class PicassoHelper {
                 requestCreator.placeholder(placeholderResId);
             }
             return requestCreator;
-        }
-    }
-
-    @Nullable
-    public static String choosePreferredImage(final List<Image> images) {
-        final Comparator<Image> comparator;
-        switch (preferredImageQuality) {
-            case NONE:
-                return null;
-            case HIGH:
-                comparator = Comparator.comparingInt(Image::getHeight).reversed();
-                break;
-            default:
-            case MEDIUM:
-                comparator = Comparator.comparingInt(image -> Math.abs(image.getHeight() - 450));
-                break;
-            case LOW:
-                comparator = Comparator.comparingInt(Image::getHeight);
-                break;
-        }
-
-        return images.stream()
-                .filter(image -> image.getEstimatedResolutionLevel() != ResolutionLevel.UNKNOWN)
-                .min(comparator)
-                .map(Image::getUrl)
-                .orElseGet(() -> images.stream()
-                        .findAny()
-                        .map(Image::getUrl)
-                        .orElse(null));
-    }
-
-    @NonNull
-    public static List<Image> urlToImageList(@Nullable final String url) {
-        if (url == null) {
-            return List.of();
-        } else {
-            return List.of(new Image(url, -1, -1, ResolutionLevel.UNKNOWN));
         }
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/util/image/PicassoHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/image/PicassoHelper.java
@@ -9,6 +9,7 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.graphics.BitmapCompat;
 
@@ -49,7 +50,7 @@ public final class PicassoHelper {
         picassoCache = new LruCache(10 * 1024 * 1024);
         picassoDownloaderClient = new OkHttpClient.Builder()
                 .cache(new okhttp3.Cache(new File(context.getExternalCacheDir(), "picasso"),
-                        50 * 1024 * 1024))
+                        50L * 1024L * 1024L))
                 // this should already be the default timeout in OkHttp3, but just to be sure...
                 .callTimeout(15, TimeUnit.SECONDS)
                 .build();
@@ -90,50 +91,50 @@ public final class PicassoHelper {
     }
 
 
-    public static RequestCreator loadAvatar(final List<Image> images) {
+    public static RequestCreator loadAvatar(@NonNull final List<Image> images) {
         return loadImageDefault(images, R.drawable.placeholder_person);
     }
 
-    public static RequestCreator loadAvatar(final String url) {
+    public static RequestCreator loadAvatar(@Nullable final String url) {
         return loadImageDefault(url, R.drawable.placeholder_person);
     }
 
-    public static RequestCreator loadThumbnail(final List<Image> images) {
+    public static RequestCreator loadThumbnail(@NonNull final List<Image> images) {
         return loadImageDefault(images, R.drawable.placeholder_thumbnail_video);
     }
 
-    public static RequestCreator loadThumbnail(final String url) {
+    public static RequestCreator loadThumbnail(@Nullable final String url) {
         return loadImageDefault(url, R.drawable.placeholder_thumbnail_video);
     }
 
-    public static RequestCreator loadDetailsThumbnail(final List<Image> images) {
+    public static RequestCreator loadDetailsThumbnail(@NonNull final List<Image> images) {
         return loadImageDefault(choosePreferredImage(images),
                 R.drawable.placeholder_thumbnail_video, false);
     }
 
-    public static RequestCreator loadBanner(final List<Image> images) {
+    public static RequestCreator loadBanner(@NonNull final List<Image> images) {
         return loadImageDefault(images, R.drawable.placeholder_channel_banner);
     }
 
-    public static RequestCreator loadPlaylistThumbnail(final List<Image> images) {
+    public static RequestCreator loadPlaylistThumbnail(@NonNull final List<Image> images) {
         return loadImageDefault(images, R.drawable.placeholder_thumbnail_playlist);
     }
 
-    public static RequestCreator loadPlaylistThumbnail(final String url) {
+    public static RequestCreator loadPlaylistThumbnail(@Nullable final String url) {
         return loadImageDefault(url, R.drawable.placeholder_thumbnail_playlist);
     }
 
-    public static RequestCreator loadSeekbarThumbnailPreview(final String url) {
+    public static RequestCreator loadSeekbarThumbnailPreview(@Nullable final String url) {
         return picassoInstance.load(url);
     }
 
-    public static RequestCreator loadNotificationIcon(final String url) {
+    public static RequestCreator loadNotificationIcon(@Nullable final String url) {
         return loadImageDefault(url, R.drawable.ic_newpipe_triangle_white);
     }
 
 
     public static RequestCreator loadScaledDownThumbnail(final Context context,
-                                                         final List<Image> images) {
+                                                         @NonNull final List<Image> images) {
         // scale down the notification thumbnail for performance
         return PicassoHelper.loadThumbnail(images)
                 .transform(new Transformation() {
@@ -182,18 +183,18 @@ public final class PicassoHelper {
     }
 
     @Nullable
-    public static Bitmap getImageFromCacheIfPresent(final String imageUrl) {
+    public static Bitmap getImageFromCacheIfPresent(@NonNull final String imageUrl) {
         // URLs in the internal cache finish with \n so we need to add \n to image URLs
         return picassoCache.get(imageUrl + "\n");
     }
 
 
-    private static RequestCreator loadImageDefault(final List<Image> images,
+    private static RequestCreator loadImageDefault(@NonNull final List<Image> images,
                                                    final int placeholderResId) {
         return loadImageDefault(choosePreferredImage(images), placeholderResId);
     }
 
-    private static RequestCreator loadImageDefault(final String url,
+    private static RequestCreator loadImageDefault(@Nullable final String url,
                                                    final int placeholderResId) {
         return loadImageDefault(url, placeholderResId, true);
     }

--- a/app/src/main/java/org/schabi/newpipe/util/image/PicassoHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/image/PicassoHelper.java
@@ -1,4 +1,4 @@
-package org.schabi.newpipe.util;
+package org.schabi.newpipe.util.image;
 
 import static org.schabi.newpipe.MainActivity.DEBUG;
 import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
@@ -46,8 +46,7 @@ public final class PicassoHelper {
     @SuppressLint("StaticFieldLeak")
     private static Picasso picassoInstance;
 
-    private static boolean shouldLoadImages;
-    private static ResolutionLevel preferredResolutionLevel = ResolutionLevel.HIGH;
+    private static PreferredImageQuality preferredImageQuality = PreferredImageQuality.MEDIUM;
 
     public static void init(final Context context) {
         picassoCache = new LruCache(10 * 1024 * 1024);
@@ -93,12 +92,12 @@ public final class PicassoHelper {
         picassoInstance.setIndicatorsEnabled(enabled); // useful for debugging
     }
 
-    public static void setShouldLoadImages(final boolean shouldLoadImages) {
-        PicassoHelper.shouldLoadImages = shouldLoadImages;
+    public static void setPreferredImageQuality(final PreferredImageQuality preferredImageQuality) {
+        PicassoHelper.preferredImageQuality = preferredImageQuality;
     }
 
-    public static boolean getShouldLoadImages() {
-        return shouldLoadImages;
+    public static boolean shouldLoadImages() {
+        return preferredImageQuality != PreferredImageQuality.NONE;
     }
 
 
@@ -231,17 +230,14 @@ public final class PicassoHelper {
 
     @Nullable
     public static String choosePreferredImage(final List<Image> images) {
-        if (!shouldLoadImages) {
-            return null;
-        }
-
         final Comparator<Image> comparator;
-        switch (preferredResolutionLevel) {
+        switch (preferredImageQuality) {
+            case NONE:
+                return null;
             case HIGH:
                 comparator = Comparator.comparingInt(Image::getHeight).reversed();
                 break;
             default:
-            case UNKNOWN:
             case MEDIUM:
                 comparator = Comparator.comparingInt(image -> Math.abs(image.getHeight() - 450));
                 break;

--- a/app/src/main/java/org/schabi/newpipe/util/image/PreferredImageQuality.java
+++ b/app/src/main/java/org/schabi/newpipe/util/image/PreferredImageQuality.java
@@ -1,0 +1,24 @@
+package org.schabi.newpipe.util.image;
+
+import android.content.Context;
+
+import org.schabi.newpipe.R;
+
+public enum PreferredImageQuality {
+    NONE,
+    LOW,
+    MEDIUM,
+    HIGH;
+
+    public static PreferredImageQuality fromPreferenceKey(final Context context, final String key) {
+        if (context.getString(R.string.image_quality_none_key).equals(key)) {
+            return NONE;
+        } else if (context.getString(R.string.image_quality_low_key).equals(key)) {
+            return LOW;
+        } else if (context.getString(R.string.image_quality_high_key).equals(key)) {
+            return HIGH;
+        } else {
+            return MEDIUM; // default to medium
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/util/image/PreferredImageQuality.java
+++ b/app/src/main/java/org/schabi/newpipe/util/image/PreferredImageQuality.java
@@ -3,6 +3,7 @@ package org.schabi.newpipe.util.image;
 import android.content.Context;
 
 import org.schabi.newpipe.R;
+import org.schabi.newpipe.extractor.Image;
 
 public enum PreferredImageQuality {
     NONE,
@@ -19,6 +20,20 @@ public enum PreferredImageQuality {
             return HIGH;
         } else {
             return MEDIUM; // default to medium
+        }
+    }
+
+    public Image.ResolutionLevel toResolutionLevel() {
+        switch (this) {
+            case LOW:
+                return Image.ResolutionLevel.LOW;
+            case MEDIUM:
+                return Image.ResolutionLevel.MEDIUM;
+            case HIGH:
+                return Image.ResolutionLevel.HIGH;
+            default:
+            case NONE:
+                return Image.ResolutionLevel.UNKNOWN;
         }
     }
 }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -243,7 +243,6 @@
     <string name="tab_bookmarks">الإشارات المرجعية</string>
     <string name="use_inexact_seek_title">استعمال التقديم السريع الغير دقيق</string>
     <string name="use_inexact_seek_summary">خاصية التقديم الغير دقيق تسمح للمشغل بالقفز خلال الفديو بشكل أسرع مع دقة قفز أقل. خاصية القفز ل5، 15 او 25 لا تعمل مع القفز الغير دقيق</string>
-    <string name="download_thumbnail_title">تحميل الصور المصغرة</string>
     <string name="thumbnail_cache_wipe_complete_notice">تم إفراغ مساحة ذاكرة التخزين المؤقتة الخاصة بالصور</string>
     <string name="file">الملف</string>
     <string name="invalid_directory">لا يوجد مثل هذا المجلد</string>
@@ -260,7 +259,6 @@
     <string name="export_ongoing">عملية التصدير جارية …</string>
     <string name="import_file_title">إستيراد ملف</string>
     <string name="import_soundcloud_instructions_hint">معرفك, soundcloud.com/هويتك</string>
-    <string name="download_thumbnail_summary">قم بإيقاف تشغيله لمنع تحميل الصور المصغرة وحفظ البيانات واستخدام الذاكرة. تمسح التغييرات كلاً من ذاكرة التخزين المؤقت للصورة الموجودة في الذاكرة والموجودة على القرص</string>
     <string name="metadata_cache_wipe_title">امسح البيانات الوصفيّة المخزّنة مؤقّتًا</string>
     <string name="metadata_cache_wipe_summary">إزالة جميع بيانات صفحات الويب المخزنة مؤقّتًا</string>
     <string name="metadata_cache_wipe_complete_notice">تم محو ذاكرة التخزين المؤقتّة للبيانات الوصفيّة</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -642,7 +642,6 @@
     <string name="metadata_privacy_private">خاص</string>
     <string name="metadata_privacy_unlisted">غير مدرج</string>
     <string name="metadata_privacy_public">عامة</string>
-    <string name="metadata_thumbnail_url">رابط الصورة المصغرة</string>
     <string name="metadata_host">المضيف</string>
     <string name="metadata_support">الدعم</string>
     <string name="metadata_language">اللغة</string>

--- a/app/src/main/res/values-as/strings.xml
+++ b/app/src/main/res/values-as/strings.xml
@@ -62,7 +62,6 @@
     <string name="progressive_load_interval_summary">লোড ব্যৱধানৰ আকাৰ সলনি কৰক (বৰ্তমানে %s) । এটা কম মানে প্ৰাৰম্ভিক ভিডিঅ\' লোডিং দ্ৰুত কৰিব পাৰে। পৰিৱৰ্তনৰ বাবে এটা খেলুৱৈ পুনৰাৰম্ভৰ প্ৰয়োজন</string>
     <string name="notification_colorize_summary">থাম্বনেইলত থকা মূল ৰং অনুসৰি এণ্ড্ৰইডক জাননীৰ ৰং কাষ্টমাইজ কৰিবলৈ কওক (মন কৰিব যে এইটো সকলো ডিভাইচতে উপলব্ধ নহয়)</string>
     <string name="clear_queue_confirmation_description">সক্ৰিয় প্লেয়াৰৰ queue সলনি কৰা হ’ব</string>
-    <string name="download_thumbnail_title">থাম্বনেইল লোড কৰক</string>
     <string name="show_comments_title">মন্তব্য দেখুৱাওক</string>
     <string name="show_description_title">বিৱৰণ দেখুৱাওক</string>
     <string name="show_meta_info_title">মেটা তথ্য দেখুৱাওক</string>
@@ -96,6 +95,5 @@
     <string name="show_description_summary">ভিডিঅ\'ৰ বিৱৰণ আৰু অতিৰিক্ত তথ্য লুকুৱাবলৈ বন্ধ কৰক</string>
     <string name="show_comments_summary">মন্তব্য লুকুৱাবলৈ বন্ধ কৰক</string>
     <string name="show_next_and_similar_title">\'পৰৱৰ্তী\' আৰু \'সাদৃশ্য থকা\' ভিডিঅ\' দেখুৱাওক</string>
-    <string name="download_thumbnail_summary">থাম্বনেইলসমূহ লোড কৰা, তথ্য আৰু মেমৰি ব্যৱহাৰ সংৰক্ষণ কৰা ৰোধ কৰিবলে বন্ধ কৰক। পৰিবৰ্তনসমূহে ইন-মেমৰি আৰু অন-ডিস্ক কেশ্ব দুয়োটা পৰিষ্কাৰ কৰে</string>
     <string name="show_meta_info_summary">ষ্ট্ৰিমৰ সৃষ্টিকৰ্তা, ষ্ট্ৰিমৰ বিষয়বস্তু বা এটা সন্ধান অনুৰোধৰ বিষয়ে অতিৰিক্ত তথ্যৰ সৈতে মেটা তথ্যৰ বাকচসমূহ লুকুৱাবলৈ বন্ধ কৰক</string>
 </resources>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -136,7 +136,6 @@
 \nOnu görmək istəyirsinizsə, tənzimləmələrdə \"%1$s\" seçimini aktivləşdirin.</string>
     <string name="youtube_restricted_mode_enabled_summary">YouTube potensial yetkin məzmunu gizlədən \"Məhdud Rejim\" təmin edir</string>
     <string name="peertube_instance_url_title">\"PeerTube\" nümunələri</string>
-    <string name="download_thumbnail_title">Miniatürləri yüklə</string>
     <string name="notification_actions_at_most_three">Yığcam bildirişdə göstərmək üçün ən çoxu üç fəaliyyət seçə bilərsiniz!</string>
     <string name="feed_update_threshold_option_always_update">Həmişə yenilə</string>
     <string name="settings_category_feed_title">Axın</string>
@@ -287,7 +286,6 @@
     <string name="audio_streams_empty">Səs yayımı tapılmadı</string>
     <string name="permission_display_over_apps">Digər tətbiqlərin üzərində göstərməyə icazə ver</string>
     <string name="restore_defaults_confirmation">İlkin tənzimləmələri qaytarmaq istəyirsiniz\?</string>
-    <string name="download_thumbnail_summary">Miniatürləri yükləməyi, məlumata qənaət və yaddaş istifadəsin azaltmaq üçün söndür. Dəyişikliklər həm yaddaşdaxilində, həm də diskdə təsvir keşini təmizləyir</string>
     <string name="enqueue_next_stream">Növbətini növbələ</string>
     <string name="retry">Təkrar Cəhd Et</string>
     <string name="settings_category_player_notification_summary">Cari oynatma yayımı bildirişini konfiqurasiya et</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -629,7 +629,6 @@
     <string name="metadata_host">Sahib</string>
     <string name="metadata_privacy_unlisted">Siyahıdan kənar</string>
     <string name="metadata_privacy_private">Şəxsi</string>
-    <string name="metadata_thumbnail_url">Miniatür URL</string>
     <string name="metadata_age_limit">Yaş həddi</string>
     <string name="metadata_language">Dil</string>
     <string name="metadata_privacy_public">İctimai</string>

--- a/app/src/main/res/values-b+ast/strings.xml
+++ b/app/src/main/res/values-b+ast/strings.xml
@@ -206,8 +206,6 @@
 \n3. Anicia sesión cuando se te pida
 \n4. Copia la URL del perfil al que te redirixeron.</string>
     <string name="import_soundcloud_instructions_hint">soundcloud.com/LaToID</string>
-    <string name="download_thumbnail_title">Cargar les miniatures</string>
-    <string name="download_thumbnail_summary">Desactiva esta opción pa eviar la carga de miniatures y aforrar datos y usu de memoria. Los cambeos llimpien la caché d\'imáxenes temporal y permanente.</string>
     <string name="minimize_on_exit_title">Minimizar al cambiar d\'aplicación</string>
     <string name="minimize_on_exit_background_description">Minimizar al reproductor en segundu planu</string>
     <string name="minimize_on_exit_popup_description">Minimizar al reproductor en ventanu</string>

--- a/app/src/main/res/values-b+uz+Latn/strings.xml
+++ b/app/src/main/res/values-b+uz+Latn/strings.xml
@@ -24,10 +24,8 @@
     <string name="metadata_cache_wipe_summary">Barcha keshlangan veb-sahifa ma\'lumotlarini olib tashlash</string>
     <string name="metadata_cache_wipe_title">Keshlangan metadatalarni o\'chirish</string>
     <string name="thumbnail_cache_wipe_complete_notice">Rasm keshi o\'chirildi</string>
-    <string name="download_thumbnail_summary">Eskizlarni yuklash, ma\'lumotlarni tejash va xotiradan foydalanishni oldini olish uchun o\'chirib qo\'ying. O\'zgarishlar xotiradagi va diskdagi rasm keshini tozalaydi.</string>
     <string name="show_comments_summary">sharhlarni yashirishni o\'chirish</string>
     <string name="show_comments_title">Izohlarni ko\'rsatish</string>
-    <string name="download_thumbnail_title">Eskizlarni yuklang</string>
     <string name="clear_queue_confirmation_description">Aktiv ijro etish navbati almashtiriladi</string>
     <string name="clear_queue_confirmation_summary">Bir ijro etishdan boshqasiga o\'tish sizning navbatingizni almashtirishi mumkin</string>
     <string name="clear_queue_confirmation_title">Navbatni tozalashdan oldin tasdiqlashni so\'rash</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -698,7 +698,6 @@
     <string name="metadata_tags">Тэгі</string>
     <string name="metadata_licence">Ліцэнзія</string>
     <string name="metadata_host">Хост</string>
-    <string name="metadata_thumbnail_url">URL мініяцюры</string>
     <string name="metadata_privacy_unlisted">Не ў спісе</string>
     <string name="metadata_privacy_private">Прыватная</string>
     <string name="enumeration_comma">,</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -55,8 +55,6 @@
     <string name="popup_remember_size_pos_summary">Запамінаць памер і становішча ўсплываючага акна</string>
     <string name="use_inexact_seek_title">Хуткі пошук пазіцыі</string>
     <string name="use_inexact_seek_summary">Недакладны пошук дазваляе плэеру знаходзіць пазіцыі хутчэй са зніжанай дакладнасцю. Пошук цягам 5, 15 ці 25 секунд пры гэтым немажлівы</string>
-    <string name="download_thumbnail_title">Загружаць мініяцюры</string>
-    <string name="download_thumbnail_summary">Адключыце, каб не загружаць мініяцюры і зэканоміць трафік і памяць. Змена налады ачысьціць кэш малюнкаў</string>
     <string name="thumbnail_cache_wipe_complete_notice">Кэш малюнкаў ачышчаны</string>
     <string name="metadata_cache_wipe_title">Ачысціць кэш метададзеных</string>
     <string name="metadata_cache_wipe_summary">Выдаліць усе загружаныя дадзеныя вэб-старонак</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -422,7 +422,6 @@
     <string name="metadata_support">Поддръжка</string>
     <string name="metadata_host">Сървър</string>
     <string name="metadata_privacy_public">Публичен</string>
-    <string name="metadata_thumbnail_url">Миниатюра линк</string>
     <string name="app_language_title">Език на интерфейса</string>
     <string name="mute">Спри звука</string>
     <string name="post_processing">пост-обработката</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -151,7 +151,6 @@
     <string name="controls_add_to_playlist_title">Добавяне към</string>
     <string name="use_inexact_seek_title">Използвай бързо, но неточно превъртане</string>
     <string name="use_inexact_seek_summary">По-бързо превъртане с по-ниска прецизност. Превъртане с по 5, 15 или 25 секунди няма да работи с тази опция</string>
-    <string name="download_thumbnail_title">Зареждай миниатюри</string>
     <string name="thumbnail_cache_wipe_complete_notice">Кеш-паметта с изображения е изтрита</string>
     <string name="metadata_cache_wipe_title">Изтрий кешираните метаданни</string>
     <string name="metadata_cache_wipe_summary">Премахни всички метаданни за уебстраници от кеш-паметта</string>
@@ -205,7 +204,6 @@
     <string name="read_privacy_policy">Прочетете нашата политика за поверителност</string>
     <string name="app_license_title">Лицензът на NewPipe</string>
     <string name="no_player_found_toast">Липсва стрийм плейър (можете да изтеглите VLC, за да пуснете стрийма).</string>
-    <string name="download_thumbnail_summary">Изключете, за да спрете зареждането на всички миниатюри, спестявайки трафик и памет. При промяна на тази настройка, текущата кеш-памет на изображенията ще бъде изтрита</string>
     <string name="show_hold_to_append_summary">Показвай подсказка при избор на фоновия режим или режим в прозорец от екрана за „Детайли“ към видео</string>
     <string name="clear_views_history_summary">Изтрива историята на възпроизвежданите стриймове и позицията на възпроизвеждането</string>
     <string name="video_streams_empty">Не са намерени видео стриймове</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -140,8 +140,6 @@
     <string name="seek_duration_title">দ্রুত-ফরওয়ার্ড/-পুনরায় সন্ধান সময়কাল</string>
     <string name="show_comments_summary">মন্তব্যসমূহ লুকাতে বন্ধ করুন</string>
     <string name="show_comments_title">মন্তব্যসমূহ দেখাও</string>
-    <string name="download_thumbnail_title">থাম্বনেইল লোড করো</string>
-    <string name="download_thumbnail_summary">থাম্বনেইল প্রদর্শন বন্ধ করার মাধ্যমে, ডাটা এবং মেমোরি সংরক্ষণ করুন। অপশনটি‌ পরিবর্তনে ইন-মেমোরি এবং অন-ডিস্ক ইমেজ ক্যাশ উভয়ই মুছে যাবে।</string>
     <string name="thumbnail_cache_wipe_complete_notice">ছবির ক্যাশ মোছা হয়েছে</string>
     <string name="metadata_cache_wipe_summary">সব ক্যাশড ওয়েবপেজ ডেটা মুছে ফেলো</string>
     <string name="metadata_cache_wipe_title">ক্যাশ করা মেটাডেটা মোছ</string>

--- a/app/src/main/res/values-bn-rIN/strings.xml
+++ b/app/src/main/res/values-bn-rIN/strings.xml
@@ -79,10 +79,8 @@
     <string name="metadata_cache_wipe_summary">সব ক্যাশড ওয়েবপেজ ডেটা মুছে ফেলো</string>
     <string name="metadata_cache_wipe_title">ক্যাশ করা মেটাডেটা মুছো</string>
     <string name="thumbnail_cache_wipe_complete_notice">ছবির ক্যাশ মুছে ফেলা হয়েছে</string>
-    <string name="download_thumbnail_summary">থাম্বনেইল প্রদর্শন বন্ধ করার মাধ্যমে, ডাটা এবং মেমোরি সংরক্ষণ করুন। অপশনটি‌ পরিবর্তনে ইন-মেমোরি এবং অন-ডিস্ক ইমেজ ক্যাশ উভয়ই মুছে যাবে</string>
     <string name="show_comments_summary">মতামত প্রদর্শন বন্ধ করতে অপশনটি বন্ধ করুন</string>
     <string name="show_comments_title">মতামত প্রদর্শন করুন</string>
-    <string name="download_thumbnail_title">থাম্বনেইল লোড করুন</string>
     <string name="seek_duration_title">দ্রুত-ফরওয়ার্ড/-পুনরায় সন্ধান সময়কাল</string>
     <string name="use_inexact_seek_summary">অনির্দিষ্ট সন্ধান প্লেয়ারকে আরো দ্রুত গতিতে সন্ধান করার সুবিধা দেয়, কিন্তু এটি সম্পূর্ণ নির্ভুল নাও হতে পারে ৷ ৫, ১৫ ও ২৫ সেকেন্ডের জন্য এটা কাজ করবে না ৷</string>
     <string name="use_inexact_seek_title">দ্রুত টানা ব্যাবহার করুন</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -548,7 +548,6 @@
     <string name="feed_load_error">প্রক্রিয়াকরণ ফিডে ত্রুটি</string>
     <string name="open_website_license">ওয়েবসাইট খুলুন</string>
     <string name="account_terminated">অ্যাকাউন্ট ধ্বংসকৃত</string>
-    <string name="metadata_thumbnail_url">প্রতিচ্ছবি সংযোগ</string>
     <string name="metadata_age_limit">বয়সসীমা</string>
     <string name="metadata_privacy_internal">অভ্যন্তরীণ</string>
     <string name="metadata_privacy_private">ব্যক্তিগত</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -225,10 +225,8 @@
     <string name="metadata_cache_wipe_summary">সব ক্যাশড ওয়েবপেজ ডেটা মুছে ফেলো</string>
     <string name="metadata_cache_wipe_title">ক্যাশ করা মেটাডেটা মুছো</string>
     <string name="thumbnail_cache_wipe_complete_notice">ছবির ক্যাশ মুছে ফেলা হয়েছে</string>
-    <string name="download_thumbnail_summary">থাম্বনেইল প্রদর্শন বন্ধ করার মাধ্যমে, ডাটা এবং মেমোরি সংরক্ষণ করুন। অপশনটি‌ পরিবর্তনে ইন-মেমোরি এবং অন-ডিস্ক ইমেজ ক্যাশ উভয়ই মুছে যাবে</string>
     <string name="show_comments_summary">মতামত প্রদর্শন বন্ধ করতে অপশনটি বন্ধ করুন</string>
     <string name="show_comments_title">মতামত প্রদর্শন করুন</string>
-    <string name="download_thumbnail_title">থাম্বনেইল লোড করুন</string>
     <string name="seek_duration_title">দ্রুত-ফরওয়ার্ড/-পুনরায় সন্ধান সময়কাল</string>
     <string name="use_inexact_seek_summary">অনির্দিষ্ট সন্ধান, চালককে আরো দ্রুত গতিতে সন্ধান করার সুবিধা দেয়, কিন্তু এটি সম্পূর্ণ নির্ভুল নাও হতে পারে ৷ ৫, ১৫ ও ২৫ সেকেন্ডের জন্য এটা কাজ করবে না।</string>
     <string name="use_inexact_seek_title">দ্রুত টানা ব্যাবহার করুন</string>

--- a/app/src/main/res/values-bs/strings.xml
+++ b/app/src/main/res/values-bs/strings.xml
@@ -73,7 +73,6 @@
     <string name="clear_queue_confirmation_summary">Prebacivanje sa jednog pokretača na drugi bi van moglo zamijeniti pokretni red</string>
     <string name="show_comments_summary">Isključite da sakrijete komentare</string>
     <string name="clear_queue_confirmation_title">Pitajte za potvrdu prije isčišćavanja reda</string>
-    <string name="download_thumbnail_summary">Isključite kako bi ste spriječili učitavanje sličica, sto če vam spasiti korištenje podataka i memorije. Promjene čiste slike oboje u memoriji i predmešiju na disku</string>
     <string name="show_comments_title">Prikažite komentare</string>
     <string name="show_next_and_similar_title">Pokažite \'Sljedeće\' i \'Slične\' video zapise</string>
     <string name="show_description_title">Prikažite opis</string>
@@ -115,5 +114,4 @@
     <string name="play_with_kodi_title">Pokrenite s KODI-jem</string>
     <string name="seek_duration_title">Vrijeme premotavanja naprijed/nazad</string>
     <string name="clear_queue_confirmation_description">Aktivni pokretni red će biti zamijenjen</string>
-    <string name="download_thumbnail_title">Učitajte sličice</string>
 </resources>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -600,7 +600,6 @@
     <string name="metadata_privacy_private">Privat</string>
     <string name="metadata_privacy_unlisted">Descatalogat</string>
     <string name="metadata_privacy_public">Públic</string>
-    <string name="metadata_thumbnail_url">URL de la miniatura</string>
     <string name="metadata_host">Amfitrió</string>
     <string name="metadata_support">Suport</string>
     <string name="metadata_language">Idioma</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -121,7 +121,6 @@
     <string name="popup_remember_size_pos_summary">Recorda la darrera mida i posició del reproductor emergent</string>
     <string name="use_inexact_seek_title">Cerca ràpida poc precisa</string>
     <string name="use_inexact_seek_summary">La cerca poc precisa permet que el reproductor cerqui una posició més ràpidament amb menys precisió. Cerques de 5, 15 o 25 segons no funcionaran</string>
-    <string name="download_thumbnail_title">Carrega les miniatures</string>
     <string name="thumbnail_cache_wipe_complete_notice">S\'ha eliminat la memòria cau d\'imatges</string>
     <string name="metadata_cache_wipe_title">Elimina les metadades de la memòria cau</string>
     <string name="metadata_cache_wipe_complete_notice">S\'ha esborrat la memòria cau de metadades</string>
@@ -217,7 +216,6 @@
     <string name="main_bg_subtitle">Toca \"Cerca\" per començar.</string>
     <string name="use_external_video_player_summary">Elimina l\'àudio en algunes resolucions</string>
     <string name="use_external_audio_player_title">Reproductor d\'àudio extern</string>
-    <string name="download_thumbnail_summary">Desactiveu-ho per no guardar miniatures i estalviar dades i memòria. Canviant aquesta opció, s\'eliminarà la memòria cau d\'imatges tant de la memòria com de l\'emmagatzematge</string>
     <string name="enable_search_history_summary">Emmagatzema les cerques localment</string>
     <string name="enable_watch_history_summary">Crea un historial de vídeos visualitzats</string>
     <string name="resume_on_audio_focus_gain_title">Reprèn la reproducció</string>

--- a/app/src/main/res/values-ckb/strings.xml
+++ b/app/src/main/res/values-ckb/strings.xml
@@ -588,7 +588,6 @@
     <string name="metadata_privacy_private">تایبەتی</string>
     <string name="metadata_privacy_unlisted">خشتەنەکراو</string>
     <string name="metadata_privacy_public">گشتی</string>
-    <string name="metadata_thumbnail_url">بەستەری وێنۆچکە</string>
     <string name="metadata_host">هۆست</string>
     <string name="metadata_support">پشتگیری</string>
     <string name="metadata_language">زمان</string>

--- a/app/src/main/res/values-ckb/strings.xml
+++ b/app/src/main/res/values-ckb/strings.xml
@@ -16,7 +16,6 @@
     <string name="privacy_policy_encouragement">پڕۆژەی نیوپایپ زانیارییە تایبەتییەکانت بە وردی دەپارێزێت. هەروەها به‌رنامه‌كه‌ هیچ زانایارییەکت بەبێ ئاگاداری تۆ بەکارنابات.
 \n‫سیاسەتی تایبەتی نیوپایپ بە وردی ڕوونکردنەوەت دەداتێ لەسەر ئەو زانیاریانەی وەریاندەگرێت و بەکاریاندەبات.</string>
     <string name="download_to_sdcard_error_message">ناتوانرێت لە بیرگەی دەرەکیدا داببەزێنرێت . شوێنی فۆڵده‌ری دابه‌زاندنەکان ڕێکبخرێتەوە؟</string>
-    <string name="download_thumbnail_summary">ناکارای بكه‌ بۆ وەستاندنی باركردنی وێنۆچكه‌كان، داتا دەپارێزێت و کەمتر بیرگە بەکاردەبات, گۆڕینی ئه‌مه‌ ده‌بێته‌ هۆی سڕینه‌وه‌یان له‌سه‌ر بیرگه‌ی مۆبایله‌كه‌ت</string>
     <string name="did_you_mean">ئایا مەبەستت ئه‌مه‌یه‌ \"%1$s\"؟</string>
     <string name="feed_update_threshold_title">ماوەی نوێكردنه‌وه‌ی فیید</string>
     <string name="grid">هێڵەکی</string>
@@ -111,7 +110,6 @@
     <string name="localization_changes_requires_app_restart">زمان دەگۆڕدرێت لەدوای داگیرساندنەوەی به‌رنامه‌كه‌</string>
     <string name="remove_watched">لادانی سەیرکراو</string>
     <string name="enable_playback_state_lists_summary">پیشاندانی نیشانەکەری شوێنی کارپێکەر لە خشتەکاندا</string>
-    <string name="download_thumbnail_title">باركردنی وێنۆچكه‌كان</string>
     <string name="enable_playback_state_lists_title">شوێنەکان لە خشتەکاندا</string>
     <string name="subscribed_button_title">به‌ژداریت</string>
     <string name="caption_setting_description">بەهۆی گۆڕانکاری لە شێوەی ژێرنووسکردنەکە. پێویستە به‌رنامه‌كه‌ دابگیرسێنیته‌وه‌</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -613,7 +613,6 @@
     <string name="metadata_privacy_private">Soukromé</string>
     <string name="metadata_privacy_unlisted">Neuvedeno v seznamu</string>
     <string name="metadata_privacy_public">Veřejné</string>
-    <string name="metadata_thumbnail_url">URL miniatury</string>
     <string name="metadata_host">Server</string>
     <string name="metadata_support">Podpora</string>
     <string name="metadata_language">Jazyk</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -251,8 +251,6 @@
     <string name="enable_disposed_exceptions_summary">Vynutit hlášení nedoručitelných výjimek Rx mimo životnost fragmentu nebo aktivity po odstranění</string>
     <string name="use_inexact_seek_title">Použít rychlé nepřesné hledání</string>
     <string name="use_inexact_seek_summary">Nepřesné hledání umožní přehrávači posouvat se rychleji, ale se sníženou přesností. Posouvání po 5, 15 nebo 25 vteřinách s tímto nefunguje</string>
-    <string name="download_thumbnail_title">Načítat náhledy</string>
-    <string name="download_thumbnail_summary">Vypnutím zabráníte načítání miniatur, ukládání dat a spotřebě paměti. Změny vymažou mezipaměť obrázků v paměti i na disku</string>
     <string name="thumbnail_cache_wipe_complete_notice">Mezipaměť obrázků vymazána</string>
     <string name="metadata_cache_wipe_title">Vymazat metadata v mezipaměti</string>
     <string name="metadata_cache_wipe_summary">Odstranit všechna data webových stránek v mezipaměti</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -669,7 +669,6 @@
 \nAktiver systemet mappevælger (SAF), hvis du vil downloade til et eksternt SD-kort</string>
     <string name="show_original_time_ago_summary">Originaltekster fra tjenester vil være synlige i stream-emner</string>
     <string name="no_video_streams_available_for_external_players">Ingen videostreams er tilgængelige for eksterne afspillere</string>
-    <string name="metadata_thumbnail_url">URL til miniaturebillede</string>
     <string name="off">Fra</string>
     <string name="tablet_mode_title">Tablet-tilstand</string>
     <string name="youtube_music_premium_content">Denne video er kun tilgængelig for YouTube Music Premium-medlemmer, så den kan ikke streames eller downloades af NewPipe.</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -57,8 +57,6 @@
     <string name="popup_remember_size_pos_summary">Husk sidste størrelse og placering af pop op-afspiller</string>
     <string name="use_inexact_seek_title">Brug hurtig og upræcis søgning</string>
     <string name="use_inexact_seek_summary">Upræcis søgning lader afspilleren finde placeringer hurtigere, men mindre præcist. Søgninger på 5, 15 eller 25 sekunder fungerer ikke med denne indstilling slået til</string>
-    <string name="download_thumbnail_title">Indlæs miniaturebilleder</string>
-    <string name="download_thumbnail_summary">Slå fra for at undgå indlæsning af billeder, hvorved der spares data og hukommelse. Ændringer sletter billedcachen i både ram og lager</string>
     <string name="thumbnail_cache_wipe_complete_notice">Billedcache slettet</string>
     <string name="metadata_cache_wipe_title">Slet metadata-cachen</string>
     <string name="metadata_cache_wipe_summary">Slet alle websidedata fra cachen</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -615,7 +615,6 @@
     <string name="metadata_tags">Schlagwörter</string>
     <string name="metadata_category">Kategorie</string>
     <string name="metadata_privacy_unlisted">Nicht gelistet</string>
-    <string name="metadata_thumbnail_url">Vorschaubild-URL</string>
     <string name="metadata_host">Server</string>
     <string name="metadata_support">Unterstützung</string>
     <string name="metadata_subscribers">Abonnenten</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -253,7 +253,6 @@
     <string name="import_network_expensive_warning">Beachte, dass diese Aktion das Netzwerk stark belasten kann. 
 \n 
 \nMöchtest du fortfahren\?</string>
-    <string name="download_thumbnail_title">Vorschaubilder laden</string>
     <string name="thumbnail_cache_wipe_complete_notice">Bilder-Cache gelöscht</string>
     <string name="metadata_cache_wipe_title">Zwischengespeicherte (Metadaten) löschen</string>
     <string name="metadata_cache_wipe_summary">Alle zwischengespeicherten Website-Daten entfernen</string>
@@ -270,7 +269,6 @@
     <string name="playback_tempo">Geschwindigkeit</string>
     <string name="playback_pitch">Tonhöhe</string>
     <string name="unhook_checkbox">Entkoppeln (kann zu Verzerrungen führen)</string>
-    <string name="download_thumbnail_summary">Ausschalten, um das Laden von Vorschaubildern zu verhindern, was Daten- und Speicherverbrauch spart. Änderungen löschen den Bildzwischenspeicher sowohl im Arbeitsspeicher als auch auf dem internen Speicher</string>
     <string name="auto_queue_title">Nächsten Stream automatisch einreihen</string>
     <string name="auto_queue_summary">Wiedergabe durch Anhängen eines verwandten Streams an die Warteschlange (ohne Wiederholungsschleife) fortsetzen</string>
     <string name="bookmark_playlist">Wiedergabeliste mit Lesezeichen versehen</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -90,8 +90,6 @@
     <string name="popup_remember_size_pos_summary">Ενθύμηση του τελευταίου μεγέθους και θέσης του παραθύρου</string>
     <string name="use_inexact_seek_title">Χρήση γρήγορης ανακριβούς αναζήτησης</string>
     <string name="use_inexact_seek_summary">Η μην ακριβής αναζήτηση επιτρέπει στην εφαρμογή να αναζητεί θέσεις στο βίντεο γρηγορότερα με μειωμένη ακρίβεια. Δε λειτουργεί για διαστήματα των 5, 15 ή 25 δευτερολέπτων</string>
-    <string name="download_thumbnail_title">Φόρτωση μικρογραφιών</string>
-    <string name="download_thumbnail_summary">Με την απενεργοποίηση δε φορτώνονται οι μικρογραφίες, εξοικονομώντας δεδομένα και μνήμη. Οι αλλαγές σβήνουν τις προσωρινά αποθηκευμένες εικόνες στη μνήμη και στον δίσκο</string>
     <string name="thumbnail_cache_wipe_complete_notice">Εκκαθαρίστηκε η προσωρινή μνήμη εικόνων</string>
     <string name="metadata_cache_wipe_title">Εκκαθάριση προσωρινά αποθηκευμένων μεταδεδομένων</string>
     <string name="metadata_cache_wipe_summary">Αφαίρεση όλων των προσωρινά αποθηκευμένων δεδομένων ιστοσελίδων</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -602,7 +602,6 @@
     <string name="metadata_privacy_private">Ιδιωτικό</string>
     <string name="metadata_privacy_unlisted">Εκτός λίστας</string>
     <string name="metadata_privacy_public">Δημόσιο</string>
-    <string name="metadata_thumbnail_url">URL εικονιδίου</string>
     <string name="metadata_support">Υποστήριξη</string>
     <string name="metadata_language">Γλώσσα</string>
     <string name="metadata_age_limit">Όριο ηλικίας</string>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -76,7 +76,6 @@
     <string name="settings_category_player_behavior_title">Behaviour</string>
     <string name="peertube_instance_url_summary">Select your favourite PeerTube instances</string>
     <string name="resume_on_audio_focus_gain_summary">Continue playing after interruptions (e.g. phone calls)</string>
-    <string name="download_thumbnail_summary">Turn off to prevent loading thumbnails, saving data and memory usage. Changes clear both in-memory and on-disc image cache.</string>
     <string name="upload_date_text">Published on %1$s</string>
     <string name="error_report_button_text">Report this error via e-mail</string>
     <string name="night_theme_summary">Select your favorite night theme – %s</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -80,7 +80,6 @@
     <string name="popup_remember_size_pos_summary">Memori lastan grandon kaj pozicion de ŝprucfenestro</string>
     <string name="use_inexact_seek_title">Uzi rapidan malekzaktan serĉon</string>
     <string name="use_inexact_seek_summary">Malekzakta serĉo permesas ke, la ludilo serĉi poziciojn pli rapide sed kun malpli ekzakto. Serĉi por 5, 15 aŭ 25 sekundoj ne funckias kun ĉi tio opcio</string>
-    <string name="download_thumbnail_title">Ŝarĝi bildetojn</string>
     <string name="could_not_setup_download_menu">Ne povis konstrui la dosierujon de elŝuto</string>
     <string name="show_age_restricted_content_title">Enhavo limigita al aĝo</string>
     <string name="duration_live">Nuna</string>
@@ -181,7 +180,6 @@
 \n2. Iru tien: %1$s
 \n3. Ensalutu kiam oni petas vin 
 \n4. Kopiu la ligilon de profilo ke oni kondikis vin.</string>
-    <string name="download_thumbnail_summary">Malŝaltu por malebligi ŝarĝajn bildetojn por konservi datumuzadon kaj memoruzadon. Ŝanĝoj vakigi ambaŭ en memoran kaj en diskan bildkaŝmemoron</string>
     <string name="thumbnail_cache_wipe_complete_notice">Bildokaŝmemoro vakigis</string>
     <string name="metadata_cache_wipe_title">Vakigi kaŝmemorigitajn metadatumojn</string>
     <string name="metadata_cache_wipe_summary">Vakigi tutajn kaŝmemorigitajn retpaĝajn datumojn</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -614,7 +614,6 @@
     <string name="metadata_privacy_private">Privado</string>
     <string name="metadata_privacy_unlisted">No listado</string>
     <string name="metadata_privacy_public">Público</string>
-    <string name="metadata_thumbnail_url">URL de la miniatura</string>
     <string name="metadata_support">Soporte</string>
     <string name="metadata_language">Lenguaje</string>
     <string name="metadata_age_limit">Límite de edad</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -288,8 +288,6 @@
     <string name="import_network_expensive_warning">Esta operación puede causar un uso intensivo de la red.
 \n
 \n¿Quieres continuar\?</string>
-    <string name="download_thumbnail_title">Cargar miniaturas</string>
-    <string name="download_thumbnail_summary">Desactivar para evitar la carga de miniaturas y ahorrar datos y memoria. Se vaciará la caché de imágenes en la memoria volátil y en el disco</string>
     <string name="thumbnail_cache_wipe_complete_notice">Se vació la caché de imágenes</string>
     <string name="metadata_cache_wipe_title">Vaciar metadatos en memoria caché</string>
     <string name="metadata_cache_wipe_summary">Quitar todos los datos guardados de páginas web</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -584,7 +584,6 @@
     <string name="metadata_privacy_internal">Sisemine</string>
     <string name="metadata_privacy_private">Privaatne</string>
     <string name="metadata_privacy_public">Avalik</string>
-    <string name="metadata_thumbnail_url">Pisipildi URL</string>
     <string name="metadata_support">Kasutajatugi</string>
     <string name="metadata_language">Keel</string>
     <string name="metadata_age_limit">Vanusepiir</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -55,8 +55,6 @@
     <string name="popup_remember_size_pos_summary">Pea hüpikakna viimane suurus ja asukoht meeles</string>
     <string name="use_inexact_seek_title">Kasuta ebatäpset kerimist</string>
     <string name="use_inexact_seek_summary">Ebatäpne kerimine lubab meediamängijal otsida asukohta kiiremini täpsuse arvel. Sellega ei tööta 5, 15 või 25 sekundi kaupa kerimine</string>
-    <string name="download_thumbnail_title">Laadi pisipildid</string>
-    <string name="download_thumbnail_summary">Lülita välja, et keelata pisipiltide laadimist, andmete salvestamist ja mälukasutust. Muutmine puhastab vahemälu nii kettal kui ka mälus</string>
     <string name="thumbnail_cache_wipe_complete_notice">Pildid kustutati vahemälust</string>
     <string name="metadata_cache_wipe_title">Kustuta metaandmed vahemälust</string>
     <string name="metadata_cache_wipe_summary">Kustuta veebilehtede andmed vahemälust</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -624,7 +624,6 @@
     <string name="account_terminated">Kontua ezabatu da</string>
     <string name="feed_load_error_fast_unknown">Jario azkarrak ez du honi buruz informazio gehiagorik ematen.</string>
     <string name="metadata_age_limit">Adin muga</string>
-    <string name="metadata_thumbnail_url">Miniaturaren URL-a</string>
     <string name="metadata_privacy_internal">Barnekoa</string>
     <string name="metadata_privacy_unlisted">Zerrendatu gabea</string>
     <string name="metadata_host">Ostalaria</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -211,7 +211,6 @@
     <string name="tab_bookmarks">Gogoko erreprodukzio-zerrendak</string>
     <string name="controls_add_to_playlist_title">Gehitu hona</string>
     <string name="use_inexact_seek_title">Erabili bilaketa azkar ez zehatza</string>
-    <string name="download_thumbnail_title">Kargatu iruditxoak</string>
     <string name="thumbnail_cache_wipe_complete_notice">Irudien cachea ezabatuta</string>
     <string name="metadata_cache_wipe_title">Ezabatu cacheko metadatuak</string>
     <string name="metadata_cache_wipe_summary">Kendu cachetik webguneen datu guztiak</string>
@@ -307,7 +306,6 @@
     <string name="unhook_checkbox">Desaktibatu (distortsioa sor lezake)</string>
     <string name="import_settings">Ezarpenak ere inportatu nahi dituzu?</string>
     <string name="use_inexact_seek_summary">Bilaketa ez zehatzak posizioak azkarrago baina prezisio gutxiagoz bilatzea ahalbidetzen du. 5, 15 edo 25 segundo bilatzea ez du honekin funtzionatzen</string>
-    <string name="download_thumbnail_summary">Desgaitu koadro txikiak ez kargatzeko, datuak eta memoria aurreztuz. Aldaketak memoria eta diskoko irudien cacheak garbituko ditu</string>
     <string name="app_license">NewPipe Software Librea eta Copyleft da: Erabili, ikertu, partekatu eta hobetu dezakezu. Zehazki, elkarbanatzea eta aldatzea Free Software Foundation-ek argitaratutako GNU General Public License-ren 3. bertsioa edo berriagoren baten terminoen arabera egiteko baimena duzu.</string>
     <string name="enable_disposed_exceptions_summary">Behartu aktibitatearen bizitza ziklotik kanpo baztertu eta gero entregatu ezin diren Rx salbuespenen inguruko txostena</string>
     <string name="privacy_policy_title">NewPipe pribatutasun politika</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -567,7 +567,6 @@
     <string name="tablet_mode_title">حالت رایانک</string>
     <string name="open_website_license">گشودن پایگاه وب</string>
     <string name="account_terminated">حساب از بین رفت</string>
-    <string name="metadata_thumbnail_url">نشانی بندانگشتی</string>
     <string name="metadata_age_limit">کرانهٔ عمر</string>
     <string name="related_items_tab_description">موارد مرتبط</string>
     <string name="show_description_title">نمایش شرح</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -96,7 +96,6 @@
     <string name="show_higher_resolutions_summary">تنها برخی دستگاه‌ها توانایی پخش ویدیوهای 2K و 4K را دارند</string>
     <string name="default_video_format_title">قالب ویدیویی پیش‌گزیده</string>
     <string name="black_theme_title">سیاه</string>
-    <string name="download_thumbnail_title">بار کردن بندانگشتی‌ها</string>
     <string name="auto_queue_title">قرار دادن خودکار جریان بعدی در صف</string>
     <string name="show_search_suggestions_title">پیشنهادهای جستجو</string>
     <string name="show_search_suggestions_summary">گزینش پیشنهادها برای نمایش هنگام جست‌وجو</string>
@@ -270,7 +269,6 @@
     <string name="resume_on_audio_focus_gain_title">پخش ادامه یابد</string>
     <string name="enable_search_history_summary">ذخیره محلی نتایج جستجو</string>
     <string name="auto_queue_summary">صف پخش در حال پایان (بدون تکرار) را با افزودن یک جریان مرتبط ادامه دهید</string>
-    <string name="download_thumbnail_summary">برای پیش‌گیری از بار کردن بندانگشتی‌ها و ذخیرهٔ داده و فضای ذخیره، خاموش کنید. تغییرات، انبارهٔ تصاویر روی حافظه و دیسک را پاک می‌کند</string>
     <string name="enable_playback_resume_title">ادامه پخش</string>
     <string name="enable_playback_resume_summary">بازگرداندن آخرین موقعیت پخش</string>
     <string name="enable_playback_state_lists_title">موقعیت در فهرست‌ها</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -595,7 +595,6 @@
     <string name="restricted_video_no_stream">Tämä video on ikärajoitettu.
 \nYouTuben uusien ikärajoitusperiaatteiden mukaisesti NewPipella ei ole pääsyä videoon eikä sitä voida toistaa.</string>
     <string name="night_theme_title">Yöteema</string>
-    <string name="metadata_thumbnail_url">Pienoiskuvakkeen osoite</string>
     <string name="description_select_disable">Poista käytöstä tekstinvalinta kuvauskentän sisältä</string>
     <string name="description_select_note">Voit nyt valita tekstin kuvauskentän sisältä. Huomioithan, että valintatilan aikana sivu voi vilkkua ja linkit eivät ehkä ole klikattavia.</string>
     <string name="service_provides_reason">%s tuo tämän syyn:</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -196,8 +196,6 @@
     <string name="controls_add_to_playlist_title">Lisää soittolistaan</string>
     <string name="use_inexact_seek_title">Käytä nopeampaa epätarkkaa pikakelausta</string>
     <string name="use_inexact_seek_summary">Epätarkka kelaus mahdollistaa videon kelauksen nopeammin huonommalla tarkkuudella. Kelaaminen 5, 15 tai 25 sekunnin hyppäyksin ei toimi tämän kanssa</string>
-    <string name="download_thumbnail_title">Lataa esikatselukuvat</string>
-    <string name="download_thumbnail_summary">Poista käytöstä estääksesi esikatselukuvien lataus. Tämä säästää dataa ja vähentää muistin käyttöä. Asetuksen muuttaminen poistaa muistissa ja levyllä olevan kuvavälimuistin</string>
     <string name="thumbnail_cache_wipe_complete_notice">Kuvavälimuisti tyhjennetty</string>
     <string name="metadata_cache_wipe_title">Poista tallennettu metatieto</string>
     <string name="metadata_cache_wipe_summary">Poista kaikki tallennettu sivutieto</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -48,7 +48,6 @@
     <string name="notification_action_1_title">Pangalawang action button</string>
     <string name="notification_action_2_title">Pangatlong action button</string>
     <string name="use_inexact_seek_summary">Pinapayagan ng di-saktong seek ang player na mag-seek sa mga posisyon nang mabilis ngunit na may pinababang kasaktuhan. Di ito gagana sa pag-seek nang 5, 15, o 25 segundo.</string>
-    <string name="download_thumbnail_summary">Patayin para mapigilan ang pag-load sa mga thumbnail, para makatipid ng data at paggamit sa memory. Lilinisin ang parehong image cache na nasa memory at nasa disk</string>
     <string name="show_search_suggestions_summary">Piliin ang mga mungkahing ipapakita habang naghahanap</string>
     <string name="show_description_summary">Patayin para itago ang paglalarawan ng video at karagdagang impormasyon</string>
     <string name="notification_actions_summary">I-edit ang bawat action sa abiso sa baba sa pamamagitan ng pagpindot sa mga ito. Pumili ng hanggang tatlong ipapakita sa siksik na abiso gamit ang mga checkbox sa kanan</string>
@@ -70,7 +69,6 @@
     <string name="clear_queue_confirmation_title">Kumpirmahin muna bago linisin ang pila</string>
     <string name="clear_queue_confirmation_summary">Maaaring mapalitan ang pila mo kung magpapalit ka ng player</string>
     <string name="clear_queue_confirmation_description">Papalitan ang aktibong pila sa player</string>
-    <string name="download_thumbnail_title">I-load ang mga thumbnail</string>
     <string name="show_description_title">Ipakita ang paglalarawan</string>
     <string name="show_meta_info_title">Ipakita ang meta info</string>
     <string name="show_meta_info_summary">Patayin para itago ang mga meta infobox na may karagdagang impormasyon tungkol sa creator ng stream, laman nito o ng hinanap</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -157,7 +157,6 @@
     <string name="metadata_licence">Lisensya</string>
     <string name="metadata_language">Wika</string>
     <string name="metadata_privacy_private">Pribado</string>
-    <string name="metadata_thumbnail_url">URL ng Thumbnail</string>
     <string name="metadata_privacy_unlisted">Hindi nakalista</string>
     <string name="off">Nakapatay</string>
     <string name="new_and_hot">Bago at patok</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -244,8 +244,6 @@
     <string name="resize_zoom">Zoomer</string>
     <string name="use_inexact_seek_title">Utiliser la recherche rapide approximative</string>
     <string name="use_inexact_seek_summary">Permet au lecteur d’accéder plus rapidement à une position au détriment de la précision. Se déplacer de 5, 15 ou 25 secondes est impossible avec cette option</string>
-    <string name="download_thumbnail_title">Charger les miniatures</string>
-    <string name="download_thumbnail_summary">Désactivez pour empêcher le chargement des miniatures afin de réduire l’utilisation de la bande passante et de la mémoire. La modification de cette option vide le cache en mémoire vive et sur le disque</string>
     <string name="thumbnail_cache_wipe_complete_notice">Images en cache effacées</string>
     <string name="metadata_cache_wipe_title">Effacer les métadonnées en cache</string>
     <string name="metadata_cache_wipe_summary">Efface toutes les données des pages Web en cache</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -616,7 +616,6 @@
     <string name="metadata_privacy_private">Privé</string>
     <string name="metadata_privacy_unlisted">Non répertorié</string>
     <string name="metadata_privacy_public">Public</string>
-    <string name="metadata_thumbnail_url">URL de la miniature</string>
     <string name="metadata_host">Hôte</string>
     <string name="metadata_support">Support</string>
     <string name="metadata_language">Langue</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -547,7 +547,6 @@
     <string name="metadata_privacy_internal">Interno</string>
     <string name="metadata_privacy_private">Privado</string>
     <string name="metadata_privacy_public">Público</string>
-    <string name="metadata_thumbnail_url">URL da miniatura</string>
     <string name="metadata_support">Apoio</string>
     <string name="metadata_language">Idioma</string>
     <string name="metadata_age_limit">Límite de idade</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -55,8 +55,6 @@
     <string name="popup_remember_size_pos_summary">Lembrar o tamaño e a posición anteriores do «popup»</string>
     <string name="use_inexact_seek_title">Usar un salto inexacto mais inexacto</string>
     <string name="use_inexact_seek_summary">A busca inexacta permite ao reprodutor procurar posicións máis rápidas con precisión reducida. A busca de 5, 15 ou 25 segundos non funciona con isto</string>
-    <string name="download_thumbnail_title">Carregar miniaturas</string>
-    <string name="download_thumbnail_summary">Desactíveo para evitar a carga de miniaturas e poupar datos e memoria. Modificar esta opción limpa a caché de imaxes da memoria e do disco</string>
     <string name="thumbnail_cache_wipe_complete_notice">A caché de imaxes foi limpada</string>
     <string name="metadata_cache_wipe_title">Os metadatos da caché foron eliminados</string>
     <string name="metadata_cache_wipe_summary">Eliminar todos os datos de páxinas en caché</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -268,8 +268,6 @@
     <string name="playback_tempo">קצב</string>
     <string name="use_inexact_seek_title">שימוש בחיפוש מהיר ולא מדויק</string>
     <string name="use_inexact_seek_summary">חיפוש גס מאפשר לנגן לחפש נקודת זמן מהר יותר, ברמת דיוק נמוכה יותר. חיפוש של 5, 15 או 25 שניות לא עובד עם ההגדרה הזאת</string>
-    <string name="download_thumbnail_title">טעינת תמונות ממוזערות</string>
-    <string name="download_thumbnail_summary">כיבוי האפשרות מונע את טעינת התמונות הממוזערות, חוסך בתקשורת נתונים ובניצולת הזיכרון. שינויים באפשרות זו מוחקים את המטמון בזיכרון ובכונן</string>
     <string name="metadata_cache_wipe_summary">הסרת כל נתוני העמודים שבמטמון</string>
     <string name="auto_queue_title">הוספת התזרים הבא לרשימת הנגינה אוטומטית</string>
     <string name="auto_queue_summary">להמשיך תור נגינה סופית (בלתי מחזורית) על ידי הוספת תזרים קשור</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -622,7 +622,6 @@
     <string name="metadata_privacy_private">פרטי</string>
     <string name="metadata_privacy_unlisted">לא מופיע ברשימות</string>
     <string name="metadata_privacy_public">ציבורי</string>
-    <string name="metadata_thumbnail_url">כתובת תמונה ממוזערת</string>
     <string name="metadata_host">אירוח</string>
     <string name="metadata_support">תמיכה</string>
     <string name="metadata_language">שפה</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -616,7 +616,6 @@
     <string name="crash_the_app">ऐप को क्रैश करें</string>
     <string name="metadata_category">श्रेणी</string>
     <string name="downloads_storage_ask_summary_no_saf_notice">आपसे पूछा जाएगा कि प्रत्येक डाउनलोड को कहां सहेजना है</string>
-    <string name="metadata_thumbnail_url">थंमनेल यूआरएल</string>
     <string name="off">ऑफ़</string>
     <string name="feed_update_threshold_option_always_update">हमेशा अपडेट करें</string>
     <string name="description_select_disable">विवरण में पाठ का चयन अक्षम करें</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -245,10 +245,8 @@
     <string name="caption_auto_generated">ऑटो-जनरेटेड</string>
     <string name="enable_leak_canary_summary">हीप डंप करने के दौरान मेमोरी लीक मॉनिटरिंग ऐप को अनुत्तरदायी बना सकता है</string>
     <string name="enable_disposed_exceptions_title">Out-of-Lifecycle त्रुटियों की रिपोर्ट करें</string>
-    <string name="download_thumbnail_title">थंमनेल लोड करें</string>
     <string name="use_inexact_seek_title">तेज और अनिश्चित तलाश का प्रयोग करें</string>
     <string name="use_inexact_seek_summary">अनिश्चित खोज से प्लेयर में कम सटीकता से लेकिन तेजी से वीडियो पोजीशन्स की तलाश कर सकता हैं। 5, 15 या 25 सेकंड की तलाश में यह काम नहीं करता</string>
-    <string name="download_thumbnail_summary">डेटा खपत, मेमोरी उपयोग की बचत और थंमनेल लोड होने से रोकने के लिए बंद करें। इस बदलाव से इन-मेमोरी और ऑन-डिस्क छवि कैश दोनों मिट जाते हैं</string>
     <string name="thumbnail_cache_wipe_complete_notice">चित्र कैश मिटाया गया</string>
     <string name="metadata_cache_wipe_title">कैश मेटाडेटा मिटाएं</string>
     <string name="metadata_cache_wipe_summary">कैश किए गए सभी वेबपेज का डेटा हटाएं</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -616,7 +616,6 @@
     <string name="metadata_privacy_private">Privatno</string>
     <string name="metadata_privacy_unlisted">Nenavedeno</string>
     <string name="metadata_privacy_public">Javno</string>
-    <string name="metadata_thumbnail_url">URL sličice</string>
     <string name="metadata_host">Poslužitelj</string>
     <string name="metadata_support">Podrška</string>
     <string name="metadata_language">Jezik</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -218,7 +218,6 @@
     <string name="show_info">Prikaži informacije</string>
     <string name="tab_bookmarks">Zabilježene playliste</string>
     <string name="controls_add_to_playlist_title">Dodaj u</string>
-    <string name="download_thumbnail_title">Učitaj sličice</string>
     <string name="thumbnail_cache_wipe_complete_notice">Slikovna predmemorija obrisana</string>
     <string name="metadata_cache_wipe_title">Izbriši metapodatke iz predmemorije</string>
     <string name="channels">Kanali</string>
@@ -312,7 +311,6 @@
     <string name="app_update_available_notification_title">Dostupna je nova verzija za NewPipe!</string>
     <string name="download_failed">Preuzimanje nije uspjelo</string>
     <string name="show_error">Prikaži pogrešku</string>
-    <string name="download_thumbnail_summary">Isključi za sprečavanje učitavanja sličica, čime se štedi korištenje podataka i memorije. Promjene čiste predmemoriju slika radne memorije i diska</string>
     <string name="metadata_cache_wipe_summary">Izbriši sve podatke web-stranica iz predmemorije</string>
     <string name="metadata_cache_wipe_complete_notice">Metapodaci su izbrisani</string>
     <string name="auto_queue_title">Automatski dodaj sljedeći stream u popisa izvođenja</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -605,7 +605,6 @@
     <string name="metadata_licence">Licenc</string>
     <string name="metadata_age_limit">Korhatár</string>
     <string name="metadata_host">Kiszolgáló</string>
-    <string name="metadata_thumbnail_url">Bélyegkép URL</string>
     <string name="metadata_privacy_public">Nyilvános</string>
     <string name="metadata_privacy_unlisted">Nem listázott</string>
     <string name="off">Ki</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -136,8 +136,6 @@
     <string name="controls_add_to_playlist_title">Hozzáadás ehhez</string>
     <string name="use_inexact_seek_title">Gyorsabb, de pontatlan tekerés használata</string>
     <string name="use_inexact_seek_summary">A pontatlan tekerés lehetővé teszi, hogy gyorsabban ugorjon a pozíciókra, de kisebb pontossággal. Az 5, 15, vagy 25 másodperces tekerés nem működik ebben a módban</string>
-    <string name="download_thumbnail_title">Bélyegképek betöltése</string>
-    <string name="download_thumbnail_summary">Kapcsolja ki, hogy a megelőzze a bélyegképek betöltését, így csökkentve az adat- és memóriahasználatot. A megváltoztatása törli a memóriában és a meghajtón lévő képgyorsítótárat</string>
     <string name="thumbnail_cache_wipe_complete_notice">A bélyegkép gyorsítótár törölve</string>
     <string name="metadata_cache_wipe_title">Gyorsítótárazott metaadatok törlése</string>
     <string name="metadata_cache_wipe_summary">Minden gyorsítótárazott weboldaladat törlése</string>

--- a/app/src/main/res/values-ia/strings.xml
+++ b/app/src/main/res/values-ia/strings.xml
@@ -227,7 +227,6 @@
     <string name="metadata_privacy_internal">Interne</string>
     <string name="open_with">Aperir con</string>
     <string name="remote_search_suggestions">Suggestiones de recerca remote</string>
-    <string name="download_thumbnail_title">Cargar miniaturas</string>
     <string name="search_showing_result_for">Monstrante resultatos pro: %s</string>
     <string name="show_higher_resolutions_summary">Solmente alicun apparatos pote reproducer videos 2K/4K</string>
     <string name="start_main_player_fullscreen_title">Initiar le reproductor principal in schermo plen</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -132,8 +132,6 @@
     <string name="notification_channel_name">Notifikasi NewPipe</string>
     <string name="title_activity_history">Riwayat</string>
     <string name="action_history">Riwayat</string>
-    <string name="download_thumbnail_title">Muat thumbnail</string>
-    <string name="download_thumbnail_summary">Matikan agar thumbnail tidak dimuat, menghemat penggunaan data dan memori. Perubahan menghapus cache gambar baik di memori dan disk</string>
     <string name="thumbnail_cache_wipe_complete_notice">Cache gambar dihapus</string>
     <string name="metadata_cache_wipe_title">Hapus cache metadata</string>
     <string name="metadata_cache_wipe_summary">Hapus semua data cache halaman web</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -592,7 +592,6 @@
     <string name="metadata_privacy_private">Privasi</string>
     <string name="metadata_privacy_unlisted">Tidak didaftar</string>
     <string name="metadata_privacy_public">Publik</string>
-    <string name="metadata_thumbnail_url">Alamat URL gambar mini/thumbnail</string>
     <string name="metadata_host">Host</string>
     <string name="metadata_support">Dukungan</string>
     <string name="metadata_language">Bahasa</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -485,7 +485,6 @@
     <string name="video_detail_by">Frá %s</string>
     <string name="account_terminated">Reikningi lokað</string>
     <string name="metadata_age_limit">Aldurstakmark</string>
-    <string name="metadata_thumbnail_url">Vefslóð smámyndar</string>
     <string name="detail_pinned_comment_view_description">Fest ummæli</string>
     <string name="tablet_mode_title">Spjaldtölvuhamur</string>
     <string name="on">Virkt</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -177,7 +177,6 @@
     <string name="use_inexact_seek_title">Nota hraða en ónákvæma leit</string>
     <string name="seek_duration_title">Lengd skrefs</string>
     <string name="clear_queue_confirmation_title">Biðja um staðfestingu áður en röð er hreinsuð</string>
-    <string name="download_thumbnail_title">Sækja smámyndir</string>
     <string name="show_comments_title">Sýna ummæli</string>
     <string name="auto_queue_toggle">Sjálfvirk biðröð</string>
     <string name="settings_category_clear_data_title">Hreinsa gögn</string>
@@ -613,7 +612,6 @@
     <string name="progressive_load_interval_title">Stærð forhleðslu</string>
     <string name="progressive_load_interval_summary">Breyta stærð forhleðslu (nú %s). Lægra gildi gæti flýtt fyrir upphaflegu hleðslu myndbands. Breytingar krefjast endurræsingar spilara</string>
     <string name="clear_queue_confirmation_description">Biðröð spilarans verður skipt út</string>
-    <string name="download_thumbnail_summary">Slökktu á til að hlaða ekki niður smámyndum til að spara bandbreidd og vinnsluminni. Breytingar eyða myndskyndiminni í bæði vinnsluminni og geymslu</string>
     <string name="show_meta_info_summary">Slökktu á til að fela lýsigagnareiti með viðbótarupplýsingum um straumhöfund, straumefni eða leitarbeiðni</string>
     <string name="metadata_cache_wipe_summary">Fjarlæga öll síðugögn úr skyndiminni</string>
     <string name="auto_queue_summary">Bæta svipuðum straumum við biðröðina þegar síðasta er spilað og endurspilun er ekki virkjuð</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -612,7 +612,6 @@
     <string name="metadata_privacy_private">Privato</string>
     <string name="metadata_privacy_unlisted">Non in elenco</string>
     <string name="metadata_privacy_public">Pubblico</string>
-    <string name="metadata_thumbnail_url">URL copertina</string>
     <string name="metadata_host">Host</string>
     <string name="metadata_support">Supporto</string>
     <string name="metadata_language">Lingua</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -287,8 +287,6 @@
     <string name="import_network_expensive_warning">Tieni presente che questa operazione può consumare una grande quantità di traffico dati.
 \n 
 \nVuoi continuare?</string>
-    <string name="download_thumbnail_title">Carica copertine</string>
-    <string name="download_thumbnail_summary">Disabilita per prevenire il caricamento delle copertine, risparmiando dati e memoria. La modifica di questa opzione cancellerà la cache delle immagini in memoria e sul disco</string>
     <string name="thumbnail_cache_wipe_complete_notice">Cache immagini svuotata</string>
     <string name="metadata_cache_wipe_title">Svuota la cache dei metadati</string>
     <string name="metadata_cache_wipe_summary">Elimina i dati delle pagine web memorizzati nella cache</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -600,7 +600,6 @@
     <string name="metadata_language">言語</string>
     <string name="metadata_support">サポート</string>
     <string name="metadata_host">ホスト</string>
-    <string name="metadata_thumbnail_url">サムネイルの URL</string>
     <string name="open_website_license">ウェブサイトを開く</string>
     <string name="downloads_storage_ask_summary_no_saf_notice">ダウンロードのたびに保存する場所を尋ねます</string>
     <string name="no_dir_yet">ダウンロードフォルダーがまだ設定されていません。今すぐデフォルトのフォルダーを選択してください</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -196,7 +196,6 @@
     <string name="controls_download_desc">動画をダウンロード</string>
     <string name="show_info">情報を表示</string>
     <string name="tab_bookmarks">ブックマークしたプレイリスト</string>
-    <string name="download_thumbnail_title">サムネイルを読み込む</string>
     <string name="thumbnail_cache_wipe_complete_notice">画像キャッシュを消去しました</string>
     <string name="metadata_cache_wipe_title">キャッシュを消去</string>
     <string name="metadata_cache_wipe_summary">アプリ内のキャッシュデータをすべて削除します</string>
@@ -254,7 +253,6 @@
     <string name="read_privacy_policy">プライバシーポリシーを確認</string>
     <string name="use_inexact_seek_title">おおまかなシーク</string>
     <string name="use_inexact_seek_summary">おおまかなシークを使用することで精度が下がる代わりに高速にシークができます。5 秒、15 秒または 25 秒間隔のシークはできません</string>
-    <string name="download_thumbnail_summary">サムネイルの読み込みと保存を無効化します。(このオプションを切り替えるとメモリとディスク上の画像キャッシュが消去されます)</string>
     <string name="auto_queue_summary">キューに関連動画を追加して再生を続ける (繰り返ししない場合)</string>
     <string name="delete_view_history_alert">すべての再生履歴を削除しますか？</string>
     <string name="delete_search_history_alert">すべての検索履歴を削除しますか？</string>

--- a/app/src/main/res/values-jv/strings.xml
+++ b/app/src/main/res/values-jv/strings.xml
@@ -10,11 +10,9 @@
     <string name="auto_queue_title">Antri otomatis stream bare</string>
     <string name="metadata_cache_wipe_complete_notice">Sampah metadata wes dibusak</string>
     <string name="metadata_cache_wipe_summary">Busak kabeh sampah ora kanggo</string>
-    <string name="download_thumbnail_summary">Pateni ben gambar cilik ora ketok, ora boros data lan memori. Iku bakal ngresiki sampah gambar.</string>
     <string name="thumbnail_cache_wipe_complete_notice">Sampah gambar wes resik</string>
     <string name="show_comments_summary">Pateni gawe ngumpetke komentar</string>
     <string name="show_comments_title">Duduhke komentar</string>
-    <string name="download_thumbnail_title">Duduhke gambar cilik</string>
     <string name="seek_duration_title">Durasi cepet maju/mundure</string>
     <string name="popup_remember_size_pos_summary">Eling-eling ukuran lan posisi ngambang terakhir</string>
     <string name="popup_remember_size_pos_title">Eling-eling ukuran lan posisi ngambang</string>

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -42,7 +42,6 @@
     <string name="use_inexact_seek_summary">არაზუსტი ძიება საშუალებას აძლევს მოთამაშეს უფრო სწრაფად მოიძიოს პოზიციები შემცირებული სიზუსტით. 5, 15 ან 25 წამის ძიება ამით არ მუშაობს</string>
     <string name="seek_duration_title">სწრაფი წინსვლა/-გადახვევა ძიების ხანგრძლივობა</string>
     <string name="clear_queue_confirmation_summary">ერთი მოთამაშიდან მეორეზე გადართვამ შესაძლოა შეცვალოს თქვენი რიგი</string>
-    <string name="download_thumbnail_summary">გამორთეთ ესკიზების ჩატვირთვის თავიდან ასაცილებლად, მონაცემთა დაზოგვისა და მეხსიერების გამოყენების თავიდან ასაცილებლად. იცვლება როგორც მეხსიერებაში, ასევე დისკზე გამოსახულების ქეშის გასუფთავება</string>
     <string name="show_search_suggestions_title">ძიების შეთავაზებები</string>
     <string name="metadata_cache_wipe_summary">წაშალეთ ყველა ქეშირებული ვებგვერდის მონაცემები</string>
     <string name="auto_queue_title">შემდეგი ნაკადის ავტომატური შეყვანა</string>
@@ -107,7 +106,6 @@
     <string name="black_theme_title">შავი</string>
     <string name="popup_remember_size_pos_title">დამახსოვრება ამომხტარი ფანჯრის თვისებები</string>
     <string name="clear_queue_confirmation_description">აქტიური მოთამაშის რიგი შეიცვლება</string>
-    <string name="download_thumbnail_title">ჩატვირთეთ ესკიზები</string>
     <string name="show_comments_title">კომენტარების ჩვენება</string>
     <string name="show_comments_summary">გამორთეთ კომენტარების დასამალად</string>
     <string name="show_next_and_similar_title">\"შემდეგი\" და \"მსგავსი\" ვიდეოების ჩვენება</string>

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -565,7 +565,6 @@
     <string name="metadata_age_limit">Ასაკობრივი შეზღუდვა</string>
     <string name="metadata_language">Ენა</string>
     <string name="metadata_host">მასპინძელი</string>
-    <string name="metadata_thumbnail_url">მინიატურების URL</string>
     <string name="metadata_privacy_public">საჯარო</string>
     <string name="metadata_privacy_unlisted">დამალული</string>
     <string name="metadata_privacy_private">პირადი</string>

--- a/app/src/main/res/values-kmr/strings.xml
+++ b/app/src/main/res/values-kmr/strings.xml
@@ -242,8 +242,6 @@
     <string name="show_next_and_similar_title">Vîdyoyên \'Pêş\' û \'Bi vî rengî\' nîşan bidin</string>
     <string name="show_comments_summary">Zivirandin da ku şîroveyan veşêrin</string>
     <string name="show_comments_title">Şîroveyan nîşan bide</string>
-    <string name="download_thumbnail_summary">Ji bo pêşîgirtina li barkirina nîgarkêşan, daneya daneyê û karanîna bîranînê xilas bibe vemirînin. Guherandinên kaşeya wêneyê hem di bîra û hem jî li ser dîskê paqij dikin.</string>
-    <string name="download_thumbnail_title">Nîgarên barkêş</string>
     <string name="clear_queue_confirmation_description">Dê rêza lîstikvanê çalak were guhertin</string>
     <string name="clear_queue_confirmation_summary">Guhertina ji lîstikvanek bi yeke din dibe ku dewsa dorê we bigire</string>
     <string name="clear_queue_confirmation_title">Berî paqijkirina dorê ji pejirandinê bipirsin</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -625,7 +625,6 @@
     <string name="detail_heart_img_view_description">창작자의 마음</string>
     <string name="metadata_privacy_private">비공개</string>
     <string name="metadata_privacy_unlisted">비공개</string>
-    <string name="metadata_thumbnail_url">썸네일 URL</string>
     <string name="metadata_host">호스트</string>
     <string name="you_successfully_subscribed">이제 이 채널을 구독했습니다</string>
     <string name="get_notified">알림 받기</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -278,8 +278,6 @@
     <string name="import_network_expensive_warning">경고: 데이터가 많이 소모될 수 있습니다. 
 \n 
 \n계속하시겠습니까\?</string>
-    <string name="download_thumbnail_title">썸네일 로드하기</string>
-    <string name="download_thumbnail_summary">동영상 썸네일을 로드하지 않으며, 데이터와 메모리 사용을 최대한 줄입니다. 이 옵션을 선택 시 모든 메모리 캐시와 저장소 캐시를 삭제합니다</string>
     <string name="thumbnail_cache_wipe_complete_notice">이미지 캐시 지워짐</string>
     <string name="metadata_cache_wipe_title">캐시된 메타데이터 지우기</string>
     <string name="metadata_cache_wipe_summary">캐시된 모든 웹페이지 데이터 지우기</string>

--- a/app/src/main/res/values-ku/strings.xml
+++ b/app/src/main/res/values-ku/strings.xml
@@ -53,9 +53,6 @@
     <string name="black_theme_title">ڕه‌ش</string>
     <string name="popup_remember_size_pos_title">بیرهاتنه‌وه‌ی شوێن و قه‌باره‌ی په‌نجه‌ره‌</string>
     <string name="popup_remember_size_pos_summary">بیرهاتنه‌وه‌ی كۆتا قه‌باره‌ و شوێنی په‌نجه‌ره‌ی بچووك</string>
-    <string name="download_thumbnail_title">باركردنی وێنۆچكه‌كان</string>
-    <string name="download_thumbnail_summary">ناچالاكی بكه‌ بۆ ڕاگرتنی وێنۆچكه‌كان له‌ باركردن و پاشه‌كه‌وتبوون له‌سه‌ر بیرگه‌ی ئامێره‌كه‌ت.
-\nگۆڕینی ئه‌مه‌ ده‌بێته‌ هۆی سڕینه‌وه‌یان له‌سه‌ر بیرگه‌ی مۆبایله‌كه‌ت.</string>
     <string name="thumbnail_cache_wipe_complete_notice">پاشماوه‌ی وێنۆچكه‌كان سڕایه‌وه‌</string>
     <string name="use_inexact_seek_title">بەکارهێنانی گەڕانی ناوردی خێرا</string>
     <string name="metadata_cache_wipe_title">خاوێنکردنەوەی پاشماوەی داتا</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -617,7 +617,6 @@
     <string name="metadata_privacy_public">Viešas</string>
     <string name="metadata_privacy_private">Privatus</string>
     <string name="metadata_privacy_unlisted">Neįtrauktas į sąrašą</string>
-    <string name="metadata_thumbnail_url">Paveikslėlio URL</string>
     <string name="metadata_host">Serveris</string>
     <string name="metadata_support">Pagalba</string>
     <string name="metadata_language">Kalba</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -374,8 +374,6 @@
     <string name="enable_playback_resume_summary">Atstatyti paskutinį atkūrimo laiką</string>
     <string name="enable_playback_resume_title">Tęsti atkūrimą</string>
     <string name="show_description_title">Rodyti aprašymą</string>
-    <string name="download_thumbnail_summary">Norėdami taupyti duomenų srautą, atminties naudojimą išjunkite. Pakeitimai išvalys duomenis atmintyje ir diske</string>
-    <string name="download_thumbnail_title">Įkelti miniatiūras</string>
     <string name="clear_queue_confirmation_description">Aktyvaus grotuvo eilė bus pakeista</string>
     <string name="clear_queue_confirmation_summary">Perjungimas iš vieno grotuvo į kitą gali pakeisti jūsų eilę</string>
     <string name="clear_queue_confirmation_title">Prieš išvalant eilę prašyti patvirtinimo</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -653,7 +653,6 @@
     <string name="low_quality_smaller">Zemas kvalitātes (mazāks)</string>
     <string name="metadata_privacy">Privātums</string>
     <string name="metadata_privacy_unlisted">Sarakstā neiekļauts</string>
-    <string name="metadata_thumbnail_url">Video attēla URL</string>
     <string name="metadata_host">Uzņēmums</string>
     <string name="remote_search_suggestions">Attālinātie meklēšanas ieteikumi</string>
     <string name="mark_as_watched">Atzīmēt kā skatītu</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -517,8 +517,6 @@
     <string name="show_next_and_similar_title">Rādīt \'Nākošos\' un \'Līdzīgos\' videoklipus</string>
     <string name="show_comments_summary">Izslēdziet, lai paslēptu komentārus</string>
     <string name="show_comments_title">Rādīt komentārus</string>
-    <string name="download_thumbnail_summary">Izslēdziet, ja vēlaties nelādēt video attēlus, ietaupot datus un atmiņu. Opcija notīra kešatmiņu, izdzēšot visus saglabātos video attēlus</string>
-    <string name="download_thumbnail_title">Ielādēt video attēlus</string>
     <string name="clear_queue_confirmation_description">Tagadējā atskaņošanas rinda tiks aizvietota</string>
     <string name="clear_queue_confirmation_summary">Mainoties vienam video uz citu, iespējams, notīrīsies jūsu atskaņošanas rinda</string>
     <string name="clear_queue_confirmation_title">Prasīt apstiprinājumu, pirms notīrīt atskaņošanas rindu</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -55,8 +55,6 @@
     <string name="popup_remember_size_pos_summary">Запамти ја последната големина и место на прозорчето</string>
     <string name="use_inexact_seek_title">Брзо, непрецизно премотување</string>
     <string name="use_inexact_seek_summary">Со непрецизното премотување се пребарува побрзо, но со намалена презицност.</string>
-    <string name="download_thumbnail_title">Прочитај мали видео-сликички</string>
-    <string name="download_thumbnail_summary">Оневозможете, за да не се читаат малите видео-сликички за штедење на меморија и интернет. Промената на оваа опцијата ќе ја избрише кеш-меморијата.</string>
     <string name="thumbnail_cache_wipe_complete_notice">Кешираните слики се избришани</string>
     <string name="metadata_cache_wipe_title">Избришете ги кешираните мета-податоци</string>
     <string name="metadata_cache_wipe_summary">Избришете ги сите кеш-податоци од веб-страни</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -331,10 +331,8 @@
     <string name="metadata_cache_wipe_summary">കാഷെ ആയ ഡേറ്റ നീക്കംചെയ്യുക</string>
     <string name="metadata_cache_wipe_title">കാഷെ ആയ മെറ്റാഡേറ്റ തുടച്ചുനീക്കി</string>
     <string name="thumbnail_cache_wipe_complete_notice">ഇമേജ് കാചെ തുടച്ചുമാറ്റി</string>
-    <string name="download_thumbnail_summary">ലഘുചിങ്ങൾ ലോഡ് ചെയ്യാതിരിക്കാനും ഡേറ്റയും മെമ്മറിയും ലാഭിക്കാനുമായി ഓഫ്ചെയ്യുക. എസ് ഡീ കാർഡിലെയും മെമ്മറിയിലെയും കാച്ചേ ക്ലിയർ ചെയ്യും</string>
     <string name="show_comments_summary">കമന്റുകൾ മറയ്ക്കാനായി ഓഫ് ചെയ്യുക</string>
     <string name="show_comments_title">കമന്റുകൾ കാണിക്കുക</string>
-    <string name="download_thumbnail_title">ലഘുചിത്രങ്ങൾ ലോഡ്‌ ചെയ്യുക</string>
     <string name="seek_duration_title">ഫാസ്റ്റ്-ഫോർവേർഡ്/റീവൈൻഡ് സമയദൈർഘ്യം</string>
     <string name="use_inexact_seek_title">Inexact seek ഉപയോഗിക്കുക</string>
     <string name="use_inexact_seek_summary">കുറഞ്ഞ കൃത്യതയോടെ സീക് ചെയ്യാൻ ഇൻ എക്സക്ട് സഹായിക്കുന്നു. 5,15,25 സെക്കൻഡ് സീക്‌ ഈ മോഡിൽ പ്രവർത്തിക്കുകയില്ല</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -609,7 +609,6 @@
     <string name="metadata_privacy_private">സ്വകാര്യം</string>
     <string name="metadata_privacy_unlisted">ലിസ്റ്റ് ചെയ്യപ്പെടാത്തത്</string>
     <string name="metadata_privacy_public">പൊതുവായത്</string>
-    <string name="metadata_thumbnail_url">ചെറുചിത്രം URL</string>
     <string name="metadata_host">ഹോസ്റ്റ്</string>
     <string name="metadata_support">പിന്തുണ</string>
     <string name="metadata_language">ഭാഷ</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -57,8 +57,6 @@
     <string name="popup_remember_size_pos_summary">Mengingat saiz dan posisi popup terakhir</string>
     <string name="use_inexact_seek_title">Gunakan tinjau laju tidak tepat</string>
     <string name="use_inexact_seek_summary">Membolehkan pemain untuk meninjau ke posisi lebih laju dengan kurang ketepatan. Mencari 5, 15 atau 25 saat tidak berfungsi dengan ini</string>
-    <string name="download_thumbnail_title">Muatkan thumbnail</string>
-    <string name="download_thumbnail_summary">Matikan untuk mengelakkan pemuatan thumbnail, menjimat penggunaan data dan ingatan. Perubahan akan menghapus cache imej dari ingatan dan disk</string>
     <string name="thumbnail_cache_wipe_complete_notice">Cache imej dihapuskan</string>
     <string name="metadata_cache_wipe_title">Hapuskan cache metadata</string>
     <string name="metadata_cache_wipe_summary">Hapuskan semua cache data halaman web</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -621,7 +621,6 @@
     <string name="metadata_privacy_private">Privat</string>
     <string name="metadata_privacy_unlisted">Ulistet</string>
     <string name="metadata_privacy_public">Offentlig</string>
-    <string name="metadata_thumbnail_url">Miniatyrbilde-nettadresse</string>
     <string name="metadata_host">Tjener</string>
     <string name="metadata_support">Støtte</string>
     <string name="metadata_language">Språk</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -257,7 +257,6 @@
     <string name="export_ongoing">Eksporterer…</string>
     <string name="import_file_title">Importer fil</string>
     <string name="previous_export">Forrige eksport</string>
-    <string name="download_thumbnail_title">Last miniatyrbilder</string>
     <string name="thumbnail_cache_wipe_complete_notice">Bildehurtiglager tømt</string>
     <string name="metadata_cache_wipe_title">Tøm hurtiglagret metadata</string>
     <string name="metadata_cache_wipe_summary">Fjern all hurtiglagret nettsidedata</string>
@@ -304,7 +303,6 @@
 \n3. Logg inn når forespurt
 \n4. Kopier profil-nettadressen du ble videresendt til.</string>
     <string name="use_inexact_seek_summary">Unøyaktig spoling lar spilleren søke posisjoner raskere med redusert presisjon. Å søke i 5, 15 eller 25 sekunder fungerer ikke med dette</string>
-    <string name="download_thumbnail_summary">Skru av for å stoppe innlasting av miniatyrbilder, noe som sparer data- og minnebruk. Endring av dette vil tømme både disk- og minne-hurtiglager</string>
     <string name="auto_queue_summary">Fortsett fullendt (ikke-repeterende) avspillingskø ved å legge til en relatert strøm</string>
     <string name="enable_leak_canary_summary">Overvåkning av minnelekkasjer kan forårsake at appen ikke svarer under heap dumping</string>
     <string name="enable_disposed_exceptions_title">Rapporter feil utenfor livssyklusen</string>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -56,10 +56,8 @@
     <string name="popup_remember_size_pos_summary">पछिल्लो आकार र पपअप को स्थिति सम्झना</string>
     <string name="use_inexact_seek_title">तेज \'inexact\' खोज्न प्रयोग गर्नुहोस</string>
     <string name="use_inexact_seek_summary">\'Inexact\' प्लेयर कम सटीक छिटो स्थितिहरू गर्न खोज्न अनुमति दिन्छ खोज्छन्। 5, 15 वा 25 सेकेन्ड को लागि खोजी यो काम गर्दैन।</string>
-    <string name="download_thumbnail_title">थम्बनेल लोड</string>
     <string name="show_comments_title">टिप्पणीहरू देखाऊ</string>
     <string name="show_comments_summary">टिप्पणीहरू लुकाउन, बन्द गर्नुहोस</string>
-    <string name="download_thumbnail_summary">डाटा र स्मृति उपयोग सुरक्षित गर्न, थम्बनेलहरू लोड रोक्न, बन्द गर्नुहोस। परिवर्तनहरू दुवै मा-स्मृति र-डिस्क छवि क्यास खाली गर्छ।</string>
     <string name="thumbnail_cache_wipe_complete_notice">छवि क्यास सखाप</string>
     <string name="metadata_cache_wipe_title">क्यास मेटाडाटा हटाउ</string>
     <string name="metadata_cache_wipe_summary">सबै क्यास वेबपेज डाटा हटाउ</string>

--- a/app/src/main/res/values-nl-rBE/strings.xml
+++ b/app/src/main/res/values-nl-rBE/strings.xml
@@ -55,8 +55,6 @@
     <string name="popup_remember_size_pos_summary">Onthoud laatste grootte en positie van pop-up</string>
     <string name="use_inexact_seek_title">Snel, minder exact spoelen gebruiken</string>
     <string name="use_inexact_seek_summary">Minder exact spoelen laat de speler sneller posities zoeken met verminderde precisie. 5, 15 en 25 seconden werken niet</string>
-    <string name="download_thumbnail_title">Miniatuurvoorbeelden laden</string>
-    <string name="download_thumbnail_summary">Schakel dit uit voor het laden van miniatuurvoorbeelden te verhinderen; dit bespaart mobiele gegevens en geheugen. Het wijzigen van deze instelling wist het geheugen en de afbeeldingscache</string>
     <string name="thumbnail_cache_wipe_complete_notice">Afbeeldingscache gewist</string>
     <string name="metadata_cache_wipe_title">Gecachete metagegevens wissen</string>
     <string name="metadata_cache_wipe_summary">Alle gecachete webpagina-gegevens wissen</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -284,8 +284,6 @@
     <string name="import_network_expensive_warning">Let op: deze actie kan veel MB’s van je mobiele netwerk gebruiken. 
 \n 
 \nWil je doorgaan?</string>
-    <string name="download_thumbnail_title">Miniatuurvoorbeelden laden</string>
-    <string name="download_thumbnail_summary">Schakel dit uit om het laden van miniatuurvoorbeelden te verhinderen; dit bespaart mobiele data en geheugen. Het wijzigen van deze instelling wist het geheugen en de afbeeldingscache</string>
     <string name="thumbnail_cache_wipe_complete_notice">Afbeeldingscache gewist</string>
     <string name="metadata_cache_wipe_title">Gecachete metagegevens wissen</string>
     <string name="metadata_cache_wipe_summary">Alle gecachete webpagina-gegevens wissen</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -600,7 +600,6 @@
     <string name="metadata_privacy_private">Privé</string>
     <string name="metadata_privacy_unlisted">Niet vermeld</string>
     <string name="metadata_privacy_public">Openbaar</string>
-    <string name="metadata_thumbnail_url">Miniatuur-URL</string>
     <string name="metadata_host">Host</string>
     <string name="metadata_support">Ondersteuning</string>
     <string name="metadata_language">Taal</string>

--- a/app/src/main/res/values-oc/strings.xml
+++ b/app/src/main/res/values-oc/strings.xml
@@ -58,7 +58,6 @@
     <string name="use_inexact_seek_title">Utilzar la recèrca rapida inexacta</string>
     <string name="use_inexact_seek_summary">La recèrca inexacta permet a l\'utilizaire de recercar mai rapidament una posicion amb mens de precision</string>
     <string name="seek_duration_title">Durada d\'avançada/reculada rapida</string>
-    <string name="download_thumbnail_title">Cargar las miniaturas</string>
     <string name="show_comments_title">Afichar los comentaris</string>
     <string name="show_comments_summary">Desactivar per afichar pas mai los comentaris</string>
     <string name="auto_queue_title">Apondre la vidèo seguenta dins la coa de lectura</string>

--- a/app/src/main/res/values-or/strings.xml
+++ b/app/src/main/res/values-or/strings.xml
@@ -419,7 +419,6 @@
     <string name="drawer_header_description">ଟୋଗଲ୍ ସେବା, ବର୍ତ୍ତମାନ ମନୋନୀତ:</string>
     <string name="give_back">ଫେରସ୍ତ କର</string>
     <string name="overwrite">ଓଭର୍ ରାଇଟ୍ କରନ୍ତୁ</string>
-    <string name="metadata_thumbnail_url">ଥମ୍ବନେଲ୍ URL</string>
     <string name="metadata_host">ହୋଷ୍ଟ</string>
     <string name="metadata_privacy_public">ସାର୍ଵଜନୀନ</string>
     <string name="metadata_privacy_unlisted">ତାଲିକାଭୁକ୍ତ ନୁହେଁ</string>

--- a/app/src/main/res/values-or/strings.xml
+++ b/app/src/main/res/values-or/strings.xml
@@ -101,7 +101,6 @@
     <string name="clear_queue_confirmation_title">ଏକ ଧାଡି ସଫା କରିବା ପୂର୍ବରୁ ନିଶ୍ଚିତକରଣ ମାଗନ୍ତୁ</string>
     <string name="clear_queue_confirmation_summary">ଗୋଟିଏ ଖେଳାଳୀରୁ ଅନ୍ୟ ଖେଳାଳୀକୁ ପରିବର୍ତ୍ତନ କରିବା ଆପଣଙ୍କ ଧାଡି ବଦଳାଇପାରେ</string>
     <string name="clear_queue_confirmation_description">ସକ୍ରିୟ ପ୍ଲେୟାର କ୍ୟୁ ବଦଳାଯିବ</string>
-    <string name="download_thumbnail_title">ଥମ୍ୱନେଲ୍ ଲୋଡ୍ କରନ୍ତୁ</string>
     <string name="show_next_and_similar_title">\'ପରବର୍ତ୍ତୀ\' ଏବଂ \'ସମାନ\' ଭିଡିଓଗୁଡିକ ଦେଖାନ୍ତୁ</string>
     <string name="show_description_title">ବର୍ଣ୍ଣନା ଦେଖାନ୍ତୁ</string>
     <string name="thumbnail_cache_wipe_complete_notice">ପ୍ରତିଛବି କ୍ୟାଚ୍ ପୋଛି ଦିଆଗଲା</string>
@@ -149,7 +148,6 @@
     <string name="settings_category_video_audio_title">ଵିଡ଼ିଓ ଓ ଅଡ଼ିଓ</string>
     <string name="start_main_player_fullscreen_summary">ମିନି ପ୍ଲେୟାରରେ ଭିଡିଓ ଆରମ୍ଭ କରନ୍ତୁ ନାହିଁ, କିନ୍ତୁ ଅଟୋ ଘୂର୍ଣ୍ଣନ ବନ୍ଦ ହୋଇଗଲେ ସିଧାସଳଖ ଫୁଲ୍ ସ୍କ୍ରିନ୍ ମୋଡ୍ କୁ ଯାଆନ୍ତୁ। ଫୁଲ୍ ସ୍କ୍ରିନ୍ ଛାଡି ଆପଣ ଏପର୍ଯ୍ୟନ୍ତ ମିନି ପ୍ଲେୟାରକୁ ପ୍ରବେଶ କରିପାରିବେ</string>
     <string name="notification_actions_summary">ଏହା ଉପରେ ଟ୍ୟାପ୍ କରି ନିମ୍ନରେ ପ୍ରତ୍ୟେକ ବିଜ୍ଞପ୍ତି କାର୍ଯ୍ୟ ସଂପାଦନ କରନ୍ତୁ। ଡାହାଣରେ ଥିବା ଚେକ୍ ବକ୍ସ ବ୍ୟବହାର କରି କମ୍ପାକ୍ଟ ବିଜ୍ଞପ୍ତିରେ ଦେଖାଯିବାକୁ ସେମାନଙ୍କ ମଧ୍ୟରୁ ତିନୋଟି ପର୍ଯ୍ୟନ୍ତ ଚୟନ କରନ୍ତୁ</string>
-    <string name="download_thumbnail_summary">ଥମ୍ବନେଲ ଲୋଡିଂ, ଡାଟା ଏବଂ ମେମୋରୀ ବ୍ୟବହାରକୁ ରୋକିବା ପାଇଁ ବନ୍ଦ କରନ୍ତୁ । ପରିବର୍ତ୍ତନଗୁଡ଼ିକ ଉଭୟ ଇନ-ମେମୋରୀ ଏବଂ ଅନ୍-ଡିସ୍କ ଇମେଜ୍ କ୍ୟାଚ୍ ସଫା କରେ</string>
     <string name="show_meta_info_summary">ଷ୍ଟ୍ରିମ୍ ସୃଷ୍ଟିକର୍ତ୍ତା, ଷ୍ଟ୍ରିମ୍ ବିଷୟବସ୍ତୁ କିମ୍ବା ଏକ ସନ୍ଧାନ ଅନୁରୋଧ ବିଷୟରେ ଅତିରିକ୍ତ ସୂଚନା ସହିତ ମେଟା ସୂଚନା ବାକ୍ସଗୁଡ଼ିକୁ ଲୁଚାଇବାକୁ ବନ୍ଦ କରନ୍ତୁ</string>
     <string name="show_age_restricted_content_summary">ପିଲାମାନଙ୍କ ପାଇଁ ସମ୍ଭବତ content ଅନୁପଯୁକ୍ତ ବିଷୟବସ୍ତୁ ଦେଖାନ୍ତୁ କାରଣ ଏହାର ବୟସ ସୀମା ଅଛି (ଯେପରିକି 18+)</string>
     <string name="restricted_video_no_stream">ଏହି ଭିଡିଓ ବୟସ-ସୀମିତ ଅଟେ ।

--- a/app/src/main/res/values-pa-rPK/strings.xml
+++ b/app/src/main/res/values-pa-rPK/strings.xml
@@ -38,7 +38,6 @@
     <string name="dark_theme_title">گوڑی</string>
     <string name="seek_duration_title">اگے لنگھاؤݨ یا پچھے کرن دی سماں معد</string>
     <string name="clear_queue_confirmation_description">سرگرم پکیئر کتار جاوےگا</string>
-    <string name="download_thumbnail_title">تھمنیل لوڈ کرو</string>
     <string name="clear_queue_confirmation_title">کتار نوں خالی کرن توں پہلاں تصویر کرن لئی پچھو</string>
     <string name="show_comments_summary">ٹپݨیاں وکھاؤݨا روکݨ لئی ایسنوں بند کرو</string>
     <string name="show_comments_title">ٹپݨیاں دِکھاؤ</string>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -441,7 +441,6 @@
     <string name="metadata_privacy_private">ਨਿੱਜੀ (ਪ੍ਰਾਈਵੇਟ)</string>
     <string name="metadata_privacy_unlisted">ਗੈਰ-ਸੂਚੀਬੱਧ</string>
     <string name="metadata_privacy_public">ਜਨਤਕ</string>
-    <string name="metadata_thumbnail_url">ਥੰਮਨੇਲ URL</string>
     <string name="metadata_host">ਮੇਜ਼ਬਾਨ</string>
     <string name="metadata_support">ਸਹਾਇਤਾ</string>
     <string name="metadata_language">ਭਾਸ਼ਾ/ਬੋਲੀ</string>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -55,8 +55,6 @@
     <string name="popup_remember_size_pos_summary">ਪੌਪ-ਅਪ ਦਾ ਆਖਰੀ ਅਕਾਰ ਅਤੇ ਸਥਿਤੀ ਯਾਦ ਰੱਖੋ</string>
     <string name="use_inexact_seek_title">ਤੇਜ਼ ਪਰ ਅਸਪੱਸ਼ਟ ਸੀਕ ਵਰਤੋ</string>
     <string name="use_inexact_seek_summary">ਅਸਪੱਸ਼ਟ ਸੀਕ ਵੀਡੀਓ ਨੂੰ ਤੇਜ਼ ਪਰ ਅਣ-ਸਟੀਕ ਢੰਗ ਨਾਲ ਅੱਗੇ-ਪਿੱਛੇ ਲਿਜਾਂਦਾ ਹੈ । ਇਸ ਨਾਲ ਅੱਗੇ-ਪਿੱਛੇ 5,15 ਜਾਂ 25 ਸਕਿੰਟ ਜਾਣਾ ਕੰਮ ਨਹੀਂ ਕਰੇਗਾ</string>
-    <string name="download_thumbnail_title">ਥੰਮਨੇਲ ਲੋਡ ਕਰੋ</string>
-    <string name="download_thumbnail_summary">ਡਾਟਾ ਤੇ ਮੈਮੋਰੀ ਖਪਤ ਦੀ ਬੱਚਤ ਅਤੇ ਥੰਮਨੇਲ ਲੋਡ ਹੋਣ ਤੋਂ ਰੋਕਣ ਲਈ ਬੰਦ ਕਰੋ। ਇਸ ਵਿਚ ਤਬਦੀਲੀ ਕਰਨ ਨਾਲ ਇਨ-ਮੈਮੋਰੀ ਅਤੇ ਆਨ-ਡਿਸਕ ਚਿੱਤਰ ਕੈਸ਼ੇ ਦੋਵੇਂ ਮਿਟ ਜਾਣਗੇ</string>
     <string name="thumbnail_cache_wipe_complete_notice">ਚਿੱਤਰ cache ਮਿਟਾ ਦਿੱਤੀ ਗਈ ਹੈ</string>
     <string name="metadata_cache_wipe_title">ਕੈਸ਼ ਕੀਤਾ ਮੈਟਾ-ਡਾਟਾ ਮਿਟਾਓ</string>
     <string name="metadata_cache_wipe_summary">ਸਾਰੇ ਕੈਸ਼ ਕੀਤੇ ਵੈੱਬ-ਪੇਜਾਂ ਦਾ ਡਾਟਾ ਮਿਟਾਓ</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -254,8 +254,6 @@
     <string name="enable_disposed_exceptions_summary">Wymuś raportowanie niedostarczonych wyjątków Rx poza cyklem życia fragmentu lub aktywności po usunięciu</string>
     <string name="use_inexact_seek_title">Używaj szybkiego, niedokładnego przewijania</string>
     <string name="use_inexact_seek_summary">Niedokładne przewijanie umożliwia szybsze przewijanie ze zmniejszoną dokładnością. Przewijanie o 5, 15 lub 25 sekund nie działa w tym przypadku</string>
-    <string name="download_thumbnail_title">Wczytuj miniatury</string>
-    <string name="download_thumbnail_summary">Wyłącz, aby nie wczytywać miniatur, oszczędzając dane i zużycie pamięci. Zmiana tej opcji czyści pamięć podręczną obrazów</string>
     <string name="thumbnail_cache_wipe_complete_notice">Wyczyszczono pamięć podręczną miniatur</string>
     <string name="metadata_cache_wipe_title">Wyczyść pamięć podręczną metadanych</string>
     <string name="metadata_cache_wipe_summary">Usuwa całą pamięć podręczną stron</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -619,7 +619,6 @@
     <string name="metadata_privacy_internal">Wewnętrzny</string>
     <string name="metadata_privacy_private">Prywatny</string>
     <string name="metadata_privacy_public">Publiczny</string>
-    <string name="metadata_thumbnail_url">Adres URL miniatury</string>
     <string name="metadata_host">Host</string>
     <string name="metadata_support">Wsparcie</string>
     <string name="metadata_language">Język</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -613,7 +613,6 @@
     <string name="metadata_privacy_unlisted">Não Listado</string>
     <string name="metadata_privacy_public">Público</string>
     <string name="metadata_age_limit">Limite de Idade</string>
-    <string name="metadata_thumbnail_url">URL da Miniatura</string>
     <string name="metadata_host">Hospedado em</string>
     <string name="metadata_support">Suporte</string>
     <string name="metadata_language">Idioma</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -284,14 +284,12 @@
     <string name="import_network_expensive_warning">Tenha em mente que esta operação poderá consumir muitos dados.
 \n
 \nVocê deseja continuar\?</string>
-    <string name="download_thumbnail_title">Carregar miniaturas</string>
     <string name="thumbnail_cache_wipe_complete_notice">Cache de imagens limpo</string>
     <string name="metadata_cache_wipe_title">Limpar cache de metadados</string>
     <string name="metadata_cache_wipe_summary">Remove todos os dados de páginas em cache</string>
     <string name="metadata_cache_wipe_complete_notice">Cache de metadados limpo</string>
     <string name="playback_speed_control">Controles de velocidade de reprodução</string>
     <string name="playback_tempo">Velocidade</string>
-    <string name="download_thumbnail_summary">Desative para não carregar miniaturas e economizar no uso de dados e memória. A alteração limpa todo o cache de imagens em memória e em disco</string>
     <string name="playback_pitch">Afinação</string>
     <string name="unhook_checkbox">Desvincular (pode causar distorção)</string>
     <string name="preferred_open_action_settings_title">Ação de \'abrir\' preferida</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -137,7 +137,6 @@
     <string name="show_higher_resolutions_title">Mostrar resoluções mais altas</string>
     <string name="no_subscribers">Sem subscritores</string>
     <string name="use_external_audio_player_title">Utilizar reprodutor de áudio externo</string>
-    <string name="download_thumbnail_summary">Desative para parar o carregamento de miniaturas, poupar dados e utilização da memória. As alterações limpam a cache de imagens do disco e da memória</string>
     <string name="did_you_mean">Será que queria dizer \"%1$s\"\?</string>
     <string name="updates_setting_description">Mostrar uma notificação para pedir a atualização da aplicação se existir uma nova versão</string>
     <string name="enqueue">Enfileirar</string>
@@ -442,7 +441,6 @@
     <string name="default_audio_format_title">Formato padrão de áudio</string>
     <string name="invalid_file">O ficheiro não existe ou não tem permissões para ler e/ou escrever</string>
     <string name="feed_group_dialog_empty_name">O nome do grupo está vazio</string>
-    <string name="download_thumbnail_title">Carregar miniaturas</string>
     <string name="share_dialog_title">Partilhar com</string>
     <string name="feed_update_threshold_summary">Tempo após a última atualização antes de a subscrição ser considerada desatualizada - %s</string>
     <string name="search">Pesquisar</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -617,7 +617,6 @@
     <string name="metadata_privacy_private">Privado</string>
     <string name="metadata_privacy_unlisted">Não listado</string>
     <string name="metadata_privacy_public">Público</string>
-    <string name="metadata_thumbnail_url">URL da miniatura</string>
     <string name="metadata_host">Servidor</string>
     <string name="metadata_support">Apoio</string>
     <string name="metadata_language">Idioma</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -204,8 +204,6 @@
     <string name="controls_add_to_playlist_title">Adicionar a</string>
     <string name="use_inexact_seek_title">Utilizar pesquisa rápida</string>
     <string name="use_inexact_seek_summary">Este tipo de pesquisa e mais rápida mas reduz a precisão. Procurar por 5, 15 ou 25 segundos não funciona corretamente</string>
-    <string name="download_thumbnail_title">Carregar miniaturas</string>
-    <string name="download_thumbnail_summary">Desative para parar o carregamento de miniaturas, poupar dados e utilização da memória. As alterações limpam a cache de imagens do disco e da memória</string>
     <string name="thumbnail_cache_wipe_complete_notice">Cache de imagens limpa</string>
     <string name="default_content_country_title">País padrão para conteúdo</string>
     <string name="settings_category_debug_title">Depuração</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -630,7 +630,6 @@
     <string name="metadata_privacy_private">Privado</string>
     <string name="metadata_privacy_unlisted">Não listado</string>
     <string name="metadata_privacy_public">Público</string>
-    <string name="metadata_thumbnail_url">URL da miniatura</string>
     <string name="metadata_host">Servidor</string>
     <string name="metadata_support">Apoio</string>
     <string name="metadata_language">Idioma</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -618,7 +618,6 @@
     <string name="metadata_privacy_private">Privat</string>
     <string name="metadata_privacy_unlisted">Nelistat</string>
     <string name="metadata_privacy_public">Public</string>
-    <string name="metadata_thumbnail_url">URL miniatură</string>
     <string name="metadata_host">Gazdă</string>
     <string name="metadata_support">Sprijin</string>
     <string name="metadata_language">Limbă</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -181,8 +181,6 @@
     <string name="controls_add_to_playlist_title">Salvare în</string>
     <string name="use_inexact_seek_title">Folosește parcurgerea rapidă inexactă</string>
     <string name="use_inexact_seek_summary">Derularea inexactă permite player-ului să deruleze mai rapid, cu o precizie redusă. Derularea timp de 5, 15 sau 25 de secunde nu funcționează cu aceasta</string>
-    <string name="download_thumbnail_title">Încarcă miniaturi</string>
-    <string name="download_thumbnail_summary">Dezactivați pentru a preveni încărcarea miniaturilor, economisirea datelor și utilizarea memoriei. Modificările șterg atât memoria cache a imaginilor în memorie, cât și pe disc</string>
     <string name="thumbnail_cache_wipe_complete_notice">Datele cache de imagini au fost șterse</string>
     <string name="metadata_cache_wipe_title">Șterge cache-ul pentru metadata</string>
     <string name="metadata_cache_wipe_summary">Șterge cache-ul pentru datele de pagini web</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -298,8 +298,6 @@
     <string name="import_network_expensive_warning">Это действие может вызвать большой расход трафика.
 \n 
 \nПродолжить?</string>
-    <string name="download_thumbnail_title">Загружать миниатюры</string>
-    <string name="download_thumbnail_summary">Отключите, чтобы не загружать миниатюры и сэкономить трафик и память. Изменение настройки очистит кэш изображений</string>
     <string name="thumbnail_cache_wipe_complete_notice">Кэш изображений очищен</string>
     <string name="metadata_cache_wipe_title">Очистить кэш метаданных</string>
     <string name="metadata_cache_wipe_complete_notice">Кэш метаданных очищен</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -629,7 +629,6 @@
     <string name="metadata_privacy_private">Приватная</string>
     <string name="metadata_privacy_unlisted">Не в списке</string>
     <string name="metadata_privacy_public">Публичная</string>
-    <string name="metadata_thumbnail_url">URL миниатюры</string>
     <string name="metadata_host">Сервер</string>
     <string name="metadata_privacy">Доступность</string>
     <string name="feed_load_error_fast_unknown">В быстром режиме обновления подробности об этом не предоставляются.</string>

--- a/app/src/main/res/values-sc/strings.xml
+++ b/app/src/main/res/values-sc/strings.xml
@@ -602,7 +602,6 @@
     <string name="metadata_privacy_unlisted">No elencadu</string>
     <string name="metadata_privacy_private">Privadu</string>
     <string name="metadata_privacy_public">Pùblicu</string>
-    <string name="metadata_thumbnail_url">URL de sa miniadura</string>
     <string name="metadata_host">Istrangiadore</string>
     <string name="metadata_support">Suportu</string>
     <string name="metadata_language">Limba</string>

--- a/app/src/main/res/values-sc/strings.xml
+++ b/app/src/main/res/values-sc/strings.xml
@@ -473,10 +473,8 @@
     <string name="metadata_cache_wipe_summary">Boga totu sos datos de sa pàgina web in sa memòria temporànea</string>
     <string name="metadata_cache_wipe_title">Iscantzella sos metadatos in sa memòria temporànea</string>
     <string name="thumbnail_cache_wipe_complete_notice">Memòria temporànea de sas immàgines isboidada</string>
-    <string name="download_thumbnail_summary">Istuda pro prevènnere su carrigamentu de sas miniaduras, su sarvamentu de sos datos e s\'impreu de sa memòria. Sas modìficas ant a isbodiare siat sa memòria temporànea de sa memòria siat cussa de su discu</string>
     <string name="show_comments_summary">Istuda pro cuare sos cummentos</string>
     <string name="show_comments_title">Ammustra sos cummentos</string>
-    <string name="download_thumbnail_title">Càrriga sas miniaduras</string>
     <string name="seek_duration_title">Longària de s\'avantzamentu e de sa torrada in segus lestros</string>
     <string name="use_inexact_seek_summary">Su moimentu inesatu permitit a su riproduidore de si mòere cara a una positzione in manera prus lestra ma prus pagu pretzisa. Su de si mòere de 5, 15 o 25 segundos non funtzionat, cun custa optzione</string>
     <string name="use_inexact_seek_title">Imprea su moimentu inesatu lestru</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -611,7 +611,6 @@
     <string name="metadata_privacy_internal">Interné</string>
     <string name="metadata_privacy_private">Súkromné</string>
     <string name="metadata_privacy_unlisted">Nezaradené</string>
-    <string name="metadata_thumbnail_url">URL miniatúry</string>
     <string name="metadata_privacy_public">Verejné</string>
     <string name="metadata_host">Hostiteľ</string>
     <string name="metadata_support">Podpora</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -246,8 +246,6 @@
     <string name="resize_zoom">Zväčšiť</string>
     <string name="use_inexact_seek_title">Používať rýchly posun</string>
     <string name="use_inexact_seek_summary">Rýchly posun umožňuje prejsť na novú pozíciu rýchlejšie, ale s menšou presnosťou. Posun o 5, 15 alebo 25 sekúnd v tomto prípade nie je možný</string>
-    <string name="download_thumbnail_title">Načítanie miniatúr</string>
-    <string name="download_thumbnail_summary">Vypnutím tejto funkcie sa nebudú vytvárať miniatúry a tým sa ušetrí miesto a pamäť. Zmena nastavení spôsobuje vyčistenie vyrovnávacej pamäte</string>
     <string name="thumbnail_cache_wipe_complete_notice">Vyrovnávacia pamäť obrázkov vymazaná</string>
     <string name="metadata_cache_wipe_title">Vymazať metadáta uložené vo vyrovnávacej pamäti</string>
     <string name="metadata_cache_wipe_summary">Odstrániť všetky údaje webových stránok vo vyrovnávacej pamäti</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -198,7 +198,6 @@
     <string name="create">Ustvari</string>
     <string name="dismiss">Opusti</string>
     <string name="rename">Preimenuj</string>
-    <string name="download_thumbnail_title">Naloži sličice</string>
     <string name="app_language_title">Jezik aplikacije</string>
     <string name="downloads_storage_use_saf_title">Uporabi SAF</string>
     <string name="downloads_storage_ask_title">Vprašaj kam shraniti</string>
@@ -309,7 +308,6 @@
     <string name="metadata_cache_wipe_complete_notice">Predpomnjeni metapodatki so bili odstranjeni</string>
     <string name="show_meta_info_title">Prikaži meta informacije</string>
     <string name="show_comments_summary">Onemogoči da se ustavi prikazovanje komentarjev</string>
-    <string name="download_thumbnail_summary">Izklopite, če želite preprečiti nalaganje sličic, s tem bo varčeval na podatkih in uporabi spomina. Spremembe bodo izbrisale predpomnilnik v spominu in na disku</string>
     <string name="clear_queue_confirmation_description">Dejavna vrsta bo zamenjana</string>
     <string name="clear_queue_confirmation_summary">Preklop na drugi predvajanik lahko zamenja vašo čakalno vrsto</string>
     <string name="clear_queue_confirmation_title">Vprašaj za potrditev pred čiščenjem vrste</string>

--- a/app/src/main/res/values-so/strings.xml
+++ b/app/src/main/res/values-so/strings.xml
@@ -602,7 +602,6 @@
     <string name="metadata_privacy_private">Gaar ah</string>
     <string name="metadata_privacy_unlisted">Aan liistada kujirin</string>
     <string name="metadata_privacy_public">Lawada arko</string>
-    <string name="metadata_thumbnail_url">Tixraaca galka</string>
     <string name="metadata_host">Martigaliye</string>
     <string name="metadata_support">Taageero</string>
     <string name="metadata_language">Luuqada</string>

--- a/app/src/main/res/values-so/strings.xml
+++ b/app/src/main/res/values-so/strings.xml
@@ -401,10 +401,8 @@
     <string name="metadata_cache_wipe_summary">Tirtir waxyaabaha K/G ah ee boga website-ka</string>
     <string name="metadata_cache_wipe_title">Tirtir faahfaahinada yaryar</string>
     <string name="thumbnail_cache_wipe_complete_notice">kaydkii kumeelgaadhka ahaa ee sawirka waa la tirtiray</string>
-    <string name="download_thumbnail_summary">Xidh si aad u joojiso soo bandhiga galka muuqaalada, adigoo yaraynaya isticmalka khadka iyo maskaxda aalada. Wax ka baddalkan wuxuu nadiifin doonaa waxa kaydka hore iyo ka caadiga ah kumeelgaadh ahaan ugu jira</string>
     <string name="show_comments_summary">Xidh si aad uqariso faallooyinka</string>
     <string name="show_comments_title">Tus faallooyinka</string>
-    <string name="download_thumbnail_title">Soodhig galalka</string>
     <string name="clear_queue_confirmation_description">Hormada daareha hadda wax shidaya waa la baddali doonaa</string>
     <string name="clear_queue_confirmation_summary">Kala baddalka daareha waxay badali kartaa hormada sidaas darteed waydii in la xaqiijiyo intaan hormada la tirtirin</string>
     <string name="clear_queue_confirmation_title">Xaqiijinta tirtirka hormada</string>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -18,7 +18,6 @@
     <string name="play_with_kodi_title">Luaj me Kodi</string>
     <string name="play_audio">Audio</string>
     <string name="black_theme_title">E zezë</string>
-    <string name="download_thumbnail_title">Ngarko pamjet miniaturë</string>
     <string name="show_search_suggestions_title">Sugjerimet e kërkimit</string>
     <string name="enable_watch_history_title">Të shikuarat</string>
     <string name="enable_watch_history_summary">Ruaji videot e shikuara</string>
@@ -487,7 +486,6 @@
     <string name="metadata_cache_wipe_complete_notice">Depoja e të dhënave meta u boshatis</string>
     <string name="metadata_cache_wipe_summary">Boshatis depon e të gjitha të dhënave të faqeve të internetit</string>
     <string name="metadata_cache_wipe_title">Boshatis depon e të dhënave meta</string>
-    <string name="download_thumbnail_summary">Fikeni për të ndaluar shfaqjen e pamjeve statike, duke kursyer internet dhe memorje. Ndryshimet boshatisin depon e imazheve në memorje dhe në disk</string>
     <string name="thumbnail_cache_wipe_complete_notice">Depoja e imazheve u boshatis</string>
     <string name="show_comments_summary">Fikeni për të fshehur komentet</string>
     <string name="show_comments_title">Shfaq komentet</string>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -587,7 +587,6 @@
     <string name="metadata_privacy_private">Private</string>
     <string name="metadata_privacy_unlisted">E palistuar</string>
     <string name="metadata_privacy_public">Publike</string>
-    <string name="metadata_thumbnail_url">URL e pamjes statike</string>
     <string name="metadata_host">Mundësuesi</string>
     <string name="metadata_support">Mbështetje</string>
     <string name="metadata_language">Gjuha</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -201,8 +201,6 @@
     <string name="hold_to_append">Задржи за стављање у ред</string>
     <string name="use_inexact_seek_title">Користи брзо, непрецизно премотавање</string>
     <string name="use_inexact_seek_summary">Непрецизно премотавање омогућава плејеру да брже долази до позиције уз смањену прецизност. Премотавање за 5, 15 или 25 секунди са овом опцијом не ради</string>
-    <string name="download_thumbnail_title">Учитај сличице</string>
-    <string name="download_thumbnail_summary">Искључите да спречите преузимање сличица, смањујући утрошак преноса података и меморије. Изменом ће се очистити и меморијски и диск кеш</string>
     <string name="thumbnail_cache_wipe_complete_notice">Очишћен кеш са сликама</string>
     <string name="metadata_cache_wipe_title">Уклони кеширане метаподатке</string>
     <string name="metadata_cache_wipe_summary">Уклања све податке кешираних веб-страна</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -612,7 +612,6 @@
     <string name="metadata_privacy_private">лично</string>
     <string name="metadata_privacy_unlisted">ненаведено</string>
     <string name="metadata_privacy_public">јавно</string>
-    <string name="metadata_thumbnail_url">УРЛ сличице</string>
     <string name="metadata_host">Домаћин</string>
     <string name="metadata_support">Подршка</string>
     <string name="metadata_language">Језик</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -193,8 +193,6 @@
     <string name="tab_bookmarks">Bokmärkta Spellistor</string>
     <string name="controls_add_to_playlist_title">Lägg till i</string>
     <string name="use_inexact_seek_title">Använd snabb icke-exakt sökning</string>
-    <string name="download_thumbnail_title">Läs in miniatyrbilder</string>
-    <string name="download_thumbnail_summary">Stäng av för att förhindra att miniatyrbilder läses in, vilket sparar data- och minnesanvändning. Ändringarna rensar både bildcacheminnet i minnet och på disken</string>
     <string name="thumbnail_cache_wipe_complete_notice">Cacheminnet för bilder rensat</string>
     <string name="settings_category_debug_title">Debug</string>
     <string name="always">Alltid</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -628,7 +628,6 @@
     <string name="featured">Aktuellt</string>
     <string name="night_theme_title">Natt-tema</string>
     <string name="hash_channel_description">Aviseringar för videohashningsframsteg</string>
-    <string name="metadata_thumbnail_url">Miniatyrbild-webbadress</string>
     <string name="disable_media_tunneling_summary">Inaktivera medietunnel om du upplever en svart skärm eller att videouppspelningen hackar.</string>
     <string name="disable_media_tunneling_title">Inaktivera medietunnel</string>
     <string name="detail_heart_img_view_description">Hjärtmärkt av innehållsskaparen</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -50,7 +50,6 @@
     <string name="black_theme_title">கருமை</string>
     <string name="popup_remember_size_pos_title">திரைமேல் பண்புகளை நினைவுகொள்</string>
     <string name="popup_remember_size_pos_summary">திரைமேல் நிலையின் கடைசி அளவையும் இடத்தையும் நினைவுகொள்</string>
-    <string name="download_thumbnail_title">சிறுபடத்தைக் இறக்கு</string>
     <string name="thumbnail_cache_wipe_complete_notice">பட பதுக்ககம் அழிக்கப்பட்டது</string>
     <string name="metadata_cache_wipe_title">மேல்நிலைத்தரவின் பதுக்ககம் அழிக்கப்பட்டது</string>
     <string name="metadata_cache_wipe_summary">பதுக்ககப்படுத்திய வலைப்பக்கத் தரவை நீக்கு</string>
@@ -264,7 +263,6 @@
     <string name="short_thousand">ஆ</string>
     <string name="short_million">ப.ல</string>
     <string name="crash_the_player">இயக்கியைச் சிதை</string>
-    <string name="download_thumbnail_summary">சிறுபடங்களேற்றுவதை தவிர்த்து தரவு மற்றும் நினைவகப் பயன்பாட்டைச் சேமிக்க அணை. மாற்றங்கள் நினைவகத்துள் மற்றும் வட்டின்மீதுள்ள பிடிதரவைத் துடைக்கும்</string>
     <string name="enable_playback_state_lists_summary">பட்டியல்களில் இயக்கக குறியட நிலைகாட்டிகளைக் காட்டு</string>
     <string name="start_main_player_fullscreen_summary">துணையியக்கியில் காணொளிகளை துவக்காதே, ஆனால் தானாக சுழற்றல் பூட்டப்பட்டிருந்தால் நேரடியாக முழுதிரைக்குத் திரும்பு. முழுதிரையை வெளியேறி நீங்கள் இன்னும் துணையியக்கியை அணுகலாம்</string>
     <string name="unsupported_url_dialog_message">உரலியை அங்கீகரக்க முடியவில்லை. மற்றொரு செயலியில் திறக்கவா\?</string>

--- a/app/src/main/res/values-te/strings.xml
+++ b/app/src/main/res/values-te/strings.xml
@@ -165,13 +165,11 @@
     <string name="show_higher_resolutions_title">అధిక స్పష్టతను చూపుము</string>
     <string name="black_theme_title">నలుపు</string>
     <string name="popup_remember_size_pos_title">పాప్అప్ లక్షణాలను గుర్తుంచుకో</string>
-    <string name="download_thumbnail_title">సూక్ష్మచిత్రాలను లోడ్ చేయండి</string>
     <string name="show_comments_title">వ్యాఖ్యలను చూపించు</string>
     <string name="show_comments_summary">వ్యాఖ్యలను దాచడాన్ని ఆఫ్ చేయండి</string>
     <string name="peertube_instance_url_help">%sలో మీకు నచ్చిన సందర్భాలను కనుగొనండి</string>
     <string name="peertube_instance_url_title">పీర్‌ట్యూబ్ ఉదాహరణలు</string>
     <string name="notification_action_2_title">మూడవ చర్య బటన్</string>
-    <string name="download_thumbnail_summary">థంబ్‌నెయిల్‌లను లోడ్ చేయడం, డేటాను సేవ్ చేయడం మరియు మెమరీ వినియోగాన్ని నిరోధించడానికి ఆఫ్ చేయండి. మార్పులు ఇన్-మెమరీ మరియు ఆన్-డిస్క్ ఇమేజ్ కాష్ రెండింటినీ క్లియర్ చేస్తాయి</string>
     <string name="use_inexact_seek_summary">ఖచ్చితమైన శోధన తగ్గిన ఖచ్చితత్వంతో వేగంగా స్థానాలను పొందేందుకు ఆటగాడిని అనుమతిస్తుంది. 5, 15 లేదా 25 సెకన్ల పాటు కోరడం దీనితో పని చేయదు</string>
     <string name="use_inexact_seek_title">వేగవంతమైన ఖచ్చితమైన శోధనను ఉపయోగించండి</string>
     <string name="controls_add_to_playlist_title">జోడించండి</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -56,10 +56,8 @@
     <string name="popup_remember_size_pos_summary">จำขนาดและตำแหน่งสุดท้ายของป๊อปอัพ</string>
     <string name="use_inexact_seek_title">ใช้การข้ามที่ไม่แม่นยำ</string>
     <string name="use_inexact_seek_summary">การข้ามช่วงที่ไม่แม่นยำจะทำให้เลื่อนไปยังตำแหน่งเวลาที่ต้องการได้เร็วขึ้น แต่จะลดความแม่นยำในการลากตำแหน่งลง</string>
-    <string name="download_thumbnail_title">โหลดภาพขนาดย่อ</string>
     <string name="show_comments_title">แสดงความคิดเห็น</string>
     <string name="show_comments_summary">ปิดใช้งานเพื่อซ่อนความคิดเห็น</string>
-    <string name="download_thumbnail_summary">ปิดเพื่อป้องกันการโหลดรูปขนาดย่อ ลดการใช้ข้อมูลและหน่วยความจำ การเปลี่ยนแปลงล้างแคชภาพในหน่วยความจำและบนดิสก์</string>
     <string name="thumbnail_cache_wipe_complete_notice">ล้างแคชของรูปภาพแล้ว</string>
     <string name="metadata_cache_wipe_summary">ลบข้อมูลเว็บเพจที่แคชไว้ทั้งหมด</string>
     <string name="auto_queue_title">คิววีดีโอถัดไปโดยอัตโนมัติ</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -601,7 +601,6 @@
     <string name="metadata_privacy_private">Gizli</string>
     <string name="metadata_privacy_unlisted">Listelenmemiş</string>
     <string name="metadata_privacy_public">Herkese Açık</string>
-    <string name="metadata_thumbnail_url">Küçük Resim URL\'si</string>
     <string name="metadata_host">Konakçı</string>
     <string name="metadata_support">Destek</string>
     <string name="metadata_language">Dil</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -280,8 +280,6 @@
     <string name="import_network_expensive_warning">Bu sürecin ağa yük olabileceğini unutmayın.
 \n
 \nSürdürmek istiyor musunuz\?</string>
-    <string name="download_thumbnail_title">Küçük resimleri yükle</string>
-    <string name="download_thumbnail_summary">Küçük resimlerin yüklenmesini önleyerek veri ve hafıza kullanımından tasarruf etmek için kapatın. Değişiklikler, hem bellek içi hem de diskteki resim önbelleğini temizler</string>
     <string name="thumbnail_cache_wipe_complete_notice">Resim önbelleği silindi</string>
     <string name="metadata_cache_wipe_title">Önbelleğe alınmış üstverileri temizle</string>
     <string name="metadata_cache_wipe_summary">Önbelleğe alınmış tüm web sayfası verilerini kaldır</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -292,8 +292,6 @@
     <string name="import_network_expensive_warning">Майте на увазі: ця операція може потребувати багато трафіку.
 \n
 \nБажаєте продовжити\?</string>
-    <string name="download_thumbnail_title">Завантажувати ескізи</string>
-    <string name="download_thumbnail_summary">Вимкніть для запобігання завантаженню ескізів, що заощадить трафік і внутрішню пам\'ять. Зміни призведуть до очищення кешу зображень</string>
     <string name="thumbnail_cache_wipe_complete_notice">Кеш зображень стерто</string>
     <string name="metadata_cache_wipe_title">Стерти кеш метаданих</string>
     <string name="metadata_cache_wipe_summary">Видалити всі кешовані дані вебсторінок</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -618,7 +618,6 @@
     <string name="metadata_privacy_public">Публічне</string>
     <string name="metadata_privacy_private">Приватне</string>
     <string name="metadata_privacy_unlisted">Поза списком</string>
-    <string name="metadata_thumbnail_url">URL мініатюри</string>
     <string name="metadata_host">Власник</string>
     <string name="metadata_support">Підтримка</string>
     <string name="metadata_language">Мова</string>

--- a/app/src/main/res/values-und/strings.xml
+++ b/app/src/main/res/values-und/strings.xml
@@ -118,7 +118,6 @@
     <string name="clear_queue_confirmation_title">کتار نوں خالی کرن توں پہلاں تصویر کرن لئی پچھو</string>
     <string name="clear_queue_confirmation_summary">پلیئر بدلݨ نال تہاڈی بدل سکدی اے</string>
     <string name="clear_queue_confirmation_description">سرگرم پکیئر کتار جاوےگا</string>
-    <string name="download_thumbnail_title">تھمنیل لوڈ کرو</string>
     <string name="show_description_title">وہروا دِکھاؤ</string>
     <string name="enable_search_history_title">کھوج دا اتیت</string>
     <string name="settings_category_clear_data_title">ڈیٹا پٹاؤ</string>

--- a/app/src/main/res/values-ur/strings.xml
+++ b/app/src/main/res/values-ur/strings.xml
@@ -55,8 +55,6 @@
     <string name="popup_remember_size_pos_summary">پچھلی جسامت اور پوپ اپ کا مقام یاد رکھیں</string>
     <string name="use_inexact_seek_title">بالواسطہ رسائی استعمال کریں</string>
     <string name="use_inexact_seek_summary">بالواسطہ تلاش مشکلات کو کم کر کے پلیئر کو تیز رفتاری سے مقامات تک رسائی کرنے دیتی ہے۔ 5 ، 15 یا 25 سیکنڈ کی تلاش اس کے ساتھ کام نہیں کرتی ہے:</string>
-    <string name="download_thumbnail_title">نظرِ انگشتی لوڈ کریں</string>
-    <string name="download_thumbnail_summary">ڈیٹا کی بچت اور میموری کے استعمال کو روکنے کیلئے تھمب نیل کو بند کریں۔ تبدیلیاں میموری اور آن ڈسک ایمیج کیشے کو صاف کریں گی</string>
     <string name="thumbnail_cache_wipe_complete_notice">تصویری کیشے کی صفائی ہوئی</string>
     <string name="metadata_cache_wipe_title">کیشے میٹا ڈیٹا کو صاف کریں</string>
     <string name="metadata_cache_wipe_summary">ویب پیج کے سبھی کیشے ڈیٹا کو ہٹا دیں</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -133,8 +133,6 @@
     <string name="controls_add_to_playlist_title">Thêm vào</string>
     <string name="use_inexact_seek_title">Sử dụng tìm kiếm nhanh không chính xác</string>
     <string name="use_inexact_seek_summary">Tua không chính xác cho phép trình phát tua đến các vị trí nhanh hơn với độ chính xác bị giảm. Tua 5, 15 hay 25 giây không dùng được với chế độ này</string>
-    <string name="download_thumbnail_title">Tải hình thu nhỏ</string>
-    <string name="download_thumbnail_summary">Tắt để ngăn chặn việc tải các hình thu nhỏ, việc này sẽ tiết kiệm lưu lượng mạng và bộ nhớ. Các thay đổi sẽ xóa bộ nhớ đệm hình ảnh cả trong RAM và trong bộ nhớ</string>
     <string name="thumbnail_cache_wipe_complete_notice">Đã xóa bộ nhớ cache hình ảnh</string>
     <string name="metadata_cache_wipe_title">Xóa siêu dữ liệu đã lưu vào bộ nhớ cache</string>
     <string name="metadata_cache_wipe_summary">Xóa tất cả dữ liệu trang web được lưu trong bộ nhớ cache</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -596,7 +596,6 @@
     <string name="metadata_privacy_private">Riêng tư</string>
     <string name="metadata_privacy_unlisted">Chưa được liệt kê</string>
     <string name="metadata_privacy_public">Công khai</string>
-    <string name="metadata_thumbnail_url">URL hình thu nhỏ</string>
     <string name="metadata_host">Nơi chứa</string>
     <string name="metadata_support">Hỗ trợ</string>
     <string name="metadata_language">Ngôn ngữ</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -593,7 +593,6 @@
     <string name="metadata_privacy_private">私享</string>
     <string name="metadata_privacy_unlisted">未分类</string>
     <string name="metadata_privacy_public">公开</string>
-    <string name="metadata_thumbnail_url">缩略图 URL</string>
     <string name="metadata_host">所在服务器</string>
     <string name="metadata_support">支持</string>
     <string name="metadata_language">语言</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -46,7 +46,6 @@
     <string name="just_once">仅一次</string>
     <string name="controls_add_to_playlist_title">添加至</string>
     <string name="file">文件</string>
-    <string name="download_thumbnail_title">加载封面</string>
     <string name="clear_views_history_title">清空播放历史</string>
     <string name="minimize_on_exit_none_description">无</string>
     <string name="minimize_on_exit_background_description">最小化至后台播放</string>
@@ -310,7 +309,6 @@
     <string name="import_network_expensive_warning">该操作消耗大量流量，
 \n
 \n你想继续吗？</string>
-    <string name="download_thumbnail_summary">关闭可禁止加载封面，节省流量和内存使用。切换该选项将立即清除内存与存储中的图片缓存</string>
     <string name="thumbnail_cache_wipe_complete_notice">清空图像缓存成功</string>
     <string name="metadata_cache_wipe_title">清空已缓存的元数据</string>
     <string name="metadata_cache_wipe_summary">清空已缓存的网页数据</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -508,7 +508,6 @@
     <string name="metadata_category">分類</string>
     <string name="metadata_tags">標籤</string>
     <string name="metadata_privacy">公開設定</string>
-    <string name="metadata_thumbnail_url">縮圖 URL</string>
     <string name="metadata_privacy_public">公開</string>
     <string name="metadata_privacy_unlisted">憑網址瀏覽</string>
     <string name="detail_pinned_comment_view_description">置頂留言</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -159,7 +159,6 @@
     <string name="notification_actions_summary">撳下面嘅掣去更改對應嘅通知動作。用右手邊嘅格仔剔選最多三個，擺喺精簡通知度</string>
     <string name="notification_actions_at_most_three">精簡通知最多淨係擺到三個動作！</string>
     <string name="notification_action_repeat">循環播放</string>
-    <string name="download_thumbnail_title">載入縮圖</string>
     <string name="show_comments_title">顯示留言</string>
     <string name="show_comments_summary">關閉去隱藏留言</string>
     <string name="enable_search_history_title">搜尋紀錄</string>
@@ -168,7 +167,6 @@
     <string name="show_description_title">顯示描述</string>
     <string name="thumbnail_cache_wipe_complete_notice">抹除咗影像快取</string>
     <string name="metadata_cache_wipe_summary">移除所有網頁嘅快取資料</string>
-    <string name="download_thumbnail_summary">關閉佢去避免載入條片嘅縮圖，慳返啲數據同埋用少啲 RAM。更改會抹走記憶體以及磁碟機上面嘅影像快取</string>
     <string name="use_inexact_seek_summary">粗略嘅快轉允許播放器比較籠統咁快轉去其他位置。快轉 5、15 或 25 秒就太仔細，做唔到</string>
     <string name="settings_category_player_title">播放器</string>
     <string name="default_content_country_title">預設嘅國家內容</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -592,7 +592,6 @@
     <string name="metadata_privacy_private">私人</string>
     <string name="metadata_privacy_unlisted">未列出</string>
     <string name="metadata_privacy_public">公開</string>
-    <string name="metadata_thumbnail_url">縮圖 URL</string>
     <string name="metadata_host">主機</string>
     <string name="metadata_support">支援</string>
     <string name="metadata_language">語言</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -278,8 +278,6 @@
 \n2. 移至此網址： %1$s 
 \n3. 當被提示時登入帳號 
 \n4. 複製您被重新導向到的個人設定檔網址。</string>
-    <string name="download_thumbnail_title">載入縮圖</string>
-    <string name="download_thumbnail_summary">關閉以防止載入縮圖，減少數據和儲存空間的用量。改變時將清除記憶體和磁碟上的縮圖快取</string>
     <string name="thumbnail_cache_wipe_complete_notice">已抹除圖片快取</string>
     <string name="metadata_cache_wipe_title">抹除已快取的中介資料</string>
     <string name="metadata_cache_wipe_summary">移除所有已快取的網頁資料</string>

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -396,8 +396,6 @@
 
     <string name="clear_cookie_key">clear_cookie</string>
 
-    <string name="download_thumbnail_key">download_thumbnail_key</string>
-
     <string name="metadata_cache_wipe_key">cache_wipe_key</string>
     <string name="clear_views_history_key">clear_play_history</string>
     <string name="clear_playback_states_key">clear_playback_states</string>
@@ -1433,4 +1431,24 @@
     <string name="media_tunneling_device_blacklist_version">media_tunneling_device_blacklist_version</string>
     <string name="use_exoplayer_decoder_fallback_key">use_exoplayer_decoder_fallback_key</string>
     <string name="always_use_exoplayer_set_output_surface_workaround_key">always_use_exoplayer_set_output_surface_workaround_key</string>
+
+    <!-- Image quality -->
+    <string name="image_quality_key">image_quality_key</string>
+    <string name="image_quality_none_key">image_quality_none</string>
+    <string name="image_quality_low_key">image_quality_low</string>
+    <string name="image_quality_medium_key">image_quality_medium</string>
+    <string name="image_quality_high_key">image_quality_high</string>
+    <string name="image_quality_default">@string/image_quality_medium_key</string>
+    <string-array name="image_quality_description">
+        <item>@string/image_quality_none</item>
+        <item>@string/image_quality_low</item>
+        <item>@string/image_quality_medium</item>
+        <item>@string/image_quality_high</item>
+    </string-array>
+    <string-array name="image_quality_values">
+        <item>@string/image_quality_none_key</item>
+        <item>@string/image_quality_low_key</item>
+        <item>@string/image_quality_medium_key</item>
+        <item>@string/image_quality_high_key</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,8 +85,6 @@
     <string name="clear_queue_confirmation_description">The active player queue will be replaced</string>
     <string name="ignore_hardware_media_buttons_title">Ignore hardware media button events</string>
     <string name="ignore_hardware_media_buttons_summary">Useful, for instance, if you are using a headset with broken physical buttons</string>
-    <string name="download_thumbnail_title">Load thumbnails</string>
-    <string name="download_thumbnail_summary">Turn off to prevent loading thumbnails, saving data and memory usage. Changes clear both in-memory and on-disk image cache</string>
     <string name="show_comments_title">Show comments</string>
     <string name="show_comments_summary">Turn off to hide comments</string>
     <string name="show_next_and_similar_title">Show \'Next\' and \'Similar\' videos</string>
@@ -822,4 +820,10 @@
     <string name="duration">Duration</string>
     <string name="rewind">Rewind</string>
     <string name="forward">Forward</string>
+    <string name="image_quality_title">Image quality</string>
+    <string name="image_quality_summary">Choose the quality of images and whether to load images at all, to reduce data and memory usage. Changes clear both in-memory and on-disk image cache — %s</string>
+    <string name="image_quality_none">Do not load images</string>
+    <string name="image_quality_low">Low quality</string>
+    <string name="image_quality_medium">Medium quality</string>
+    <string name="image_quality_high">High quality</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -753,9 +753,11 @@
     <string name="metadata_language">Language</string>
     <string name="metadata_support">Support</string>
     <string name="metadata_host">Host</string>
-    <string name="metadata_thumbnail_url">Thumbnail URL</string>
-    <string name="metadata_avatar_url">Avatar URL</string>
-    <string name="metadata_banner_url">Banner URL</string>
+    <string name="metadata_thumbnails">Thumbnails</string>
+    <string name="metadata_uploader_avatars">Uploader avatars</string>
+    <string name="metadata_subchannel_avatars">Sub-channel avatars</string>
+    <string name="metadata_avatars">Avatars</string>
+    <string name="metadata_banners">Banners</string>
     <string name="metadata_privacy_public">Public</string>
     <string name="metadata_privacy_unlisted">Unlisted</string>
     <string name="metadata_privacy_private">Private</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -828,4 +828,5 @@
     <string name="image_quality_low">Low quality</string>
     <string name="image_quality_medium">Medium quality</string>
     <string name="image_quality_high">High quality</string>
+    <string name="question_mark">\?</string>
 </resources>

--- a/app/src/main/res/xml/content_settings.xml
+++ b/app/src/main/res/xml/content_settings.xml
@@ -85,11 +85,13 @@
         app:singleLineTitle="false"
         app:iconSpaceReserved="false" />
 
-    <SwitchPreferenceCompat
-        android:defaultValue="true"
-        android:key="@string/download_thumbnail_key"
-        android:summary="@string/download_thumbnail_summary"
-        android:title="@string/download_thumbnail_title"
+    <ListPreference
+        android:defaultValue="@string/image_quality_default"
+        android:entries="@array/image_quality_description"
+        android:entryValues="@array/image_quality_values"
+        android:key="@string/image_quality_key"
+        android:summary="@string/image_quality_summary"
+        android:title="@string/image_quality_title"
         app:singleLineTitle="false"
         app:iconSpaceReserved="false" />
 

--- a/app/src/test/java/org/schabi/newpipe/util/image/ImageStrategyTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/image/ImageStrategyTest.java
@@ -1,0 +1,195 @@
+package org.schabi.newpipe.util.image;
+
+import static org.junit.Assert.assertEquals;
+import static org.schabi.newpipe.extractor.Image.HEIGHT_UNKNOWN;
+import static org.schabi.newpipe.extractor.Image.WIDTH_UNKNOWN;
+import static org.schabi.newpipe.util.image.ImageStrategy.choosePreferredImage;
+import static org.schabi.newpipe.util.image.ImageStrategy.estimatePixelCount;
+
+import org.junit.Test;
+import org.schabi.newpipe.extractor.Image;
+import org.schabi.newpipe.extractor.Image.ResolutionLevel;
+
+import java.util.List;
+
+public class ImageStrategyTest {
+
+    private static final List<ResolutionLevel> RESOLUTION_LEVELS = List.of(
+            ResolutionLevel.LOW, ResolutionLevel.MEDIUM, ResolutionLevel.HIGH);
+
+    private Image img(final int height, final int width) {
+        return new Image("", height, width, ResolutionLevel.UNKNOWN);
+    }
+
+    private Image img(final String url, final ResolutionLevel resolutionLevel) {
+        return new Image(url, HEIGHT_UNKNOWN, WIDTH_UNKNOWN, resolutionLevel);
+    }
+
+    private Image img(final String url,
+                      final int height,
+                      final int width,
+                      final ResolutionLevel resolutionLevel) {
+        return new Image(url, height, width, resolutionLevel);
+    }
+
+    private void assertChoosePreferredImage(final String low,
+                                            final String medium,
+                                            final String high,
+                                            final List<Image> images) {
+        assertEquals(low, choosePreferredImage(images, PreferredImageQuality.LOW));
+        assertEquals(medium, choosePreferredImage(images, PreferredImageQuality.MEDIUM));
+        assertEquals(high, choosePreferredImage(images, PreferredImageQuality.HIGH));
+    }
+
+
+    // CHECKSTYLE:OFF
+    @Test
+    public void testEstimatePixelCountAllKnown() {
+        assertEquals(20000.0, estimatePixelCount(img(100, 200),  1.0), 0.0);
+        assertEquals(20000.0, estimatePixelCount(img(100, 200), 12.0), 0.0);
+        assertEquals(  100.0, estimatePixelCount(img(100,   1), 12.0), 0.0);
+        assertEquals(  100.0, estimatePixelCount(img(  1, 100),  0.5), 0.0);
+    }
+
+    @Test
+    public void testEstimatePixelCountHeightUnknown() {
+        assertEquals( 10000.0, estimatePixelCount(img(HEIGHT_UNKNOWN, 100),  1.0    ), 0.0);
+        assertEquals( 20000.0, estimatePixelCount(img(HEIGHT_UNKNOWN, 200),  2.0    ), 0.0);
+        assertEquals(    10.0, estimatePixelCount(img(HEIGHT_UNKNOWN,   1),  0.1    ), 0.0);
+        assertEquals(230400.0, estimatePixelCount(img(HEIGHT_UNKNOWN, 640), 16.0/9.0), 0.0);
+    }
+
+    @Test
+    public void testEstimatePixelCountWidthUnknown() {
+        assertEquals( 10000.0, estimatePixelCount(img(100, WIDTH_UNKNOWN),  1.0    ), 0.0);
+        assertEquals( 20000.0, estimatePixelCount(img(200, WIDTH_UNKNOWN),  0.5    ), 0.0);
+        assertEquals(    12.0, estimatePixelCount(img(  1, WIDTH_UNKNOWN), 12.0    ), 0.0);
+        assertEquals(230400.0, estimatePixelCount(img(360, WIDTH_UNKNOWN), 16.0/9.0), 0.0);
+    }
+
+    @Test
+    public void testEstimatePixelCountAllUnknown() {
+        assertEquals(0.0, estimatePixelCount(img(HEIGHT_UNKNOWN, WIDTH_UNKNOWN),  1.0    ), 0.0);
+        assertEquals(0.0, estimatePixelCount(img(HEIGHT_UNKNOWN, WIDTH_UNKNOWN), 12.0    ), 0.0);
+        assertEquals(0.0, estimatePixelCount(img(HEIGHT_UNKNOWN, WIDTH_UNKNOWN),  0.1    ), 0.0);
+        assertEquals(0.0, estimatePixelCount(img(HEIGHT_UNKNOWN, WIDTH_UNKNOWN), 16.0/9.0), 0.0);
+    }
+    // CHECKSTYLE:ON
+
+
+    @Test
+    public void testChoosePreferredImageAllKnown() {
+        // the resolution level of the images is more important than the actual resolution
+        assertChoosePreferredImage("a", "b", "c", List.of(
+                img("a", 1, 1, ResolutionLevel.LOW),
+                img("b", 200, 200, ResolutionLevel.MEDIUM),
+                img("c", 10000, 10000, ResolutionLevel.HIGH)
+        ));
+        assertChoosePreferredImage("a", "b", "c", List.of(
+                img("a", 10000, 10000, ResolutionLevel.LOW),
+                img("b", 200, 200, ResolutionLevel.MEDIUM),
+                img("c", 1, 1, ResolutionLevel.HIGH)
+        ));
+
+        assertChoosePreferredImage("b", "c", "d", List.of(
+                img("a", 2, 1, ResolutionLevel.LOW),
+                img("b", 50, 25, ResolutionLevel.LOW),
+                img("c", 200, 100, ResolutionLevel.LOW),
+                img("d", 300, 150, ResolutionLevel.LOW)
+        ));
+
+        assertChoosePreferredImage("c", "d", "d", List.of(
+                img("a", 2, 1, ResolutionLevel.MEDIUM),
+                img("b", 50, 25, ResolutionLevel.MEDIUM),
+                img("c", 60, 30, ResolutionLevel.MEDIUM),
+                img("d", 300, 150, ResolutionLevel.MEDIUM)
+        ));
+    }
+
+    @Test
+    public void testChoosePreferredImageSomeKnown() {
+        // the resolution level of the images is more important than the actual resolution
+        assertChoosePreferredImage("a", "b", "c", List.of(
+                img("a", 1, WIDTH_UNKNOWN, ResolutionLevel.LOW),
+                img("b", HEIGHT_UNKNOWN, 200, ResolutionLevel.MEDIUM),
+                img("c", 10000, WIDTH_UNKNOWN, ResolutionLevel.HIGH)
+        ));
+        assertChoosePreferredImage("a", "b", "c", List.of(
+                img("a", HEIGHT_UNKNOWN, 10000, ResolutionLevel.LOW),
+                img("b", 200, WIDTH_UNKNOWN, ResolutionLevel.MEDIUM),
+                img("c", HEIGHT_UNKNOWN, 1, ResolutionLevel.HIGH)
+        ));
+
+        assertChoosePreferredImage("b", "c", "d", List.of(
+                img("a", HEIGHT_UNKNOWN, 1, ResolutionLevel.HIGH),
+                img("b", 50, WIDTH_UNKNOWN, ResolutionLevel.HIGH),
+                img("c", HEIGHT_UNKNOWN, 120, ResolutionLevel.HIGH),
+                img("d", 340, WIDTH_UNKNOWN, ResolutionLevel.HIGH)
+        ));
+
+        assertChoosePreferredImage("c", "d", "d", List.of(
+                img("a", 2, WIDTH_UNKNOWN, ResolutionLevel.MEDIUM),
+                img("b", HEIGHT_UNKNOWN, 50, ResolutionLevel.MEDIUM),
+                img("c", 60, WIDTH_UNKNOWN, ResolutionLevel.MEDIUM),
+                img("d", HEIGHT_UNKNOWN, 340, ResolutionLevel.MEDIUM)
+        ));
+    }
+
+    @Test
+    public void testChoosePreferredImageMixed() {
+        for (final ResolutionLevel resolutionLevel : RESOLUTION_LEVELS) {
+            assertChoosePreferredImage("d", "b", "c", List.of(
+                    img("a", ResolutionLevel.UNKNOWN),
+                    img("b", 200, 100, resolutionLevel),
+                    img("c", 400, WIDTH_UNKNOWN, resolutionLevel),
+                    img("d", HEIGHT_UNKNOWN, 50, resolutionLevel),
+                    img("e", resolutionLevel)
+            ));
+        }
+        for (final ResolutionLevel resolutionLevel : RESOLUTION_LEVELS) {
+            assertChoosePreferredImage("b", "b", "b", List.of(
+                    img("a", ResolutionLevel.UNKNOWN),
+                    img("b", 200, 100, resolutionLevel),
+                    img("e", resolutionLevel)
+            ));
+        }
+        assertChoosePreferredImage("b", "b", "e", List.of(
+                img("a", ResolutionLevel.UNKNOWN),
+                img("b", 200, 100, ResolutionLevel.LOW),
+                img("e", ResolutionLevel.HIGH)
+        ));
+    }
+
+    @Test
+    public void testChoosePreferredImageAllUnknown() {
+        assertChoosePreferredImage("b", "c", "d", List.of(
+                img("a", ResolutionLevel.UNKNOWN),
+                img("b", ResolutionLevel.LOW),
+                img("c", ResolutionLevel.MEDIUM),
+                img("d", ResolutionLevel.HIGH)
+        ));
+        assertChoosePreferredImage("c", "c", "d", List.of(
+                img("a", ResolutionLevel.UNKNOWN),
+                img("c", ResolutionLevel.MEDIUM),
+                img("d", ResolutionLevel.HIGH)
+        ));
+        assertChoosePreferredImage("b", "c", "c", List.of(
+                img("a", ResolutionLevel.UNKNOWN),
+                img("b", ResolutionLevel.LOW),
+                img("c", ResolutionLevel.MEDIUM)
+        ));
+
+        // UNKNOWN is avoided as much as possible
+        assertChoosePreferredImage("d", "d", "d", List.of(
+                img("a", ResolutionLevel.UNKNOWN),
+                img("d", ResolutionLevel.HIGH)
+        ));
+        assertChoosePreferredImage("b", "b", "b", List.of(
+                img("a", ResolutionLevel.UNKNOWN),
+                img("b", ResolutionLevel.LOW)
+        ));
+        assertChoosePreferredImage("a", "a", "a", List.of(
+                img("a", ResolutionLevel.UNKNOWN)
+        ));
+    }
+}

--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -69,6 +69,8 @@
     <module name="SuppressWarningsFilter" />
 
     <module name="TreeWalker">
+        <module name="SuppressionCommentFilter"/>
+
         <!-- Checks for Javadoc comments.                     -->
         <!-- See https://checkstyle.org/config_javadoc.html -->
         <module name="InvalidJavadocPosition"/>


### PR DESCRIPTION
#### What is it?
- [x] Feature (user facing)

#### Description of the changes in your PR
- This PR adapts to https://github.com/TeamNewPipe/NewPipeExtractor/pull/889, which introduces breaking changes regarding images. Instead of providing just one URL per image (e.g. `getThumbnailUrl()`), **the extractor now provides a `List<Image>`** (e.g. `getThumbnails()`), and each image has `width`, `height` and `resolutionLevel` attributes that allow determining an image's quality.
- This PR introduces a preference that allows users to either disable images completely, or to **choose a level amongst "low", "medium" and "high"**. This setting replaces the "Load thumbnails" switch.
- The strategy that determines which image is chosen based on the user preference is [here](https://github.com/Stypox/NewPipe/blob/multiple-images/app/src/main/java/org/schabi/newpipe/util/image/ImageStrategy.java#L54), along with documentation.
- **In the database only one image URL is still stored, instead of the whole `List<Image>`.** The saved URL is the preferred one at the time of saving. This keeps it simple, avoids needing to do database migrations (not really a big deal, but still) and saves storage. Otherwise we would probably double the database size just to store a whole lot of images that will never be all used anyway. The only downside is that upon changing preferred resolution level in settings, only newly fetched `List<Image>`s will have the correct level, while videos in history/feed will not. I don't think it's such a big deal, also because when opening a (remote) video (or playlist), the thumbnail(s) would get updated to the newly set preferred resolution level.
- The description tab in the video detail fragment now shows all available thumbnails, highlighting the one being chosen and allowing to tap on them to open in browser.

#### Before/After Screenshots/Screen Record

<table>
  <tr>
    <th>Before preference</th>
    <th>Before list</th>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/36421898/235771294-122f0252-8174-4795-9659-d5013b8bd6a4.png" width="200px"/></td>
    <td><img src="https://user-images.githubusercontent.com/36421898/235771165-b2e9485b-d1e2-4c77-83c7-9e1a3089943a.png" width="200px"/></td>
  </tr>
</table>

<table>
  <tr>
    <th>Preference</th>
    <th>Low (list)</th>
    <th>Medium (list)</th>
    <th>High (video details)</th>
    <th>Description</th>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/36421898/235770044-611c2ca6-17a8-486f-9c7a-8b8b0801b81a.png" width="200px"/></td>
    <td><img src="https://user-images.githubusercontent.com/36421898/235770127-c213157a-018f-45fc-9913-04039410bc90.png" width="200px"/></td>
    <td><img src="https://user-images.githubusercontent.com/36421898/235770183-e46e8a97-34af-4e4e-a3ca-e8b661213dd1.png" width="200px"/></td>
    <td><img src="https://user-images.githubusercontent.com/36421898/235772899-8445e751-f529-4752-8f56-72d8bc7c2adf.png" width="200px"/></td>
    <td><img src="https://user-images.githubusercontent.com/36421898/235770481-22ae8c21-d0f5-401c-8bbc-0c7dcfe690d8.png" width="200px"/></td>
  </tr>
</table>

#### TODO
- [x] Add description to PR
- [x] Allow user to choose thumbnail quality
- [x] Refine preferred image choosing method
- [x] Decide whether it's fine to save only one thumbnail in the database - Yes, it's fine.
- [x] How should `PlaylistRemoteEntity.isIdenticalTo` behave? - it's fine if the thumbnail is updated in the database if the current preference has changed (since that implies `choosePreferredImage` returns a different url than the one saved in the database, and hence `isIdenticalTo` returns `false`)
- [x] The description fragment should show all thumbnail URLs (and maybe highlight the preferred one being chosen)
- [x] Add comments to the code, and possibly rename some variables
- [x] Add tests for `ImageStrategy`
- [ ] Update extractor commit after channel tabs PR is merged

#### Fixes the following issue(s)
- Fixes #3121
- Closes #3190 because we chose a different approach
- Closes #1782
- Closes #7656
- Also implements the ability to close #10055, by sending the highest resolution image URL to an external app such as a browser

#### Relies on the following changes

https://github.com/TeamNewPipe/NewPipeExtractor/pull/889

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

At the moment the highest quality thumbnails will load everywhere, and that's the only noticeable difference with normal NewPipe, until a quality setting is added.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).