### PR TITLE
Update new version check to match new API structure

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/NewVersionWorker.kt
+++ b/app/src/main/java/org/schabi/newpipe/NewVersionWorker.kt
@@ -120,13 +120,13 @@ class NewVersionWorker(
 
         // Parse the json from the response.
         try {
-            val githubStableObject = JsonParser.`object`()
+            val newpipeVersionInfo = JsonParser.`object`()
                 .from(response.responseBody()).getObject("flavors")
-                .getObject("github").getObject("stable")
+                .getObject("newpipe")
 
-            val versionName = githubStableObject.getString("version")
-            val versionCode = githubStableObject.getInt("version_code")
-            val apkLocationUrl = githubStableObject.getString("apk")
+            val versionName = newpipeVersionInfo.getString("version")
+            val versionCode = newpipeVersionInfo.getInt("version_code")
+            val apkLocationUrl = newpipeVersionInfo.getString("apk")
             compareAppVersionAndShowNotification(versionName, apkLocationUrl, versionCode)
         } catch (e: JsonParserException) {
             // Most likely something is wrong in data received from NEWPIPE_API_URL.


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
The NewPipe API endpoint providing info on the current app version has been updated int TeamNewPipe/web-api#17
I restored backwards compatibility to enabled current versions to notify about new versions in https://github.com/TeamNewPipe/web-api/commit/0bccef026ae9c3e9ccef1bb89da3ec8a3ea61cde. Backwards compatibility will be removed after some time.

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
