### PR TITLE
Fix player audio focus not respecting mute

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -1082,7 +1082,7 @@ public final class Player implements PlaybackListener, Listener {
 
         UIs.call(PlayerUi::onPrepared);
 
-        if (playWhenReady) {
+        if (playWhenReady && !isMuted()) {
             audioReactor.requestAudioFocus();
         }
     }
@@ -1223,6 +1223,11 @@ public final class Player implements PlaybackListener, Listener {
     public void toggleMute() {
         final boolean wasMuted = isMuted();
         simpleExoPlayer.setVolume(wasMuted ? 1 : 0);
+        if (wasMuted) {
+            audioReactor.requestAudioFocus();
+        } else {
+            audioReactor.abandonAudioFocus();
+        }
         UIs.call(playerUi -> playerUi.onMuteUnmuteChanged(!wasMuted));
         notifyPlaybackUpdateToListeners();
     }
@@ -1620,7 +1625,9 @@ public final class Player implements PlaybackListener, Listener {
             return;
         }
 
-        audioReactor.requestAudioFocus();
+        if (!isMuted()) {
+            audioReactor.requestAudioFocus();
+        }
 
         if (currentState == STATE_COMPLETED) {
             if (playQueue.getIndex() == 0) {


### PR DESCRIPTION
This issue is right on the line between feature and bug, so I'm selfishly calling it a bug. Very straightforward fix, tested with no obvious problems.

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
- Puts checks for mute state around each call to change audio focus in player
- Makes toggling mute state request/abandon focus

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #9537

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
