### PR TITLE
Fix uploader and subchannel avatars being swapped and disable loading thumbnail message failure on content details page

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -61,7 +61,6 @@ import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.android.material.tabs.TabLayout;
-import com.squareup.picasso.Callback;
 
 import org.schabi.newpipe.App;
 import org.schabi.newpipe.R;
@@ -647,27 +646,6 @@ public final class VideoDetailFragment
         } else {
             playerHolder.startService(false, this);
         }
-    }
-
-    private void initThumbnailViews(@NonNull final StreamInfo info) {
-        PicassoHelper.loadDetailsThumbnail(info.getThumbnailUrl()).tag(PICASSO_VIDEO_DETAILS_TAG)
-                .into(binding.detailThumbnailImageView, new Callback() {
-                    @Override
-                    public void onSuccess() {
-                        // nothing to do, the image was loaded correctly into the thumbnail
-                    }
-
-                    @Override
-                    public void onError(final Exception e) {
-                        showSnackBarError(new ErrorInfo(e, UserAction.LOAD_IMAGE,
-                                info.getThumbnailUrl(), info));
-                    }
-                });
-
-        PicassoHelper.loadAvatar(info.getSubChannelAvatarUrl()).tag(PICASSO_VIDEO_DETAILS_TAG)
-                .into(binding.detailSubChannelThumbnailView);
-        PicassoHelper.loadAvatar(info.getUploaderAvatarUrl()).tag(PICASSO_VIDEO_DETAILS_TAG)
-                .into(binding.detailUploaderThumbnailView);
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -1480,12 +1458,9 @@ public final class VideoDetailFragment
         binding.detailSubChannelThumbnailView.setVisibility(View.GONE);
 
         if (!isEmpty(info.getSubChannelName())) {
-            displayBothUploaderAndSubChannel(info, activity);
-        } else if (!isEmpty(info.getUploaderName())) {
-            displayUploaderAsSubChannel(info, activity);
+            displayBothUploaderAndSubChannel(info);
         } else {
-            binding.detailUploaderTextView.setVisibility(View.GONE);
-            binding.detailUploaderThumbnailView.setVisibility(View.GONE);
+            displayUploaderAsSubChannel(info);
         }
 
         final Drawable buddyDrawable =
@@ -1559,7 +1534,8 @@ public final class VideoDetailFragment
         binding.detailSecondaryControlPanel.setVisibility(View.GONE);
 
         checkUpdateProgressInfo(info);
-        initThumbnailViews(info);
+        PicassoHelper.loadDetailsThumbnail(info.getThumbnailUrl()).tag(PICASSO_VIDEO_DETAILS_TAG)
+                .into(binding.detailThumbnailImageView);
         showMetaInfoInTextView(info.getMetaInfo(), binding.detailMetaInfoTextView,
                 binding.detailMetaInfoSeparator, disposables);
 
@@ -1596,26 +1572,29 @@ public final class VideoDetailFragment
                 noVideoStreams ? R.drawable.ic_headset_shadow : R.drawable.ic_play_arrow_shadow);
     }
 
-    private void displayUploaderAsSubChannel(final StreamInfo info, final Context context) {
+    private void displayUploaderAsSubChannel(final StreamInfo info) {
         binding.detailSubChannelTextView.setText(info.getUploaderName());
         binding.detailSubChannelTextView.setVisibility(View.VISIBLE);
         binding.detailSubChannelTextView.setSelected(true);
 
         if (info.getUploaderSubscriberCount() > -1) {
             binding.detailUploaderTextView.setText(
-                    Localization.shortSubscriberCount(context, info.getUploaderSubscriberCount()));
+                    Localization.shortSubscriberCount(activity, info.getUploaderSubscriberCount()));
             binding.detailUploaderTextView.setVisibility(View.VISIBLE);
         } else {
             binding.detailUploaderTextView.setVisibility(View.GONE);
         }
+
+        PicassoHelper.loadAvatar(info.getUploaderAvatarUrl()).tag(PICASSO_VIDEO_DETAILS_TAG)
+                .into(binding.detailSubChannelThumbnailView);
+        binding.detailSubChannelThumbnailView.setVisibility(View.VISIBLE);
+        binding.detailUploaderThumbnailView.setVisibility(View.GONE);
     }
 
-    private void displayBothUploaderAndSubChannel(final StreamInfo info, final Context context) {
+    private void displayBothUploaderAndSubChannel(final StreamInfo info) {
         binding.detailSubChannelTextView.setText(info.getSubChannelName());
         binding.detailSubChannelTextView.setVisibility(View.VISIBLE);
         binding.detailSubChannelTextView.setSelected(true);
-
-        binding.detailSubChannelThumbnailView.setVisibility(View.VISIBLE);
 
         final StringBuilder subText = new StringBuilder();
         if (!isEmpty(info.getUploaderName())) {
@@ -1627,7 +1606,7 @@ public final class VideoDetailFragment
                 subText.append(Localization.DOT_SEPARATOR);
             }
             subText.append(
-                    Localization.shortSubscriberCount(context, info.getUploaderSubscriberCount()));
+                    Localization.shortSubscriberCount(activity, info.getUploaderSubscriberCount()));
         }
 
         if (subText.length() > 0) {
@@ -1637,6 +1616,13 @@ public final class VideoDetailFragment
         } else {
             binding.detailUploaderTextView.setVisibility(View.GONE);
         }
+
+        PicassoHelper.loadAvatar(info.getSubChannelAvatarUrl()).tag(PICASSO_VIDEO_DETAILS_TAG)
+                .into(binding.detailSubChannelThumbnailView);
+        binding.detailSubChannelThumbnailView.setVisibility(View.VISIBLE);
+        PicassoHelper.loadAvatar(info.getUploaderAvatarUrl()).tag(PICASSO_VIDEO_DETAILS_TAG)
+                .into(binding.detailUploaderThumbnailView);
+        binding.detailUploaderThumbnailView.setVisibility(View.VISIBLE);
     }
 
     public void openDownloadDialog() {

--- a/app/src/main/res/layout-large-land/fragment_video_detail.xml
+++ b/app/src/main/res/layout-large-land/fragment_video_detail.xml
@@ -267,23 +267,21 @@
                                     android:layout_height="wrap_content">
 
                                     <com.google.android.material.imageview.ShapeableImageView
-                                        android:id="@+id/detail_uploader_thumbnail_view"
+                                        android:id="@+id/detail_sub_channel_thumbnail_view"
                                         android:layout_width="@dimen/video_item_detail_uploader_image_size"
                                         android:layout_height="@dimen/video_item_detail_uploader_image_size"
-                                        android:contentDescription="@string/detail_uploader_thumbnail_view_description"
+                                        android:contentDescription="@string/detail_sub_channel_thumbnail_view_description"
                                         android:src="@drawable/placeholder_person"
                                         app:shapeAppearance="@style/CircularImageView" />
 
                                     <com.google.android.material.imageview.ShapeableImageView
-                                        android:id="@+id/detail_sub_channel_thumbnail_view"
+                                        android:id="@+id/detail_uploader_thumbnail_view"
                                         android:layout_width="@dimen/video_item_detail_sub_channel_image_size"
                                         android:layout_height="@dimen/video_item_detail_sub_channel_image_size"
                                         android:layout_gravity="bottom|right"
-                                        android:contentDescription="@string/detail_sub_channel_thumbnail_view_description"
+                                        android:contentDescription="@string/detail_uploader_thumbnail_view_description"
                                         android:src="@drawable/placeholder_person"
-                                        android:visibility="gone"
-                                        app:shapeAppearance="@style/CircularImageView"
-                                        tools:visibility="visible" />
+                                        app:shapeAppearance="@style/CircularImageView" />
 
                                 </FrameLayout>
 

--- a/app/src/main/res/layout/fragment_video_detail.xml
+++ b/app/src/main/res/layout/fragment_video_detail.xml
@@ -254,24 +254,22 @@
                                 android:layout_height="wrap_content">
 
                                 <com.google.android.material.imageview.ShapeableImageView
-                                    android:id="@+id/detail_uploader_thumbnail_view"
+                                    android:id="@+id/detail_sub_channel_thumbnail_view"
                                     android:layout_width="@dimen/video_item_detail_uploader_image_size"
                                     android:layout_height="@dimen/video_item_detail_uploader_image_size"
-                                    android:contentDescription="@string/detail_uploader_thumbnail_view_description"
+                                    android:contentDescription="@string/detail_sub_channel_thumbnail_view_description"
                                     android:src="@drawable/placeholder_person"
                                     app:shapeAppearance="@style/CircularImageView" />
 
                                 <com.google.android.material.imageview.ShapeableImageView
-                                    android:id="@+id/detail_sub_channel_thumbnail_view"
+                                    android:id="@+id/detail_uploader_thumbnail_view"
                                     android:layout_width="@dimen/video_item_detail_sub_channel_image_size"
                                     android:layout_height="@dimen/video_item_detail_sub_channel_image_size"
                                     android:layout_gravity="bottom|right"
-                                    android:contentDescription="@string/detail_sub_channel_thumbnail_view_description"
+                                    android:contentDescription="@string/detail_uploader_thumbnail_view_description"
                                     android:src="@drawable/placeholder_person"
-                                    android:visibility="gone"
                                     app:shapeAppearance="@style/CircularImageView"
-                                    tools:ignore="RtlHardcoded"
-                                    tools:visibility="visible" />
+                                    tools:ignore="RtlHardcoded" />
 
                             </FrameLayout>
 


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
- In the XML of video details, the uploader and sub-channel images were swapped. Moreover, the code in `VideoDetailFragment` didn't really take into account the fact that when no sub-channel is present, the uploader is shown as sub-channel. So I fixed both of these things.
- When there is no *sub-channel*, now the logic is the same regardless of whether the *uploader* name is empty (which would likely be caused by an extractor error) or not. So now when there is not even an *uploader* name, the subscribers and avatar are still shown.
- I removed the error reporting snackbar that popped up when the video thumbnail failed loading: it's not really needed as if there is an issue with thumbnails not loading, we can just ask users to send us the thumbnail URL that can be found in the description. This is even more true after #10062 will be merged.
- I tested both YouTube and PeerTube on a phone (normal layout) and on a table (large-land layout).

#### Before/After Screenshots/Screen Record
Before:
<img width="248" alt="image" src="https://user-images.githubusercontent.com/36421898/235870512-931ba972-c746-4a3f-82d3-864fb587307d.png">
After:
<img width="196" alt="image" src="https://user-images.githubusercontent.com/36421898/235870320-16dff628-1ff1-4a37-836b-686f60759394.png">
The NewPipe channel page is correct: https://tube.tchncs.de/video-channels/she_drives_mobility
<img width="234" alt="image" src="https://user-images.githubusercontent.com/36421898/235870373-eda45994-a6d1-4dbf-bd41-0c79b47f9142.png">

#### Fixes the following issue(s)
Closes #7416.

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
