### PR TITLE
Calculate cache key based on info type instead of item type

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -198,7 +198,7 @@ dependencies {
     // name and the commit hash with the commit hash of the (pushed) commit you want to test
     // This works thanks to JitPack: https://jitpack.io/
     implementation 'com.github.TeamNewPipe:nanojson:1d9e1aea9049fc9f85e68b43ba39fe7be1c1f751'
-    implementation 'com.github.TeamNewPipe:NewPipeExtractor:v0.23.1'
+    implementation 'com.github.Stypox:NewPipeExtractor:aaf3231fc75d7b4177549fec4aa7e672bfe84015'
     implementation 'com.github.TeamNewPipe:NoNonsense-FilePicker:5.0.0'
 
 /** Checkstyle **/

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -72,7 +72,6 @@ import org.schabi.newpipe.error.ErrorUtil;
 import org.schabi.newpipe.error.ReCaptchaActivity;
 import org.schabi.newpipe.error.UserAction;
 import org.schabi.newpipe.extractor.Image;
-import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.comments.CommentsInfoItem;
 import org.schabi.newpipe.extractor.exceptions.ContentNotSupportedException;
@@ -107,16 +106,17 @@ import org.schabi.newpipe.player.ui.VideoPlayerUi;
 import org.schabi.newpipe.util.Constants;
 import org.schabi.newpipe.util.DeviceUtils;
 import org.schabi.newpipe.util.ExtractorHelper;
+import org.schabi.newpipe.util.InfoCache;
 import org.schabi.newpipe.util.ListHelper;
 import org.schabi.newpipe.util.Localization;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.PermissionHelper;
-import org.schabi.newpipe.util.image.PicassoHelper;
+import org.schabi.newpipe.util.PlayButtonHelper;
 import org.schabi.newpipe.util.StreamTypeUtil;
 import org.schabi.newpipe.util.ThemeHelper;
 import org.schabi.newpipe.util.external_communication.KoreUtils;
 import org.schabi.newpipe.util.external_communication.ShareUtils;
-import org.schabi.newpipe.util.PlayButtonHelper;
+import org.schabi.newpipe.util.image.PicassoHelper;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -1445,7 +1445,7 @@ public final class VideoDetailFragment
         super.showLoading();
 
         //if data is already cached, transition from VISIBLE -> INVISIBLE -> VISIBLE is not required
-        if (!ExtractorHelper.isCached(serviceId, url, InfoItem.InfoType.STREAM)) {
+        if (!ExtractorHelper.isCached(serviceId, url, InfoCache.Type.STREAM)) {
             binding.detailContentRootHiding.setVisibility(View.INVISIBLE);
         }
 

--- a/app/src/main/java/org/schabi/newpipe/util/ExtractorHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ExtractorHelper.java
@@ -27,6 +27,7 @@ import android.util.Log;
 import android.view.View;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.text.HtmlCompat;
 import androidx.preference.PreferenceManager;
@@ -113,14 +114,14 @@ public final class ExtractorHelper {
     public static Single<StreamInfo> getStreamInfo(final int serviceId, final String url,
                                                    final boolean forceLoad) {
         checkServiceId(serviceId);
-        return checkCache(forceLoad, serviceId, url, InfoItem.InfoType.STREAM,
+        return checkCache(forceLoad, serviceId, url, InfoCache.Type.STREAM,
                 Single.fromCallable(() -> StreamInfo.getInfo(NewPipe.getService(serviceId), url)));
     }
 
     public static Single<ChannelInfo> getChannelInfo(final int serviceId, final String url,
                                                      final boolean forceLoad) {
         checkServiceId(serviceId);
-        return checkCache(forceLoad, serviceId, url, InfoItem.InfoType.CHANNEL,
+        return checkCache(forceLoad, serviceId, url, InfoCache.Type.CHANNEL,
                 Single.fromCallable(() ->
                         ChannelInfo.getInfo(NewPipe.getService(serviceId), url)));
     }
@@ -130,7 +131,7 @@ public final class ExtractorHelper {
                                                        final boolean forceLoad) {
         checkServiceId(serviceId);
         return checkCache(forceLoad, serviceId,
-                listLinkHandler.getUrl(), InfoItem.InfoType.CHANNEL,
+                listLinkHandler.getUrl(), InfoCache.Type.CHANNEL_TAB,
                 Single.fromCallable(() ->
                         ChannelTabInfo.getInfo(NewPipe.getService(serviceId), listLinkHandler)));
     }
@@ -145,10 +146,11 @@ public final class ExtractorHelper {
                         listLinkHandler, nextPage));
     }
 
-    public static Single<CommentsInfo> getCommentsInfo(final int serviceId, final String url,
+    public static Single<CommentsInfo> getCommentsInfo(final int serviceId,
+                                                       final String url,
                                                        final boolean forceLoad) {
         checkServiceId(serviceId);
-        return checkCache(forceLoad, serviceId, url, InfoItem.InfoType.COMMENT,
+        return checkCache(forceLoad, serviceId, url, InfoCache.Type.COMMENTS,
                 Single.fromCallable(() ->
                         CommentsInfo.getInfo(NewPipe.getService(serviceId), url)));
     }
@@ -175,7 +177,7 @@ public final class ExtractorHelper {
                                                        final String url,
                                                        final boolean forceLoad) {
         checkServiceId(serviceId);
-        return checkCache(forceLoad, serviceId, url, InfoItem.InfoType.PLAYLIST,
+        return checkCache(forceLoad, serviceId, url, InfoCache.Type.PLAYLIST,
                 Single.fromCallable(() ->
                         PlaylistInfo.getInfo(NewPipe.getService(serviceId), url)));
     }
@@ -188,9 +190,10 @@ public final class ExtractorHelper {
                 PlaylistInfo.getMoreItems(NewPipe.getService(serviceId), url, nextPage));
     }
 
-    public static Single<KioskInfo> getKioskInfo(final int serviceId, final String url,
+    public static Single<KioskInfo> getKioskInfo(final int serviceId,
+                                                 final String url,
                                                  final boolean forceLoad) {
-        return checkCache(forceLoad, serviceId, url, InfoItem.InfoType.PLAYLIST,
+        return checkCache(forceLoad, serviceId, url, InfoCache.Type.KIOSK,
                 Single.fromCallable(() -> KioskInfo.getInfo(NewPipe.getService(serviceId), url)));
     }
 
@@ -202,7 +205,7 @@ public final class ExtractorHelper {
     }
 
     /*//////////////////////////////////////////////////////////////////////////
-    // Utils
+    // Cache
     //////////////////////////////////////////////////////////////////////////*/
 
     /**
@@ -214,24 +217,25 @@ public final class ExtractorHelper {
      * @param forceLoad       whether to force loading from the network instead of from the cache
      * @param serviceId       the service to load from
      * @param url             the URL to load
-     * @param infoType        the {@link InfoItem.InfoType} of the item
+     * @param cacheType       the {@link InfoCache.Type} of the item
      * @param loadFromNetwork the {@link Single} to load the item from the network
      * @return a {@link Single} that loads the item
      */
     private static <I extends Info> Single<I> checkCache(final boolean forceLoad,
-                                                         final int serviceId, final String url,
-                                                         final InfoItem.InfoType infoType,
-                                                         final Single<I> loadFromNetwork) {
+                                                         final int serviceId,
+                                                         @NonNull final String url,
+                                                         @NonNull final InfoCache.Type cacheType,
+                                                         @NonNull final Single<I> loadFromNetwork) {
         checkServiceId(serviceId);
         final Single<I> actualLoadFromNetwork = loadFromNetwork
-                .doOnSuccess(info -> CACHE.putInfo(serviceId, url, info, infoType));
+                .doOnSuccess(info -> CACHE.putInfo(serviceId, url, info, cacheType));
 
         final Single<I> load;
         if (forceLoad) {
-            CACHE.removeInfo(serviceId, url, infoType);
+            CACHE.removeInfo(serviceId, url, cacheType);
             load = actualLoadFromNetwork;
         } else {
-            load = Maybe.concat(ExtractorHelper.loadFromCache(serviceId, url, infoType),
+            load = Maybe.concat(ExtractorHelper.loadFromCache(serviceId, url, cacheType),
                             actualLoadFromNetwork.toMaybe())
                     .firstElement() // Take the first valid
                     .toSingle();
@@ -246,15 +250,17 @@ public final class ExtractorHelper {
      * @param <I>       the item type's class that extends {@link Info}
      * @param serviceId the service to load from
      * @param url       the URL to load
-     * @param infoType  the {@link InfoItem.InfoType} of the item
+     * @param cacheType the {@link InfoCache.Type} of the item
      * @return a {@link Single} that loads the item
      */
-    private static <I extends Info> Maybe<I> loadFromCache(final int serviceId, final String url,
-                                                           final InfoItem.InfoType infoType) {
+    private static <I extends Info> Maybe<I> loadFromCache(
+            final int serviceId,
+            @NonNull final String url,
+            @NonNull final InfoCache.Type cacheType) {
         checkServiceId(serviceId);
         return Maybe.defer(() -> {
             //noinspection unchecked
-            final I info = (I) CACHE.getFromKey(serviceId, url, infoType);
+            final I info = (I) CACHE.getFromKey(serviceId, url, cacheType);
             if (MainActivity.DEBUG) {
                 Log.d(TAG, "loadFromCache() called, info > " + info);
             }
@@ -268,10 +274,16 @@ public final class ExtractorHelper {
         });
     }
 
-    public static boolean isCached(final int serviceId, final String url,
-                                   final InfoItem.InfoType infoType) {
-        return null != loadFromCache(serviceId, url, infoType).blockingGet();
+    public static boolean isCached(final int serviceId,
+                                   @NonNull final String url,
+                                   @NonNull final InfoCache.Type cacheType) {
+        return null != loadFromCache(serviceId, url, cacheType).blockingGet();
     }
+
+
+    /*//////////////////////////////////////////////////////////////////////////
+    // Utils
+    //////////////////////////////////////////////////////////////////////////*/
 
     /**
      * Formats the text contained in the meta info list as HTML and puts it into the text view,


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
It didn't really make sense to consider two cache keys as equal based on the type of items contained within that list. The proper way is to distinguish the actual kind of `Info` being saved/retrieved, so I created a new `enum` independent from the extractor's one

This PR includes the extractor from https://github.com/TeamNewPipe/NewPipeExtractor/pull/1148 to showcase that the problem is fixed, since there MediaCCC channels and channel tabs have the same url.

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
