### PR TITLE
Fix LeakCanary startup in debug builds and fix a memory leak

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -288,8 +288,8 @@ dependencies {
 
 /** Debugging **/
     // Memory leak detection
-    implementation "com.squareup.leakcanary:leakcanary-object-watcher-android:${leakCanaryVersion}"
-    implementation "com.squareup.leakcanary:plumber-android:${leakCanaryVersion}"
+    debugImplementation "com.squareup.leakcanary:leakcanary-object-watcher-android:${leakCanaryVersion}"
+    debugImplementation "com.squareup.leakcanary:plumber-android:${leakCanaryVersion}"
     debugImplementation "com.squareup.leakcanary:leakcanary-android-core:${leakCanaryVersion}"
     // Debug bridge for Android
     debugImplementation "com.facebook.stetho:stetho:${stethoVersion}"

--- a/app/src/debug/java/org/schabi/newpipe/DebugApp.kt
+++ b/app/src/debug/java/org/schabi/newpipe/DebugApp.kt
@@ -3,7 +3,6 @@ package org.schabi.newpipe
 import androidx.preference.PreferenceManager
 import com.facebook.stetho.Stetho
 import com.facebook.stetho.okhttp3.StethoInterceptor
-import leakcanary.AppWatcher
 import leakcanary.LeakCanary
 import okhttp3.OkHttpClient
 import org.schabi.newpipe.extractor.downloader.Downloader
@@ -13,8 +12,6 @@ class DebugApp : App() {
         super.onCreate()
         initStetho()
 
-        // Give each object 10 seconds to be GC'ed, before LeakCanary gets nosy on it
-        AppWatcher.manualInstall(this, retainedDelayMillis = 10000)
         LeakCanary.config = LeakCanary.config.copy(
             dumpHeap = PreferenceManager
                 .getDefaultSharedPreferences(this).getBoolean(

--- a/app/src/main/java/org/schabi/newpipe/BaseFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/BaseFragment.java
@@ -12,7 +12,6 @@ import androidx.fragment.app.FragmentManager;
 
 import icepick.Icepick;
 import icepick.State;
-import leakcanary.AppWatcher;
 
 public abstract class BaseFragment extends Fragment {
     protected final String TAG = getClass().getSimpleName() + "@" + Integer.toHexString(hashCode());
@@ -75,14 +74,6 @@ public abstract class BaseFragment extends Fragment {
     }
 
     protected void onRestoreInstanceState(@NonNull final Bundle savedInstanceState) {
-    }
-
-    @Override
-    public void onDestroy() {
-        super.onDestroy();
-
-        AppWatcher.INSTANCE.getObjectWatcher().expectWeaklyReachable(
-                this, "Watch for leaks from destroyed fragments.");
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/app/src/main/java/org/schabi/newpipe/player/PlayerService.java
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayerService.java
@@ -31,6 +31,8 @@ import android.util.Log;
 import org.schabi.newpipe.player.mediasession.MediaSessionPlayerUi;
 import org.schabi.newpipe.util.ThemeHelper;
 
+import java.lang.ref.WeakReference;
+
 
 /**
  * One service for all players.
@@ -41,7 +43,7 @@ public final class PlayerService extends Service {
 
     private Player player;
 
-    private final IBinder mBinder = new PlayerService.LocalBinder();
+    private final IBinder mBinder = new PlayerService.LocalBinder(this);
 
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -134,14 +136,19 @@ public final class PlayerService extends Service {
         return mBinder;
     }
 
-    public class LocalBinder extends Binder {
+    public static class LocalBinder extends Binder {
+        private final WeakReference<PlayerService> playerService;
+
+        LocalBinder(final PlayerService playerService) {
+            this.playerService = new WeakReference<>(playerService);
+        }
 
         public PlayerService getService() {
-            return PlayerService.this;
+            return playerService.get();
         }
 
         public Player getPlayer() {
-            return PlayerService.this.player;
+            return playerService.get().player;
         }
     }
 }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
- According to the stacktrace provided in https://github.com/TeamNewPipe/NewPipe/pull/10085#issuecomment-1635848614, LeakCanary now takes care to install the AppWatcher by itself, so we don't need to set it up manually, so I just removed the incriminating line. Also see #10231 and [this changelog](https://square.github.io/leakcanary/changelog/#configuring-retained-object-detection).
- I have tested by enabling LeakCanary in the settings and capturing a few leaks. Among those leaks I then found a really suspicious `PlayerService`-related leak and I decided to fix it, for more info see https://stackoverflow.com/q/63787707 and the leak report below. You can verify that this was fixed by opening the player, closing it and then taking a heap dump from LeakCanary. Note that these steps did not always lead to the leak before, idk why. **Remember to close the app after you enable LeakCanary in debug settings!**
- I also set all LeakCanary dependencies as `debugImplementation` only, as it does not make sense to include those in release builds. Previously they were included just because `BaseFragment.onDestroy()` called `AppWatcher.expectWeaklyReachable(this)`, but I don't think we need to do it manually, since LeakCanary already takes care of detecting fragments being destroyed. After removing this manual call, I still saw some leaks being detected because "[...] MainFragment received onDestroyView", so I guess the automatic detection works. The release builds fine, here is a release APK signed by me: 

<details><summary>The leak report I fixed</summary>

┬───
│ GC Root: Global variable in native code
│
├─ org.schabi.newpipe.player.PlayerService$LocalBinder instance
│    Leaking: UNKNOWN
│    Retaining 6.8 kB in 103 objects
│    this$0 instance of org.schabi.newpipe.player.PlayerService
│    ↓ PlayerService$LocalBinder.this$0
│                                ~~~~~~
╰→ org.schabi.newpipe.player.PlayerService instance
​     Leaking: YES (ObjectWatcher was watching this because org.schabi.newpipe.
​     player.PlayerService received Service#onDestroy() callback and Service
​     not held by ActivityThread)
​     Retaining 6.3 kB in 102 objects
​     key = cd33af62-1bd6-4297-bc44-2f05fab9fa16
​     watchDurationMillis = 19136
​     retainedDurationMillis = 14120
​     mApplication instance of org.schabi.newpipe.DebugApp
​     mBase instance of org.schabi.newpipe.player.AudioServiceLeakFix

METADATA

Build.VERSION.SDK_INT: 33
Build.MANUFACTURER: Google
LeakCanary version: 2.12
App process name: org.schabi.newpipe.debug
Class count: 30345
Instance count: 297963
Primitive array count: 185241
Object array count: 45771
Thread count: 74
Heap total bytes: 40216348
Bitmap count: 55
Bitmap total bytes: 10275621
Large bitmap count: 0
Large bitmap total bytes: 0
Db 1: open /data/user/0/org.schabi.newpipe.debug/databases/newpipe.db
Db 2: open /data/user/0/org.schabi.newpipe.debug/databases/exoplayer_internal.db
Db 3: open /data/user/0/org.schabi.newpipe.debug/no_backup/androidx.work.workdb
Stats: LruCache[maxSize=3000,hits=136480,misses=286718,hitRate=32%]
RandomAccess[bytes=15166205,reads=286718,travel=153801922092,range=44549734,size
=57029441]
Analysis duration: 24471 ms

</details>

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- See https://github.com/TeamNewPipe/NewPipe/pull/10085#issuecomment-1635848614
- Replaces #10231

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
