### PR TITLE
Fix LeakCanary crash

### DIFF
--- a/app/src/main/res/values/bools.xml
+++ b/app/src/main/res/values/bools.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <bool name="leak_canary_add_launcher_icon">false</bool>
+    <bool name="leak_canary_watcher_auto_install">false</bool>
 </resources>


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
- Fix LeakCanary "AppWatcher already installed" double-install crash by disabling the auto-install (since we manually install): https://square.github.io/leakcanary/changelog/#configuring-retained-object-detection

#### Fixes the following issue(s)
- The crashlog shown in https://github.com/TeamNewPipe/NewPipe/pull/10085#issuecomment-1635848614

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
