### PR TITLE
Fix restoring software license dialog

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/about/LicenseFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/about/LicenseFragment.kt
@@ -1,15 +1,24 @@
 package org.schabi.newpipe.about
 
 import android.os.Bundle
+import android.util.Base64
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.webkit.WebView
+import androidx.appcompat.app.AlertDialog
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
+import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.disposables.CompositeDisposable
+import io.reactivex.rxjava3.disposables.Disposable
+import io.reactivex.rxjava3.schedulers.Schedulers
 import org.schabi.newpipe.R
 import org.schabi.newpipe.databinding.FragmentLicensesBinding
 import org.schabi.newpipe.databinding.ItemSoftwareComponentBinding
+import org.schabi.newpipe.util.Localization
+import org.schabi.newpipe.util.external_communication.ShareUtils
 
 /**
  * Fragment containing the software licenses.
@@ -41,7 +50,7 @@ class LicenseFragment : Fragment() {
         binding.licensesAppReadLicense.setOnClickListener {
             activeLicense = StandardLicenses.GPL3
             compositeDisposable.add(
-                showLicense(activity, StandardLicenses.GPL3)
+                showLicense(StandardLicenses.GPL3)
             )
         }
         for (component in softwareComponents) {
@@ -59,19 +68,64 @@ class LicenseFragment : Fragment() {
             root.setOnClickListener {
                 activeLicense = component.license
                 compositeDisposable.add(
-                    showLicense(activity, component)
+                    showLicense(component)
                 )
             }
             binding.licensesSoftwareComponents.addView(root)
             registerForContextMenu(root)
         }
-        activeLicense?.let { compositeDisposable.add(showLicense(activity, it)) }
+        activeLicense?.let { compositeDisposable.add(showLicense(it)) }
         return binding.root
     }
 
     override fun onSaveInstanceState(savedInstanceState: Bundle) {
         super.onSaveInstanceState(savedInstanceState)
         activeLicense?.let { savedInstanceState.putSerializable(LICENSE_KEY, it) }
+    }
+
+    private fun showLicense(component: SoftwareComponent): Disposable {
+        return showLicense(component.license) {
+            setPositiveButton(R.string.dismiss) { dialog, _ ->
+                dialog.dismiss()
+            }
+            setNeutralButton(R.string.open_website_license) { _, _ ->
+                ShareUtils.openUrlInApp(requireContext(), component.link)
+            }
+        }
+    }
+
+    private fun showLicense(license: License) = showLicense(license) {
+        setPositiveButton(R.string.ok) { dialog, _ -> dialog.dismiss() }
+    }
+
+    private fun showLicense(
+        license: License,
+        block: AlertDialog.Builder.() -> AlertDialog.Builder
+    ): Disposable {
+        return if (context == null) {
+            Disposable.empty()
+        } else {
+            val context = requireContext()
+            Observable.fromCallable { getFormattedLicense(context, license) }
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe { formattedLicense ->
+                    val webViewData = Base64.encodeToString(
+                        formattedLicense.toByteArray(), Base64.NO_PADDING
+                    )
+                    val webView = WebView(context)
+                    webView.loadData(webViewData, "text/html; charset=UTF-8", "base64")
+
+                    Localization.assureCorrectAppLanguage(context)
+                    AlertDialog.Builder(requireContext())
+                        .setTitle(license.name)
+                        .setView(webView)
+                        .setOnCancelListener { activeLicense = null }
+                        .setOnDismissListener { activeLicense = null }
+                        .block()
+                        .show()
+                }
+        }
     }
 
     companion object {

--- a/app/src/main/java/org/schabi/newpipe/about/LicenseFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/about/LicenseFragment.kt
@@ -106,15 +106,12 @@ class LicenseFragment : Fragment() {
                         .setView(webView)
                         .setOnCancelListener { activeSoftwareComponent = null }
                         .setOnDismissListener { activeSoftwareComponent = null }
-                    if (softwareComponent == NEWPIPE_SOFTWARE_COMPONENT) {
-                        builder.setPositiveButton(R.string.ok) { dialog, _ -> dialog.dismiss() }
-                    } else {
-                        builder.setPositiveButton(R.string.dismiss) { dialog, _ ->
-                            dialog.dismiss()
+                        .setPositiveButton(R.string.done) { dialog, _ -> dialog.dismiss() }
+
+                    if (softwareComponent != NEWPIPE_SOFTWARE_COMPONENT) {
+                        builder.setNeutralButton(R.string.open_website_license) { _, _ ->
+                            ShareUtils.openUrlInApp(requireContext(), softwareComponent.link)
                         }
-                            .setNeutralButton(R.string.open_website_license) { _, _ ->
-                                ShareUtils.openUrlInApp(requireContext(), softwareComponent.link)
-                            }
                     }
 
                     builder.show()

--- a/app/src/main/java/org/schabi/newpipe/about/LicenseFragmentHelper.kt
+++ b/app/src/main/java/org/schabi/newpipe/about/LicenseFragmentHelper.kt
@@ -1,17 +1,8 @@
 package org.schabi.newpipe.about
 
 import android.content.Context
-import android.util.Base64
-import android.webkit.WebView
-import androidx.appcompat.app.AlertDialog
-import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
-import io.reactivex.rxjava3.core.Observable
-import io.reactivex.rxjava3.disposables.Disposable
-import io.reactivex.rxjava3.schedulers.Schedulers
 import org.schabi.newpipe.R
-import org.schabi.newpipe.util.Localization
 import org.schabi.newpipe.util.ThemeHelper
-import org.schabi.newpipe.util.external_communication.ShareUtils
 import java.io.IOException
 
 /**
@@ -20,7 +11,7 @@ import java.io.IOException
  * @return String which contains a HTML formatted license page
  * styled according to the context's theme
  */
-private fun getFormattedLicense(context: Context, license: License): String {
+fun getFormattedLicense(context: Context, license: License): String {
     try {
         return context.assets.open(license.filename).bufferedReader().use { it.readText() }
             // split the HTML file and insert the stylesheet into the HEAD of the file
@@ -34,7 +25,7 @@ private fun getFormattedLicense(context: Context, license: License): String {
  * @param context the Android context
  * @return String which is a CSS stylesheet according to the context's theme
  */
-private fun getLicenseStylesheet(context: Context): String {
+fun getLicenseStylesheet(context: Context): String {
     val isLightTheme = ThemeHelper.isLightThemeSelected(context)
     val licenseBackgroundColor = getHexRGBColor(
         context, if (isLightTheme) R.color.light_license_background_color else R.color.dark_license_background_color
@@ -56,48 +47,6 @@ private fun getLicenseStylesheet(context: Context): String {
  * @param color   the color number from R.color
  * @return a six characters long String with hexadecimal RGB values
  */
-private fun getHexRGBColor(context: Context, color: Int): String {
+fun getHexRGBColor(context: Context, color: Int): String {
     return context.getString(color).substring(3)
-}
-
-fun showLicense(context: Context?, component: SoftwareComponent): Disposable {
-    return showLicense(context, component.license) {
-        setPositiveButton(R.string.dismiss) { dialog, _ ->
-            dialog.dismiss()
-        }
-        setNeutralButton(R.string.open_website_license) { _, _ ->
-            ShareUtils.openUrlInApp(context!!, component.link)
-        }
-    }
-}
-
-fun showLicense(context: Context?, license: License) = showLicense(context, license) {
-    setPositiveButton(R.string.ok) { dialog, _ -> dialog.dismiss() }
-}
-
-private fun showLicense(
-    context: Context?,
-    license: License,
-    block: AlertDialog.Builder.() -> AlertDialog.Builder
-): Disposable {
-    return if (context == null) {
-        Disposable.empty()
-    } else {
-        Observable.fromCallable { getFormattedLicense(context, license) }
-            .subscribeOn(Schedulers.io())
-            .observeOn(AndroidSchedulers.mainThread())
-            .subscribe { formattedLicense ->
-                val webViewData =
-                    Base64.encodeToString(formattedLicense.toByteArray(), Base64.NO_PADDING)
-                val webView = WebView(context)
-                webView.loadData(webViewData, "text/html; charset=UTF-8", "base64")
-
-                Localization.assureCorrectAppLanguage(context)
-                AlertDialog.Builder(context)
-                    .setTitle(license.name)
-                    .setView(webView)
-                    .block()
-                    .show()
-            }
-    }
 }

--- a/app/src/main/java/org/schabi/newpipe/about/SoftwareComponent.kt
+++ b/app/src/main/java/org/schabi/newpipe/about/SoftwareComponent.kt
@@ -2,6 +2,7 @@ package org.schabi.newpipe.about
 
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
+import java.io.Serializable
 
 @Parcelize
 class SoftwareComponent
@@ -13,4 +14,4 @@ constructor(
     val link: String,
     val license: License,
     val version: String? = null
-) : Parcelable
+) : Parcelable, Serializable

--- a/app/src/main/res/menu/menu_recaptcha.xml
+++ b/app/src/main/res/menu/menu_recaptcha.xml
@@ -5,6 +5,6 @@
     <item
         android:id="@+id/menu_item_done"
         android:icon="@drawable/ic_done"
-        android:title="@string/recaptcha_done_button"
+        android:title="@string/done"
         app:showAsAction="always" />
 </menu>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -466,7 +466,7 @@
     <string name="app_language_title">لغة التطبيق</string>
     <string name="systems_language">النظام الافتراضي</string>
     <string name="subtitle_activity_recaptcha">اضغط على \"تم\" عند حلها</string>
-    <string name="recaptcha_done_button">منجز</string>
+    <string name="done">منجز</string>
     <string name="videos_string">الفيديوهات</string>
     <plurals name="seconds">
         <item quantity="zero">%d ثانية</item>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -327,7 +327,7 @@
     <string name="no_dir_yet">Hələ endirmə qovluğu təyin edilməyib, indi standart endirmə qovluğu seç</string>
     <string name="title_activity_recaptcha">reCAPTCHA çağırışı</string>
     <string name="recaptcha_request_toast">reCAPTCHA sorğusu göndərildi</string>
-    <string name="recaptcha_done_button">Bitdi</string>
+    <string name="done">Bitdi</string>
     <string name="settings_file_replacement_character_summary">Etibarsız simvollar bu dəyərlə əvəz olunur</string>
     <string name="settings_file_replacement_character_title">Əvəzedici xarakter</string>
     <string name="charset_most_special_characters">Ən xüsusi simvollar</string>

--- a/app/src/main/res/values-b+ast/strings.xml
+++ b/app/src/main/res/values-b+ast/strings.xml
@@ -420,7 +420,7 @@
     <string name="app_description">Un aplicación llibre pa ver/sentir plataformes de tresmisión n\'Android.</string>
     <string name="settings_file_replacement_character_title">Caráuteres de troquéu</string>
     <string name="settings_file_replacement_character_summary">Los caráuteres que nun son válidos van trocase por esti valor</string>
-    <string name="recaptcha_done_button">Fecho</string>
+    <string name="done">Fecho</string>
     <string name="subtitle_activity_recaptcha">Primi «Fecho» al resolvelu</string>
     <string name="one_item_deleted">Desanicióse 1 elementu.</string>
     <string name="no_available_dir">Defini una capeta de descargues dempués, nos axustes de l\'aplicación</string>

--- a/app/src/main/res/values-b+uz+Latn/strings.xml
+++ b/app/src/main/res/values-b+uz+Latn/strings.xml
@@ -214,7 +214,7 @@
     <string name="settings_file_replacement_character_summary">Noto\'g\'ri belgilar ushbu qiymat bilan almashtiriladi</string>
     <string name="settings_file_charset_title">Fayl nomidagi ruxsat berilgan belgilar</string>
     <string name="settings_category_downloads_title">Yuklab olish</string>
-    <string name="recaptcha_done_button">Bajarildi</string>
+    <string name="done">Bajarildi</string>
     <string name="recaptcha_request_toast">reCAPTCHA muammosi so\'raldi</string>
     <string name="subtitle_activity_recaptcha">Hal etilganda \"Bajarildi\" tugmasini bosing</string>
     <string name="title_activity_recaptcha">reCAPTCHA muammosi</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -453,7 +453,7 @@
     <string name="no_playlist_bookmarked_yet">Няма закладак у плейлісце</string>
     <string name="select_a_playlist">Выберыце плэйліст</string>
     <string name="default_kiosk_page_summary">Кіёск па змаўчанні</string>
-    <string name="recaptcha_done_button">Так</string>
+    <string name="done">Так</string>
     <string name="subtitle_activity_recaptcha">Націсніце \"Так\" калі вырашана</string>
     <string name="infinite_videos">∞ відэа</string>
     <string name="more_than_100_videos">100+ відэа</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -445,7 +445,7 @@
     <string name="detail_heart_img_view_description">Отбелязан със сърце от автора</string>
     <string name="conferences">Конференции</string>
     <string name="most_liked">Най-харесвани</string>
-    <string name="recaptcha_done_button">Готово</string>
+    <string name="done">Готово</string>
     <string name="comments_tab_description">Коментари</string>
     <string name="localization_changes_requires_app_restart">Езикът ще се смени след рестартиране на приложението</string>
     <string name="metadata_privacy_unlisted">Скрит</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -257,7 +257,7 @@
     <string name="peertube_instance_url_title">পিয়ার টিউব এর ইন্সটান্স সমূহ</string>
     <string name="grid">ছক</string>
     <string name="local">স্থানীয়</string>
-    <string name="recaptcha_done_button">হয়েছে</string>
+    <string name="done">হয়েছে</string>
     <string name="events">ইভেন্টগুলো</string>
     <string name="settings_category_updates_title">আপডেট</string>
     <string name="minimize_on_exit_none_description">কোনোটি না</string>

--- a/app/src/main/res/values-bn-rIN/strings.xml
+++ b/app/src/main/res/values-bn-rIN/strings.xml
@@ -239,7 +239,7 @@
     <string name="contribution_title">যোগদান</string>
     <string name="title_activity_about">নিউ পাইপ এর সম্বন্ধে</string>
     <string name="charset_letters_and_digits">শব্দ ও নম্বর</string>
-    <string name="recaptcha_done_button">হয়েছে</string>
+    <string name="done">হয়েছে</string>
     <string name="no_comments">কোন মন্তব্য নেই</string>
     <string name="no_subscribers">কোন সাবস্ক্রাইবার নেই</string>
     <string name="no_streams_available_download">ডাউন লোড এর জন্য কোন স্ট্রিম নেই</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -78,7 +78,7 @@
     <string name="title_activity_about">নিউপাইপ এর সম্বন্ধে</string>
     <string name="charset_letters_and_digits">শব্দ ও নম্বর</string>
     <string name="settings_category_downloads_title">ডাউনলোড</string>
-    <string name="recaptcha_done_button">হয়েছে</string>
+    <string name="done">হয়েছে</string>
     <string name="recaptcha_request_toast">reCAPTCHA চ্যালেঞ্জ অনুরোধ করা হয়েছে</string>
     <string name="title_activity_recaptcha">reCAPTCHA চ্যালেঞ্জ</string>
     <string name="one_item_deleted">একটি আইটেম ডিলিট হয়েছে।</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -535,7 +535,7 @@
     <string name="local">Local</string>
     <string name="no_playlist_bookmarked_yet">Encara no hi ha llistes de reproducció favorites</string>
     <string name="select_a_playlist">Sel·leccioneu una llista de reproducció</string>
-    <string name="recaptcha_done_button">Fet</string>
+    <string name="done">Fet</string>
     <string name="msg_calculating_hash">Calculant-ne la funció de verificació</string>
     <string name="error_report_open_github_notice">Si us plau, comproveu abans si el problema que ha causat aquesta fallada ja ha estat informat. Els tiquets per duplicat fan que perdem temps que podríem aprofitar resolent-los.</string>
     <string name="error_report_open_issue_button_text">Avisa del problema a GitHub</string>

--- a/app/src/main/res/values-ckb/strings.xml
+++ b/app/src/main/res/values-ckb/strings.xml
@@ -293,7 +293,7 @@
     <string name="download_already_pending">دابه‌زاندنێكی دیكه‌ له‌ نۆره‌دایه‌ بەهەمان ناو</string>
     <string name="feed_group_dialog_empty_selection">هیچ بەژدارییەک دیار نەکراوە</string>
     <string name="feed_group_dialog_empty_name">ناوی کۆمەڵە بەتاڵە</string>
-    <string name="recaptcha_done_button">كرا</string>
+    <string name="done">كرا</string>
     <string name="detail_likes_img_view_description">بەدڵه‌كان</string>
     <string name="popup_remember_size_pos_summary">بیرهاتنه‌وه‌ی كۆتا قه‌باره‌ و شوێنی په‌نجه‌ره‌</string>
     <string name="create">سازکردن</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -451,7 +451,7 @@
     <string name="app_language_title">Jazyk aplikace</string>
     <string name="systems_language">Jazyk systému</string>
     <string name="subtitle_activity_recaptcha">Po vyřešení klepněte na „Hotovo“</string>
-    <string name="recaptcha_done_button">Hotovo</string>
+    <string name="done">Hotovo</string>
     <string name="videos_string">Videa</string>
     <plurals name="seconds">
         <item quantity="one">%d vteřina</item>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -620,7 +620,7 @@
     <string name="most_liked">Mest likede</string>
     <string name="error_unable_to_load_comments">Kunne ikke indlæse kommentarer</string>
     <string name="default_kiosk_page_summary">Standard Kiosk</string>
-    <string name="recaptcha_done_button">Færdig</string>
+    <string name="done">Færdig</string>
     <string name="subtitle_activity_recaptcha">Tryk på \"Færdig\" når den er løst</string>
     <string name="no_comments">Ingen kommentarer</string>
     <string name="infinite_videos">∞ videoer</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -455,7 +455,7 @@
     <string name="app_language_title">Sprache der App</string>
     <string name="systems_language">Systemstandard</string>
     <string name="subtitle_activity_recaptcha">„Fertig“ drücken, wenn es gelöst wurde</string>
-    <string name="recaptcha_done_button">Fertig</string>
+    <string name="done">Fertig</string>
     <string name="videos_string">Videos</string>
     <plurals name="seconds">
         <item quantity="one">%d Sekunde</item>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -459,7 +459,7 @@
     <string name="title_activity_play_queue">Αναπαραγωγή ουράς</string>
     <string name="no_playlist_bookmarked_yet">Δεν υπάρχουν σελιδοδείκτες λίστας αναπαραγωγής ακόμα</string>
     <string name="select_a_playlist">Επιλέξτε μια λίστα αναπαραγωγής</string>
-    <string name="recaptcha_done_button">Τέλος</string>
+    <string name="done">Τέλος</string>
     <string name="subtitle_activity_recaptcha">Πατήστε «Τέλος» όταν επιλυθεί</string>
     <string name="infinite_videos">∞ βίντεο</string>
     <string name="more_than_100_videos">100+ βίντεο</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -445,7 +445,7 @@
     <string name="app_language_title">Preferata aplingvo</string>
     <string name="systems_language">Sistemnormo</string>
     <string name="subtitle_activity_recaptcha">Premu “Finita” kiam solvita</string>
-    <string name="recaptcha_done_button">Finita</string>
+    <string name="done">Finita</string>
     <plurals name="seconds">
         <item quantity="one">%d sekundo</item>
         <item quantity="other">%d sekundoj</item>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -454,7 +454,7 @@
     <string name="app_language_title">Idioma de aplicación</string>
     <string name="systems_language">Predefinido del sistema</string>
     <string name="subtitle_activity_recaptcha">Pulsa en «Hecho» al resolverlo</string>
-    <string name="recaptcha_done_button">Hecho</string>
+    <string name="done">Hecho</string>
     <string name="videos_string">Vídeos</string>
     <plurals name="seconds">
         <item quantity="one">%d segundo</item>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -494,7 +494,7 @@
     <string name="no_playlist_bookmarked_yet">Esitusloendi järjehoidjaid veel pole</string>
     <string name="select_a_playlist">Vali esitusloend</string>
     <string name="default_kiosk_page_summary">Vaikimisi seadistatud kiosk</string>
-    <string name="recaptcha_done_button">Valmis</string>
+    <string name="done">Valmis</string>
     <string name="subtitle_activity_recaptcha">Kui oled lõpetanud, siis vajuta „Valmis“ nuppu</string>
     <string name="no_comments">Kommentaare pole</string>
     <string name="infinite_videos">∞ videot</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -446,7 +446,7 @@
     <string name="app_language_title">Aplikazioaren hizkuntza</string>
     <string name="systems_language">Sistemaren lehenetsia</string>
     <string name="subtitle_activity_recaptcha">Sakatu \"Egina\" konponduta dagoenean</string>
-    <string name="recaptcha_done_button">Egina</string>
+    <string name="done">Egina</string>
     <string name="videos_string">Bideoak</string>
     <plurals name="seconds">
         <item quantity="one">segundu %d</item>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -471,7 +471,7 @@
     <string name="local">محلی</string>
     <string name="localization_changes_requires_app_restart">با آغاز دوبارهٔ کاره، زبان تغییر خواهد کرد</string>
     <string name="default_kiosk_page_summary">کیوسک پیش‌فرض</string>
-    <string name="recaptcha_done_button">انجام شد</string>
+    <string name="done">انجام شد</string>
     <string name="subtitle_activity_recaptcha">وقتی انجام شد، «Done» یا «انجام شد» را بفشارید</string>
     <string name="infinite_videos">∞ ویدیو</string>
     <string name="more_than_100_videos">بیش از ۱۰۰ ویدیو</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -340,7 +340,7 @@
     <string name="localization_changes_requires_app_restart">Kieli vaihtuu, kun sovellus uudelleenkäynnistetään</string>
     <string name="error_unable_to_load_comments">Kommentteja ei voitu ladata</string>
     <string name="main_page_content_summary">Mitkä välilehdet näytetään pääsivulla</string>
-    <string name="recaptcha_done_button">Valmis</string>
+    <string name="done">Valmis</string>
     <string name="subtitle_activity_recaptcha">Paina ”Valmis”, kun ratkaistu</string>
     <string name="infinite_videos">∞ videota</string>
     <string name="more_than_100_videos">100+ videota</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -451,7 +451,7 @@
     <string name="app_language_title">Langue de l’application</string>
     <string name="systems_language">Prédéfini par le système</string>
     <string name="subtitle_activity_recaptcha">Appuyez sur « Terminé » une fois résolu</string>
-    <string name="recaptcha_done_button">Terminé</string>
+    <string name="done">Terminé</string>
     <string name="videos_string">Vidéos</string>
     <string name="new_seek_duration_toast">En raison des contraintes d’ExoPlayer, le pas de déplacement a été réglée à %d secondes</string>
     <string name="mute">Couper le son</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -469,7 +469,7 @@
     <string name="select_a_playlist">Seleccionar unha lista de reprodución</string>
     <string name="default_kiosk_page_summary">Quiosco predeterminado</string>
     <string name="main_page_content_summary">Que lapelas se amosan na páxina principal</string>
-    <string name="recaptcha_done_button">Feito</string>
+    <string name="done">Feito</string>
     <string name="subtitle_activity_recaptcha">Prema \"Feito\" cando o resolva</string>
     <string name="no_comments">Ningún comentario</string>
     <string name="infinite_videos">∞ vídeos</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -456,7 +456,7 @@
     <string name="app_language_title">שפת היישומון</string>
     <string name="systems_language">ברירת המחדל של המערכת</string>
     <string name="subtitle_activity_recaptcha">יש ללחוץ על „סיום” לאחר הפתירה</string>
-    <string name="recaptcha_done_button">סיום</string>
+    <string name="done">סיום</string>
     <string name="videos_string">סרטונים</string>
     <plurals name="seconds">
         <item quantity="one">שנייה אחת</item>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -445,7 +445,7 @@
     <string name="channel_created_by">%s के द्वारा बनाया गया</string>
     <string name="playlist_page_summary">प्लेलिस्ट पन्ना</string>
     <string name="search_showing_result_for">%s : के लिए परिणाम दिखाया जा रहा है</string>
-    <string name="recaptcha_done_button">संपन्न</string>
+    <string name="done">संपन्न</string>
     <string name="artists">कलाकार</string>
     <string name="songs">गीत</string>
     <string name="never">कभी नहीं</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -429,7 +429,7 @@
     <string name="error_insufficient_storage">Memorija uređaja je popunjena</string>
     <string name="most_liked">Najomiljeniji</string>
     <string name="subtitle_activity_recaptcha">Pritisni „Gotovo” kad je riješeno</string>
-    <string name="recaptcha_done_button">Gotovo</string>
+    <string name="done">Gotovo</string>
     <string name="infinite_videos">∞ videa</string>
     <string name="more_than_100_videos">Više od 100 videa</string>
     <string name="error_report_open_issue_button_text">Prijavi grešku na GitHub-u</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -457,7 +457,7 @@
     <string name="feed_group_dialog_select_subscriptions">Feliratkozások kiválasztása</string>
     <string name="copyright">© %1$s %2$s, %3$s licenc alatt</string>
     <string name="title_licenses">Harmadik féltől származó licencek</string>
-    <string name="recaptcha_done_button">Kész</string>
+    <string name="done">Kész</string>
     <string name="no_comments">Nincs megjegyzés</string>
     <string name="infinite_videos">∞ videó</string>
     <string name="more_than_100_videos">100+ videó</string>

--- a/app/src/main/res/values-hy/strings.xml
+++ b/app/src/main/res/values-hy/strings.xml
@@ -192,7 +192,7 @@
     <string name="select_a_playlist">Նշել նվագացանկ</string>
     <string name="charset_letters_and_digits">Տառեր և թվեր</string>
     <string name="settings_category_downloads_title">Բեռնումներ</string>
-    <string name="recaptcha_done_button">Եղավ</string>
+    <string name="done">Եղավ</string>
     <string name="play_all">Նվագել ամենը</string>
     <string name="duration_live">Ուղիղ</string>
     <string name="enable_playback_resume_title">Շարունակել նվագարկումը</string>

--- a/app/src/main/res/values-ia/strings.xml
+++ b/app/src/main/res/values-ia/strings.xml
@@ -140,7 +140,7 @@
     <string name="title_most_played">Le plus reproducite</string>
     <string name="main_page_content">Contento del pagina principal</string>
     <string name="select_a_channel">Selige un canal</string>
-    <string name="recaptcha_done_button">Preste</string>
+    <string name="done">Preste</string>
     <string name="popup_remember_size_pos_summary">Rememorar ultime grandor e position del reproductor emergente</string>
     <string name="popup_remember_size_pos_title">Rememorar grandor e position del fenestra emergente</string>
     <plurals name="videos">

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -439,7 +439,7 @@
     <string name="permission_display_over_apps">Izinkan untuk ditampilkan di atas aplikasi lain</string>
     <string name="app_language_title">Bahasa apl</string>
     <string name="systems_language">Default sistem</string>
-    <string name="recaptcha_done_button">Selesai</string>
+    <string name="done">Selesai</string>
     <string name="seek_duration_title">Durasi maju/mundur cepat</string>
     <string name="subtitle_activity_recaptcha">Tekan \"Selesai\" saat selesai</string>
     <string name="videos_string">Video</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -250,7 +250,7 @@
     <string name="msg_copied">Afritað á klemmuspjald</string>
     <string name="one_item_deleted">1 atriði eytt.</string>
     <string name="recaptcha_solve">Leysa</string>
-    <string name="recaptcha_done_button">Lokið</string>
+    <string name="done">Lokið</string>
     <string name="recaptcha_request_toast">Beðið eftir þraut reCAPTCHA</string>
     <string name="title_licenses">Leyfi þriðja aðila</string>
     <string name="tab_licenses">Hugbúnaðarleyfi</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -451,7 +451,7 @@
     <string name="app_language_title">Lingua dell\'applicazione</string>
     <string name="systems_language">Predefinita di sistema</string>
     <string name="subtitle_activity_recaptcha">Premere \"Fatto\" quando risolto</string>
-    <string name="recaptcha_done_button">Fatto</string>
+    <string name="done">Fatto</string>
     <string name="videos_string">Video</string>
     <plurals name="seconds">
         <item quantity="one">%d secondo</item>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -441,7 +441,7 @@
     <string name="app_language_title">アプリの言語</string>
     <string name="systems_language">システムの既定</string>
     <string name="subtitle_activity_recaptcha">解けたら「完了」を押してください</string>
-    <string name="recaptcha_done_button">完了</string>
+    <string name="done">完了</string>
     <string name="videos_string">動画</string>
     <plurals name="seconds">
         <item quantity="other">%d 秒</item>

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -292,7 +292,7 @@
     <string name="subtitle_activity_recaptcha">როდესაც მოგვარდება, დააჭირეთ შესრულებულია</string>
     <string name="recaptcha_request_toast">მოთხოვნილია reCAPTCHA გამოწვევა</string>
     <string name="recaptcha_solve">ამოხსნა</string>
-    <string name="recaptcha_done_button">შესრულებულია</string>
+    <string name="done">შესრულებულია</string>
     <string name="settings_file_replacement_character_title">შემცვლელი პერსონაჟი</string>
     <string name="charset_letters_and_digits">ასოები და ციფრები</string>
     <string name="title_activity_about">NewPipe-ის შესახებ</string>

--- a/app/src/main/res/values-kab/strings.xml
+++ b/app/src/main/res/values-kab/strings.xml
@@ -69,7 +69,7 @@
     <string name="grid">Iẓiki</string>
     <string name="missions_header_finished">Immed</string>
     <string name="local">Adigan</string>
-    <string name="recaptcha_done_button">Immed</string>
+    <string name="done">Immed</string>
     <string name="playback_reset">Wennez</string>
     <string name="create">Snulfu-d</string>
     <string name="accept">Qbel</string>

--- a/app/src/main/res/values-kmr/strings.xml
+++ b/app/src/main/res/values-kmr/strings.xml
@@ -537,7 +537,7 @@
     <string name="settings_file_replacement_character_summary">Karakteyên nederbasdar bi vê nirxê têne veguheztin</string>
     <string name="settings_file_charset_title">Di navên pelan de tîpan destûr dan</string>
     <string name="settings_category_downloads_title">Dakêşînin</string>
-    <string name="recaptcha_done_button">Kirî</string>
+    <string name="done">Kirî</string>
     <string name="recaptcha_request_toast">reCAPTCHA dijwarî xwestin</string>
     <string name="subtitle_activity_recaptcha">Dema ku çareser bibe \"Kirî\" çap bikin</string>
     <string name="import_youtube_instructions">Tevlêbûnên YouTube-ê ji barkirina Google-ê bikişînin:

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -459,7 +459,7 @@
     <string name="restricted_video">이 비디오는 연령제한이 있습니다.
 \n
 \n만약, 시청을 원한다면 설정에 \"%1$s\"를 활성화 하세요.</string>
-    <string name="recaptcha_done_button">완료</string>
+    <string name="done">완료</string>
     <string name="artists">아티스트</string>
     <string name="albums">앨범</string>
     <string name="videos_string">비디오</string>

--- a/app/src/main/res/values-ku/strings.xml
+++ b/app/src/main/res/values-ku/strings.xml
@@ -444,7 +444,7 @@
     <string name="app_language_title">زمانی ئەپ</string>
     <string name="systems_language">بنەڕەتی سیستەم</string>
     <string name="subtitle_activity_recaptcha">گرتە بکە لەسەر ”تەواو” کاتێ کە چارەسەرکرا</string>
-    <string name="recaptcha_done_button">تەواو</string>
+    <string name="done">تەواو</string>
     <string name="videos_string">ڤیدیۆکان</string>
     <plurals name="seconds">
         <item quantity="one">%d چرکە</item>

--- a/app/src/main/res/values-la/strings.xml
+++ b/app/src/main/res/values-la/strings.xml
@@ -93,7 +93,7 @@
         <item quantity="one">%d secundus</item>
         <item quantity="other">%d secundi</item>
     </plurals>
-    <string name="recaptcha_done_button">Factum</string>
+    <string name="done">Factum</string>
     <string name="always_ask_open_action">Quaere semper</string>
     <string name="list">Index</string>
     <string name="limit_data_usage_none_description">Nullus limus</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -505,7 +505,7 @@
     <string name="privacy_policy_encouragement">NewPipe į jūsų privatumą žiūri labai rimtai. Programa be jūsų sutikimo nerenka jokių duomenų.
 \nNewPipe privatumo politika išsamiai parodo kokie duomenys siunčiami ir saugomi pranešant apie problemą.</string>
     <string name="privacy_policy_title">NewPipe privatumo politika</string>
-    <string name="recaptcha_done_button">Atlikta</string>
+    <string name="done">Atlikta</string>
     <string name="recaptcha_solve">Išspręsta</string>
     <string name="subtitle_activity_recaptcha">Paspauskite \"atlikta\" kai išspręsta</string>
     <string name="error_report_open_github_notice">Patikrinkite ar apie problemą su kuria susidūrėte dar nėra pranešta. Sukurdami kelis pranešimus apie tą pačią problemą atimate iš mūsų laiką kurį galėtume skirti klaidų taisymui.</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -77,7 +77,7 @@
     <string name="settings_file_replacement_character_summary">Nederīgas rakstzīmes tiks aizvietotas ar šo</string>
     <string name="settings_file_charset_title">Atļautās rakstzīmes failu nosaukumos</string>
     <string name="settings_category_downloads_title">Lejupielādēt</string>
-    <string name="recaptcha_done_button">Pabeigts</string>
+    <string name="done">Pabeigts</string>
     <string name="recaptcha_request_toast">reCAPTCHA izaicinājums dots</string>
     <string name="subtitle_activity_recaptcha">Nospiediet \"Pabeigts\", kad to atrisinat</string>
     <string name="title_activity_recaptcha">reCAPTCHA izaicinājums</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -131,7 +131,7 @@
     <string name="settings_file_replacement_character_summary">സ്വീകാര്യമല്ലാത്ത അടയാളങ്ങൾ ഈ അടയാളം കൊണ്ട് മാറ്റുന്നതാണ്</string>
     <string name="settings_file_charset_title">ഫയൽനാമങ്ങളിൽ അനുവദിച്ചിട്ടുള്ള അടയാളങ്ങൾ</string>
     <string name="settings_category_downloads_title">ഡൗൺലോഡ്</string>
-    <string name="recaptcha_done_button">ഓകെ</string>
+    <string name="done">ഓകെ</string>
     <string name="recaptcha_request_toast">reCAPTCHA ചാലഞ്ചിനായി അഭ്യർത്ഥിച്ചു</string>
     <string name="subtitle_activity_recaptcha">തീർന്നാൽ \"Done\" അമർത്തുക</string>
     <string name="title_activity_recaptcha">reCAPTCHA ചാലഞ്ച്</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -377,7 +377,7 @@
         <item quantity="other">%s pendengar</item>
     </plurals>
     <string name="subtitle_activity_recaptcha">Tekan \"Selesai\" saat selesai</string>
-    <string name="recaptcha_done_button">Selesai</string>
+    <string name="done">Selesai</string>
     <string name="recaptcha_solve">Selesaikan</string>
     <string name="no_comments">Tidak ada ulasan</string>
     <plurals name="videos">

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -446,7 +446,7 @@
     <string name="app_language_title">Programspråk</string>
     <string name="systems_language">Systemforvalg</string>
     <string name="subtitle_activity_recaptcha">Trykk \"Ferdig\" når den er løst</string>
-    <string name="recaptcha_done_button">Ferdig</string>
+    <string name="done">Ferdig</string>
     <string name="videos_string">Videoer</string>
     <plurals name="seconds">
         <item quantity="one">%d sekund</item>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -441,7 +441,7 @@
     <string name="systems_language">सिस्टम पूर्वनिर्धारित</string>
     <string name="title_activity_recaptcha">reCAPTCHA चुनौती</string>
     <string name="subtitle_activity_recaptcha">प्रेस हल गर्दा \"डन\"</string>
-    <string name="recaptcha_done_button">सकियो</string>
+    <string name="done">सकियो</string>
     <string name="videos_string">भिडियोहरु</string>
     <plurals name="seconds">
         <item quantity="one">%d सेकेन्ड</item>

--- a/app/src/main/res/values-nl-rBE/strings.xml
+++ b/app/src/main/res/values-nl-rBE/strings.xml
@@ -490,7 +490,7 @@
     <string name="no_playlist_bookmarked_yet">Geen afspeellijst bladwijzers</string>
     <string name="select_a_playlist">Selecteer een afspeellijst</string>
     <string name="default_kiosk_page_summary">Standaard kiosk</string>
-    <string name="recaptcha_done_button">Klaar</string>
+    <string name="done">Klaar</string>
     <string name="subtitle_activity_recaptcha">Tik op ‘Klaar’ zodra opgelost</string>
     <string name="infinite_videos">∞ video\'s</string>
     <string name="more_than_100_videos">100+ video\'s</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -443,7 +443,7 @@
     <string name="app_language_title">App-taal</string>
     <string name="systems_language">Systeemtaal gebruiken</string>
     <string name="subtitle_activity_recaptcha">Druk op ‘Klaar’ als u dit heeft opgelost</string>
-    <string name="recaptcha_done_button">Klaar</string>
+    <string name="done">Klaar</string>
     <string name="videos_string">Video\'s</string>
     <string name="new_seek_duration_toast">Door beperkingen van ExoPlayer is de zoekduur ingesteld op %d seconden</string>
     <string name="mute">Geluid dempen</string>

--- a/app/src/main/res/values-nqo/strings.xml
+++ b/app/src/main/res/values-nqo/strings.xml
@@ -382,7 +382,7 @@
     <string name="settings_file_charset_title">ߞߟߏߘߋ߲߫ ߠߊߘߌ߬ߢߍ߬ߣߍ߲ ߠߎ߬ ߞߐߕߐ߯ ߕߐ߮ ߘߐ߫</string>
     <string name="settings_file_replacement_character_summary">ߞߟߏߘߋ߲߫ ߠߊߘߌ߬ߢߍ߬ߓߊߟߌ ߟߎ߫ ߣߐ߬ߘߐߓߌ߬ߟߊ߬ߕߐ߫ ߡߐ߬ߟߐ߲ ߣߌ߬ ߠߋ߬ ߟߊ߫</string>
     <string name="settings_file_replacement_character_title">ߣߘߐ߬ߓߌ߬ߟߊ߬ߟߌ߬ ߞߟߏߘߋ߲</string>
-    <string name="recaptcha_done_button">ߊ߬ ߓߘߊ߫ ߓߊ߲߫</string>
+    <string name="done">ߊ߬ ߓߘߊ߫ ߓߊ߲߫</string>
     <string name="settings_category_downloads_title">ߟߊ߬ߖߌ߰ߟߌ</string>
     <string name="tab_licenses">ߟߊ߬ߘߌߢߍ ߟߎ߬</string>
     <string name="view_on_github">ߊ߬ ߡߊߝߍߣߍ߲߫ GitHub ߞߊ߲߬</string>

--- a/app/src/main/res/values-or/strings.xml
+++ b/app/src/main/res/values-or/strings.xml
@@ -304,7 +304,7 @@
     <string name="msg_copied">କ୍ଲିପବୋର୍ଡରେ କପି କରାଯାଇଛି</string>
     <string name="one_item_deleted">1 ଆଇଟମ୍ ଡିଲିଟ୍ ହୋଇଛି ।</string>
     <string name="title_activity_recaptcha">reCAPTCHA ଆହ୍ୱାନ</string>
-    <string name="recaptcha_done_button">ସମାପ୍ତ</string>
+    <string name="done">ସମାପ୍ତ</string>
     <string name="settings_category_downloads_title">ଡାଉନଲୋଡ୍ କରନ୍ତୁ</string>
     <string name="settings_file_replacement_character_summary">ଅବୈଧ ବର୍ଣ୍ଣଗୁଡିକ ଏହି ମୂଲ୍ୟ ସହିତ ବଦଳାଯାଏ</string>
     <string name="settings_file_replacement_character_title">ପ୍ରତିସ୍ଥାପନ ବର୍ଣ୍ଣ</string>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -542,7 +542,7 @@
     <string name="local">ਸਥਾਨਕ</string>
     <string name="localization_changes_requires_app_restart">ਭਾਸ਼ਾ ਐਪ ਨੂੰ ਦੋਬਾਰਾ ਚਲਾਉਣ \'ਤੇ ਬਦਲੇਗੀ</string>
     <string name="select_a_playlist">ਪਲੇ-ਸੂਚੀ ਚੁਣੋ</string>
-    <string name="recaptcha_done_button">ਹੋ ਗਿਆ</string>
+    <string name="done">ਹੋ ਗਿਆ</string>
     <string name="recaptcha_solve">ਹੱਲ ਕਰੋ</string>
     <string name="subtitle_activity_recaptcha">ਹੱਲ ਹੋਣ \'ਤੇ \"ਹੋ ਗਿਆ\" ਨੱਪੋ</string>
     <string name="no_dir_yet">ਹਾਲੇ ਕੋਈ ਡਾਊਨਲੋਡ ਫੋਲਡਰ ਸੈੱਟ ਨਹੀਂ ਕੀਤਾ ਹੋਇਆ, ਹੁਣੇ ਡਿਫ਼ਾਲਟ ਡਾਊਨਲੋਡ ਫੋਲਡਰ ਚੁਣੋ</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -455,7 +455,7 @@
     <string name="app_language_title">Język aplikacji</string>
     <string name="systems_language">Domyślny systemowy</string>
     <string name="subtitle_activity_recaptcha">Po rozwiązaniu naciśnij „Gotowe”</string>
-    <string name="recaptcha_done_button">Gotowe</string>
+    <string name="done">Gotowe</string>
     <string name="videos_string">Wideo</string>
     <plurals name="seconds">
         <item quantity="one">%d sekunda</item>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -451,7 +451,7 @@
     <string name="app_language_title">Idioma do app</string>
     <string name="systems_language">Padrão do sistema</string>
     <string name="subtitle_activity_recaptcha">Toque em \"Pronto\" ao resolver</string>
-    <string name="recaptcha_done_button">Pronto</string>
+    <string name="done">Pronto</string>
     <string name="videos_string">Vídeos</string>
     <plurals name="seconds">
         <item quantity="one">%d segundo</item>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -537,7 +537,7 @@
     <string name="msg_running_detail">Toque para detalhes</string>
     <string name="paused">em pausa</string>
     <string name="show_comments_title">Mostrar comentários</string>
-    <string name="recaptcha_done_button">Aceitar</string>
+    <string name="done">Aceitar</string>
     <string name="feed_use_dedicated_fetch_method_disable_button">Desativar modo rápido</string>
     <string name="never">Nunca</string>
     <string name="wifi_only">Apenas em Wi-Fi</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -451,7 +451,7 @@
     <string name="app_language_title">Idioma da aplicação</string>
     <string name="systems_language">Predefinição do sistema</string>
     <string name="subtitle_activity_recaptcha">Prima \"Feito\" ao resolver</string>
-    <string name="recaptcha_done_button">Aceitar</string>
+    <string name="done">Aceitar</string>
     <string name="feed_use_dedicated_fetch_method_help_text">Acha que a fonte demora muito tempo a carregar\? Se sim, tente ativar o carregamento rápido (pode alterar a opção nas definições ou no botão abaixo).
 \n
 \nNewPipe oferece duas estratégias de carregamento:

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -337,7 +337,7 @@
     <string name="peertube_instance_url_summary">Selectați instanțele PeerTube preferate</string>
     <string name="peertube_instance_url_title">Instanțe PeerTube</string>
     <string name="seek_duration_title">Durată derulare rapidă înainte/înapoi</string>
-    <string name="recaptcha_done_button">Gata</string>
+    <string name="done">Gata</string>
     <string name="subtitle_activity_recaptcha">Apăsați \"Gata\" după ce ați rezolvat problema</string>
     <string name="error_report_open_issue_button_text">Raportați pe GitHub</string>
     <string name="clear_cookie_summary">Ștergeți cookie-urile pe care NewPipe le stochează atunci când rezolvați un reCAPTCHA</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -457,7 +457,7 @@
     <string name="app_language_title">Язык интерфейса</string>
     <string name="systems_language">Как в системе</string>
     <string name="subtitle_activity_recaptcha">По завершении нажмите Готово</string>
-    <string name="recaptcha_done_button">Готово</string>
+    <string name="done">Готово</string>
     <string name="videos_string">Видео</string>
     <plurals name="seconds">
         <item quantity="one">%d секунда</item>

--- a/app/src/main/res/values-ryu/strings.xml
+++ b/app/src/main/res/values-ryu/strings.xml
@@ -446,7 +446,7 @@
     <string name="app_language_title">アプリぬぎんぐ</string>
     <string name="systems_language">システムぬっちうぅい</string>
     <string name="subtitle_activity_recaptcha">とぅきーねー「かんりょう」うちくぃみそーれー</string>
-    <string name="recaptcha_done_button">かんりょう</string>
+    <string name="done">かんりょう</string>
     <string name="videos_string">ちゃーしが</string>
     <plurals name="seconds">
         <item quantity="one">%dびょう</item>

--- a/app/src/main/res/values-sc/strings.xml
+++ b/app/src/main/res/values-sc/strings.xml
@@ -115,7 +115,7 @@
     <string name="settings_file_replacement_character_summary">Sos caràteres non vàlidos benint remplasados cun custu valore</string>
     <string name="settings_file_charset_title">Caràteres permìtidos in sos nùmenes de sos documentos</string>
     <string name="settings_category_downloads_title">Iscàrriga</string>
-    <string name="recaptcha_done_button">Fatu</string>
+    <string name="done">Fatu</string>
     <string name="recaptcha_request_toast">B\'at bisòngiu de risòlvere unu reCAPTCHA</string>
     <string name="subtitle_activity_recaptcha">Incarca \"Fatu\" cando est risoltu</string>
     <string name="title_activity_recaptcha">Disafiu reCAPTCHA</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -451,7 +451,7 @@
     <string name="app_language_title">Jazyk aplikácie</string>
     <string name="systems_language">Predvolený</string>
     <string name="subtitle_activity_recaptcha">Vyrieš a stlač \"Hotovo\"</string>
-    <string name="recaptcha_done_button">Hotovo</string>
+    <string name="done">Hotovo</string>
     <string name="videos_string">Videá</string>
     <string name="new_seek_duration_toast">Pre obmedzenie ExoPlayera bolo prehľadávania nastavené na %d sekúnd</string>
     <string name="mute">Stlmiť</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -264,7 +264,7 @@
     <string name="read_privacy_policy">Preberi pravilnik zasebnosti</string>
     <string name="privacy_policy_title">NewPipe-ovi pravilnik zasebnosti</string>
     <string name="website_encouragement">Obiščite spletno mesto od NewPipe za več informacij in novic.</string>
-    <string name="recaptcha_done_button">Končano</string>
+    <string name="done">Končano</string>
     <string name="no_comments">Ni komantarjev</string>
     <string name="no_one_listening">Nobeden ne posluša</string>
     <string name="no_one_watching">Nobeden ne gleda</string>

--- a/app/src/main/res/values-so/strings.xml
+++ b/app/src/main/res/values-so/strings.xml
@@ -189,7 +189,7 @@
     <string name="settings_file_replacement_character_summary">Xarfaha aan la taageerin waxaa lagu bdadali midkan</string>
     <string name="settings_file_charset_title">Xarafyada magaca shayga loo ogol yahay</string>
     <string name="settings_category_downloads_title">Dajinta</string>
-    <string name="recaptcha_done_button">Dhameeyay</string>
+    <string name="done">Dhameeyay</string>
     <string name="recaptcha_request_toast">Tijaabada reCAPTCHA ayaa la codsaday</string>
     <string name="subtitle_activity_recaptcha">Taabo \"Dhameeyay\" ✅ markaad xaliso</string>
     <string name="title_activity_recaptcha">Tijaabada reCAPTCHA</string>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -255,7 +255,7 @@
     <string name="settings_file_replacement_character_summary">Karakteret e palejuara zëvendësohen me këtë vlerë</string>
     <string name="settings_file_charset_title">Karakteret e lejuara në emrat e skedarëve</string>
     <string name="settings_category_downloads_title">Shkarko</string>
-    <string name="recaptcha_done_button">U bë</string>
+    <string name="done">U bë</string>
     <string name="recaptcha_request_toast">sfida reCAPTCHA u kërkua</string>
     <string name="subtitle_activity_recaptcha">Shtyp \"U bë\" kur ta zgjidhni</string>
     <string name="title_activity_recaptcha">sfida reCAPTCHA</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -387,7 +387,7 @@
     <string name="privacy_policy_encouragement">Пројекат NewPipe веома озбиљно схвата вашу приватност. Стога, апликација не прикупља никакве податке без вашег пристанка.
 \nПолитика приватности NewPipe-а детаљно објашњава који се подаци шаљу и чувају када пошаљете извештај о отказивању апликације.</string>
     <string name="privacy_policy_title">Политика приватности NewPipe-а</string>
-    <string name="recaptcha_done_button">Готово</string>
+    <string name="done">Готово</string>
     <string name="recaptcha_solve">Реши</string>
     <string name="subtitle_activity_recaptcha">Притисните „Готово“ када решите</string>
     <string name="one_item_deleted">Избрисана је 1 ставка.</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -434,7 +434,7 @@
     <string name="most_liked">Mest gillade</string>
     <string name="recently_added">Nyligen tillagd</string>
     <string name="local">Lokala</string>
-    <string name="recaptcha_done_button">Klar</string>
+    <string name="done">Klar</string>
     <string name="youtube_restricted_mode_enabled_title">Slå på YouTubes \"Begränsat läge\"</string>
     <string name="localization_changes_requires_app_restart">Språket ändras när appen startas om</string>
     <string name="error_unable_to_load_comments">Det gick inte att läsa in kommentarerna</string>

--- a/app/src/main/res/values-te/strings.xml
+++ b/app/src/main/res/values-te/strings.xml
@@ -345,7 +345,7 @@
     <string name="one_item_deleted">1 అంశం తొలగించబడింది.</string>
     <string name="subtitle_activity_recaptcha">పరిష్కరించబడినప్పుడు \"పూర్తయింది\" నొక్కండి</string>
     <string name="recaptcha_solve">పరిష్కరించండి</string>
-    <string name="recaptcha_done_button">పూర్తి</string>
+    <string name="done">పూర్తి</string>
     <string name="charset_most_special_characters">చాలా ప్రత్యేక పాత్రలు</string>
     <string name="app_description">ఆండ్రాయిడ్‌లో లిబ్రే తేలికపాటి స్ట్రీమింగ్.</string>
     <string name="donation_encouragement">వాలంటీర్లు తమ ఖాళీ సమయాన్ని వెచ్చిస్తూ మీకు ఉత్తమ వినియోగదారు అనుభవాన్ని అందించడం ద్వారా NewPipe అభివృద్ధి చేయబడింది. డెవలపర్‌లు ఒక కప్పు కాఫీని ఆస్వాదిస్తున్నప్పుడు న్యూపైప్‌ని మరింత మెరుగ్గా చేయడంలో సహాయపడటానికి తిరిగి ఇవ్వండి.</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -445,7 +445,7 @@
     <string name="app_language_title">Uygulama dili</string>
     <string name="systems_language">Sistem öntanımlısı</string>
     <string name="subtitle_activity_recaptcha">Çözüldüğünde \"Bitti\" düğmesine basın</string>
-    <string name="recaptcha_done_button">Bitti</string>
+    <string name="done">Bitti</string>
     <string name="videos_string">Videolar</string>
     <plurals name="seconds">
         <item quantity="one">%d saniye</item>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -448,7 +448,7 @@
     <string name="app_language_title">Мова</string>
     <string name="systems_language">Мова телефону</string>
     <string name="subtitle_activity_recaptcha">Розв\'язавши натисніть «Готово»</string>
-    <string name="recaptcha_done_button">Готово</string>
+    <string name="done">Готово</string>
     <string name="feed_create_new_group_button_title">Нова</string>
     <string name="feed_group_dialog_delete_message">Бажаєте видалити цю групу\?</string>
     <string name="feed_group_dialog_empty_selection">Підписки не вибрані</string>

--- a/app/src/main/res/values-ur/strings.xml
+++ b/app/src/main/res/values-ur/strings.xml
@@ -513,7 +513,7 @@
         <item quantity="other">%s نئی اسٹریمز</item>
     </plurals>
     <string name="no_dir_yet">ابھی تک کوئی ڈاؤن لوڈ فولڈر سیٹ نہیں ہے، ابھی ڈیفالٹ ڈاؤن لوڈ فولڈر کا انتخاب کریں</string>
-    <string name="recaptcha_done_button">Done</string>
+    <string name="done">Done</string>
     <string name="title_activity_play_queue">قطار چلائیں</string>
     <string name="play_queue_audio_track">آڈیو: %s</string>
     <string name="audio_track">آڈیو ٹریک</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -443,7 +443,7 @@
     <string name="recently_added">Thêm vào gần đây</string>
     <string name="localization_changes_requires_app_restart">Ngôn ngữ sẽ thay đổi khi ứng dụng khởi động lại</string>
     <string name="subtitle_activity_recaptcha">Bấm \"Xong\" khi hoàn thành</string>
-    <string name="recaptcha_done_button">Đã hoàn thành</string>
+    <string name="done">Đã hoàn thành</string>
     <string name="infinite_videos">∞ video</string>
     <string name="more_than_100_videos">100+ video</string>
     <plurals name="listening">

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -441,7 +441,7 @@
     <string name="app_language_title">应用语言</string>
     <string name="systems_language">系统默认</string>
     <string name="subtitle_activity_recaptcha">完成后请点击“完成”</string>
-    <string name="recaptcha_done_button">完成</string>
+    <string name="done">完成</string>
     <string name="videos_string">视频</string>
     <plurals name="seconds">
         <item quantity="other">%d 秒</item>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -317,7 +317,7 @@
     <string name="no_dir_yet">未設定下載資料夾，請立即揀選預設嘅下載資料夾</string>
     <string name="one_item_deleted">刪除咗 1 個項目。</string>
     <string name="recaptcha_solve">執執佢</string>
-    <string name="recaptcha_done_button">搞掂</string>
+    <string name="done">搞掂</string>
     <string name="privacy_policy_encouragement">NewPipe 專案非常著重你嘅私隱。因此，呢個 app 未得你同意係唔會收集任何資料。
 \nNewPipe 嘅私隱政策會詳述，當你傳送彈 app 報告嗰陣，有咩資料會傳送同保存。</string>
     <string name="title_last_played">最近播放</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -441,7 +441,7 @@
     <string name="app_language_title">應用程式語言</string>
     <string name="systems_language">系統預設值</string>
     <string name="subtitle_activity_recaptcha">解決後請按「完成」</string>
-    <string name="recaptcha_done_button">完成</string>
+    <string name="done">完成</string>
     <string name="videos_string">影片</string>
     <plurals name="seconds">
         <item quantity="other">%d 秒</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -348,7 +348,7 @@
     <string name="subtitle_activity_recaptcha">Press \"Done\" when solved</string>
     <string name="recaptcha_request_toast">reCAPTCHA challenge requested</string>
     <string name="recaptcha_solve">Solve</string>
-    <string name="recaptcha_done_button">Done</string>
+    <string name="done">Done</string>
     <!-- Downloads -->
     <string name="settings_category_downloads_title">Download</string>
     <string name="settings_file_charset_title">Allowed characters in filenames</string>


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
The last viewed license was re-opened after an orientation change in the About and License Fragments even if the license view/dialog has been closed by the user earlier. I needed to move the method creating the AlertDialog into the Fragment class to access `activeLicense`. An alternative implementation would have been to pass the listener as variable. But I think that the AlertDialog creation is part of the Fragment and should therefore be in the LicenseFragment and not a helper class.

The dialog buttons to open the software's website is also restored correctly after a rotation change now.


#### Before/After Screenshots/Screen Record

| Before | After |
|--------|--------|
| https://github.com/TeamNewPipe/NewPipe/assets/17365767/6efedaaf-8680-4481-be06-0ef86357ce21 | https://github.com/TeamNewPipe/NewPipe/assets/17365767/82f54007-f2c3-4139-8f87-a2452daa5eba | 




#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
