### PR TITLE
Update some AndroidX libraries and compileSdk to 34

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -106,9 +106,9 @@ android {
 ext {
     checkstyleVersion = '10.12.1'
 
-    androidxLifecycleVersion = '2.5.1'
+    androidxLifecycleVersion = '2.6.2'
     androidxRoomVersion = '2.5.2'
-    androidxWorkVersion = '2.7.1'
+    androidxWorkVersion = '2.8.1'
 
     icepickVersion = '3.2.0'
     exoPlayerVersion = '2.18.7'
@@ -208,25 +208,25 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
 
 /** AndroidX **/
-    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation 'androidx.core:core-ktx:1.10.0'
+    implementation 'androidx.core:core-ktx:1.12.0'
     implementation 'androidx.documentfile:documentfile:1.0.1'
-    implementation 'androidx.fragment:fragment-ktx:1.4.1'
+    implementation 'androidx.fragment:fragment-ktx:1.6.1'
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:${androidxLifecycleVersion}"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:${androidxLifecycleVersion}"
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.1.0'
     implementation 'androidx.media:media:1.6.0'
-    implementation 'androidx.preference:preference:1.2.0'
-    implementation 'androidx.recyclerview:recyclerview:1.2.1'
+    implementation 'androidx.preference:preference:1.2.1'
+    implementation 'androidx.recyclerview:recyclerview:1.3.2'
     implementation "androidx.room:room-runtime:${androidxRoomVersion}"
     implementation "androidx.room:room-rxjava3:${androidxRoomVersion}"
     kapt "androidx.room:room-compiler:${androidxRoomVersion}"
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     // Newer version specified to prevent accessibility regressions with RecyclerView, see:
     // https://developer.android.com/jetpack/androidx/releases/viewpager2#1.1.0-alpha01
-    implementation 'androidx.viewpager2:viewpager2:1.1.0-beta01'
+    implementation 'androidx.viewpager2:viewpager2:1.1.0-beta02'
     implementation "androidx.work:work-runtime-ktx:${androidxWorkVersion}"
     implementation "androidx.work:work-rxjava3:${androidxWorkVersion}"
     implementation 'com.google.android.material:material:1.9.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 android {
-    compileSdk 33
+    compileSdk 34
     namespace 'org.schabi.newpipe'
 
     defaultConfig {

--- a/app/src/main/java/androidx/fragment/app/FragmentStatePagerAdapterMenuWorkaround.java
+++ b/app/src/main/java/androidx/fragment/app/FragmentStatePagerAdapterMenuWorkaround.java
@@ -25,6 +25,7 @@ import android.view.ViewGroup;
 import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.os.BundleCompat;
 import androidx.lifecycle.Lifecycle;
 import androidx.viewpager.widget.PagerAdapter;
 
@@ -284,7 +285,7 @@ public abstract class FragmentStatePagerAdapterMenuWorkaround extends PagerAdapt
         Bundle state = null;
         if (!mSavedState.isEmpty()) {
             state = new Bundle();
-            state.putParcelableArray("states", mSavedState.toArray(new Fragment.SavedState[0]));
+            state.putParcelableArrayList("states", mSavedState);
         }
         for (int i = 0; i < mFragments.size(); i++) {
             final Fragment f = mFragments.get(i);
@@ -311,13 +312,12 @@ public abstract class FragmentStatePagerAdapterMenuWorkaround extends PagerAdapt
         if (state != null) {
             final Bundle bundle = (Bundle) state;
             bundle.setClassLoader(loader);
-            final Parcelable[] fss = bundle.getParcelableArray("states");
+            final var states = BundleCompat.getParcelableArrayList(bundle, "states",
+                    Fragment.SavedState.class);
             mSavedState.clear();
             mFragments.clear();
-            if (fss != null) {
-                for (final Parcelable parcelable : fss) {
-                    mSavedState.add((Fragment.SavedState) parcelable);
-                }
+            if (states != null) {
+                mSavedState.addAll(states);
             }
             final Iterable<String> keys = bundle.keySet();
             for (final String key : keys) {

--- a/app/src/main/java/org/schabi/newpipe/about/AboutActivity.kt
+++ b/app/src/main/java/org/schabi/newpipe/about/AboutActivity.kt
@@ -116,7 +116,7 @@ class AboutActivity : AppCompatActivity() {
         /**
          * List of all software components.
          */
-        private val SOFTWARE_COMPONENTS = arrayOf(
+        private val SOFTWARE_COMPONENTS = arrayListOf(
             SoftwareComponent(
                 "ACRA", "2013", "Kevin Gaudin",
                 "https://github.com/ACRA/acra", StandardLicenses.APACHE2

--- a/app/src/main/java/org/schabi/newpipe/about/LicenseFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/about/LicenseFragment.kt
@@ -18,6 +18,7 @@ import org.schabi.newpipe.BuildConfig
 import org.schabi.newpipe.R
 import org.schabi.newpipe.databinding.FragmentLicensesBinding
 import org.schabi.newpipe.databinding.ItemSoftwareComponentBinding
+import org.schabi.newpipe.ktx.parcelableArrayList
 import org.schabi.newpipe.util.Localization
 import org.schabi.newpipe.util.external_communication.ShareUtils
 
@@ -25,16 +26,15 @@ import org.schabi.newpipe.util.external_communication.ShareUtils
  * Fragment containing the software licenses.
  */
 class LicenseFragment : Fragment() {
-    private lateinit var softwareComponents: Array<SoftwareComponent>
+    private lateinit var softwareComponents: List<SoftwareComponent>
     private var activeSoftwareComponent: SoftwareComponent? = null
     private val compositeDisposable = CompositeDisposable()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        softwareComponents = arguments?.getParcelableArray(ARG_COMPONENTS) as Array<SoftwareComponent>
+        softwareComponents = arguments?.parcelableArrayList<SoftwareComponent>(ARG_COMPONENTS)!!
+            .sortedBy { it.name } // Sort components by name
         activeSoftwareComponent = savedInstanceState?.getSerializable(SOFTWARE_COMPONENT_KEY) as? SoftwareComponent
-        // Sort components by name
-        softwareComponents.sortBy { it.name }
     }
 
     override fun onDestroy() {
@@ -130,7 +130,8 @@ class LicenseFragment : Fragment() {
             StandardLicenses.GPL3,
             BuildConfig.VERSION_NAME
         )
-        fun newInstance(softwareComponents: Array<SoftwareComponent>): LicenseFragment {
+
+        fun newInstance(softwareComponents: ArrayList<SoftwareComponent>): LicenseFragment {
             val fragment = LicenseFragment()
             fragment.arguments = bundleOf(ARG_COMPONENTS to softwareComponents)
             return fragment

--- a/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
@@ -74,6 +74,7 @@ import org.schabi.newpipe.util.ThemeHelper;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -1052,7 +1053,7 @@ public class DownloadDialog extends DialogFragment
         final char kind;
         int threads = dialogBinding.threads.getProgress() + 1;
         final String[] urls;
-        final MissionRecoveryInfo[] recoveryInfo;
+        final List<MissionRecoveryInfo> recoveryInfo;
         String psName = null;
         String[] psArgs = null;
         long nearLength = 0;
@@ -1117,9 +1118,7 @@ public class DownloadDialog extends DialogFragment
             urls = new String[] {
                     selectedStream.getContent()
             };
-            recoveryInfo = new MissionRecoveryInfo[] {
-                    new MissionRecoveryInfo(selectedStream)
-            };
+            recoveryInfo = List.of(new MissionRecoveryInfo(selectedStream));
         } else {
             if (secondaryStream.getDeliveryMethod() != PROGRESSIVE_HTTP) {
                 throw new IllegalArgumentException("Unsupported stream delivery format"
@@ -1129,12 +1128,14 @@ public class DownloadDialog extends DialogFragment
             urls = new String[] {
                     selectedStream.getContent(), secondaryStream.getContent()
             };
-            recoveryInfo = new MissionRecoveryInfo[] {new MissionRecoveryInfo(selectedStream),
-                    new MissionRecoveryInfo(secondaryStream)};
+            recoveryInfo = List.of(
+                    new MissionRecoveryInfo(selectedStream),
+                    new MissionRecoveryInfo(secondaryStream)
+            );
         }
 
         DownloadManagerService.startMission(context, urls, storage, kind, threads,
-                currentInfo.getUrl(), psName, psArgs, nearLength, recoveryInfo);
+                currentInfo.getUrl(), psName, psArgs, nearLength, new ArrayList<>(recoveryInfo));
 
         Toast.makeText(context, getString(R.string.download_has_started),
                 Toast.LENGTH_SHORT).show();

--- a/app/src/main/java/org/schabi/newpipe/error/ErrorActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/error/ErrorActivity.java
@@ -17,6 +17,7 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.IntentCompat;
 
 import com.grack.nanojson.JsonWriter;
 
@@ -105,7 +106,7 @@ public class ErrorActivity extends AppCompatActivity {
             actionBar.setDisplayShowTitleEnabled(true);
         }
 
-        errorInfo = intent.getParcelableExtra(ERROR_INFO);
+        errorInfo = IntentCompat.getParcelableExtra(intent, ERROR_INFO, ErrorInfo.class);
 
         // important add guru meditation
         addGuruMeditation();

--- a/app/src/main/java/org/schabi/newpipe/ktx/Bundle.kt
+++ b/app/src/main/java/org/schabi/newpipe/ktx/Bundle.kt
@@ -1,0 +1,9 @@
+package org.schabi.newpipe.ktx
+
+import android.os.Bundle
+import android.os.Parcelable
+import androidx.core.os.BundleCompat
+
+inline fun <reified T : Parcelable> Bundle.parcelableArrayList(key: String?): ArrayList<T>? {
+    return BundleCompat.getParcelableArrayList(this, key, T::class.java)
+}

--- a/app/src/main/java/org/schabi/newpipe/local/feed/notifications/NotificationWorker.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/notifications/NotificationWorker.kt
@@ -137,7 +137,7 @@ class NotificationWorker(
                 .enqueueUniquePeriodicWork(
                     WORK_TAG,
                     if (force) {
-                        ExistingPeriodicWorkPolicy.REPLACE
+                        ExistingPeriodicWorkPolicy.CANCEL_AND_REENQUEUE
                     } else {
                         ExistingPeriodicWorkPolicy.KEEP
                     },

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/services/SubscriptionsExportService.java
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/services/SubscriptionsExportService.java
@@ -25,6 +25,7 @@ import android.content.Intent;
 import android.net.Uri;
 import android.util.Log;
 
+import androidx.core.content.IntentCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import org.reactivestreams.Subscriber;
@@ -65,7 +66,7 @@ public class SubscriptionsExportService extends BaseImportExportService {
             return START_NOT_STICKY;
         }
 
-        final Uri path = intent.getParcelableExtra(KEY_FILE_PATH);
+        final Uri path = IntentCompat.getParcelableExtra(intent, KEY_FILE_PATH, Uri.class);
         if (path == null) {
             stopAndReportError(new IllegalStateException(
                     "Exporting to a file, but the path is null"),

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/services/SubscriptionsImportService.java
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/services/SubscriptionsImportService.java
@@ -30,6 +30,7 @@ import android.util.Pair;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.content.IntentCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import org.reactivestreams.Subscriber;
@@ -108,7 +109,7 @@ public class SubscriptionsImportService extends BaseImportExportService {
         if (currentMode == CHANNEL_URL_MODE) {
             channelUrl = intent.getStringExtra(KEY_VALUE);
         } else {
-            final Uri uri = intent.getParcelableExtra(KEY_VALUE);
+            final Uri uri = IntentCompat.getParcelableExtra(intent, KEY_VALUE, Uri.class);
             if (uri == null) {
                 stopAndReportError(new IllegalStateException(
                         "Importing from input stream, but file path is null"),

--- a/app/src/main/java/org/schabi/newpipe/player/gesture/MainPlayerGestureListener.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/gesture/MainPlayerGestureListener.kt
@@ -160,13 +160,12 @@ class MainPlayerGestureListener(
     }
 
     override fun onScroll(
-        initialEvent: MotionEvent,
+        initialEvent: MotionEvent?,
         movingEvent: MotionEvent,
         distanceX: Float,
         distanceY: Float
     ): Boolean {
-
-        if (!playerUi.isFullscreen) {
+        if (initialEvent == null || !playerUi.isFullscreen) {
             return false
         }
 

--- a/app/src/main/java/org/schabi/newpipe/player/gesture/PopupPlayerGestureListener.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/gesture/PopupPlayerGestureListener.kt
@@ -167,7 +167,7 @@ class PopupPlayerGestureListener(
     }
 
     override fun onFling(
-        e1: MotionEvent,
+        e1: MotionEvent?,
         e2: MotionEvent,
         velocityX: Float,
         velocityY: Float
@@ -218,11 +218,14 @@ class PopupPlayerGestureListener(
     }
 
     override fun onScroll(
-        initialEvent: MotionEvent,
+        initialEvent: MotionEvent?,
         movingEvent: MotionEvent,
         distanceX: Float,
         distanceY: Float
     ): Boolean {
+        if (initialEvent == null) {
+            return false
+        }
 
         if (isResizing) {
             return super.onScroll(initialEvent, movingEvent, distanceX, distanceY)

--- a/app/src/main/java/org/schabi/newpipe/player/notification/NotificationUtil.java
+++ b/app/src/main/java/org/schabi/newpipe/player/notification/NotificationUtil.java
@@ -364,7 +364,7 @@ public final class NotificationUtil {
         final Bitmap thumbnail = player.getThumbnail();
         if (thumbnail == null || !showThumbnail) {
             // since the builder is reused, make sure the thumbnail is unset if there is not one
-            builder.setLargeIcon(null);
+            builder.setLargeIcon((Bitmap) null);
             return;
         }
 

--- a/app/src/main/java/org/schabi/newpipe/util/StateSaver.java
+++ b/app/src/main/java/org/schabi/newpipe/util/StateSaver.java
@@ -27,6 +27,7 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.os.BundleCompat;
 
 import org.schabi.newpipe.BuildConfig;
 import org.schabi.newpipe.MainActivity;
@@ -82,7 +83,8 @@ public final class StateSaver {
             return null;
         }
 
-        final SavedState savedState = outState.getParcelable(KEY_SAVED_STATE);
+        final SavedState savedState = BundleCompat.getParcelable(
+                outState, KEY_SAVED_STATE, SavedState.class);
         if (savedState == null) {
             return null;
         }

--- a/app/src/main/java/org/schabi/newpipe/views/player/CircleClipTapView.kt
+++ b/app/src/main/java/org/schabi/newpipe/views/player/CircleClipTapView.kt
@@ -80,10 +80,10 @@ class CircleClipTapView(context: Context?, attrs: AttributeSet) : View(context, 
         updatePathShape()
     }
 
-    override fun onDraw(canvas: Canvas?) {
+    override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
 
-        canvas?.clipPath(shapePath)
-        canvas?.drawPath(shapePath, backgroundPaint)
+        canvas.clipPath(shapePath)
+        canvas.drawPath(shapePath, backgroundPaint)
     }
 }


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
- Update AppCompat 1.5.1 -> 1.6.1 ([changelog](https://developer.android.com/jetpack/androidx/releases/appcompat))
- Update Core 1.10.0 -> 1.12.0 ([changelog](https://developer.android.com/jetpack/androidx/releases/core#1.12.0))
- Update Fragment 1.4.1 -> 1.6.1 ([changelog](https://developer.android.com/jetpack/androidx/releases/fragment#1.6.1))
- Update Lifecycle 2.5.1 -> 2.6.2 ([changelog](https://developer.android.com/jetpack/androidx/releases/lifecycle))
- Update Preference 1.2.0 -> 1.2.1 ([changelog](https://developer.android.com/jetpack/androidx/releases/preference#1.2.1))
- Update RecyclerView 1.2.1 -> 1.3.2 ([changelog](https://developer.android.com/jetpack/androidx/releases/recyclerview))
- Update ViewPager2 1.1.0-beta1 -> 1.1.0-beta2 ([changelog](https://developer.android.com/jetpack/androidx/releases/viewpager2#1.1.0-beta02))
- Update WorkManager 2.7.1 -> 2.8.1 ([changelog](https://developer.android.com/jetpack/androidx/releases/work#2.8.1))
- Update `compileSdk` to 34
- Use new compatibility methods in `BundleCompat` and `IntentCompat` to fix some deprecations

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
