### PR TITLE
Fix crash when setting the masking of the new feed items button if the context is null

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
@@ -607,9 +607,13 @@ class FeedFragment : BaseStateFragment<FeedState>() {
                 execOnEnd = {
                     // Disabled animations would result in immediately hiding the button
                     // after it showed up
-                    if (DeviceUtils.hasAnimationsAnimatorDurationEnabled(context)) {
-                        // Hide the new items-"popup" after 10s
-                        hideNewItemsLoaded(true, 10000)
+                    // Context can be null in some cases, so we have to make sure it is not null in
+                    // order to avoid a NullPointerException
+                    context?.let {
+                        if (DeviceUtils.hasAnimationsAnimatorDurationEnabled(it)) {
+                            // Hide the new items button after 10s
+                            hideNewItemsLoaded(true, 10000)
+                        }
                     }
                 }
             )


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)

#### Description of the changes in your PR

This PR fixes a crash when setting the masking of the new feed items button if the feed fragment context is null (see the Javadoc of [`Fragment.getContext()`](https://developer.android.com/reference/androidx/fragment/app/Fragment?hl=en#getContext())).

It makes sure that the context is not null before calling `DeviceUtils.hasAnimationsAnimatorDurationEnabled`.

If the context is null, the button will now not be hidden automatically instead of crashing the app.

#### Fixes the following issue(s)
- Fixes #9031, reported again on Reddit recently: https://www.reddit.com/r/NewPipe/comments/17u8zc9/this_app_keeps_crashing_every_time_i_watch_a/

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).