### PR TITLE
Added "free space" check before downloading, eliminates all bug relat…

### DIFF
--- a/app/src/main/java/us/shandian/giga/util/Utility.java
+++ b/app/src/main/java/us/shandian/giga/util/Utility.java
@@ -2,6 +2,8 @@ package us.shandian.giga.util;
 
 import android.content.Context;
 import android.os.Build;
+import android.os.Environment;
+import android.os.StatFs;
 import android.util.Log;
 
 import androidx.annotation.ColorInt;
@@ -26,10 +28,8 @@ import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.net.HttpURLConnection;
 import java.util.Locale;
-import java.util.Random;
 
 import okio.ByteString;
-import us.shandian.giga.get.DownloadMission;
 
 public class Utility {
 
@@ -38,6 +38,20 @@ public class Utility {
         MUSIC,
         SUBTITLE,
         UNKNOWN
+    }
+
+    /**
+     * Get amount of free system's memory.
+     * @return free memory (bytes)
+     */
+    public static long getSystemFreeMemory() {
+        try {
+            final StatFs statFs = new StatFs(Environment.getExternalStorageDirectory().getPath());
+            return statFs.getAvailableBlocksLong() * statFs.getBlockSizeLong();
+        } catch (final Exception e) {
+            // do nothing
+        }
+        return -1;
     }
 
     public static String formatBytes(long bytes) {


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [X] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [X] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
Added a  **[Check for empty storage space](https://github.com/TeamNewPipe/NewPipe/blob/13b0e4f7305c3fde86e25dfdc98768c664e821ea/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java#L886-L901)** of the chosen directory before starting the download (as the download shouldn't start in the first place if device storage cannot hold the download):
- **Show a toast** message "no space left on device" if there is not enough space left for the download, **prevent the download from happening**, and send users to the storage-setting page of the device.
- Able to **prevent** all sorts of **bugs** when the user attempts to download a stream while the device is running out of space.
- **Error handling implemented** to ensure the **app continues to run** like normal if (and is not limited to) the following:
    - Cannot get the free storage space of the chosen *dir* (often occurs when selected dir is on an SD card as each manufacturer encodes SD card pointer in a different manner, there are no conventions)
    - Chosen *dir* is invalid.
<br> 

**Bonus**: deleted 2 unused import statements in Utility.java to conform to the style.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before:
https://github.com/TeamNewPipe/NewPipe/assets/76801836/c745e125-6685-4ec3-9c85-3eaa4bdc0dae

- After:
<img src="https://github.com/TeamNewPipe/NewPipe/assets/76801836/6d5b09d6-4f29-4943-a328-a8a884fdde0a" alt="show error toast" width="200"/>
<img src="https://github.com/TeamNewPipe/NewPipe/assets/76801836/dfc6bebf-2ba1-4a8f-857b-2e127cddff11" alt="Intent switching after no space" width="200"/>


#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes https://github.com/TeamNewPipe/NewPipe/issues/10485
- Fixes https://github.com/TeamNewPipe/NewPipe/issues/10504

#### Relies on the following changes
<!-- Delete this if it doesn't apply to your PR. -->
- [getFreeMemory()](https://github.com/CloudyRowly/NewPipe/blob/13b0e4f7305c3fde86e25dfdc98768c664e821ea/app/src/main/java/org/schabi/newpipe/streams/io/StoredDirectoryHelper.java#L178-L214), a method added in [StoredDirectoryHelper.java](https://github.com/CloudyRowly/NewPipe/blob/13b0e4f7305c3fde86e25dfdc98768c664e821ea/app/src/main/java/org/schabi/newpipe/streams/io/StoredDirectoryHelper.java)
- [getSystemFreeMemory()](https://github.com/CloudyRowly/NewPipe/blob/13b0e4f7305c3fde86e25dfdc98768c664e821ea/app/src/main/java/us/shandian/giga/util/Utility.java#L43-L54), a method added in [Utility.java](https://github.com/CloudyRowly/NewPipe/blob/13b0e4f7305c3fde86e25dfdc98768c664e821ea/app/src/main/java/us/shandian/giga/util/Utility.java#L43-L54)
#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [X] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
