### PR TITLE
Android 13 notification action buttons

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/mediasession/MediaSessionPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/mediasession/MediaSessionPlayerUi.java
@@ -29,7 +29,7 @@ public class MediaSessionPlayerUi extends PlayerUi
     private static final String TAG = "MediaSessUi";
 
     private MediaSessionCompat mediaSession;
-    private MediaSessionConnector sessionConnector;
+    public MediaSessionConnector sessionConnector;
 
     private final String ignoreHardwareMediaButtonsKey;
     private boolean shouldIgnoreHardwareMediaButtons = false;

--- a/app/src/main/java/org/schabi/newpipe/player/mediasession/PlayQueueNavigator.java
+++ b/app/src/main/java/org/schabi/newpipe/player/mediasession/PlayQueueNavigator.java
@@ -5,6 +5,7 @@ import static android.support.v4.media.session.PlaybackStateCompat.ACTION_SKIP_T
 import static android.support.v4.media.session.PlaybackStateCompat.ACTION_SKIP_TO_QUEUE_ITEM;
 
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.ResultReceiver;
 import android.support.v4.media.MediaDescriptionCompat;
@@ -46,7 +47,16 @@ public class PlayQueueNavigator implements MediaSessionConnector.QueueNavigator 
     @Override
     public long getSupportedQueueNavigatorActions(
             @Nullable final com.google.android.exoplayer2.Player exoPlayer) {
-        return ACTION_SKIP_TO_NEXT | ACTION_SKIP_TO_PREVIOUS | ACTION_SKIP_TO_QUEUE_ITEM;
+        // As documented in
+        // https://developer.android.com/about/versions/13/behavior-changes-13#playback-controls
+        // starting with android 13, setting ACTION_SKIP_TO_PREVIOUS and ACTION_SKIP_TO_NEXT forces
+        // buttons 2 and 3 to be the system provided "Previous" and "Next".
+        // Thus, we pretend to not support those actions to have the ability to customize those
+        // buttons
+        return ACTION_SKIP_TO_QUEUE_ITEM |
+                (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ?
+                        ACTION_SKIP_TO_NEXT | ACTION_SKIP_TO_PREVIOUS :
+                        0);
     }
 
     @Override


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [X] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Made MediaSessionPlayerUi.sessionConnector public
- Only return ACTION_SKIP_TO_NEXT and ACTION_SKIP_TO_PREVIOUS in getSupportedQueueNavigatorActions for android < 13
- Set custom actions using sessionConnector.setCustomActionProviders for android >= 13

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before:
![imagen](https://github.com/TeamNewPipe/NewPipe/assets/24706838/4385d2dc-4ae4-486e-857e-2588d21b0847)
- After:
![280436537-736300f3-35a0-45e0-8c18-b7684cf10cde](https://github.com/TeamNewPipe/NewPipe/assets/24706838/d74f523e-c327-4c46-943a-fb9ddc972ee5)


#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #9764

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [X] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).


I don't really do much java, used a one-element array as a hacky way of getting an out parameter. The two other questionable things that come to mind are making sessionConnector public and maybe the ternary operator usage in getSupportedQueueNavigatorActions.
I have not tested this on android <13 since I don't have on on hand at the moment.