### PR TITLE
Update AndroidX Room library

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -110,7 +110,7 @@ ext {
     checkstyleVersion = '10.12.1'
 
     androidxLifecycleVersion = '2.5.1'
-    androidxRoomVersion = '2.4.3'
+    androidxRoomVersion = '2.5.2'
     androidxWorkVersion = '2.7.1'
 
     icepickVersion = '3.2.0'

--- a/app/src/androidTest/java/org/schabi/newpipe/database/DatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/database/DatabaseMigrationTest.kt
@@ -4,7 +4,6 @@ import android.content.ContentValues
 import android.database.sqlite.SQLiteDatabase
 import androidx.room.Room
 import androidx.room.testing.MigrationTestHelper
-import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -33,8 +32,7 @@ class DatabaseMigrationTest {
     @get:Rule
     val testHelper = MigrationTestHelper(
         InstrumentationRegistry.getInstrumentation(),
-        AppDatabase::class.java.canonicalName,
-        FrameworkSQLiteOpenHelperFactory()
+        AppDatabase::class.java
     )
 
     @Test

--- a/app/src/main/java/org/schabi/newpipe/database/feed/model/FeedGroupSubscriptionEntity.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/feed/model/FeedGroupSubscriptionEntity.kt
@@ -3,7 +3,6 @@ package org.schabi.newpipe.database.feed.model
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.ForeignKey
-import androidx.room.ForeignKey.CASCADE
 import androidx.room.Index
 import org.schabi.newpipe.database.feed.model.FeedGroupSubscriptionEntity.Companion.FEED_GROUP_SUBSCRIPTION_TABLE
 import org.schabi.newpipe.database.feed.model.FeedGroupSubscriptionEntity.Companion.GROUP_ID
@@ -19,14 +18,14 @@ import org.schabi.newpipe.database.subscription.SubscriptionEntity
             entity = FeedGroupEntity::class,
             parentColumns = [FeedGroupEntity.ID],
             childColumns = [GROUP_ID],
-            onDelete = CASCADE, onUpdate = CASCADE, deferred = true
+            onDelete = ForeignKey.CASCADE, onUpdate = ForeignKey.CASCADE, deferred = true
         ),
 
         ForeignKey(
             entity = SubscriptionEntity::class,
             parentColumns = [SubscriptionEntity.SUBSCRIPTION_UID],
             childColumns = [SUBSCRIPTION_ID],
-            onDelete = CASCADE, onUpdate = CASCADE, deferred = true
+            onDelete = ForeignKey.CASCADE, onUpdate = ForeignKey.CASCADE, deferred = true
         )
     ]
 )


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
- Fix MigrationTestHelper deprecation
- Update AndroidX Room 2.4.3 -> 2.5.2 ([changelog](https://developer.android.com/jetpack/androidx/releases/room))

I had to cherry-pick my LeakCanary fix to test this, but I tested the feed, history, playlists, streams, and subscriptions, and everything works fine.

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
