### PR TITLE
Add support for new GitHub assets URLs in image minimizer workflow

### DIFF
--- a/.github/workflows/image-minimizer.js
+++ b/.github/workflows/image-minimizer.js
@@ -30,10 +30,12 @@ module.exports = async ({github, context}) => {
     }
 
     // Regex for finding images (simple variant) ![ALT_TEXT](https://*.githubusercontent.com/<number>/<variousHexStringsAnd->.<fileExtension>)
-    const REGEX_IMAGE_LOOKUP = /\!\[(.*)\]\((https:\/\/[-a-z0-9]+\.githubusercontent\.com\/\d+\/[-0-9a-f]{32,512}\.(jpg|gif|png))\)/gm;
+    const REGEX_USER_CONTENT_IMAGE_LOOKUP = /\!\[(.*)\]\((https:\/\/[-a-z0-9]+\.githubusercontent\.com\/\d+\/[-0-9a-f]{32,512}\.(jpg|gif|png))\)/gm;
+    const REGEX_ASSETS_IMAGE_LOCKUP = /\!\[(.*)\]\((https:\/\/github\.com\/[-\w\d]+\/[-\w\d]+\/assets\/\d+\/[\-0-9a-f]{32,512})\)/gm;
 
     // Check if we found something
-    let foundSimpleImages = REGEX_IMAGE_LOOKUP.test(initialBody);
+    let foundSimpleImages = REGEX_USER_CONTENT_IMAGE_LOOKUP.test(initialBody)
+        || REGEX_ASSETS_IMAGE_LOCKUP.test(initialBody);
     if (!foundSimpleImages) {
         console.log('Found no simple images to process');
         return;
@@ -47,53 +49,8 @@ module.exports = async ({github, context}) => {
     var wasMatchModified = false;
 
     // Try to find and replace the images with minimized ones
-    let newBody = await replaceAsync(initialBody, REGEX_IMAGE_LOOKUP, async (match, g1, g2) => {
-        console.log(`Found match '${match}'`);
-        
-        if (g1.endsWith(IGNORE_ALT_NAME_END)) {
-            console.log(`Ignoring match '${match}': IGNORE_ALT_NAME_END`);
-            return match;
-        }
-        
-        let probeAspectRatio = 0;
-        let shouldModify = false;
-        try {
-            console.log(`Probing ${g2}`);
-            let probeResult = await probe(g2);
-            if (probeResult == null) {
-                throw 'No probeResult';
-            }
-            if (probeResult.hUnits != 'px') {
-                throw `Unexpected probeResult.hUnits (expected px but got ${probeResult.hUnits})`;
-            }
-            if (probeResult.height <= 0) {
-                throw `Unexpected probeResult.height (height is invalid: ${probeResult.height})`;
-            }
-            if (probeResult.wUnits != 'px') {
-                throw `Unexpected probeResult.wUnits (expected px but got ${probeResult.wUnits})`;
-            }
-            if (probeResult.width <= 0) {
-                throw `Unexpected probeResult.width (width is invalid: ${probeResult.width})`;
-            }
-            console.log(`Probing resulted in ${probeResult.width}x${probeResult.height}px`);
-            
-            probeAspectRatio = probeResult.width / probeResult.height;
-            shouldModify = probeResult.height > IMG_MAX_HEIGHT_PX && probeAspectRatio < MIN_ASPECT_RATIO;
-        } catch(e) {
-            console.log('Probing failed:', e);
-            // Immediately abort
-            return match;
-        }
-        
-        if (shouldModify) {
-            wasMatchModified = true;
-            console.log(`Modifying match '${match}'`);
-            return `<img alt="${g1}" src="${g2}" width=${Math.min(600, (IMG_MAX_HEIGHT_PX * probeAspectRatio).toFixed(0))} />`;
-        }
-        
-        console.log(`Match '${match}' is ok/will not be modified`);
-        return match;
-    });
+    let newBody = await replaceAsync(initialBody, REGEX_USER_CONTENT_IMAGE_LOOKUP, minimizeAsync);
+    newBody = await replaceAsync(newBody, REGEX_ASSETS_IMAGE_LOCKUP, minimizeAsync);
     
     if (!wasMatchModified) {
         console.log('Nothing was modified. Skipping update');
@@ -129,4 +86,52 @@ module.exports = async ({github, context}) => {
         const data = await Promise.all(promises);
         return str.replace(regex, () => data.shift());
     }
+
+    async function minimizeAsync(match, g1, g2) {
+            console.log(`Found match '${match}'`);
+
+            if (g1.endsWith(IGNORE_ALT_NAME_END)) {
+                console.log(`Ignoring match '${match}': IGNORE_ALT_NAME_END`);
+                return match;
+            }
+
+            let probeAspectRatio = 0;
+            let shouldModify = false;
+            try {
+                console.log(`Probing ${g2}`);
+                let probeResult = await probe(g2);
+                if (probeResult == null) {
+                    throw 'No probeResult';
+                }
+                if (probeResult.hUnits != 'px') {
+                    throw `Unexpected probeResult.hUnits (expected px but got ${probeResult.hUnits})`;
+                }
+                if (probeResult.height <= 0) {
+                    throw `Unexpected probeResult.height (height is invalid: ${probeResult.height})`;
+                }
+                if (probeResult.wUnits != 'px') {
+                    throw `Unexpected probeResult.wUnits (expected px but got ${probeResult.wUnits})`;
+                }
+                if (probeResult.width <= 0) {
+                    throw `Unexpected probeResult.width (width is invalid: ${probeResult.width})`;
+                }
+                console.log(`Probing resulted in ${probeResult.width}x${probeResult.height}px`);
+
+                probeAspectRatio = probeResult.width / probeResult.height;
+                shouldModify = probeResult.height > IMG_MAX_HEIGHT_PX && probeAspectRatio < MIN_ASPECT_RATIO;
+            } catch(e) {
+                console.log('Probing failed:', e);
+                // Immediately abort
+                return match;
+            }
+
+            if (shouldModify) {
+                wasMatchModified = true;
+                console.log(`Modifying match '${match}'`);
+                return `<img alt="${g1}" src="${g2}" width=${Math.min(600, (IMG_MAX_HEIGHT_PX * probeAspectRatio).toFixed(0))} />`;
+            }
+
+            console.log(`Match '${match}' is ok/will not be modified`);
+            return match;
+        }
 }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [x] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Images are now linked to the repo and have a different URL.
Other files like .zip-files are stored under the /files/ URl and are thus not effected by the workflow change.

You can test the changes in my repo, e.g. by posting to this comment: https://github.com/TobiGr/NewPipe/issues/11

#### Fixes the following issue(s)
Fixes the image minimizer workflow doing nothing on new images


#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
