### PR TITLE
Android 13+ custom notification actions

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/mediasession/PlayQueueNavigator.java
+++ b/app/src/main/java/org/schabi/newpipe/player/mediasession/PlayQueueNavigator.java
@@ -5,6 +5,7 @@ import static android.support.v4.media.session.PlaybackStateCompat.ACTION_SKIP_T
 import static android.support.v4.media.session.PlaybackStateCompat.ACTION_SKIP_TO_QUEUE_ITEM;
 
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.ResultReceiver;
 import android.support.v4.media.MediaDescriptionCompat;
@@ -46,7 +47,16 @@ public class PlayQueueNavigator implements MediaSessionConnector.QueueNavigator 
     @Override
     public long getSupportedQueueNavigatorActions(
             @Nullable final com.google.android.exoplayer2.Player exoPlayer) {
-        return ACTION_SKIP_TO_NEXT | ACTION_SKIP_TO_PREVIOUS | ACTION_SKIP_TO_QUEUE_ITEM;
+        // As documented in
+        // https://developer.android.com/about/versions/13/behavior-changes-13#playback-controls
+        // starting with android 13, setting ACTION_SKIP_TO_PREVIOUS and ACTION_SKIP_TO_NEXT forces
+        // buttons 2 and 3 to be the system provided "Previous" and "Next".
+        // Thus, we pretend to not support those actions to have the ability to customize them in
+        // MediaSessionPlayerUi.updateMediaSessionActions().
+        return ACTION_SKIP_TO_QUEUE_ITEM
+                | (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU
+                        ? ACTION_SKIP_TO_NEXT | ACTION_SKIP_TO_PREVIOUS
+                        : 0);
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/player/mediasession/SessionConnectorActionProvider.java
+++ b/app/src/main/java/org/schabi/newpipe/player/mediasession/SessionConnectorActionProvider.java
@@ -1,0 +1,51 @@
+package org.schabi.newpipe.player.mediasession;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.v4.media.session.PlaybackStateCompat;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.google.android.exoplayer2.Player;
+import com.google.android.exoplayer2.ext.mediasession.MediaSessionConnector;
+
+import org.schabi.newpipe.player.notification.NotificationActionData;
+
+import java.lang.ref.WeakReference;
+
+public class SessionConnectorActionProvider implements MediaSessionConnector.CustomActionProvider {
+
+    private final NotificationActionData data;
+    @NonNull
+    private final WeakReference<Context> context;
+
+    public SessionConnectorActionProvider(final NotificationActionData notificationActionData,
+                                          @NonNull final Context context) {
+        this.data = notificationActionData;
+        this.context = new WeakReference<>(context);
+    }
+
+    @Override
+    public void onCustomAction(@NonNull final Player player,
+                               @NonNull final String action,
+                               @Nullable final Bundle extras) {
+        final Context actualContext = context.get();
+        if (actualContext != null) {
+            actualContext.sendBroadcast(new Intent(action));
+        }
+    }
+
+    @Nullable
+    @Override
+    public PlaybackStateCompat.CustomAction getCustomAction(@NonNull final Player player) {
+        if (data.action() == null) {
+            return null;
+        } else {
+            return new PlaybackStateCompat.CustomAction.Builder(
+                    data.action(), data.name(), data.icon()
+            ).build();
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/notification/NotificationActionData.java
+++ b/app/src/main/java/org/schabi/newpipe/player/notification/NotificationActionData.java
@@ -1,0 +1,168 @@
+package org.schabi.newpipe.player.notification;
+
+import static com.google.android.exoplayer2.Player.REPEAT_MODE_ALL;
+import static com.google.android.exoplayer2.Player.REPEAT_MODE_ONE;
+import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_CLOSE;
+import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_FAST_FORWARD;
+import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_FAST_REWIND;
+import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_PLAY_NEXT;
+import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_PLAY_PAUSE;
+import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_PLAY_PREVIOUS;
+import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_REPEAT;
+import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_SHUFFLE;
+
+import android.content.Context;
+
+import androidx.annotation.DrawableRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.schabi.newpipe.R;
+import org.schabi.newpipe.player.Player;
+
+public final class NotificationActionData {
+    @Nullable
+    private final String action;
+    @NonNull
+    private final String name;
+    @DrawableRes
+    private final int icon;
+
+    public NotificationActionData(@Nullable final String action, @NonNull final String name,
+                                  @DrawableRes final int icon) {
+        this.action = action;
+        this.name = name;
+        this.icon = icon;
+    }
+
+    @Nullable
+    public String action() {
+        return action;
+    }
+
+    @NonNull
+    public String name() {
+        return name;
+    }
+
+    @DrawableRes
+    public int icon() {
+        return icon;
+    }
+
+
+    @Nullable
+    public static NotificationActionData fromNotificationActionEnum(
+            @NonNull final Player player,
+            @NotificationConstants.Action final int selectedAction
+    ) {
+
+        final int baseActionIcon = NotificationConstants.ACTION_ICONS[selectedAction];
+        final Context ctx = player.getContext();
+
+        switch (selectedAction) {
+            case NotificationConstants.PREVIOUS:
+                return new NotificationActionData(ACTION_PLAY_PREVIOUS,
+                        ctx.getString(R.string.exo_controls_previous_description), baseActionIcon);
+
+            case NotificationConstants.NEXT:
+                return new NotificationActionData(ACTION_PLAY_NEXT,
+                        ctx.getString(R.string.exo_controls_next_description), baseActionIcon);
+
+            case NotificationConstants.REWIND:
+                return new NotificationActionData(ACTION_FAST_REWIND,
+                        ctx.getString(R.string.exo_controls_rewind_description), baseActionIcon);
+
+            case NotificationConstants.FORWARD:
+                return new NotificationActionData(ACTION_FAST_FORWARD,
+                        ctx.getString(R.string.exo_controls_fastforward_description),
+                        baseActionIcon);
+
+            case NotificationConstants.SMART_REWIND_PREVIOUS:
+                if (player.getPlayQueue() != null && player.getPlayQueue().size() > 1) {
+                    return new NotificationActionData(ACTION_PLAY_PREVIOUS,
+                            ctx.getString(R.string.exo_controls_previous_description),
+                            R.drawable.exo_notification_previous);
+                } else {
+                    return new NotificationActionData(ACTION_FAST_REWIND,
+                            ctx.getString(R.string.exo_controls_rewind_description),
+                            R.drawable.exo_controls_rewind);
+                }
+
+            case NotificationConstants.SMART_FORWARD_NEXT:
+                if (player.getPlayQueue() != null && player.getPlayQueue().size() > 1) {
+                    return new NotificationActionData(ACTION_PLAY_NEXT,
+                            ctx.getString(R.string.exo_controls_next_description),
+                            R.drawable.exo_notification_next);
+                } else {
+                    return new NotificationActionData(ACTION_FAST_FORWARD,
+                            ctx.getString(R.string.exo_controls_fastforward_description),
+                            R.drawable.exo_controls_fastforward);
+                }
+
+            case NotificationConstants.PLAY_PAUSE_BUFFERING:
+                if (player.getCurrentState() == Player.STATE_PREFLIGHT
+                        || player.getCurrentState() == Player.STATE_BLOCKED
+                        || player.getCurrentState() == Player.STATE_BUFFERING) {
+                    // null intent action -> show hourglass icon that does nothing when clicked
+                    return new NotificationActionData(null,
+                            ctx.getString(R.string.notification_action_buffering),
+                            R.drawable.ic_hourglass_top);
+                }
+
+                // fallthrough
+            case NotificationConstants.PLAY_PAUSE:
+                if (player.getCurrentState() == Player.STATE_COMPLETED) {
+                    return new NotificationActionData(ACTION_PLAY_PAUSE,
+                            ctx.getString(R.string.exo_controls_pause_description),
+                            R.drawable.ic_replay);
+                } else if (player.isPlaying()
+                        || player.getCurrentState() == Player.STATE_PREFLIGHT
+                        || player.getCurrentState() == Player.STATE_BLOCKED
+                        || player.getCurrentState() == Player.STATE_BUFFERING) {
+                    return new NotificationActionData(ACTION_PLAY_PAUSE,
+                            ctx.getString(R.string.exo_controls_pause_description),
+                            R.drawable.exo_notification_pause);
+                } else {
+                    return new NotificationActionData(ACTION_PLAY_PAUSE,
+                            ctx.getString(R.string.exo_controls_play_description),
+                            R.drawable.exo_notification_play);
+                }
+
+            case NotificationConstants.REPEAT:
+                if (player.getRepeatMode() == REPEAT_MODE_ALL) {
+                    return new NotificationActionData(ACTION_REPEAT,
+                            ctx.getString(R.string.exo_controls_repeat_all_description),
+                            R.drawable.exo_media_action_repeat_all);
+                } else if (player.getRepeatMode() == REPEAT_MODE_ONE) {
+                    return new NotificationActionData(ACTION_REPEAT,
+                            ctx.getString(R.string.exo_controls_repeat_one_description),
+                            R.drawable.exo_media_action_repeat_one);
+                } else /* player.getRepeatMode() == REPEAT_MODE_OFF */ {
+                    return new NotificationActionData(ACTION_REPEAT,
+                            ctx.getString(R.string.exo_controls_repeat_off_description),
+                            R.drawable.exo_media_action_repeat_off);
+                }
+
+            case NotificationConstants.SHUFFLE:
+                if (player.getPlayQueue() != null && player.getPlayQueue().isShuffled()) {
+                    return new NotificationActionData(ACTION_SHUFFLE,
+                            ctx.getString(R.string.exo_controls_shuffle_on_description),
+                            R.drawable.exo_controls_shuffle_on);
+                } else {
+                    return new NotificationActionData(ACTION_SHUFFLE,
+                            ctx.getString(R.string.exo_controls_shuffle_off_description),
+                            R.drawable.exo_controls_shuffle_off);
+                }
+
+            case NotificationConstants.CLOSE:
+                return new NotificationActionData(ACTION_CLOSE, ctx.getString(R.string.close),
+                        R.drawable.ic_close);
+
+            case NotificationConstants.NOTHING:
+            default:
+                // do nothing
+                return null;
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/notification/NotificationUtil.java
+++ b/app/src/main/java/org/schabi/newpipe/player/notification/NotificationUtil.java
@@ -1,16 +1,19 @@
 package org.schabi.newpipe.player.notification;
 
+import static android.app.PendingIntent.FLAG_UPDATE_CURRENT;
+import static androidx.media.app.NotificationCompat.MediaStyle;
+import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_CLOSE;
+
 import android.annotation.SuppressLint;
+import android.app.PendingIntent;
 import android.content.Intent;
 import android.content.pm.ServiceInfo;
 import android.graphics.Bitmap;
 import android.os.Build;
 import android.util.Log;
 
-import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.StringRes;
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
 import androidx.core.app.PendingIntentCompat;
@@ -26,19 +29,6 @@ import org.schabi.newpipe.util.NavigationHelper;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-
-import static android.app.PendingIntent.FLAG_UPDATE_CURRENT;
-import static androidx.media.app.NotificationCompat.MediaStyle;
-import static com.google.android.exoplayer2.Player.REPEAT_MODE_ALL;
-import static com.google.android.exoplayer2.Player.REPEAT_MODE_ONE;
-import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_CLOSE;
-import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_FAST_FORWARD;
-import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_FAST_REWIND;
-import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_PLAY_NEXT;
-import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_PLAY_PAUSE;
-import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_PLAY_PREVIOUS;
-import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_REPEAT;
-import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_SHUFFLE;
 
 /**
  * This is a utility class for player notifications.
@@ -227,115 +217,25 @@ public final class NotificationUtil {
 
     private void addAction(final NotificationCompat.Builder builder,
                            @NotificationConstants.Action final int slot) {
-        final NotificationCompat.Action action = getAction(slot);
-        if (action != null) {
-            builder.addAction(action);
+        @Nullable final NotificationActionData data =
+                NotificationActionData.fromNotificationActionEnum(player, slot);
+        if (data != null) {
+            builder.addAction(getNotificationCompatAction(data));
         }
     }
 
-    @Nullable
-    private NotificationCompat.Action getAction(
-            @NotificationConstants.Action final int selectedAction) {
-        final int baseActionIcon = NotificationConstants.ACTION_ICONS[selectedAction];
-        switch (selectedAction) {
-            case NotificationConstants.PREVIOUS:
-                return getAction(baseActionIcon,
-                        R.string.exo_controls_previous_description, ACTION_PLAY_PREVIOUS);
-
-            case NotificationConstants.NEXT:
-                return getAction(baseActionIcon,
-                        R.string.exo_controls_next_description, ACTION_PLAY_NEXT);
-
-            case NotificationConstants.REWIND:
-                return getAction(baseActionIcon,
-                        R.string.exo_controls_rewind_description, ACTION_FAST_REWIND);
-
-            case NotificationConstants.FORWARD:
-                return getAction(baseActionIcon,
-                        R.string.exo_controls_fastforward_description, ACTION_FAST_FORWARD);
-
-            case NotificationConstants.SMART_REWIND_PREVIOUS:
-                if (player.getPlayQueue() != null && player.getPlayQueue().size() > 1) {
-                    return getAction(R.drawable.exo_notification_previous,
-                            R.string.exo_controls_previous_description, ACTION_PLAY_PREVIOUS);
-                } else {
-                    return getAction(R.drawable.exo_controls_rewind,
-                            R.string.exo_controls_rewind_description, ACTION_FAST_REWIND);
-                }
-
-            case NotificationConstants.SMART_FORWARD_NEXT:
-                if (player.getPlayQueue() != null && player.getPlayQueue().size() > 1) {
-                    return getAction(R.drawable.exo_notification_next,
-                            R.string.exo_controls_next_description, ACTION_PLAY_NEXT);
-                } else {
-                    return getAction(R.drawable.exo_controls_fastforward,
-                            R.string.exo_controls_fastforward_description, ACTION_FAST_FORWARD);
-                }
-
-            case NotificationConstants.PLAY_PAUSE_BUFFERING:
-                if (player.getCurrentState() == Player.STATE_PREFLIGHT
-                        || player.getCurrentState() == Player.STATE_BLOCKED
-                        || player.getCurrentState() == Player.STATE_BUFFERING) {
-                    // null intent -> show hourglass icon that does nothing when clicked
-                    return new NotificationCompat.Action(R.drawable.ic_hourglass_top,
-                            player.getContext().getString(R.string.notification_action_buffering),
-                            null);
-                }
-
-                // fallthrough
-            case NotificationConstants.PLAY_PAUSE:
-                if (player.getCurrentState() == Player.STATE_COMPLETED) {
-                    return getAction(R.drawable.ic_replay,
-                            R.string.exo_controls_pause_description, ACTION_PLAY_PAUSE);
-                } else if (player.isPlaying()
-                        || player.getCurrentState() == Player.STATE_PREFLIGHT
-                        || player.getCurrentState() == Player.STATE_BLOCKED
-                        || player.getCurrentState() == Player.STATE_BUFFERING) {
-                    return getAction(R.drawable.exo_notification_pause,
-                            R.string.exo_controls_pause_description, ACTION_PLAY_PAUSE);
-                } else {
-                    return getAction(R.drawable.exo_notification_play,
-                            R.string.exo_controls_play_description, ACTION_PLAY_PAUSE);
-                }
-
-            case NotificationConstants.REPEAT:
-                if (player.getRepeatMode() == REPEAT_MODE_ALL) {
-                    return getAction(R.drawable.exo_media_action_repeat_all,
-                            R.string.exo_controls_repeat_all_description, ACTION_REPEAT);
-                } else if (player.getRepeatMode() == REPEAT_MODE_ONE) {
-                    return getAction(R.drawable.exo_media_action_repeat_one,
-                            R.string.exo_controls_repeat_one_description, ACTION_REPEAT);
-                } else /* player.getRepeatMode() == REPEAT_MODE_OFF */ {
-                    return getAction(R.drawable.exo_media_action_repeat_off,
-                            R.string.exo_controls_repeat_off_description, ACTION_REPEAT);
-                }
-
-            case NotificationConstants.SHUFFLE:
-                if (player.getPlayQueue() != null && player.getPlayQueue().isShuffled()) {
-                    return getAction(R.drawable.exo_controls_shuffle_on,
-                            R.string.exo_controls_shuffle_on_description, ACTION_SHUFFLE);
-                } else {
-                    return getAction(R.drawable.exo_controls_shuffle_off,
-                            R.string.exo_controls_shuffle_off_description, ACTION_SHUFFLE);
-                }
-
-            case NotificationConstants.CLOSE:
-                return getAction(R.drawable.ic_close,
-                        R.string.close, ACTION_CLOSE);
-
-            case NotificationConstants.NOTHING:
-            default:
-                // do nothing
-                return null;
+    private NotificationCompat.Action getNotificationCompatAction(
+            @NonNull final NotificationActionData data
+    ) {
+        final PendingIntent intent;
+        if (data.action() == null) {
+            intent = null;
+        } else {
+            intent = PendingIntentCompat.getBroadcast(player.getContext(), NOTIFICATION_ID,
+                    new Intent(data.action()), FLAG_UPDATE_CURRENT, false);
         }
-    }
 
-    private NotificationCompat.Action getAction(@DrawableRes final int drawable,
-                                                @StringRes final int title,
-                                                final String intentAction) {
-        return new NotificationCompat.Action(drawable, player.getContext().getString(title),
-                PendingIntentCompat.getBroadcast(player.getContext(), NOTIFICATION_ID,
-                        new Intent(intentAction), FLAG_UPDATE_CURRENT, false));
+        return new NotificationCompat.Action(data.icon(), data.name(), intent);
     }
 
     private Intent getIntentForNotification() {


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
- Supersedes https://github.com/TeamNewPipe/NewPipe/pull/10567 because the code there was too hacky.
- Create class `NotificationActionData` and move there (from `NotificationUtil`) the function that turns actions from the enum format (i.e. the number stored into preferences) into the triple (action string, name, icon). This allows deduplication of such function, instead of passing arrays around like in https://github.com/TeamNewPipe/NewPipe/pull/10567.
- Set custom action providers in the media session to customize actions on Android 13+.
- Use the workaround initially suggested in https://github.com/TeamNewPipe/NewPipe/pull/10567 to basically tell the system that we're not able to handle "prev" and "next", in order to have 4 customizable action slots instead of just 2.
- On Android 13+ normal notification actions are useless, so they are not set into the notification builder anymore, to save battery
- The opposite happens on Android 12-, where media session actions are not set because they don't seem to do anything
- Exclude the play-pause and play-pause-buffering actions from ever being set to media session actions, as the play-pause-buffering action is always shown by the system. The only difference between the system-provided play-pause-buffering and ours is that when the a video completes, the replay icon is not shown, but just a normal "play".
- Currently the UI in the settings has not been changed. This can be done in another PR, which should just remove one of the 5 customizable actions and the play-pause* actions in the settings (just for Android 13+), along with a settings migration that should kick in on Android system updates.

#### Before/After Screenshots/Screen Record

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://github.com/TeamNewPipe/NewPipe/assets/36421898/f1fbba02-ac33-4eab-a9aa-150758effb15" width="200px" alt="Before"/></td>
    <td><img src="https://github.com/TeamNewPipe/NewPipe/assets/36421898/fd92992f-663b-4e14-983c-5df2c9cea4c3" width="200px" alt="After"/></td>
  </tr>
</table>


#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #9764

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
