### PR TITLE
Show play queue button in main player when there is one stream

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
@@ -434,7 +434,7 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
             return;
         }
 
-        final boolean showQueue = playQueue.getStreams().size() > 1;
+        final boolean showQueue = !playQueue.getStreams().isEmpty();
         final boolean showSegment = !player.getCurrentStreamInfo()
                 .map(StreamInfo::getStreamSegments)
                 .map(List::isEmpty)


### PR DESCRIPTION
#### What is it?
- [x] Feature (user facing)

#### Description of the changes in your PR
This PR makes the play queue button visible when there is at least a stream instead of two, allowing users to access to the play queue directly from the main player and so to loop/don't loop a single stream.

This solution seems to be the easiest one to always show a loop button without using the play queue activity or the media notification (currently on Android 12 and below only) before the player is rewritten with a new UI and UX in mind.

#### Fixes the following issue(s)
- Fixes #6914

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).