### PR TITLE
Use different commit for NPE

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -201,7 +201,7 @@ dependencies {
     // name and the commit hash with the commit hash of the (pushed) commit you want to test
     // This works thanks to JitPack: https://jitpack.io/
     implementation 'com.github.TeamNewPipe:nanojson:1d9e1aea9049fc9f85e68b43ba39fe7be1c1f751'
-    implementation 'com.github.TeamNewPipe:NewPipeExtractor:v0.22.6'
+    implementation 'com.github.TeamNewPipe:NewPipeExtractor:533121fb8175d8cefa5b135a5e0329d25a6c7480'
     implementation 'com.github.TeamNewPipe:NoNonsense-FilePicker:5.0.0'
 
 /** Checkstyle **/


### PR DESCRIPTION
#### What is it?
- [x] Codebase improvement (dev facing)

#### Description of the changes in your PR
The previous version (v0.22.6) did not exist anymore on JitPack servers, so I've switched to the latest commit on dev, i.e. https://github.com/TeamNewPipe/NewPipeExtractor/commit/533121fb8175d8cefa5b135a5e0329d25a6c7480. The build now works fine.

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
