### PR TITLE
Fix crash when building the play queue audio track menu if the player is null

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/PlayQueueActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayQueueActivity.java
@@ -619,11 +619,13 @@ public final class PlayQueueActivity extends AppCompatActivity
 
         final MenuItem audioTrackSelector = menu.findItem(R.id.action_audio_track);
         final List<AudioStream> availableStreams =
-                Optional.ofNullable(player.getCurrentMetadata())
+                Optional.ofNullable(player)
+                        .map(Player::getCurrentMetadata)
                         .flatMap(MediaItemTag::getMaybeAudioTrack)
                         .map(MediaItemTag.AudioTrack::getAudioStreams)
                         .orElse(null);
-        final Optional<AudioStream> selectedAudioStream = player.getSelectedAudioStream();
+        final Optional<AudioStream> selectedAudioStream = Optional.ofNullable(player)
+                .flatMap(Player::getSelectedAudioStream);
 
         if (availableStreams == null || availableStreams.size() < 2
                 || selectedAudioStream.isEmpty()) {


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)

#### Description of the changes in your PR

This PR fixes a crash when building the play queue audio track menu if the player is null.

It makes sure that the player is not null, by using `Optional`s on the player itself instead of its methods returning `Optional`s.

If the player is null, the play queue audio track menu will now be hidden instead of crashing the app.

#### Fixes the following issue(s)
- Fixes #10339, reported again on Reddit recently: https://www.reddit.com/r/NewPipe/comments/17b0vre/please_help_make_this_crash_stop_galaxy_s21/

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).