### PR TITLE
Add workflow "PR size labeler" to label PRs based on the number of changed lines

### DIFF
--- a/.github/changed-lines-count-labeler.yml
+++ b/.github/changed-lines-count-labeler.yml
@@ -1,0 +1,17 @@
+# Add 'size/small' label to any changes with less than 50 lines
+size/small:
+  max: 49
+
+# Add 'size/medium' label to any changes between 50 and 249 lines
+size/medium:
+  min: 50
+  max: 249
+
+# Add 'size/large' label to any changes between 250 and 749 lines
+size/large:
+  min: 250
+  max: 749
+
+# Add 'size/giant' label to any changes for more than 749 lines
+size/giant:
+  min: 750

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,13 @@
+name: "PR size labeler"
+on: [pull_request]
+
+jobs:
+  changed-lines-count-labeler:
+    runs-on: ubuntu-latest
+    name: Automatically labelling pull requests based on the changed lines count
+    steps:
+    - name: Set a label
+      uses: vkirilichev/changed-lines-count-labeler@v0.2
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        configuration-path: .github/changed-lines-count-labeler.yml


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [x] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Add a workflow to label PRs based on the number of changed lines. This should help reviewers to determine which PRs to review.

Current configuration:
- small: < 50 changed lines
- medium: 50 - 249 changed lines
- large: > 250 changed lines

I was thinking about adding a two more categories for 250 - 500 and > 500 changed lines. Wdyt?

#### Before/After Screenshots/Screen Record
For a live demo, see https://github.com/TobiGr/NewPipe/pull/12, https://github.com/TobiGr/NewPipe/pull/13, https://github.com/TobiGr/NewPipe/pull/14
![grafik](https://github.com/TeamNewPipe/NewPipe/assets/17365767/f7844768-a400-4e90-8aa2-3b630ae9c0a9)

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
