### PR TITLE
Fix language Picker Selecting Wrong Languages

### DIFF
--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -1238,7 +1238,6 @@
         <item>Íslenska</item>
         <item>Italiano</item>
         <item>日本語</item>
-        <item>うちなーぐち</item>
         <item>ꦧꦱꦗꦮ</item>
         <item>Taqbaylit</item>
         <item>Kurmancî</item>
@@ -1263,6 +1262,7 @@
         <item>Português (PT)</item>
         <item>Română</item>
         <item>Pусский</item>
+        <item>うちなーぐち</item>
         <item>ᱥᱟᱱᱛᱟᱲᱤ</item>
         <item>sardu</item>
         <item>Slovenčina</item>


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Fix Language Selector Bug introduced by #10250 , by placing Uchinaguchi Language correctly in language selector settings.

Fixes:
Language Selector Bug
Description:

In App language Content Settings, when I choose Punjabi, app language actually changes to Polish after restart (that means language picker picking up the lower placed language instead). App shows selected language Punjabi, even though app is now in Polish language.

Try changing any language after ~~Italian~~ Japanese in language selector settings, bug will be noticeable except last few languages.

Tested on:
Device: Samsung Galaxy A22 5G
OS: Android 13 OneUI 5.0
App Version: 0.25.2
#### APK testing
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
