### PR TITLE
Fix NPE when ChannelTabLHFactory not implemented for a service

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelTabFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelTabFragment.java
@@ -17,6 +17,7 @@ import org.schabi.newpipe.extractor.ListExtractor;
 import org.schabi.newpipe.extractor.channel.tabs.ChannelTabInfo;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
+import org.schabi.newpipe.extractor.linkhandler.ListLinkHandlerFactory;
 import org.schabi.newpipe.extractor.linkhandler.ReadyChannelTabListLinkHandler;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.fragments.list.BaseListInfoFragment;
@@ -128,10 +129,13 @@ public class ChannelTabFragment extends BaseListInfoFragment<InfoItem, ChannelTa
                 // once `handleResult` is called, the parsed data was already saved to cache, so
                 // we can discard any raw data in ReadyChannelTabListLinkHandler and create a
                 // link handler with identical properties, but without any raw data
-                tabHandler = result.getService()
-                        .getChannelTabLHFactory()
-                        .fromQuery(tabHandler.getId(), tabHandler.getContentFilters(),
-                                tabHandler.getSortFilter());
+                final ListLinkHandlerFactory channelTabLHFactory = result.getService()
+                        .getChannelTabLHFactory();
+                if (channelTabLHFactory != null) {
+                    // some services do not not have a ChannelTabLHFactory
+                    tabHandler = channelTabLHFactory.fromQuery(tabHandler.getId(),
+                            tabHandler.getContentFilters(), tabHandler.getSortFilter());
+                }
             } catch (final ParsingException e) {
                 // silently ignore the error, as the app can continue to function normally
                 Log.w(TAG, "Could not recreate channel tab handler", e);


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Catch NPE. The regression was introduced by #10673 

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #10698

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
