### PR TITLE
Fix transaction too large in channel tab fragments

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelTabFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelTabFragment.java
@@ -1,6 +1,7 @@
 package org.schabi.newpipe.fragments.list.channel;
 
 import android.os.Bundle;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -14,7 +15,9 @@ import org.schabi.newpipe.error.UserAction;
 import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.ListExtractor;
 import org.schabi.newpipe.extractor.channel.tabs.ChannelTabInfo;
+import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
+import org.schabi.newpipe.extractor.linkhandler.ReadyChannelTabListLinkHandler;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.fragments.list.BaseListInfoFragment;
 import org.schabi.newpipe.fragments.list.playlist.PlaylistControlViewHolder;
@@ -113,6 +116,27 @@ public class ChannelTabFragment extends BaseListInfoFragment<InfoItem, ChannelTa
     @Override
     public void handleResult(@NonNull final ChannelTabInfo result) {
         super.handleResult(result);
+
+        // FIXME this is a really hacky workaround, to avoid storing useless data in the fragment
+        //  state. The problem is, `ReadyChannelTabListLinkHandler` might contain raw JSON data that
+        //  uses a lot of memory (e.g. ~800KB for YouTube). While 800KB doesn't seem much, if
+        //  you combine just a couple of channel tab fragments you easily go over the 1MB
+        //  save&restore transaction limit, and get `TransactionTooLargeException`s. A proper
+        //  solution would require rethinking about `ReadyChannelTabListLinkHandler`s.
+        if (tabHandler instanceof ReadyChannelTabListLinkHandler) {
+            try {
+                // once `handleResult` is called, the parsed data was already saved to cache, so
+                // we can discard any raw data in ReadyChannelTabListLinkHandler and create a
+                // link handler with identical properties, but without any raw data
+                tabHandler = result.getService()
+                        .getChannelTabLHFactory()
+                        .fromQuery(tabHandler.getId(), tabHandler.getContentFilters(),
+                                tabHandler.getSortFilter());
+            } catch (final ParsingException e) {
+                // silently ignore the error, as the app can continue to function normally
+                Log.w(TAG, "Could not recreate channel tab handler", e);
+            }
+        }
 
         if (playlistControlBinding != null) {
             // PlaylistControls should be visible only if there is some item in


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR

This PR contains a really hacky workaround, that avoids storing useless data in the `ChannelTabFragment` state. `ChannelTabFragment` uses the corresponding tab link handler to be able to fetch data, since unlike other things in the extractor, channel tabs are not supposed to be obtained from a url (e.g. provided by the user), but rather always from a channel page internally in the app.

The problem is, `ReadyChannelTabListLinkHandler` might contain raw JSON data that uses a lot of memory (e.g. ~800KB for YouTube). While 800KB doesn't seem much, if you combine just a couple of channel tab fragments you easily go over the 1MB save&restore transaction limit, and get `TransactionTooLargeException`s.

What this PR does is to discard the `ReadyChannelTabListLinkHandler` after the first time the raw data has been parsed (i.e. the fragment's `handleResult` has been called). A new link handler with the same properties is then created. The good thing is, even if now the raw data is not in the link handler anymore, if `getChannelTab` is called on the newly created link handler, the app cache will kick in to still prevent network requests. Note that I didn't test this link-handler-recreation with all services, I will let users do this (or @AudricV could provide some feedback).

A proper solution would require rethinking about `ReadyChannelTabListLinkHandler`s, but that's out of scope for 0.26.0. We might need to rethink how the cache works, and instead of returning link handlers with raw data (which turned out to be a really bad idea) , we should put the raw data directly in an extractor cache. 

You can test the changes by putting one channel from all NewPipe services (Youtube, Soundcloud, ...) as a main page tab. Then open settings and the app should not crash. All video/audio tabs from all channels should still allow e.g. playing in the background without crashing.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes https://github.com/TeamNewPipe/NewPipe/issues/10471#issuecomment-1826689278

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
