### PR TITLE
Adjust empty state message for ListInfoFragments depending on Info stream type

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -200,7 +200,7 @@ dependencies {
     // name and the commit hash with the commit hash of the (pushed) commit you want to test
     // This works thanks to JitPack: https://jitpack.io/
     implementation 'com.github.TeamNewPipe:nanojson:1d9e1aea9049fc9f85e68b43ba39fe7be1c1f751'
-    implementation 'com.github.TeamNewPipe:NewPipeExtractor:v0.22.7'
+    implementation 'com.github.TeamNewPipe:NewPipeExtractor:340095515d45ecbee576872c7198992ebd8e4f08'
     implementation 'com.github.TeamNewPipe:NoNonsense-FilePicker:5.0.0'
 
 /** Checkstyle **/

--- a/app/src/main/java/org/schabi/newpipe/fragments/BaseStateFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/BaseStateFragment.java
@@ -1,12 +1,16 @@
 package org.schabi.newpipe.fragments;
 
+import static org.schabi.newpipe.ktx.ViewUtils.animate;
+
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
 import android.widget.ProgressBar;
+import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
 import androidx.fragment.app.Fragment;
 
 import org.schabi.newpipe.BaseFragment;
@@ -20,15 +24,15 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import icepick.State;
 
-import static org.schabi.newpipe.ktx.ViewUtils.animate;
-
 public abstract class BaseStateFragment<I> extends BaseFragment implements ViewContract<I> {
     @State
     protected AtomicBoolean wasLoading = new AtomicBoolean();
     protected AtomicBoolean isLoading = new AtomicBoolean();
 
     @Nullable
-    private View emptyStateView;
+    protected View emptyStateView;
+    @Nullable
+    protected TextView emptyStateMessageView;
     @Nullable
     private ProgressBar loadingProgressBar;
 
@@ -65,6 +69,7 @@ public abstract class BaseStateFragment<I> extends BaseFragment implements ViewC
     protected void initViews(final View rootView, final Bundle savedInstanceState) {
         super.initViews(rootView, savedInstanceState);
         emptyStateView = rootView.findViewById(R.id.empty_state_view);
+        emptyStateMessageView = rootView.findViewById(R.id.empty_state_message);
         loadingProgressBar = rootView.findViewById(R.id.loading_progress_bar);
         errorPanelHelper = new ErrorPanelHelper(this, rootView, this::onRetryButtonClicked);
     }
@@ -187,6 +192,12 @@ public abstract class BaseStateFragment<I> extends BaseFragment implements ViewC
         }
 
         errorPanelHelper.showTextError(errorString);
+    }
+
+    protected void setEmptyStateMessage(@StringRes final int text) {
+        if (emptyStateMessageView != null) {
+            emptyStateMessageView.setText(text);
+        }
     }
 
     public final void hideErrorPanel() {

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListInfoFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListInfoFragment.java
@@ -1,5 +1,7 @@
 package org.schabi.newpipe.fragments.list;
 
+import static org.schabi.newpipe.extractor.ServiceList.SoundCloud;
+
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Log;
@@ -7,6 +9,7 @@ import android.view.View;
 
 import androidx.annotation.NonNull;
 
+import org.schabi.newpipe.R;
 import org.schabi.newpipe.error.ErrorInfo;
 import org.schabi.newpipe.error.UserAction;
 import org.schabi.newpipe.extractor.InfoItem;
@@ -250,6 +253,19 @@ public abstract class BaseListInfoFragment<I extends InfoItem, L extends ListInf
                         errorUserAction, "Start loading: " + url, serviceId));
             }
         }
+    }
+
+    @Override
+    public void showEmptyState() {
+        // show "no live streams" for live stream kiosk; otherwise no videos.
+        if (emptyStateView != null) {
+            if (currentInfo.getService() == SoundCloud) {
+                setEmptyStateMessage(R.string.no_streams);
+            } else {
+                setEmptyStateMessage(R.string.no_videos);
+            }
+        }
+        super.showEmptyState();
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
@@ -573,7 +573,7 @@ public class ChannelFragment extends BaseListInfoFragment<StreamInfoItem, Channe
         channelBinding.errorContentNotSupported.setVisibility(View.VISIBLE);
         channelBinding.channelKaomoji.setText("(︶︹︺)");
         channelBinding.channelKaomoji.setTextSize(TypedValue.COMPLEX_UNIT_SP, 45f);
-        channelBinding.channelNoVideos.setVisibility(View.GONE);
+        channelBinding.emptyStateMessage.setVisibility(View.GONE);
     }
 
     private PlayQueue getPlayQueue() {

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/kiosk/KioskFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/kiosk/KioskFragment.java
@@ -16,11 +16,13 @@ import org.schabi.newpipe.error.ErrorInfo;
 import org.schabi.newpipe.error.UserAction;
 import org.schabi.newpipe.extractor.ListExtractor;
 import org.schabi.newpipe.extractor.NewPipe;
+import org.schabi.newpipe.extractor.ServiceList;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.kiosk.KioskInfo;
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandlerFactory;
 import org.schabi.newpipe.extractor.localization.ContentCountry;
+import org.schabi.newpipe.extractor.services.media_ccc.extractors.MediaCCCLiveStreamKiosk;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.fragments.list.BaseListInfoFragment;
 import org.schabi.newpipe.util.ExtractorHelper;
@@ -160,5 +162,15 @@ public class KioskFragment extends BaseListInfoFragment<StreamInfoItem, KioskInf
 
         name = kioskTranslatedName;
         setTitle(kioskTranslatedName);
+    }
+
+    @Override
+    public void showEmptyState() {
+        // show "no live streams" for live stream kiosk
+        super.showEmptyState();
+        if (MediaCCCLiveStreamKiosk.KIOSK_ID.equals(currentInfo.getId())
+                && ServiceList.MediaCCC.getServiceId() == currentInfo.getServiceId()) {
+            setEmptyStateMessage(R.string.no_live_streams);
+        }
     }
 }

--- a/app/src/main/res/layout/fragment_channel.xml
+++ b/app/src/main/res/layout/fragment_channel.xml
@@ -42,7 +42,7 @@
             tools:ignore="HardcodedText,UnusedAttribute" />
 
         <org.schabi.newpipe.views.NewPipeTextView
-            android:id="@+id/channel_no_videos"
+            android:id="@+id/empty_state_message"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"

--- a/app/src/main/res/layout/fragment_kiosk.xml
+++ b/app/src/main/res/layout/fragment_kiosk.xml
@@ -42,6 +42,7 @@
             tools:ignore="HardcodedText,UnusedAttribute" />
 
         <org.schabi.newpipe.views.NewPipeTextView
+            android:id="@+id/empty_state_message"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"

--- a/app/src/main/res/layout/fragment_playlist.xml
+++ b/app/src/main/res/layout/fragment_playlist.xml
@@ -41,6 +41,7 @@
             tools:ignore="HardcodedText,UnusedAttribute" />
 
         <org.schabi.newpipe.views.NewPipeTextView
+            android:id="@+id/empty_state_message"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -317,6 +317,8 @@
     </plurals>
     <string name="no_comments">No comments</string>
     <string name="comments_are_disabled">Comments are disabled</string>
+    <string name="no_streams">No streams</string>
+    <string name="no_live_streams">No live streams</string>
     <plurals name="new_streams">
         <item quantity="one">%s new stream</item>
         <item quantity="other">%s new streams</item>


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
- Update Extractor to not show media.ccc.de live stream rooms if they are currently not providing a live stream.
- Show "no streams" for SoundClound, "no live streams" for MeidaCCCLiveStreamKiosk and otherwise "no videos"


#### Relies on the following changes
<!-- Delete this if it doesn't apply to your PR. -->
- https://github.com/TeamNewPipe/NewPipeExtractor/pull/1089

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
