### PR TITLE
Bump AGP to 8.1.1

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/streams/io/StoredDirectoryHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/streams/io/StoredDirectoryHelper.java
@@ -170,8 +170,8 @@ public class StoredDirectoryHelper {
 
     /**
      * Only using Java I/O. Creates the directory named by this abstract pathname, including any
-     * necessary but nonexistent parent directories.  Note that if this
-     * operation fails it may have succeeded in creating some of the necessary
+     * necessary but nonexistent parent directories.
+     * Note that if this operation fails it may have succeeded in creating some of the necessary
      * parent directories.
      *
      * @return <code>true</code> if and only if the directory was created,

--- a/app/src/main/java/org/schabi/newpipe/streams/io/StoredDirectoryHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/streams/io/StoredDirectoryHelper.java
@@ -180,9 +180,12 @@ public class StoredDirectoryHelper {
      */
     public boolean mkdirs() {
         if (docTree == null) {
-            // TODO: Use Files.createDirectories() when AGP 8.1 is available:
-            // https://issuetracker.google.com/issues/282544786
-            return Files.exists(ioTree) || ioTree.toFile().mkdirs();
+            try {
+                Files.createDirectories(ioTree);
+            } catch (final IOException e) {
+                Log.e(TAG, "Error while creating directories at " + ioTree, e);
+            }
+            return Files.exists(ioTree);
         }
 
         if (docTree.exists()) {

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'com.android.tools.build:gradle:8.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Codebase improvement (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Bump AGP to 8.1.1.
- Switch to [`Files.createDirectories()`](https://docs.oracle.com/javase/8/docs/api/java/nio/file/Files.html#createDirectories-java.nio.file.Path-java.nio.file.attribute.FileAttribute...-), as [the issue](https://issuetracker.google.com/issues/282544786) affecting it has been fixed in AGP 8.1.

Follow up on  #10248

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
