### PR TITLE
Quote filename replacement characters to fix crashes when downloading streams with special characters

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/util/FilenameUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/FilenameUtils.java
@@ -7,6 +7,7 @@ import androidx.preference.PreferenceManager;
 
 import org.schabi.newpipe.R;
 
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public final class FilenameUtils {
@@ -51,7 +52,7 @@ public final class FilenameUtils {
 
         final Pattern pattern = Pattern.compile(charset);
 
-        return createFilename(title, pattern, replacementChar);
+        return createFilename(title, pattern, Matcher.quoteReplacement(replacementChar));
     }
 
     /**


### PR DESCRIPTION
#### What is it?
- [X] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
- fixes crash by quoting replacement char in filename util

#### Fixes the following issue(s)
- Fixes #10346


#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [X] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
