### PR TITLE
[Android 13+] Restore support of custom notification actions

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/mediasession/SessionConnectorActionProvider.java
+++ b/app/src/main/java/org/schabi/newpipe/player/mediasession/SessionConnectorActionProvider.java
@@ -40,12 +40,8 @@ public class SessionConnectorActionProvider implements MediaSessionConnector.Cus
     @Nullable
     @Override
     public PlaybackStateCompat.CustomAction getCustomAction(@NonNull final Player player) {
-        if (data.action() == null) {
-            return null;
-        } else {
-            return new PlaybackStateCompat.CustomAction.Builder(
-                    data.action(), data.name(), data.icon()
-            ).build();
-        }
+        return new PlaybackStateCompat.CustomAction.Builder(
+                data.action(), data.name(), data.icon()
+        ).build();
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/player/mediasession/SessionConnectorActionProvider.java
+++ b/app/src/main/java/org/schabi/newpipe/player/mediasession/SessionConnectorActionProvider.java
@@ -1,0 +1,51 @@
+package org.schabi.newpipe.player.mediasession;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.v4.media.session.PlaybackStateCompat;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.google.android.exoplayer2.Player;
+import com.google.android.exoplayer2.ext.mediasession.MediaSessionConnector;
+
+import org.schabi.newpipe.player.notification.NotificationActionData;
+
+import java.lang.ref.WeakReference;
+
+public class SessionConnectorActionProvider implements MediaSessionConnector.CustomActionProvider {
+
+    private final NotificationActionData data;
+    @NonNull
+    private final WeakReference<Context> context;
+
+    public SessionConnectorActionProvider(final NotificationActionData notificationActionData,
+                                          @NonNull final Context context) {
+        this.data = notificationActionData;
+        this.context = new WeakReference<>(context);
+    }
+
+    @Override
+    public void onCustomAction(@NonNull final Player player,
+                               @NonNull final String action,
+                               @Nullable final Bundle extras) {
+        final Context actualContext = context.get();
+        if (actualContext != null) {
+            actualContext.sendBroadcast(new Intent(action));
+        }
+    }
+
+    @Nullable
+    @Override
+    public PlaybackStateCompat.CustomAction getCustomAction(@NonNull final Player player) {
+        if (data.action() == null) {
+            return null;
+        } else {
+            return new PlaybackStateCompat.CustomAction.Builder(
+                    data.action(), data.name(), data.icon()
+            ).build();
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/notification/NotificationActionData.java
+++ b/app/src/main/java/org/schabi/newpipe/player/notification/NotificationActionData.java
@@ -20,6 +20,8 @@ import androidx.annotation.Nullable;
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.player.Player;
 
+import java.util.Objects;
+
 public final class NotificationActionData {
     @Nullable
     private final String action;
@@ -49,7 +51,6 @@ public final class NotificationActionData {
     public int icon() {
         return icon;
     }
-
 
     @Nullable
     public static NotificationActionData fromNotificationActionEnum(
@@ -164,5 +165,19 @@ public final class NotificationActionData {
                 // do nothing
                 return null;
         }
+    }
+
+
+    @Override
+    public boolean equals(@Nullable final Object obj) {
+        return (obj instanceof NotificationActionData other)
+                && Objects.equals(this.action, other.action)
+                && this.name.equals(other.name)
+                && this.icon == other.icon;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(action, name, icon);
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/player/notification/NotificationActionData.java
+++ b/app/src/main/java/org/schabi/newpipe/player/notification/NotificationActionData.java
@@ -1,0 +1,168 @@
+package org.schabi.newpipe.player.notification;
+
+import static com.google.android.exoplayer2.Player.REPEAT_MODE_ALL;
+import static com.google.android.exoplayer2.Player.REPEAT_MODE_ONE;
+import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_CLOSE;
+import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_FAST_FORWARD;
+import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_FAST_REWIND;
+import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_PLAY_NEXT;
+import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_PLAY_PAUSE;
+import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_PLAY_PREVIOUS;
+import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_REPEAT;
+import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_SHUFFLE;
+
+import android.content.Context;
+
+import androidx.annotation.DrawableRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.schabi.newpipe.R;
+import org.schabi.newpipe.player.Player;
+
+public final class NotificationActionData {
+    @Nullable
+    private final String action;
+    @NonNull
+    private final String name;
+    @DrawableRes
+    private final int icon;
+
+    public NotificationActionData(@Nullable final String action, @NonNull final String name,
+                                  @DrawableRes final int icon) {
+        this.action = action;
+        this.name = name;
+        this.icon = icon;
+    }
+
+    @Nullable
+    public String action() {
+        return action;
+    }
+
+    @NonNull
+    public String name() {
+        return name;
+    }
+
+    @DrawableRes
+    public int icon() {
+        return icon;
+    }
+
+
+    @Nullable
+    public static NotificationActionData fromNotificationActionEnum(
+            @NonNull final Player player,
+            @NotificationConstants.Action final int selectedAction
+    ) {
+
+        final int baseActionIcon = NotificationConstants.ACTION_ICONS[selectedAction];
+        final Context ctx = player.getContext();
+
+        switch (selectedAction) {
+            case NotificationConstants.PREVIOUS:
+                return new NotificationActionData(ACTION_PLAY_PREVIOUS,
+                        ctx.getString(R.string.exo_controls_previous_description), baseActionIcon);
+
+            case NotificationConstants.NEXT:
+                return new NotificationActionData(ACTION_PLAY_NEXT,
+                        ctx.getString(R.string.exo_controls_next_description), baseActionIcon);
+
+            case NotificationConstants.REWIND:
+                return new NotificationActionData(ACTION_FAST_REWIND,
+                        ctx.getString(R.string.exo_controls_rewind_description), baseActionIcon);
+
+            case NotificationConstants.FORWARD:
+                return new NotificationActionData(ACTION_FAST_FORWARD,
+                        ctx.getString(R.string.exo_controls_fastforward_description),
+                        baseActionIcon);
+
+            case NotificationConstants.SMART_REWIND_PREVIOUS:
+                if (player.getPlayQueue() != null && player.getPlayQueue().size() > 1) {
+                    return new NotificationActionData(ACTION_PLAY_PREVIOUS,
+                            ctx.getString(R.string.exo_controls_previous_description),
+                            R.drawable.exo_notification_previous);
+                } else {
+                    return new NotificationActionData(ACTION_FAST_REWIND,
+                            ctx.getString(R.string.exo_controls_rewind_description),
+                            R.drawable.exo_controls_rewind);
+                }
+
+            case NotificationConstants.SMART_FORWARD_NEXT:
+                if (player.getPlayQueue() != null && player.getPlayQueue().size() > 1) {
+                    return new NotificationActionData(ACTION_PLAY_NEXT,
+                            ctx.getString(R.string.exo_controls_next_description),
+                            R.drawable.exo_notification_next);
+                } else {
+                    return new NotificationActionData(ACTION_FAST_FORWARD,
+                            ctx.getString(R.string.exo_controls_fastforward_description),
+                            R.drawable.exo_controls_fastforward);
+                }
+
+            case NotificationConstants.PLAY_PAUSE_BUFFERING:
+                if (player.getCurrentState() == Player.STATE_PREFLIGHT
+                        || player.getCurrentState() == Player.STATE_BLOCKED
+                        || player.getCurrentState() == Player.STATE_BUFFERING) {
+                    // null intent action -> show hourglass icon that does nothing when clicked
+                    return new NotificationActionData(null,
+                            ctx.getString(R.string.notification_action_buffering),
+                            R.drawable.ic_hourglass_top);
+                }
+
+                // fallthrough
+            case NotificationConstants.PLAY_PAUSE:
+                if (player.getCurrentState() == Player.STATE_COMPLETED) {
+                    return new NotificationActionData(ACTION_PLAY_PAUSE,
+                            ctx.getString(R.string.exo_controls_pause_description),
+                            R.drawable.ic_replay);
+                } else if (player.isPlaying()
+                        || player.getCurrentState() == Player.STATE_PREFLIGHT
+                        || player.getCurrentState() == Player.STATE_BLOCKED
+                        || player.getCurrentState() == Player.STATE_BUFFERING) {
+                    return new NotificationActionData(ACTION_PLAY_PAUSE,
+                            ctx.getString(R.string.exo_controls_pause_description),
+                            R.drawable.exo_notification_pause);
+                } else {
+                    return new NotificationActionData(ACTION_PLAY_PAUSE,
+                            ctx.getString(R.string.exo_controls_play_description),
+                            R.drawable.exo_notification_play);
+                }
+
+            case NotificationConstants.REPEAT:
+                if (player.getRepeatMode() == REPEAT_MODE_ALL) {
+                    return new NotificationActionData(ACTION_REPEAT,
+                            ctx.getString(R.string.exo_controls_repeat_all_description),
+                            R.drawable.exo_media_action_repeat_all);
+                } else if (player.getRepeatMode() == REPEAT_MODE_ONE) {
+                    return new NotificationActionData(ACTION_REPEAT,
+                            ctx.getString(R.string.exo_controls_repeat_one_description),
+                            R.drawable.exo_media_action_repeat_one);
+                } else /* player.getRepeatMode() == REPEAT_MODE_OFF */ {
+                    return new NotificationActionData(ACTION_REPEAT,
+                            ctx.getString(R.string.exo_controls_repeat_off_description),
+                            R.drawable.exo_media_action_repeat_off);
+                }
+
+            case NotificationConstants.SHUFFLE:
+                if (player.getPlayQueue() != null && player.getPlayQueue().isShuffled()) {
+                    return new NotificationActionData(ACTION_SHUFFLE,
+                            ctx.getString(R.string.exo_controls_shuffle_on_description),
+                            R.drawable.exo_controls_shuffle_on);
+                } else {
+                    return new NotificationActionData(ACTION_SHUFFLE,
+                            ctx.getString(R.string.exo_controls_shuffle_off_description),
+                            R.drawable.exo_controls_shuffle_off);
+                }
+
+            case NotificationConstants.CLOSE:
+                return new NotificationActionData(ACTION_CLOSE, ctx.getString(R.string.close),
+                        R.drawable.ic_close);
+
+            case NotificationConstants.NOTHING:
+            default:
+                // do nothing
+                return null;
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/notification/NotificationActionData.java
+++ b/app/src/main/java/org/schabi/newpipe/player/notification/NotificationActionData.java
@@ -11,6 +11,7 @@ import static org.schabi.newpipe.player.notification.NotificationConstants.ACTIO
 import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_REPEAT;
 import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_SHUFFLE;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 
 import androidx.annotation.DrawableRes;
@@ -23,21 +24,23 @@ import org.schabi.newpipe.player.Player;
 import java.util.Objects;
 
 public final class NotificationActionData {
-    @Nullable
+
+    @NonNull
     private final String action;
     @NonNull
     private final String name;
     @DrawableRes
     private final int icon;
 
-    public NotificationActionData(@Nullable final String action, @NonNull final String name,
+
+    public NotificationActionData(@NonNull final String action, @NonNull final String name,
                                   @DrawableRes final int icon) {
         this.action = action;
         this.name = name;
         this.icon = icon;
     }
 
-    @Nullable
+    @NonNull
     public String action() {
         return action;
     }
@@ -52,6 +55,8 @@ public final class NotificationActionData {
         return icon;
     }
 
+
+    @SuppressLint("PrivateResource") // we currently use Exoplayer's internal strings and icons
     @Nullable
     public static NotificationActionData fromNotificationActionEnum(
             @NonNull final Player player,
@@ -105,8 +110,7 @@ public final class NotificationActionData {
                 if (player.getCurrentState() == Player.STATE_PREFLIGHT
                         || player.getCurrentState() == Player.STATE_BLOCKED
                         || player.getCurrentState() == Player.STATE_BUFFERING) {
-                    // null intent action -> show hourglass icon that does nothing when clicked
-                    return new NotificationActionData(null,
+                    return new NotificationActionData(ACTION_PLAY_PAUSE,
                             ctx.getString(R.string.notification_action_buffering),
                             R.drawable.ic_hourglass_top);
                 }
@@ -171,7 +175,7 @@ public final class NotificationActionData {
     @Override
     public boolean equals(@Nullable final Object obj) {
         return (obj instanceof NotificationActionData other)
-                && Objects.equals(this.action, other.action)
+                && this.action.equals(other.action)
                 && this.name.equals(other.name)
                 && this.icon == other.icon;
     }

--- a/app/src/main/java/org/schabi/newpipe/player/notification/NotificationConstants.java
+++ b/app/src/main/java/org/schabi/newpipe/player/notification/NotificationConstants.java
@@ -13,7 +13,7 @@ import org.schabi.newpipe.util.Localization;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -65,9 +65,15 @@ public final class NotificationConstants {
     public static final int CLOSE = 11;
 
     @Retention(RetentionPolicy.SOURCE)
-    @IntDef({NOTHING, PREVIOUS, NEXT, REWIND, FORWARD, SMART_REWIND_PREVIOUS, SMART_FORWARD_NEXT,
-            PLAY_PAUSE, PLAY_PAUSE_BUFFERING, REPEAT, SHUFFLE, CLOSE})
+    @IntDef({NOTHING, PREVIOUS, NEXT, REWIND, FORWARD,
+            SMART_REWIND_PREVIOUS, SMART_FORWARD_NEXT, PLAY_PAUSE, PLAY_PAUSE_BUFFERING, REPEAT,
+            SHUFFLE, CLOSE})
     public @interface Action { }
+
+    @Action
+    public static final int[] ALL_ACTIONS = {NOTHING, PREVIOUS, NEXT, REWIND, FORWARD,
+            SMART_REWIND_PREVIOUS, SMART_FORWARD_NEXT, PLAY_PAUSE, PLAY_PAUSE_BUFFERING, REPEAT,
+            SHUFFLE, CLOSE};
 
     @DrawableRes
     public static final int[] ACTION_ICONS = {
@@ -93,16 +99,6 @@ public final class NotificationConstants {
             SMART_FORWARD_NEXT,
             REPEAT,
             CLOSE,
-    };
-
-    @Action
-    public static final int[][] SLOT_ALLOWED_ACTIONS = {
-            new int[] {PREVIOUS, REWIND, SMART_REWIND_PREVIOUS},
-            new int[] {REWIND, PLAY_PAUSE, PLAY_PAUSE_BUFFERING},
-            new int[] {NEXT, FORWARD, SMART_FORWARD_NEXT, PLAY_PAUSE, PLAY_PAUSE_BUFFERING},
-            new int[] {NOTHING, PREVIOUS, NEXT, REWIND, FORWARD, SMART_REWIND_PREVIOUS,
-                    SMART_FORWARD_NEXT, REPEAT, SHUFFLE, CLOSE},
-            new int[] {NOTHING, NEXT, FORWARD, SMART_FORWARD_NEXT, REPEAT, SHUFFLE, CLOSE},
     };
 
     public static final int[] SLOT_PREF_KEYS = {
@@ -165,14 +161,11 @@ public final class NotificationConstants {
     /**
      * @param context the context to use
      * @param sharedPreferences the shared preferences to query values from
-     * @param slotCount remove indices >= than this value (set to {@code 5} to do nothing, or make
-     *                  it lower if there are slots with empty actions)
      * @return a sorted list of the indices of the slots to use as compact slots
      */
-    public static List<Integer> getCompactSlotsFromPreferences(
+    public static Collection<Integer> getCompactSlotsFromPreferences(
             @NonNull final Context context,
-            final SharedPreferences sharedPreferences,
-            final int slotCount) {
+            final SharedPreferences sharedPreferences) {
         final SortedSet<Integer> compactSlots = new TreeSet<>();
         for (int i = 0; i < 3; i++) {
             final int compactSlot = sharedPreferences.getInt(
@@ -180,14 +173,14 @@ public final class NotificationConstants {
 
             if (compactSlot == Integer.MAX_VALUE) {
                 // settings not yet populated, return default values
-                return new ArrayList<>(SLOT_COMPACT_DEFAULTS);
+                return SLOT_COMPACT_DEFAULTS;
             }
 
-            // a negative value (-1) is set when the user does not want a particular compact slot
-            if (compactSlot >= 0 && compactSlot < slotCount) {
+            if (compactSlot >= 0) {
+                // compact slot is < 0 if there are less than 3 checked checkboxes
                 compactSlots.add(compactSlot);
             }
         }
-        return new ArrayList<>(compactSlots);
+        return compactSlots;
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/player/notification/NotificationUtil.java
+++ b/app/src/main/java/org/schabi/newpipe/player/notification/NotificationUtil.java
@@ -92,15 +92,21 @@ public final class NotificationUtil {
         final NotificationCompat.Builder builder =
                 new NotificationCompat.Builder(player.getContext(),
                 player.getContext().getString(R.string.notification_channel_id));
+        final MediaStyle mediaStyle = new MediaStyle();
 
-        final int[] compactSlots = initializeNotificationSlots();
-
-        final MediaStyle mediaStyle = new MediaStyle().setShowActionsInCompactView(compactSlots);
+        // setup media style (compact notification slots and media session)
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            // notification actions are ignored on Android 13+, and are replaced by code in
+            // MediaSessionPlayerUi
+            final int[] compactSlots = initializeNotificationSlots();
+            mediaStyle.setShowActionsInCompactView(compactSlots);
+        }
         player.UIs()
                 .get(MediaSessionPlayerUi.class)
                 .flatMap(MediaSessionPlayerUi::getSessionToken)
                 .ifPresent(mediaStyle::setMediaSession);
 
+        // setup notification builder
         builder.setStyle(mediaStyle)
                 .setPriority(NotificationCompat.PRIORITY_HIGH)
                 .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
@@ -135,7 +141,11 @@ public final class NotificationUtil {
         notificationBuilder.setContentText(player.getUploaderName());
         notificationBuilder.setTicker(player.getVideoTitle());
 
-        updateActions(notificationBuilder);
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            // notification actions are ignored on Android 13+, and are replaced by code in
+            // MediaSessionPlayerUi
+            updateActions(notificationBuilder);
+        }
     }
 
 

--- a/app/src/main/java/org/schabi/newpipe/player/notification/NotificationUtil.java
+++ b/app/src/main/java/org/schabi/newpipe/player/notification/NotificationUtil.java
@@ -244,14 +244,8 @@ public final class NotificationUtil {
             return;
         }
 
-        final PendingIntent intent;
-        if (data.action() == null) {
-            intent = null;
-        } else {
-            intent = PendingIntentCompat.getBroadcast(player.getContext(), NOTIFICATION_ID,
-                    new Intent(data.action()), FLAG_UPDATE_CURRENT, false);
-        }
-
+        final PendingIntent intent = PendingIntentCompat.getBroadcast(player.getContext(),
+                NOTIFICATION_ID, new Intent(data.action()), FLAG_UPDATE_CURRENT, false);
         builder.addAction(new NotificationCompat.Action(data.icon(), data.name(), intent));
     }
 

--- a/app/src/main/java/org/schabi/newpipe/player/notification/NotificationUtil.java
+++ b/app/src/main/java/org/schabi/newpipe/player/notification/NotificationUtil.java
@@ -1,16 +1,19 @@
 package org.schabi.newpipe.player.notification;
 
+import static android.app.PendingIntent.FLAG_UPDATE_CURRENT;
+import static androidx.media.app.NotificationCompat.MediaStyle;
+import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_CLOSE;
+
 import android.annotation.SuppressLint;
+import android.app.PendingIntent;
 import android.content.Intent;
 import android.content.pm.ServiceInfo;
 import android.graphics.Bitmap;
 import android.os.Build;
 import android.util.Log;
 
-import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.StringRes;
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
 import androidx.core.app.PendingIntentCompat;
@@ -28,19 +31,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-
-import static android.app.PendingIntent.FLAG_UPDATE_CURRENT;
-import static androidx.media.app.NotificationCompat.MediaStyle;
-import static com.google.android.exoplayer2.Player.REPEAT_MODE_ALL;
-import static com.google.android.exoplayer2.Player.REPEAT_MODE_ONE;
-import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_CLOSE;
-import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_FAST_FORWARD;
-import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_FAST_REWIND;
-import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_PLAY_NEXT;
-import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_PLAY_PAUSE;
-import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_PLAY_PREVIOUS;
-import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_REPEAT;
-import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_SHUFFLE;
 
 /**
  * This is a utility class for player notifications.
@@ -238,115 +228,21 @@ public final class NotificationUtil {
 
     private void addAction(final NotificationCompat.Builder builder,
                            @NotificationConstants.Action final int slot) {
-        final NotificationCompat.Action action = getAction(slot);
-        if (action != null) {
-            builder.addAction(action);
+        @Nullable final NotificationActionData data =
+                NotificationActionData.fromNotificationActionEnum(player, slot);
+        if (data == null) {
+            return;
         }
-    }
 
-    @Nullable
-    private NotificationCompat.Action getAction(
-            @NotificationConstants.Action final int selectedAction) {
-        final int baseActionIcon = NotificationConstants.ACTION_ICONS[selectedAction];
-        switch (selectedAction) {
-            case NotificationConstants.PREVIOUS:
-                return getAction(baseActionIcon,
-                        R.string.exo_controls_previous_description, ACTION_PLAY_PREVIOUS);
-
-            case NotificationConstants.NEXT:
-                return getAction(baseActionIcon,
-                        R.string.exo_controls_next_description, ACTION_PLAY_NEXT);
-
-            case NotificationConstants.REWIND:
-                return getAction(baseActionIcon,
-                        R.string.exo_controls_rewind_description, ACTION_FAST_REWIND);
-
-            case NotificationConstants.FORWARD:
-                return getAction(baseActionIcon,
-                        R.string.exo_controls_fastforward_description, ACTION_FAST_FORWARD);
-
-            case NotificationConstants.SMART_REWIND_PREVIOUS:
-                if (player.getPlayQueue() != null && player.getPlayQueue().size() > 1) {
-                    return getAction(R.drawable.exo_notification_previous,
-                            R.string.exo_controls_previous_description, ACTION_PLAY_PREVIOUS);
-                } else {
-                    return getAction(R.drawable.exo_controls_rewind,
-                            R.string.exo_controls_rewind_description, ACTION_FAST_REWIND);
-                }
-
-            case NotificationConstants.SMART_FORWARD_NEXT:
-                if (player.getPlayQueue() != null && player.getPlayQueue().size() > 1) {
-                    return getAction(R.drawable.exo_notification_next,
-                            R.string.exo_controls_next_description, ACTION_PLAY_NEXT);
-                } else {
-                    return getAction(R.drawable.exo_controls_fastforward,
-                            R.string.exo_controls_fastforward_description, ACTION_FAST_FORWARD);
-                }
-
-            case NotificationConstants.PLAY_PAUSE_BUFFERING:
-                if (player.getCurrentState() == Player.STATE_PREFLIGHT
-                        || player.getCurrentState() == Player.STATE_BLOCKED
-                        || player.getCurrentState() == Player.STATE_BUFFERING) {
-                    // null intent -> show hourglass icon that does nothing when clicked
-                    return new NotificationCompat.Action(R.drawable.ic_hourglass_top,
-                            player.getContext().getString(R.string.notification_action_buffering),
-                            null);
-                }
-
-                // fallthrough
-            case NotificationConstants.PLAY_PAUSE:
-                if (player.getCurrentState() == Player.STATE_COMPLETED) {
-                    return getAction(R.drawable.ic_replay,
-                            R.string.exo_controls_pause_description, ACTION_PLAY_PAUSE);
-                } else if (player.isPlaying()
-                        || player.getCurrentState() == Player.STATE_PREFLIGHT
-                        || player.getCurrentState() == Player.STATE_BLOCKED
-                        || player.getCurrentState() == Player.STATE_BUFFERING) {
-                    return getAction(R.drawable.exo_notification_pause,
-                            R.string.exo_controls_pause_description, ACTION_PLAY_PAUSE);
-                } else {
-                    return getAction(R.drawable.exo_notification_play,
-                            R.string.exo_controls_play_description, ACTION_PLAY_PAUSE);
-                }
-
-            case NotificationConstants.REPEAT:
-                if (player.getRepeatMode() == REPEAT_MODE_ALL) {
-                    return getAction(R.drawable.exo_media_action_repeat_all,
-                            R.string.exo_controls_repeat_all_description, ACTION_REPEAT);
-                } else if (player.getRepeatMode() == REPEAT_MODE_ONE) {
-                    return getAction(R.drawable.exo_media_action_repeat_one,
-                            R.string.exo_controls_repeat_one_description, ACTION_REPEAT);
-                } else /* player.getRepeatMode() == REPEAT_MODE_OFF */ {
-                    return getAction(R.drawable.exo_media_action_repeat_off,
-                            R.string.exo_controls_repeat_off_description, ACTION_REPEAT);
-                }
-
-            case NotificationConstants.SHUFFLE:
-                if (player.getPlayQueue() != null && player.getPlayQueue().isShuffled()) {
-                    return getAction(R.drawable.exo_controls_shuffle_on,
-                            R.string.exo_controls_shuffle_on_description, ACTION_SHUFFLE);
-                } else {
-                    return getAction(R.drawable.exo_controls_shuffle_off,
-                            R.string.exo_controls_shuffle_off_description, ACTION_SHUFFLE);
-                }
-
-            case NotificationConstants.CLOSE:
-                return getAction(R.drawable.ic_close,
-                        R.string.close, ACTION_CLOSE);
-
-            case NotificationConstants.NOTHING:
-            default:
-                // do nothing
-                return null;
+        final PendingIntent intent;
+        if (data.action() == null) {
+            intent = null;
+        } else {
+            intent = PendingIntentCompat.getBroadcast(player.getContext(), NOTIFICATION_ID,
+                    new Intent(data.action()), FLAG_UPDATE_CURRENT, false);
         }
-    }
 
-    private NotificationCompat.Action getAction(@DrawableRes final int drawable,
-                                                @StringRes final int title,
-                                                final String intentAction) {
-        return new NotificationCompat.Action(drawable, player.getContext().getString(title),
-                PendingIntentCompat.getBroadcast(player.getContext(), NOTIFICATION_ID,
-                        new Intent(intentAction), FLAG_UPDATE_CURRENT, false));
+        builder.addAction(new NotificationCompat.Action(data.icon(), data.name(), intent));
     }
 
     private Intent getIntentForNotification() {

--- a/app/src/main/java/org/schabi/newpipe/settings/custom/NotificationActionsPreference.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/custom/NotificationActionsPreference.java
@@ -5,38 +5,22 @@ import static org.schabi.newpipe.player.notification.NotificationConstants.ACTIO
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.content.res.ColorStateList;
 import android.os.Build;
 import android.util.AttributeSet;
-import android.view.LayoutInflater;
 import android.view.View;
-import android.view.ViewGroup;
 import android.widget.CheckBox;
-import android.widget.ImageView;
-import android.widget.RadioButton;
-import android.widget.RadioGroup;
 import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.AlertDialog;
-import androidx.appcompat.content.res.AppCompatResources;
-import androidx.core.widget.TextViewCompat;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceViewHolder;
 
 import org.schabi.newpipe.App;
 import org.schabi.newpipe.R;
-import org.schabi.newpipe.databinding.ListRadioIconItemBinding;
-import org.schabi.newpipe.databinding.SingleChoiceDialogViewBinding;
 import org.schabi.newpipe.player.notification.NotificationConstants;
-import org.schabi.newpipe.util.DeviceUtils;
-import org.schabi.newpipe.util.ThemeHelper;
-import org.schabi.newpipe.views.FocusOverlayView;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.IntStream;
 
 public class NotificationActionsPreference extends Preference {
@@ -47,8 +31,9 @@ public class NotificationActionsPreference extends Preference {
     }
 
 
-    @Nullable private NotificationSlot[] notificationSlots = null;
-    @Nullable private List<Integer> compactSlots = null;
+    private NotificationSlot[] notificationSlots;
+    private List<Integer> compactSlots;
+
 
     ////////////////////////////////////////////////////////////////////////////
     // Lifecycle
@@ -85,8 +70,24 @@ public class NotificationActionsPreference extends Preference {
         compactSlots = NotificationConstants.getCompactSlotsFromPreferences(getContext(),
                 getSharedPreferences(), 5);
         notificationSlots = IntStream.range(0, 5)
-                .mapToObj(i -> new NotificationSlot(i, view))
+                .mapToObj(i -> new NotificationSlot(getContext(), getSharedPreferences(), i, view,
+                        compactSlots.contains(i), this::onToggleCompactSlot))
                 .toArray(NotificationSlot[]::new);
+    }
+
+    private void onToggleCompactSlot(final int i, final CheckBox checkBox) {
+        if (checkBox.isChecked()) {
+            compactSlots.remove((Integer) i);
+        } else if (compactSlots.size() < 3) {
+            compactSlots.add(i);
+        } else {
+            Toast.makeText(getContext(),
+                    R.string.notification_actions_at_most_three,
+                    Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        checkBox.toggle();
     }
 
 
@@ -106,156 +107,10 @@ public class NotificationActionsPreference extends Preference {
 
             for (int i = 0; i < 5; i++) {
                 editor.putInt(getContext().getString(NotificationConstants.SLOT_PREF_KEYS[i]),
-                        notificationSlots[i].selectedAction);
+                        notificationSlots[i].getSelectedAction());
             }
 
             editor.apply();
-        }
-    }
-
-
-    ////////////////////////////////////////////////////////////////////////////
-    // Notification action
-    ////////////////////////////////////////////////////////////////////////////
-
-    private static final int[] SLOT_ITEMS = {
-            R.id.notificationAction0,
-            R.id.notificationAction1,
-            R.id.notificationAction2,
-            R.id.notificationAction3,
-            R.id.notificationAction4,
-    };
-
-    private static final int[] SLOT_TITLES = {
-            R.string.notification_action_0_title,
-            R.string.notification_action_1_title,
-            R.string.notification_action_2_title,
-            R.string.notification_action_3_title,
-            R.string.notification_action_4_title,
-    };
-
-    private class NotificationSlot {
-
-        final int i;
-        @NotificationConstants.Action int selectedAction;
-
-        ImageView icon;
-        TextView summary;
-
-        NotificationSlot(final int actionIndex, final View parentView) {
-            this.i = actionIndex;
-            selectedAction = Objects.requireNonNull(getSharedPreferences()).getInt(
-                    getContext().getString(NotificationConstants.SLOT_PREF_KEYS[i]),
-                    NotificationConstants.SLOT_DEFAULTS[i]);
-            final View view = parentView.findViewById(SLOT_ITEMS[i]);
-
-            // only show the last two notification slots on Android 13+
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU || i >= 3) {
-                setupSelectedAction(view);
-                setupTitle(view);
-                setupCheckbox(view);
-            } else {
-                view.setVisibility(View.GONE);
-            }
-        }
-
-        void setupTitle(final View view) {
-            ((TextView) view.findViewById(R.id.notificationActionTitle))
-                    .setText(SLOT_TITLES[i]);
-            view.findViewById(R.id.notificationActionClickableArea).setOnClickListener(
-                    v -> openActionChooserDialog());
-        }
-
-        void setupCheckbox(final View view) {
-            final CheckBox compactSlotCheckBox = view.findViewById(R.id.notificationActionCheckBox);
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                // there are no compact slots to customize on Android 33+
-                compactSlotCheckBox.setVisibility(View.GONE);
-                view.findViewById(R.id.notificationActionCheckBoxClickableArea)
-                        .setVisibility(View.GONE);
-                return;
-            }
-
-            compactSlotCheckBox.setChecked(compactSlots.contains(i));
-            view.findViewById(R.id.notificationActionCheckBoxClickableArea).setOnClickListener(
-                    v -> {
-                        if (compactSlotCheckBox.isChecked()) {
-                            compactSlots.remove((Integer) i);
-                        } else if (compactSlots.size() < 3) {
-                            compactSlots.add(i);
-                        } else {
-                            Toast.makeText(getContext(),
-                                    R.string.notification_actions_at_most_three,
-                                    Toast.LENGTH_SHORT).show();
-                            return;
-                        }
-
-                        compactSlotCheckBox.toggle();
-                    });
-        }
-
-        void setupSelectedAction(final View view) {
-            icon = view.findViewById(R.id.notificationActionIcon);
-            summary = view.findViewById(R.id.notificationActionSummary);
-            updateInfo();
-        }
-
-        void updateInfo() {
-            if (NotificationConstants.ACTION_ICONS[selectedAction] == 0) {
-                icon.setImageDrawable(null);
-            } else {
-                icon.setImageDrawable(AppCompatResources.getDrawable(getContext(),
-                        NotificationConstants.ACTION_ICONS[selectedAction]));
-            }
-
-            summary.setText(NotificationConstants.getActionName(getContext(), selectedAction));
-        }
-
-        void openActionChooserDialog() {
-            final LayoutInflater inflater = LayoutInflater.from(getContext());
-            final SingleChoiceDialogViewBinding binding =
-                    SingleChoiceDialogViewBinding.inflate(inflater);
-
-            final AlertDialog alertDialog = new AlertDialog.Builder(getContext())
-                    .setTitle(SLOT_TITLES[i])
-                    .setView(binding.getRoot())
-                    .setCancelable(true)
-                    .create();
-
-            final View.OnClickListener radioButtonsClickListener = v -> {
-                selectedAction = NotificationConstants.SLOT_ALLOWED_ACTIONS[i][v.getId()];
-                updateInfo();
-                alertDialog.dismiss();
-            };
-
-            for (int id = 0; id < NotificationConstants.SLOT_ALLOWED_ACTIONS[i].length; ++id) {
-                final int action = NotificationConstants.SLOT_ALLOWED_ACTIONS[i][id];
-                final RadioButton radioButton = ListRadioIconItemBinding.inflate(inflater)
-                        .getRoot();
-
-                // if present set action icon with correct color
-                final int iconId = NotificationConstants.ACTION_ICONS[action];
-                if (iconId != 0) {
-                    radioButton.setCompoundDrawablesRelativeWithIntrinsicBounds(0, 0, iconId, 0);
-
-                    final var color = ColorStateList.valueOf(ThemeHelper
-                            .resolveColorFromAttr(getContext(), android.R.attr.textColorPrimary));
-                    TextViewCompat.setCompoundDrawableTintList(radioButton, color);
-                }
-
-                radioButton.setText(NotificationConstants.getActionName(getContext(), action));
-                radioButton.setChecked(action == selectedAction);
-                radioButton.setId(id);
-                radioButton.setLayoutParams(new RadioGroup.LayoutParams(
-                        ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
-                radioButton.setOnClickListener(radioButtonsClickListener);
-                binding.list.addView(radioButton);
-            }
-            alertDialog.show();
-
-            if (DeviceUtils.isTv(getContext())) {
-                FocusOverlayView.setupFocusObserver(alertDialog);
-            }
         }
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/settings/custom/NotificationActionsPreference.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/custom/NotificationActionsPreference.java
@@ -20,6 +20,7 @@ import org.schabi.newpipe.App;
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.player.notification.NotificationConstants;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
 
@@ -67,8 +68,8 @@ public class NotificationActionsPreference extends Preference {
     ////////////////////////////////////////////////////////////////////////////
 
     private void setupActions(@NonNull final View view) {
-        compactSlots = NotificationConstants.getCompactSlotsFromPreferences(getContext(),
-                getSharedPreferences(), 5);
+        compactSlots = new ArrayList<>(NotificationConstants.getCompactSlotsFromPreferences(
+                getContext(), getSharedPreferences()));
         notificationSlots = IntStream.range(0, 5)
                 .mapToObj(i -> new NotificationSlot(getContext(), getSharedPreferences(), i, view,
                         compactSlots.contains(i), this::onToggleCompactSlot))

--- a/app/src/main/java/org/schabi/newpipe/settings/custom/NotificationSlot.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/custom/NotificationSlot.java
@@ -89,7 +89,7 @@ class NotificationSlot {
     void setupCheckbox(final View view, final boolean isCompactSlotChecked) {
         final CheckBox compactSlotCheckBox = view.findViewById(R.id.notificationActionCheckBox);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            // there are no compact slots to customize on Android 33+
+            // there are no compact slots to customize on Android 13+
             compactSlotCheckBox.setVisibility(View.GONE);
             view.findViewById(R.id.notificationActionCheckBoxClickableArea)
                     .setVisibility(View.GONE);

--- a/app/src/main/java/org/schabi/newpipe/settings/custom/NotificationSlot.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/custom/NotificationSlot.java
@@ -1,0 +1,172 @@
+package org.schabi.newpipe.settings.custom;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.res.ColorStateList;
+import android.os.Build;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.CheckBox;
+import android.widget.ImageView;
+import android.widget.RadioButton;
+import android.widget.RadioGroup;
+import android.widget.TextView;
+
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.content.res.AppCompatResources;
+import androidx.core.widget.TextViewCompat;
+
+import org.schabi.newpipe.R;
+import org.schabi.newpipe.databinding.ListRadioIconItemBinding;
+import org.schabi.newpipe.databinding.SingleChoiceDialogViewBinding;
+import org.schabi.newpipe.player.notification.NotificationConstants;
+import org.schabi.newpipe.util.DeviceUtils;
+import org.schabi.newpipe.util.ThemeHelper;
+import org.schabi.newpipe.views.FocusOverlayView;
+
+import java.util.Objects;
+import java.util.function.BiConsumer;
+
+class NotificationSlot {
+
+    private static final int[] SLOT_ITEMS = {
+            R.id.notificationAction0,
+            R.id.notificationAction1,
+            R.id.notificationAction2,
+            R.id.notificationAction3,
+            R.id.notificationAction4,
+    };
+
+    private static final int[] SLOT_TITLES = {
+            R.string.notification_action_0_title,
+            R.string.notification_action_1_title,
+            R.string.notification_action_2_title,
+            R.string.notification_action_3_title,
+            R.string.notification_action_4_title,
+    };
+
+    private final int i;
+    private @NotificationConstants.Action int selectedAction;
+    private final Context context;
+    private final BiConsumer<Integer, CheckBox> onToggleCompactSlot;
+
+    private ImageView icon;
+    private TextView summary;
+
+    NotificationSlot(final Context context,
+                     final SharedPreferences prefs,
+                     final int actionIndex,
+                     final View parentView,
+                     final boolean isCompactSlotChecked,
+                     final BiConsumer<Integer, CheckBox> onToggleCompactSlot) {
+        this.context = context;
+        this.i = actionIndex;
+        this.onToggleCompactSlot = onToggleCompactSlot;
+
+        selectedAction = Objects.requireNonNull(prefs).getInt(
+                context.getString(NotificationConstants.SLOT_PREF_KEYS[i]),
+                NotificationConstants.SLOT_DEFAULTS[i]);
+        final View view = parentView.findViewById(SLOT_ITEMS[i]);
+
+        // only show the last two notification slots on Android 13+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU || i >= 3) {
+            setupSelectedAction(view);
+            setupTitle(view);
+            setupCheckbox(view, isCompactSlotChecked);
+        } else {
+            view.setVisibility(View.GONE);
+        }
+    }
+
+    void setupTitle(final View view) {
+        ((TextView) view.findViewById(R.id.notificationActionTitle))
+                .setText(SLOT_TITLES[i]);
+        view.findViewById(R.id.notificationActionClickableArea).setOnClickListener(
+                v -> openActionChooserDialog());
+    }
+
+    void setupCheckbox(final View view, final boolean isCompactSlotChecked) {
+        final CheckBox compactSlotCheckBox = view.findViewById(R.id.notificationActionCheckBox);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            // there are no compact slots to customize on Android 33+
+            compactSlotCheckBox.setVisibility(View.GONE);
+            view.findViewById(R.id.notificationActionCheckBoxClickableArea)
+                    .setVisibility(View.GONE);
+            return;
+        }
+
+        compactSlotCheckBox.setChecked(isCompactSlotChecked);
+        view.findViewById(R.id.notificationActionCheckBoxClickableArea).setOnClickListener(
+                v -> onToggleCompactSlot.accept(i, compactSlotCheckBox));
+    }
+
+    void setupSelectedAction(final View view) {
+        icon = view.findViewById(R.id.notificationActionIcon);
+        summary = view.findViewById(R.id.notificationActionSummary);
+        updateInfo();
+    }
+
+    void updateInfo() {
+        if (NotificationConstants.ACTION_ICONS[selectedAction] == 0) {
+            icon.setImageDrawable(null);
+        } else {
+            icon.setImageDrawable(AppCompatResources.getDrawable(context,
+                    NotificationConstants.ACTION_ICONS[selectedAction]));
+        }
+
+        summary.setText(NotificationConstants.getActionName(context, selectedAction));
+    }
+
+    void openActionChooserDialog() {
+        final LayoutInflater inflater = LayoutInflater.from(context);
+        final SingleChoiceDialogViewBinding binding =
+                SingleChoiceDialogViewBinding.inflate(inflater);
+
+        final AlertDialog alertDialog = new AlertDialog.Builder(context)
+                .setTitle(SLOT_TITLES[i])
+                .setView(binding.getRoot())
+                .setCancelable(true)
+                .create();
+
+        final View.OnClickListener radioButtonsClickListener = v -> {
+            selectedAction = NotificationConstants.SLOT_ALLOWED_ACTIONS[i][v.getId()];
+            updateInfo();
+            alertDialog.dismiss();
+        };
+
+        for (int id = 0; id < NotificationConstants.SLOT_ALLOWED_ACTIONS[i].length; ++id) {
+            final int action = NotificationConstants.SLOT_ALLOWED_ACTIONS[i][id];
+            final RadioButton radioButton = ListRadioIconItemBinding.inflate(inflater)
+                    .getRoot();
+
+            // if present set action icon with correct color
+            final int iconId = NotificationConstants.ACTION_ICONS[action];
+            if (iconId != 0) {
+                radioButton.setCompoundDrawablesRelativeWithIntrinsicBounds(0, 0, iconId, 0);
+
+                final var color = ColorStateList.valueOf(ThemeHelper
+                        .resolveColorFromAttr(context, android.R.attr.textColorPrimary));
+                TextViewCompat.setCompoundDrawableTintList(radioButton, color);
+            }
+
+            radioButton.setText(NotificationConstants.getActionName(context, action));
+            radioButton.setChecked(action == selectedAction);
+            radioButton.setId(id);
+            radioButton.setLayoutParams(new RadioGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
+            radioButton.setOnClickListener(radioButtonsClickListener);
+            binding.list.addView(radioButton);
+        }
+        alertDialog.show();
+
+        if (DeviceUtils.isTv(context)) {
+            FocusOverlayView.setupFocusObserver(alertDialog);
+        }
+    }
+
+    @NotificationConstants.Action
+    public int getSelectedAction() {
+        return selectedAction;
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/settings/custom/NotificationSlot.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/custom/NotificationSlot.java
@@ -130,13 +130,13 @@ class NotificationSlot {
                 .create();
 
         final View.OnClickListener radioButtonsClickListener = v -> {
-            selectedAction = NotificationConstants.SLOT_ALLOWED_ACTIONS[i][v.getId()];
+            selectedAction = NotificationConstants.ALL_ACTIONS[v.getId()];
             updateInfo();
             alertDialog.dismiss();
         };
 
-        for (int id = 0; id < NotificationConstants.SLOT_ALLOWED_ACTIONS[i].length; ++id) {
-            final int action = NotificationConstants.SLOT_ALLOWED_ACTIONS[i][id];
+        for (int id = 0; id < NotificationConstants.ALL_ACTIONS.length; ++id) {
+            final int action = NotificationConstants.ALL_ACTIONS[id];
             final RadioButton radioButton = ListRadioIconItemBinding.inflate(inflater)
                     .getRoot();
 

--- a/app/src/main/res/layout/settings_notification.xml
+++ b/app/src/main/res/layout/settings_notification.xml
@@ -7,7 +7,7 @@
         android:paddingTop="16dp">
 
     <org.schabi.newpipe.views.NewPipeTextView
-        android:id="@+id/textView"
+        android:id="@+id/summary"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
@@ -29,7 +29,7 @@
         android:layout_marginTop="8dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/textView" />
+        app:layout_constraintTop_toBottomOf="@+id/summary" />
 
     <include
         android:id="@+id/notificationAction1"

--- a/app/src/main/res/layout/settings_notification.xml
+++ b/app/src/main/res/layout/settings_notification.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <androidx.constraintlayout.widget.ConstraintLayout
         xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
@@ -8,64 +7,64 @@
         android:paddingTop="16dp">
 
     <org.schabi.newpipe.views.NewPipeTextView
-            android:id="@+id/textView"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginEnd="16dp"
-            android:clickable="false"
-            android:focusable="false"
-            android:gravity="center"
-            android:text="@string/notification_actions_summary"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.0"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+        android:id="@+id/textView"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:clickable="false"
+        android:focusable="false"
+        android:gravity="center"
+        android:text="@string/notification_actions_summary"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-        <include
-            android:id="@+id/notificationAction0"
-            layout="@layout/settings_notification_action"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/textView" />
+    <include
+        android:id="@+id/notificationAction0"
+        layout="@layout/settings_notification_action"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textView" />
 
-        <include
-            android:id="@+id/notificationAction1"
-            layout="@layout/settings_notification_action"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/notificationAction0" />
+    <include
+        android:id="@+id/notificationAction1"
+        layout="@layout/settings_notification_action"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/notificationAction0" />
 
-        <include
-            android:id="@+id/notificationAction2"
-            layout="@layout/settings_notification_action"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/notificationAction1" />
+    <include
+        android:id="@+id/notificationAction2"
+        layout="@layout/settings_notification_action"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/notificationAction1" />
 
-        <include
-            android:id="@+id/notificationAction3"
-            layout="@layout/settings_notification_action"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/notificationAction2" />
+    <include
+        android:id="@+id/notificationAction3"
+        layout="@layout/settings_notification_action"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/notificationAction2" />
 
-        <include
-            android:id="@+id/notificationAction4"
-            layout="@layout/settings_notification_action"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/notificationAction3" />
+    <include
+        android:id="@+id/notificationAction4"
+        layout="@layout/settings_notification_action"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/notificationAction3" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,7 +57,8 @@
     <string name="notification_action_2_title">Third action button</string>
     <string name="notification_action_3_title">Fourth action button</string>
     <string name="notification_action_4_title">Fifth action button</string>
-    <string name="notification_actions_summary">Edit each notification action below by tapping on it. Select up to three of them to be shown in the compact notification by using the checkboxes on the right</string>
+    <string name="notification_actions_summary">Edit each notification action below by tapping on it. Select up to three of them to be shown in the compact notification by using the checkboxes on the right.</string>
+    <string name="notification_actions_summary_android13">Edit each notification action below by tapping on it. The first three actions (play/pause, previous and next) are set by the system and cannot be customized.</string>
     <string name="notification_actions_at_most_three">You can select at most three actions to show in the compact notification!</string>
     <string name="notification_action_repeat">Repeat</string>
     <string name="notification_action_shuffle">Shuffle</string>


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
- Supersedes https://github.com/TeamNewPipe/NewPipe/pull/10580 and https://github.com/TeamNewPipe/NewPipe/pull/10567 because the **hacky workaround** to allow customizing 4 actions [turned out to cause problems](https://github.com/TeamNewPipe/NewPipe/pull/10580#discussion_r1435593734)
- Set notification actions only via `MediaSessionConnector` on Android 13+, and only via the notification builder on Android 12-, to save battery
- Notification actions in `MediaSessionPlayerUi` are only updated when something really changes, to avoid `setCustomActionProviders()` calling `invalidateMediaSessionPlaybackState()` more times as needed, which I figure might be costly
- Adapts the player notification settings page to allow customizing only two actions on Android 13+. The preference keys for the first three actions are actually still set, to avoid complicating the logic too much, and to allow seamless transitioning between Android 12- and 13+ back and forth (e.g. when a user exports and imports a database).
- Allows each notification slot to contain any possible action (which required changing how compact notification slot indices are computed, since the assumption that "Nothing" slots are always last does not hold anymore)
- Allows play/pausing from the notification when the player is buffering, which is in line with what happens in the main player ui
- Cleans up the code by extracting `NotificationSlot` from `NotificationActionsPreference`, and `NotificationActionData` from `NotificationUtil`

I tested a bit and caught some small inconsistencies in the code that now are fixed, and everything seems to work as expected.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
<table>
  <tr>
    <th>Before notification</th>
    <th>After notification</th>
    <th>Settings in 12-</th>
    <th>Settings in 13+</th>
  </tr>
  <tr>
    <td><img src="https://github.com/TeamNewPipe/NewPipe/assets/36421898/f1fbba02-ac33-4eab-a9aa-150758effb15" width="200px" alt="Before"/></td>
    <td><img src="https://github.com/TeamNewPipe/NewPipe/assets/36421898/481938c7-2148-4861-a50b-6132142cf1e3" width="200px" alt="After"/></td>
    <td><img src="https://github.com/TeamNewPipe/NewPipe/assets/36421898/de0cfe69-f1a9-4e11-a0dd-0abc3f728b4d" width="200px" alt="After"/></td>
    <td><img src="https://github.com/TeamNewPipe/NewPipe/assets/36421898/9adb41be-b053-4382-bd76-5737b4e3b704" width="200px" alt="After"/></td>
  </tr>
</table>

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes https://github.com/TeamNewPipe/NewPipe/issues/9764

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
