### PR TITLE
Disable media tunneling by default on known unsupported devices

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
@@ -267,10 +267,10 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
         // R.string.disabled_media_tunneling_automatically_key == 0:
         //     automatic value overridden by user in settings
         // R.string.disabled_media_tunneling_automatically_key == -1: not set
-        final boolean wasMediaTunnelingEnabledAutomatically =
+        final boolean wasMediaTunnelingDisabledAutomatically =
                 prefs.getInt(automaticTunnelingKey, -1) == 1
                         && prefs.getBoolean(tunnelingKey, false);
-        if (wasMediaTunnelingEnabledAutomatically) {
+        if (wasMediaTunnelingDisabledAutomatically) {
             prefs.edit()
                     .putInt(automaticTunnelingKey, -1)
                     .putBoolean(tunnelingKey, false)

--- a/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
@@ -15,6 +15,7 @@ import android.widget.Toast;
 import androidx.activity.result.ActivityResult;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult;
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.core.content.ContextCompat;
 import androidx.preference.Preference;
@@ -230,8 +231,11 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
                         })
                         .setPositiveButton(R.string.ok, (dialog, which) -> {
                             dialog.dismiss();
-                            manager.loadSharedPreferences(PreferenceManager
-                                    .getDefaultSharedPreferences(requireContext()));
+                            final Context context = requireContext();
+                            final SharedPreferences prefs = PreferenceManager
+                                    .getDefaultSharedPreferences(context);
+                            manager.loadSharedPreferences(prefs);
+                            cleanImport(context, prefs);
                             finishImport(importDataUri);
                         })
                         .show();
@@ -240,6 +244,38 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
             }
         } catch (final Exception e) {
             ErrorUtil.showUiErrorSnackbar(this, "Importing database", e);
+        }
+    }
+
+    /**
+     * Remove settings that are not supposed to be imported on different devices
+     * and reset them to default values.
+     * @param context the context used for the import
+     * @param prefs the preferences used while running the import
+     */
+    private void cleanImport(@NonNull final Context context,
+                             @NonNull final SharedPreferences prefs) {
+        // Check if media tunnelling needs to be disabled automatically,
+        // if it was disabled automatically in the imported preferences.
+        final String tunnelingKey = context.getString(R.string.disable_media_tunneling_key);
+        final String automaticTunnelingKey =
+                context.getString(R.string.disabled_media_tunneling_automatically_key);
+        // R.string.disable_media_tunneling_key should always be true
+        // if R.string.disabled_media_tunneling_automatically_key equals 1,
+        // but we double check here just to be sure and to avoid regressions
+        // caused by possible later modification of the media tunneling functionality.
+        // R.string.disabled_media_tunneling_automatically_key == 0:
+        //     automatic value overridden by user in settings
+        // R.string.disabled_media_tunneling_automatically_key == -1: not set
+        final boolean wasMediaTunnelingEnabledAutomatically =
+                prefs.getInt(automaticTunnelingKey, -1) == 1
+                        && prefs.getBoolean(tunnelingKey, false);
+        if (wasMediaTunnelingEnabledAutomatically) {
+            prefs.edit()
+                    .putInt(automaticTunnelingKey, -1)
+                    .putBoolean(tunnelingKey, false)
+                    .apply();
+            NewPipeSettings.setMediaTunneling(context);
         }
     }
 

--- a/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsManager.kt
@@ -67,6 +67,9 @@ class ContentSettingsManager(private val fileLocator: NewPipeFileLocator) {
         return ZipHelper.extractFileFromZip(file, fileLocator.settings.path, "newpipe.settings")
     }
 
+    /**
+     * Remove all shared preferences from the app and load the preferences supplied to the manager.
+     */
     fun loadSharedPreferences(preferences: SharedPreferences) {
         try {
             val preferenceEditor = preferences.edit()

--- a/app/src/main/java/org/schabi/newpipe/settings/ExoPlayerSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/ExoPlayerSettingsFragment.java
@@ -1,8 +1,14 @@
 package org.schabi.newpipe.settings;
 
+import android.content.SharedPreferences;
 import android.os.Bundle;
 
 import androidx.annotation.Nullable;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceManager;
+import androidx.preference.SwitchPreferenceCompat;
+
+import org.schabi.newpipe.R;
 
 public class ExoPlayerSettingsFragment extends BasePreferenceFragment {
 
@@ -10,5 +16,30 @@ public class ExoPlayerSettingsFragment extends BasePreferenceFragment {
     public void onCreatePreferences(@Nullable final Bundle savedInstanceState,
                                     @Nullable final String rootKey) {
         addPreferencesFromResourceRegistry();
+
+        final String disableMediaTunnelingAutomaticallyKey =
+                getString(R.string.disabled_media_tunneling_automatically_key);
+        final SwitchPreferenceCompat disableMediaTunnelingPref =
+                (SwitchPreferenceCompat) requirePreference(R.string.disable_media_tunneling_key);
+        final SharedPreferences prefs = PreferenceManager
+                .getDefaultSharedPreferences(requireContext());
+        final boolean mediaTunnelingAutomaticallyEnabled =
+                prefs.getInt(disableMediaTunnelingAutomaticallyKey, -1) == 1;
+        final String summaryText = getString(R.string.disable_media_tunneling_summary);
+        disableMediaTunnelingPref.setSummary(mediaTunnelingAutomaticallyEnabled
+                ? summaryText + getString(R.string.disable_media_tunneling_automatic_info)
+                : summaryText);
+
+        disableMediaTunnelingPref.setOnPreferenceChangeListener((Preference p, Object enabled) -> {
+                    if (Boolean.FALSE.equals(enabled)) {
+                        PreferenceManager.getDefaultSharedPreferences(requireContext())
+                                .edit()
+                                .putInt(disableMediaTunnelingAutomaticallyKey, 0)
+                                .apply();
+                        // the info text might have been shown before
+                        p.setSummary(R.string.disable_media_tunneling_summary);
+                    }
+                    return true;
+                });
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/settings/ExoPlayerSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/ExoPlayerSettingsFragment.java
@@ -17,24 +17,24 @@ public class ExoPlayerSettingsFragment extends BasePreferenceFragment {
                                     @Nullable final String rootKey) {
         addPreferencesFromResourceRegistry();
 
-        final String disableMediaTunnelingAutomaticallyKey =
+        final String disabledMediaTunnelingAutomaticallyKey =
                 getString(R.string.disabled_media_tunneling_automatically_key);
         final SwitchPreferenceCompat disableMediaTunnelingPref =
                 (SwitchPreferenceCompat) requirePreference(R.string.disable_media_tunneling_key);
         final SharedPreferences prefs = PreferenceManager
                 .getDefaultSharedPreferences(requireContext());
-        final boolean mediaTunnelingAutomaticallyEnabled =
-                prefs.getInt(disableMediaTunnelingAutomaticallyKey, -1) == 1;
+        final boolean mediaTunnelingAutomaticallyDisabled =
+                prefs.getInt(disabledMediaTunnelingAutomaticallyKey, -1) == 1;
         final String summaryText = getString(R.string.disable_media_tunneling_summary);
-        disableMediaTunnelingPref.setSummary(mediaTunnelingAutomaticallyEnabled
-                ? summaryText + getString(R.string.disable_media_tunneling_automatic_info)
+        disableMediaTunnelingPref.setSummary(mediaTunnelingAutomaticallyDisabled
+                ? summaryText + " " + getString(R.string.disable_media_tunneling_automatic_info)
                 : summaryText);
 
         disableMediaTunnelingPref.setOnPreferenceChangeListener((Preference p, Object enabled) -> {
                     if (Boolean.FALSE.equals(enabled)) {
                         PreferenceManager.getDefaultSharedPreferences(requireContext())
                                 .edit()
-                                .putInt(disableMediaTunnelingAutomaticallyKey, 0)
+                                .putInt(disabledMediaTunnelingAutomaticallyKey, 0)
                                 .apply();
                         // the info text might have been shown before
                         p.setSummary(R.string.disable_media_tunneling_summary);

--- a/app/src/main/java/org/schabi/newpipe/settings/NewPipeSettings.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/NewPipeSettings.java
@@ -76,6 +76,10 @@ public final class NewPipeSettings {
 
         saveDefaultVideoDownloadDirectory(context);
         saveDefaultAudioDownloadDirectory(context);
+
+        if (isFirstRun) { // NOSONAR: isFirstRun is never null
+            setMediaTunneling(context);
+        }
     }
 
     static void saveDefaultVideoDownloadDirectory(final Context context) {
@@ -151,5 +155,19 @@ public final class NewPipeSettings {
                                                       final SharedPreferences sharedPreferences) {
         return showSearchSuggestions(context, sharedPreferences,
                 R.string.show_remote_search_suggestions_key);
+    }
+
+    /**
+     * Check if device does not support media tunneling
+     * and disable that exoplayer feature if necessary.
+     * @see DeviceUtils#shouldSupportMediaTunneling()
+     * @param context
+     */
+    public static void setMediaTunneling(@NonNull final Context context) {
+        if (!DeviceUtils.shouldSupportMediaTunneling()) {
+            PreferenceManager.getDefaultSharedPreferences(context).edit()
+                    .putBoolean(context.getString(R.string.disable_media_tunneling_key), true)
+                    .apply();
+        }
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/settings/NewPipeSettings.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/NewPipeSettings.java
@@ -1,5 +1,7 @@
 package org.schabi.newpipe.settings;
 
+import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
+
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Build;
@@ -14,8 +16,6 @@ import org.schabi.newpipe.util.DeviceUtils;
 
 import java.io.File;
 import java.util.Set;
-
-import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
 
 /*
  * Created by k3b on 07.01.2016.
@@ -61,7 +61,7 @@ public final class NewPipeSettings {
         }
 
         // first run migrations, then setDefaultValues, since the latter requires the correct types
-        SettingMigrations.initMigrations(context, isFirstRun);
+        SettingMigrations.runMigrationsIfNeeded(context, isFirstRun);
 
         // readAgain is true so that if new settings are added their default value is set
         PreferenceManager.setDefaultValues(context, R.xml.main_settings, true);
@@ -77,9 +77,7 @@ public final class NewPipeSettings {
         saveDefaultVideoDownloadDirectory(context);
         saveDefaultAudioDownloadDirectory(context);
 
-        if (isFirstRun) { // NOSONAR: isFirstRun is never null
-            setMediaTunneling(context);
-        }
+        disableMediaTunnelingIfNecessary(context, isFirstRun);
     }
 
     static void saveDefaultVideoDownloadDirectory(final Context context) {
@@ -157,6 +155,28 @@ public final class NewPipeSettings {
                 R.string.show_remote_search_suggestions_key);
     }
 
+    private static void disableMediaTunnelingIfNecessary(@NonNull final Context context,
+                                                         final boolean isFirstRun) {
+        final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        final String disabledTunnelingKey = context.getString(R.string.disable_media_tunneling_key);
+        final String disabledTunnelingAutomaticallyKey =
+                context.getString(R.string.disabled_media_tunneling_automatically_key);
+        final String blacklistVersionKey =
+                context.getString(R.string.media_tunneling_device_blacklist_version);
+
+        final int lastMediaTunnelingUpdate = prefs.getInt(blacklistVersionKey, 0);
+        final boolean wasDeviceBlacklistUpdated =
+                DeviceUtils.MEDIA_TUNNELING_DEVICE_BLACKLIST_VERSION != lastMediaTunnelingUpdate;
+        final boolean wasMediaTunnelingEnabledByUser =
+                prefs.getInt(disabledTunnelingAutomaticallyKey, -1) == 0
+                        && !prefs.getBoolean(disabledTunnelingKey, false);
+
+        if (Boolean.TRUE.equals(isFirstRun)
+                || (wasDeviceBlacklistUpdated && !wasMediaTunnelingEnabledByUser)) {
+            setMediaTunneling(context);
+        }
+    }
+
     /**
      * Check if device does not support media tunneling
      * and disable that exoplayer feature if necessary.
@@ -164,12 +184,19 @@ public final class NewPipeSettings {
      * @param context
      */
     public static void setMediaTunneling(@NonNull final Context context) {
+        final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         if (!DeviceUtils.shouldSupportMediaTunneling()) {
-            PreferenceManager.getDefaultSharedPreferences(context).edit()
+            prefs.edit()
                     .putBoolean(context.getString(R.string.disable_media_tunneling_key), true)
                     .putInt(context.getString(
                             R.string.disabled_media_tunneling_automatically_key), 1)
+                    .putInt(context.getString(R.string.media_tunneling_device_blacklist_version),
+                            DeviceUtils.MEDIA_TUNNELING_DEVICE_BLACKLIST_VERSION)
                     .apply();
+        } else {
+            prefs.edit()
+                    .putInt(context.getString(R.string.media_tunneling_device_blacklist_version),
+                            DeviceUtils.MEDIA_TUNNELING_DEVICE_BLACKLIST_VERSION).apply();
         }
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/settings/NewPipeSettings.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/NewPipeSettings.java
@@ -167,6 +167,8 @@ public final class NewPipeSettings {
         if (!DeviceUtils.shouldSupportMediaTunneling()) {
             PreferenceManager.getDefaultSharedPreferences(context).edit()
                     .putBoolean(context.getString(R.string.disable_media_tunneling_key), true)
+                    .putInt(context.getString(
+                            R.string.disabled_media_tunneling_automatically_key), 1)
                     .apply();
         }
     }

--- a/app/src/main/java/org/schabi/newpipe/settings/SettingMigrations.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/SettingMigrations.java
@@ -128,6 +128,17 @@ public final class SettingMigrations {
         }
     };
 
+    private static final Migration MIGRATION_5_6 = new Migration(5, 6) {
+        @Override
+        protected void migrate(@NonNull final Context context) {
+            // PR #8875 added a new settings page for exoplayer introducing a specific setting
+            // to disable media tunneling. However, media tunneling should be disabled by default
+            // for some devices, because they are known for not supporting media tunneling
+            // which can result in a black screen while playing videos.
+            NewPipeSettings.setMediaTunneling(context);
+        }
+    };
+
     /**
      * List of all implemented migrations.
      * <p>
@@ -140,12 +151,13 @@ public final class SettingMigrations {
             MIGRATION_2_3,
             MIGRATION_3_4,
             MIGRATION_4_5,
+            MIGRATION_5_6,
     };
 
     /**
      * Version number for preferences. Must be incremented every time a migration is necessary.
      */
-    private static final int VERSION = 5;
+    private static final int VERSION = 6;
 
 
     public static void initMigrations(@NonNull final Context context, final boolean isFirstRun) {

--- a/app/src/main/java/org/schabi/newpipe/settings/SettingMigrations.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/SettingMigrations.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
 import androidx.preference.PreferenceManager;
 
 import org.schabi.newpipe.R;
@@ -30,9 +31,9 @@ public final class SettingMigrations {
     private static final String TAG = SettingMigrations.class.toString();
     private static SharedPreferences sp;
 
-    public static final Migration MIGRATION_0_1 = new Migration(0, 1) {
+    private static final Migration MIGRATION_0_1 = new Migration(0, 1) {
         @Override
-        public void migrate(final Context context) {
+        public void migrate(@NonNull final Context context) {
             // We changed the content of the dialog which opens when sharing a link to NewPipe
             // by removing the "open detail page" option.
             // Therefore, show the dialog once again to ensure users need to choose again and are
@@ -44,9 +45,9 @@ public final class SettingMigrations {
         }
     };
 
-    public static final Migration MIGRATION_1_2 = new Migration(1, 2) {
+    private static final Migration MIGRATION_1_2 = new Migration(1, 2) {
         @Override
-        protected void migrate(final Context context) {
+        protected void migrate(@NonNull final Context context) {
             // The new application workflow introduced in #2907 allows minimizing videos
             // while playing to do other stuff within the app.
             // For an even better workflow, we minimize a stream when switching the app to play in
@@ -63,9 +64,9 @@ public final class SettingMigrations {
         }
     };
 
-    public static final Migration MIGRATION_2_3 = new Migration(2, 3) {
+    private static final Migration MIGRATION_2_3 = new Migration(2, 3) {
         @Override
-        protected void migrate(final Context context) {
+        protected void migrate(@NonNull final Context context) {
             // Storage Access Framework implementation was improved in #5415, allowing the modern
             // and standard way to access folders and files to be used consistently everywhere.
             // We reset the setting to its default value, i.e. "use SAF", since now there are no
@@ -79,9 +80,9 @@ public final class SettingMigrations {
         }
     };
 
-    public static final Migration MIGRATION_3_4 = new Migration(3, 4) {
+    private static final Migration MIGRATION_3_4 = new Migration(3, 4) {
         @Override
-        protected void migrate(final Context context) {
+        protected void migrate(@NonNull final Context context) {
             // Pull request #3546 added support for choosing the type of search suggestions to
             // show, replacing the on-off switch used before, so migrate the previous user choice
 
@@ -108,9 +109,9 @@ public final class SettingMigrations {
         }
     };
 
-    public static final Migration MIGRATION_4_5 = new Migration(4, 5) {
+    private static final Migration MIGRATION_4_5 = new Migration(4, 5) {
         @Override
-        protected void migrate(final Context context) {
+        protected void migrate(@NonNull final Context context) {
             final boolean brightness = sp.getBoolean("brightness_gesture_control", true);
             final boolean volume = sp.getBoolean("volume_gesture_control", true);
 
@@ -144,10 +145,10 @@ public final class SettingMigrations {
     /**
      * Version number for preferences. Must be incremented every time a migration is necessary.
      */
-    public static final int VERSION = 5;
+    private static final int VERSION = 5;
 
 
-    public static void initMigrations(final Context context, final boolean isFirstRun) {
+    public static void initMigrations(@NonNull final Context context, final boolean isFirstRun) {
         // setup migrations and check if there is something to do
         sp = PreferenceManager.getDefaultSharedPreferences(context);
         final String lastPrefVersionKey = context.getString(R.string.last_used_preferences_version);
@@ -212,7 +213,7 @@ public final class SettingMigrations {
             return oldVersion >= currentVersion;
         }
 
-        protected abstract void migrate(Context context);
+        protected abstract void migrate(@NonNull Context context);
 
     }
 

--- a/app/src/main/java/org/schabi/newpipe/settings/SettingMigrations.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/SettingMigrations.java
@@ -128,17 +128,6 @@ public final class SettingMigrations {
         }
     };
 
-    private static final Migration MIGRATION_5_6 = new Migration(5, 6) {
-        @Override
-        protected void migrate(@NonNull final Context context) {
-            // PR #8875 added a new settings page for exoplayer introducing a specific setting
-            // to disable media tunneling. However, media tunneling should be disabled by default
-            // for some devices, because they are known for not supporting media tunneling
-            // which can result in a black screen while playing videos.
-            NewPipeSettings.setMediaTunneling(context);
-        }
-    };
-
     /**
      * List of all implemented migrations.
      * <p>
@@ -151,16 +140,16 @@ public final class SettingMigrations {
             MIGRATION_2_3,
             MIGRATION_3_4,
             MIGRATION_4_5,
-            MIGRATION_5_6,
     };
 
     /**
      * Version number for preferences. Must be incremented every time a migration is necessary.
      */
-    private static final int VERSION = 6;
+    private static final int VERSION = 5;
 
 
-    public static void initMigrations(@NonNull final Context context, final boolean isFirstRun) {
+    public static void runMigrationsIfNeeded(@NonNull final Context context,
+                                             final boolean isFirstRun) {
         // setup migrations and check if there is something to do
         sp = PreferenceManager.getDefaultSharedPreferences(context);
         final String lastPrefVersionKey = context.getString(R.string.last_used_preferences_version);

--- a/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
@@ -36,20 +36,32 @@ public final class DeviceUtils {
     private static Boolean isTV = null;
     private static Boolean isFireTV = null;
 
-
-    // region: devices not supporting media tunneling
     /**
-     * Formuler Z8 Pro, Z8, CC, Z Alpha, Z+ Neo.
+     * <p>The app version code that corresponds to the last update
+     * of the media tunneling device blacklist.</p>
+     * <p>The value of this variable needs to be updated everytime a new device that does not
+     * support media tunneling to match the <strong>upcoming</strong> version code.</p>
+     * @see #shouldSupportMediaTunneling()
+     */
+    public static final int MEDIA_TUNNELING_DEVICE_BLACKLIST_VERSION = 994;
+
+    // region: devices not supporting media tunneling / media tunneling blacklist
+    /**
+     * <p>Formuler Z8 Pro, Z8, CC, Z Alpha, Z+ Neo.</p>
+     * <p>Blacklist reason: black screen</p>
+     * <p>Board: HiSilicon Hi3798MV200</p>
      */
     private static final boolean HI3798MV200 = Build.VERSION.SDK_INT == 24
             && Build.DEVICE.equals("Hi3798MV200");
     /**
-     * Zephir TS43UHD-2.
+     * <p>Zephir TS43UHD-2.</p>
+     * <p>Blacklist reason: black screen</p>
      */
     private static final boolean CVT_MT5886_EU_1G = Build.VERSION.SDK_INT == 24
             && Build.DEVICE.equals("cvt_mt5886_eu_1g");
     /**
      * Hilife TV.
+     * <p>Blacklist reason: black screen</p>
      */
     private static final boolean REALTEKATV = Build.VERSION.SDK_INT == 25
             && Build.DEVICE.equals("RealtekATV");
@@ -60,19 +72,23 @@ public final class DeviceUtils {
     private static final boolean PH7M_EU_5596 = Build.VERSION.SDK_INT >= 26
             && Build.DEVICE.equals("PH7M_EU_5596");
     /**
-     * Philips QM16XE.
+     * <p>Philips QM16XE.</p>
+     * <p>Blacklist reason: black screen</p>
      */
     private static final boolean QM16XE_U = Build.VERSION.SDK_INT == 23
             && Build.DEVICE.equals("QM16XE_U");
     /**
      * <p>Sony Bravia VH1.</p>
-     * Processor: MT5895
+     * <p>Processor: MT5895</p>
+     * <p>Blacklist reason: fullscreen crash / stuttering</p>
      */
     private static final boolean BRAVIA_VH1 = Build.VERSION.SDK_INT == 29
             && Build.DEVICE.equals("BRAVIA_VH1");
     /**
      * <p>Sony Bravia VH2.</p>
-     * This includes model A90J.
+     * <p>Blacklist reason: fullscreen crash; this includes model A90J as reported in
+     * <a href="https://github.com/TeamNewPipe/NewPipe/issues/9023#issuecomment-1387106242">
+     * #9023</a></p>
      */
     private static final boolean BRAVIA_VH2 = Build.VERSION.SDK_INT == 29
             && Build.DEVICE.equals("BRAVIA_VH2");
@@ -85,18 +101,22 @@ public final class DeviceUtils {
     private static final boolean BRAVIA_ATV2 = Build.DEVICE.equals("BRAVIA_ATV2");
     /**
      * <p>Sony Bravia Android TV platform 3 4K.</p>
-     * Uses ARM MT5891 and a {@link #BRAVIA_ATV2} motherboard.
+     * <p>Uses ARM MT5891 and a {@link #BRAVIA_ATV2} motherboard.</p>
+     *
      * @see <a href="https://browser.geekbench.com/v4/cpu/9101105">
      *     https://browser.geekbench.com/v4/cpu/9101105</a>
      */
     private static final boolean BRAVIA_ATV3_4K = Build.DEVICE.equals("BRAVIA_ATV3_4K");
     /**
-     * Panasonic 4KTV-JUP.
+     * <p>Panasonic 4KTV-JUP.</p>
+     * <p>Blacklist reason: fullscreen crash</p>
      */
     private static final boolean TX_50JXW834 = Build.DEVICE.equals("TX_50JXW834");
     /**
      * <p>Bouygtel4K / Bouygues Telecom Bbox 4K.</p>
-     * Reported at https://github.com/TeamNewPipe/NewPipe/pull/10122#issuecomment-1638475769
+     * <p>Blacklist reason: black screen; reported at
+     * <a href="https://github.com/TeamNewPipe/NewPipe/pull/10122#issuecomment-1638475769">
+     *     #10122</a></p>
      */
     private static final boolean HMB9213NW = Build.DEVICE.equals("HMB9213NW");
     // endregion
@@ -292,24 +312,27 @@ public final class DeviceUtils {
 
     /**
      * <p>Some devices have broken tunneled video playback but claim to support it.</p>
-     * See https://github.com/TeamNewPipe/NewPipe/issues/5911
-     * @Note Add a new {@link org.schabi.newpipe.settings.SettingMigrations.Migration} which calls
-     * {@link org.schabi.newpipe.settings.NewPipeSettings#setMediaTunneling(Context)}
+     * <p>This can cause a black video player surface while attempting to play a video or
+     * crashes while entering or exiting the full screen player.
+     * The issue effects Android TVs most commonly.
+     * See <a href="https://github.com/TeamNewPipe/NewPipe/issues/5911">#5911</a> and
+     * <a href="https://github.com/TeamNewPipe/NewPipe/issues/9023">#9023</a> for more info.</p>
+     * @Note Update {@link #MEDIA_TUNNELING_DEVICE_BLACKLIST_VERSION}
      * when adding a new device to the method.
      * @return {@code false} if affected device; {@code true} otherwise
      */
     public static boolean shouldSupportMediaTunneling() {
-        // Maintainers note: add a new SettingsMigration which calls
+        // Maintainers note: update MEDIA_TUNNELING_DEVICES_UPDATE_APP_VERSION_CODE
         return !HI3798MV200
                 && !CVT_MT5886_EU_1G
                 && !REALTEKATV
                 && !QM16XE_U
                 && !BRAVIA_VH1
                 && !BRAVIA_VH2
-                && !BRAVIA_ATV2    // crash caused by exiting full screen
-                && !BRAVIA_ATV3_4K // crash caused by exiting full screen
+                && !BRAVIA_ATV2
+                && !BRAVIA_ATV3_4K
                 && !PH7M_EU_5596
                 && !TX_50JXW834
-                && !HMB9213NW; // crash caused by exiting full screen
+                && !HMB9213NW;
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
@@ -255,7 +255,7 @@ public final class DeviceUtils {
      * See https://github.com/TeamNewPipe/NewPipe/issues/5911
      * @Note Add a new {@link org.schabi.newpipe.settings.SettingMigrations.Migration} which calls
      * {@link org.schabi.newpipe.settings.NewPipeSettings#setMediaTunneling(Context)}
-     * when adding a new device to the method
+     * when adding a new device to the method.
      * @return {@code false} if affected device; {@code true} otherwise
      */
     public static boolean shouldSupportMediaTunneling() {

--- a/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
@@ -36,6 +36,31 @@ public final class DeviceUtils {
     private static Boolean isTV = null;
     private static Boolean isFireTV = null;
 
+    /*
+     * Devices that do not support media tunneling
+     */
+
+    /**
+     * Formuler Z8 Pro, Z8, CC, Z Alpha, Z+ Neo.
+     */
+    private static final boolean HI3798MV200 = Build.VERSION.SDK_INT == 24
+            && Build.DEVICE.equals("Hi3798MV200");
+    /**
+     * Zephir TS43UHD-2.
+     */
+    private static final boolean CVT_MT5886_EU_1G = Build.VERSION.SDK_INT == 24
+            && Build.DEVICE.equals("cvt_mt5886_eu_1g");
+    /**
+     * Hilife TV.
+     */
+    private static final boolean REALTEKATV = Build.VERSION.SDK_INT == 25
+            && Build.DEVICE.equals("RealtekATV");
+    /**
+     * Philips QM16XE.
+     */
+    private static final boolean QM16XE_U = Build.VERSION.SDK_INT == 23
+            && Build.DEVICE.equals("QM16XE_U");
+
     private DeviceUtils() {
     }
 
@@ -223,5 +248,21 @@ public final class DeviceUtils {
             windowManager.getDefaultDisplay().getSize(point);
             return point.y;
         }
+    }
+
+    /**
+     * Some devices have broken tunneled video playback but claim to support it.
+     * See https://github.com/TeamNewPipe/NewPipe/issues/5911
+     * @Note Add a new {@link org.schabi.newpipe.settings.SettingMigrations.Migration} which calls
+     * {@link org.schabi.newpipe.settings.NewPipeSettings#setMediaTunneling(Context)}
+     * when adding a new device to the method
+     * @return {@code false} if affected device; {@code true} otherwise
+     */
+    public static boolean shouldSupportMediaTunneling() {
+        // Maintainers note: add a new SettingsMigration which calls
+        return !HI3798MV200
+                && !CVT_MT5886_EU_1G
+                && !REALTEKATV
+                && !QM16XE_U;
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
@@ -36,10 +36,8 @@ public final class DeviceUtils {
     private static Boolean isTV = null;
     private static Boolean isFireTV = null;
 
-    /*
-     * Devices that do not support media tunneling
-     */
 
+    // region: devices not supporting media tunneling
     /**
      * Formuler Z8 Pro, Z8, CC, Z Alpha, Z+ Neo.
      */
@@ -56,10 +54,52 @@ public final class DeviceUtils {
     private static final boolean REALTEKATV = Build.VERSION.SDK_INT == 25
             && Build.DEVICE.equals("RealtekATV");
     /**
+     * <p>Phillips 4K (O)LED TV.</p>
+     * Supports custom ROMs with different API levels
+     */
+    private static final boolean PH7M_EU_5596 = Build.VERSION.SDK_INT >= 26
+            && Build.DEVICE.equals("PH7M_EU_5596");
+    /**
      * Philips QM16XE.
      */
     private static final boolean QM16XE_U = Build.VERSION.SDK_INT == 23
             && Build.DEVICE.equals("QM16XE_U");
+    /**
+     * <p>Sony Bravia VH1.</p>
+     * Processor: MT5895
+     */
+    private static final boolean BRAVIA_VH1 = Build.VERSION.SDK_INT == 29
+            && Build.DEVICE.equals("BRAVIA_VH1");
+    /**
+     * <p>Sony Bravia VH2.</p>
+     * This includes model A90J.
+     */
+    private static final boolean BRAVIA_VH2 = Build.VERSION.SDK_INT == 29
+            && Build.DEVICE.equals("BRAVIA_VH2");
+    /**
+     * <p>Sony Bravia Android TV platform 2.</p>
+     * Uses a MediaTek MT5891 (MT5596) SoC.
+     * @see <a href="https://github.com/CiNcH83/bravia_atv2">
+     *     https://github.com/CiNcH83/bravia_atv2</a>
+     */
+    private static final boolean BRAVIA_ATV2 = Build.DEVICE.equals("BRAVIA_ATV2");
+    /**
+     * <p>Sony Bravia Android TV platform 3 4K.</p>
+     * Uses ARM MT5891 and a {@link #BRAVIA_ATV2} motherboard.
+     * @see <a href="https://browser.geekbench.com/v4/cpu/9101105">
+     *     https://browser.geekbench.com/v4/cpu/9101105</a>
+     */
+    private static final boolean BRAVIA_ATV3_4K = Build.DEVICE.equals("BRAVIA_ATV3_4K");
+    /**
+     * Panasonic 4KTV-JUP.
+     */
+    private static final boolean TX_50JXW834 = Build.DEVICE.equals("TX_50JXW834");
+    /**
+     * <p>Bouygtel4K / Bouygues Telecom Bbox 4K.</p>
+     * Reported at https://github.com/TeamNewPipe/NewPipe/pull/10122#issuecomment-1638475769
+     */
+    private static final boolean HMB9213NW = Build.DEVICE.equals("HMB9213NW");
+    // endregion
 
     private DeviceUtils() {
     }
@@ -251,7 +291,7 @@ public final class DeviceUtils {
     }
 
     /**
-     * Some devices have broken tunneled video playback but claim to support it.
+     * <p>Some devices have broken tunneled video playback but claim to support it.</p>
      * See https://github.com/TeamNewPipe/NewPipe/issues/5911
      * @Note Add a new {@link org.schabi.newpipe.settings.SettingMigrations.Migration} which calls
      * {@link org.schabi.newpipe.settings.NewPipeSettings#setMediaTunneling(Context)}
@@ -263,6 +303,13 @@ public final class DeviceUtils {
         return !HI3798MV200
                 && !CVT_MT5886_EU_1G
                 && !REALTEKATV
-                && !QM16XE_U;
+                && !QM16XE_U
+                && !BRAVIA_VH1
+                && !BRAVIA_VH2
+                && !BRAVIA_ATV2    // crash caused by exiting full screen
+                && !BRAVIA_ATV3_4K // crash caused by exiting full screen
+                && !PH7M_EU_5596
+                && !TX_50JXW834
+                && !HMB9213NW; // crash caused by exiting full screen
     }
 }

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -1382,6 +1382,7 @@
     <!-- ExoPlayer settings -->
     <string name="exoplayer_settings_key">exoplayer_settings_key</string>
     <string name="disable_media_tunneling_key">disable_media_tunneling_key</string>
+    <string name="disabled_media_tunneling_automatically_key">disabled_media_tunneling_automatically_key</string>
     <string name="use_exoplayer_decoder_fallback_key">use_exoplayer_decoder_fallback_key</string>
     <string name="always_use_exoplayer_set_output_surface_workaround_key">always_use_exoplayer_set_output_surface_workaround_key</string>
 </resources>

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -1383,6 +1383,7 @@
     <string name="exoplayer_settings_key">exoplayer_settings_key</string>
     <string name="disable_media_tunneling_key">disable_media_tunneling_key</string>
     <string name="disabled_media_tunneling_automatically_key">disabled_media_tunneling_automatically_key</string>
+    <string name="media_tunneling_device_blacklist_version">media_tunneling_device_blacklist_version</string>
     <string name="use_exoplayer_decoder_fallback_key">use_exoplayer_decoder_fallback_key</string>
     <string name="always_use_exoplayer_set_output_surface_workaround_key">always_use_exoplayer_set_output_surface_workaround_key</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -480,7 +480,8 @@
     <string name="show_original_time_ago_title">Show original time ago on items</string>
     <string name="show_original_time_ago_summary">Original texts from services will be visible in stream items</string>
     <string name="disable_media_tunneling_title">Disable media tunneling</string>
-    <string name="disable_media_tunneling_summary">Disable media tunneling if you experience a black screen or stuttering on video playback</string>
+    <string name="disable_media_tunneling_summary">Disable media tunneling if you experience a black screen or stuttering on video playback.</string>
+    <string name="disable_media_tunneling_automatic_info">Media tunneling was disabled by default on your device because your device model is known to not support it.</string>
     <string name="show_image_indicators_title">Show image indicators</string>
     <string name="show_image_indicators_summary">Show Picasso colored ribbons on top of images indicating their source: red for network, blue for disk and green for memory</string>
     <string name="show_crash_the_player_title">Show \"Crash the player\"</string>


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
In #8875 a setting to disable media tunneling was added. However, the info on devices which do not support media tunneling was removed. That info is re-added and used to disable media tunneling on those devices by default.

Disabling media tunneling seems to also fix the full screen enter/exit bug on Android TVs (#9023)

##### New models added:
- Sony Bravia VH1 (`BRAVIA_VH1`)
- Sony Bravia VH2 (`BRAVIA_VH2`), e.g. model A90J
- Sony Bravia Android TV platform 2 (`BRAVIA_ATV2`)
- Sony Bravia Android TV platform 3 4K (`BRAVIA_ATV3_4K`)
- Phillips 4K (O)LED TV (`PH7M_EU_5596`)
- Panasonic 4KTV-JUP (`TX_50JXW834`)
- Bouygtel4K (Bouygues Telecom Bbox 4K) (`HMB9213NW`)

##### Other changes: 
- Added info to ExoPlayer settings explaining that media tunneling was disabled automatically.  
<details><summary>Media tunneling setting screenshot</summary>

<img alt="grafik" src="https://github.com/TeamNewPipe/NewPipe/assets/17365767/3d6a24a0-58c8-41d3-bf47-6c207764a13c" width=292 />

</details>

#### Fixes the following issue(s)
- Fixes https://github.com/TeamNewPipe/NewPipe/pull/8875#discussion_r1059742968
- Fixes #8829
- Fixes #9023 

#### ToDo
- [ ] Rework applying device detection results and restoring that info correctly from a backup.

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
