### PR TITLE
Remove OPUS HLS streams from playable streams

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
@@ -189,13 +189,16 @@ public final class ListHelper {
 
     /**
      * Return a {@link Stream} list which only contains streams which can be played by the player.
-     * <br>
-     * Some formats are not supported. For more info, see {@link #SUPPORTED_ITAG_IDS}.
-     * Torrent streams are also removed, because they cannot be retrieved.
+     *
+     * <p>
+     * Some formats are not supported, see {@link #SUPPORTED_ITAG_IDS} for more details.
+     * Torrent streams are also removed, because they cannot be retrieved, like OPUS streams using
+     * HLS as their delivery method, since they are not supported by ExoPlayer.
+     * </p>
      *
      * @param <S>        the item type's class that extends {@link Stream}
      * @param streamList the original stream list
-     * @param serviceId
+     * @param serviceId  the service ID from which the streams' list comes from
      * @return a stream list which only contains streams that can be played the player
      */
     @NonNull
@@ -204,6 +207,8 @@ public final class ListHelper {
         final int youtubeServiceId = YouTube.getServiceId();
         return getFilteredStreamList(streamList,
                 stream -> stream.getDeliveryMethod() != DeliveryMethod.TORRENT
+                        && (stream.getDeliveryMethod() != DeliveryMethod.HLS
+                        || stream.getFormat() != MediaFormat.OPUS)
                         && (serviceId != youtubeServiceId
                         || stream.getItagItem() == null
                         || SUPPORTED_ITAG_IDS.contains(stream.getItagItem().id)));
@@ -295,7 +300,9 @@ public final class ListHelper {
         final Comparator<AudioStream> cmp = getAudioFormatComparator(context);
 
         for (final AudioStream stream : audioStreams) {
-            if (stream.getDeliveryMethod() == DeliveryMethod.TORRENT) {
+            if (stream.getDeliveryMethod() == DeliveryMethod.TORRENT
+                    || (stream.getDeliveryMethod() == DeliveryMethod.HLS
+                    && stream.getFormat() == MediaFormat.OPUS)) {
                 continue;
             }
 


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [x] Codebase improvement (dev facing)

#### Description of the changes in your PR

This PR removes OPUS HLS streams from playable streams. This format is not supported by ExoPlayer when returned as HLS streams, so we can't play streams using this format and this delivery method.

It also improves the Javadoc of `ListHelper.getPlayableStreams`.

#### Fixes the following issue(s)
- Fixes #9227

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).