### PR TITLE
Fix PR labeler permissions

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -8,6 +8,8 @@ jobs:
   changed-lines-count-labeler:
     runs-on: ubuntu-latest
     name: Automatically labelling pull requests based on the changed lines count
+    permissions:
+      pull-requests: write
     steps:
     - name: Set a label
       uses: vkirilichev/changed-lines-count-labeler@v0.2


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [x] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Although the permission to modify PRs is granted to the entire workflow, the job still reports that it does not the permission to do so:
```
GITHUB_TOKEN Permissions
  Contents: read
  Metadata: read
  PullRequests: read
```
This adds the permission to the job directly.

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
