### PR TITLE
Restore player service start handling before player UI separation and fix some issues in this service

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/notification/NotificationPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/notification/NotificationPlayerUi.java
@@ -17,21 +17,11 @@ import org.schabi.newpipe.player.helper.PlayerHelper;
 import org.schabi.newpipe.player.ui.PlayerUi;
 
 public final class NotificationPlayerUi extends PlayerUi {
-    private boolean foregroundNotificationAlreadyCreated = false;
     private final NotificationUtil notificationUtil;
 
     public NotificationPlayerUi(@NonNull final Player player) {
         super(player);
         notificationUtil = new NotificationUtil(player);
-    }
-
-    @Override
-    public void initPlayer() {
-        super.initPlayer();
-        if (!foregroundNotificationAlreadyCreated) {
-            notificationUtil.createNotificationAndStartForeground();
-            foregroundNotificationAlreadyCreated = true;
-        }
     }
 
     @Override
@@ -121,5 +111,9 @@ public final class NotificationPlayerUi extends PlayerUi {
     public void onPlayQueueEdited() {
         super.onPlayQueueEdited();
         notificationUtil.createNotificationIfNeededAndUpdate(false);
+    }
+
+    public void createNotificationAndStartForeground() {
+        notificationUtil.createNotificationAndStartForeground();
     }
 }


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)

#### Description of the changes in your PR

This PR restores the player service start handling before player UI separation, shipped with 0.24.0. This handling avoided crashes about the service service not starting in the foreground, in time or not at all (so crashes for which their exception contained `Context.startForegroundService() did not then call Service.startForeground()`). See https://github.com/TeamNewPipe/NewPipe/issues/9358#issuecomment-1722546621 for more details.

This PR also adds some player nullability checks, and the player service is now stopped when it has been started from a media button and there is nothing to play, which should avoid empty player notifications with the previous behavior.

A proper and better player code and architecture is required in order to solve this player service issue in the good way, which must be made in the upcoming app rewrite.

#### Fixes the following issue(s)

- Fixes #9030, fixes #9063, fixes #9070, fixes #9358, fixes #9390, fixes #9448, fixes #10460

Although this PR should fixes these issues, there is a chance, thanks to the current bad player code, that it may not fix them entirely; if so, it should mitigate them a lot.

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).