### PR TITLE
Improve audio stream selection for video-only streams in the downloader

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
@@ -267,8 +267,8 @@ public class DownloadDialog extends DialogFragment
             if (!videoStreams.get(i).isVideoOnly()) {
                 continue;
             }
-            final AudioStream audioStream = SecondaryStreamHelper
-                    .getAudioStreamFor(audioStreams.getStreamsList(), videoStreams.get(i));
+            final AudioStream audioStream = SecondaryStreamHelper.getAudioStreamFor(
+                    context, audioStreams.getStreamsList(), videoStreams.get(i));
 
             if (audioStream != null) {
                 secondaryStreams.append(i, new SecondaryStreamHelper<>(audioStreams, audioStream));

--- a/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
@@ -46,10 +46,10 @@ public final class ListHelper {
             List.of(MediaFormat.MP3, MediaFormat.M4A, MediaFormat.WEBMA);
     // Use a Set for better performance
     private static final Set<String> HIGH_RESOLUTION_LIST = Set.of("1440p", "2160p");
-    // Audio track types in order of priotity. 0=lowest, n=highest
+    // Audio track types in order of priority. 0=lowest, n=highest
     private static final List<AudioTrackType> AUDIO_TRACK_TYPE_RANKING =
             List.of(AudioTrackType.DESCRIPTIVE, AudioTrackType.DUBBED, AudioTrackType.ORIGINAL);
-    // Audio track types in order of priotity when descriptive audio is preferred.
+    // Audio track types in order of priority when descriptive audio is preferred.
     private static final List<AudioTrackType> AUDIO_TRACK_TYPE_RANKING_DESCRIPTIVE =
             List.of(AudioTrackType.ORIGINAL, AudioTrackType.DUBBED, AudioTrackType.DESCRIPTIVE);
 
@@ -689,7 +689,7 @@ public final class ListHelper {
         }
     }
 
-    private static boolean isLimitingDataUsage(final Context context) {
+    static boolean isLimitingDataUsage(@NonNull final Context context) {
         return getResolutionLimit(context) != null;
     }
 
@@ -731,7 +731,7 @@ public final class ListHelper {
     /**
      * Get a {@link Comparator} to compare {@link AudioStream}s by their format and bitrate.
      *
-     * <p>The prefered stream will be ordered last.</p>
+     * <p>The preferred stream will be ordered last.</p>
      *
      * @param context app context
      * @return Comparator
@@ -746,7 +746,7 @@ public final class ListHelper {
     /**
      * Get a {@link Comparator} to compare {@link AudioStream}s by their format and bitrate.
      *
-     * <p>The prefered stream will be ordered last.</p>
+     * <p>The preferred stream will be ordered last.</p>
      *
      * @param defaultFormat  the default format to look for
      * @param limitDataUsage choose low bitrate audio stream
@@ -788,7 +788,7 @@ public final class ListHelper {
      * <li>Language is English</li>
      * </ol>
      *
-     * <p>The prefered track will be ordered last.</p>
+     * <p>The preferred track will be ordered last.</p>
      *
      * @param context App context
      * @return Comparator
@@ -825,7 +825,7 @@ public final class ListHelper {
      * <li>Language is English</li>
      * </ol>
      *
-     * <p>The prefered track will be ordered last.</p>
+     * <p>The preferred track will be ordered last.</p>
      *
      * @param preferredLanguage      Preferred audio stream language
      * @param preferOriginalAudio    Get the original audio track regardless of its language

--- a/app/src/main/java/org/schabi/newpipe/util/SecondaryStreamHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/SecondaryStreamHelper.java
@@ -1,5 +1,7 @@
 package org.schabi.newpipe.util;
 
+import android.content.Context;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -9,6 +11,7 @@ import org.schabi.newpipe.extractor.stream.Stream;
 import org.schabi.newpipe.extractor.stream.VideoStream;
 import org.schabi.newpipe.util.StreamItemAdapter.StreamInfoWrapper;
 
+import java.util.Comparator;
 import java.util.List;
 
 public class SecondaryStreamHelper<T extends Stream> {
@@ -27,12 +30,14 @@ public class SecondaryStreamHelper<T extends Stream> {
     /**
      * Find the correct audio stream for the desired video stream.
      *
+     * @param context      Android context
      * @param audioStreams list of audio streams
      * @param videoStream  desired video ONLY stream
      * @return selected audio stream or null if a candidate was not found
      */
     @Nullable
-    public static AudioStream getAudioStreamFor(@NonNull final List<AudioStream> audioStreams,
+    public static AudioStream getAudioStreamFor(@NonNull final Context context,
+                                                @NonNull final List<AudioStream> audioStreams,
                                                 @NonNull final VideoStream videoStream) {
         final MediaFormat mediaFormat = videoStream.getFormat();
         if (mediaFormat == null) {
@@ -41,33 +46,36 @@ public class SecondaryStreamHelper<T extends Stream> {
 
         switch (mediaFormat) {
             case WEBM:
-            case MPEG_4:// ¿is mpeg-4 DASH?
+            case MPEG_4: // Is MPEG-4 DASH?
                 break;
             default:
                 return null;
         }
 
-        final boolean m4v = (mediaFormat == MediaFormat.MPEG_4);
+        final boolean m4v = mediaFormat == MediaFormat.MPEG_4;
+        final boolean isLimitingDataUsage = ListHelper.isLimitingDataUsage(context);
 
-        for (final AudioStream audio : audioStreams) {
-            if (audio.getFormat() == (m4v ? MediaFormat.M4A : MediaFormat.WEBMA)) {
-                return audio;
+        Comparator<AudioStream> comparator = ListHelper.getAudioFormatComparator(
+                m4v ? MediaFormat.M4A : MediaFormat.WEBMA, isLimitingDataUsage);
+        int preferredAudioStreamIndex = ListHelper.getAudioIndexByHighestRank(
+                audioStreams, comparator);
+
+        if (preferredAudioStreamIndex == -1) {
+            if (m4v) {
+                return null;
+            }
+
+            comparator = ListHelper.getAudioFormatComparator(
+                    MediaFormat.WEBMA_OPUS, isLimitingDataUsage);
+            preferredAudioStreamIndex = ListHelper.getAudioIndexByHighestRank(
+                    audioStreams, comparator);
+
+            if (preferredAudioStreamIndex == -1) {
+                return null;
             }
         }
 
-        if (m4v) {
-            return null;
-        }
-
-        // retry, but this time in reverse order
-        for (int i = audioStreams.size() - 1; i >= 0; i--) {
-            final AudioStream audio = audioStreams.get(i);
-            if (audio.getFormat() == MediaFormat.WEBMA_OPUS) {
-                return audio;
-            }
-        }
-
-        return null;
+        return audioStreams.get(preferredAudioStreamIndex);
     }
 
     public T getStream() {

--- a/app/src/main/java/org/schabi/newpipe/util/SecondaryStreamHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/SecondaryStreamHelper.java
@@ -28,12 +28,15 @@ public class SecondaryStreamHelper<T extends Stream> {
     }
 
     /**
-     * Find the correct audio stream for the desired video stream.
+     * Finds an audio stream compatible with the provided video-only stream, so that the two streams
+     * can be combined in a single file by the downloader. If there are multiple available audio
+     * streams, chooses either the highest or the lowest quality one based on
+     * {@link ListHelper#isLimitingDataUsage(Context)}.
      *
      * @param context      Android context
      * @param audioStreams list of audio streams
-     * @param videoStream  desired video ONLY stream
-     * @return selected audio stream or null if a candidate was not found
+     * @param videoStream  desired video-ONLY stream
+     * @return the selected audio stream or null if a candidate was not found
      */
     @Nullable
     public static AudioStream getAudioStreamFor(@NonNull final Context context,


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)

#### Description of the changes in your PR
Instead of searching for the first audio stream compatible with a media format, this change makes the method to get audio-only streams for video-only streams in the downloader (`SecondaryStreamHelper.getAudioStreamFor`) use some methods used to get available audio streams for playback (`isLimitingDataUsage`, `getAudioFormatComparator` and `getAudioIndexByHighestRank` of `ListHelper` class).

This means that the audio stream quality selection in the downloader will now follow the setting of a default video resolution on mobile data: if a resolution is set, the lowest audio stream should be selected, otherwise the highest audio stream should be selected. This behavior should be already applied for playback.

#### Fixes the following issue(s)
- Fixes #8490

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).