### PR TITLE
Simplify selection of video stream

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/resolver/AudioPlaybackResolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/AudioPlaybackResolver.java
@@ -45,7 +45,6 @@ public class AudioPlaybackResolver implements PlaybackResolver {
      * @param info of the stream
      * @return the audio source to use or null if none could be found
      */
-    @Override
     @Nullable
     public MediaSource resolve(@NonNull final StreamInfo info) {
         final MediaSource liveSource = PlaybackResolver.maybeBuildLiveMediaSource(dataSource, info);

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/PlaybackResolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/PlaybackResolver.java
@@ -46,11 +46,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
 /**
- * This interface is just a shorthand for {@link Resolver} with {@link StreamInfo} as source and
- * {@link MediaSource} as product. It contains many static methods that can be used by classes
+ * This interface contains many static methods that can be used by classes
  * implementing this interface, and nothing else.
  */
-public interface PlaybackResolver extends Resolver<StreamInfo, MediaSource> {
+public interface PlaybackResolver {
     String TAG = PlaybackResolver.class.getSimpleName();
 
 

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/Resolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/Resolver.java
@@ -1,9 +1,0 @@
-package org.schabi.newpipe.player.resolver;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-
-public interface Resolver<Source, Product> {
-    @Nullable
-    Product resolve(@NonNull Source source);
-}

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/VideoPlaybackResolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/VideoPlaybackResolver.java
@@ -102,24 +102,12 @@ public class VideoPlaybackResolver implements PlaybackResolver {
                     );
                 }
             }
-
         } else {
-            switch (selectedPlayer) {
-                case MAIN -> {
-                    videoIndex = ListHelper.getDefaultResolutionWithDefaultFormat(
-                            context,
-                            getPlaybackQuality(),
-                            videoStreamsList
-                    );
-                }
-                case POPUP -> {
-                    videoIndex = ListHelper.getDefaultResolutionWithDefaultFormat(
-                            context,
-                            getPlaybackQuality(),
-                            videoStreamsList
-                    );
-                }
-            }
+            videoIndex = ListHelper.getDefaultResolutionWithDefaultFormat(
+                    context,
+                    getPlaybackQuality(),
+                    videoStreamsList
+            );
         }
 
         final int audioIndex =

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/VideoPlaybackResolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/VideoPlaybackResolver.java
@@ -106,17 +106,17 @@ public class VideoPlaybackResolver implements PlaybackResolver {
         } else {
             switch (selectedPlayer) {
                 case MAIN -> {
-                    videoIndex = ListHelper.getResolutionIndex(
+                    videoIndex = ListHelper.getDefaultResolutionWithDefaultFormat(
                             context,
-                            videoStreamsList,
-                            getPlaybackQuality()
+                            getPlaybackQuality(),
+                            videoStreamsList
                     );
                 }
                 case POPUP -> {
-                    videoIndex = ListHelper.getPopupResolutionIndex(
+                    videoIndex = ListHelper.getDefaultResolutionWithDefaultFormat(
                             context,
-                            videoStreamsList,
-                            getPlaybackQuality()
+                            getPlaybackQuality(),
+                            videoStreamsList
                     );
                 }
             }

--- a/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
@@ -371,9 +371,8 @@ public final class ListHelper {
                 PreferenceManager.getDefaultSharedPreferences(context);
 
         // Load the preferred resolution otherwise the best available
-        String resolution = preferences != null
-                ? preferences.getString(context.getString(key), context.getString(value))
-                : context.getString(R.string.best_resolution_key);
+        String resolution =
+                 preferences.getString(context.getString(key), context.getString(value));
 
         final String maxResolution = getResolutionLimit(context);
         if (maxResolution != null

--- a/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
@@ -83,18 +83,6 @@ public final class ListHelper {
         return getDefaultResolutionWithDefaultFormat(context, defaultResolution, videoStreams);
     }
 
-    /**
-     * @param context           Android app context
-     * @param videoStreams      list of the video streams to check
-     * @param defaultResolution the default resolution to look for
-     * @return index of the video stream with the default index
-     * @see #getDefaultResolutionIndex(String, String, MediaFormat, List)
-     */
-    public static int getResolutionIndex(final Context context,
-                                         final List<VideoStream> videoStreams,
-                                         final String defaultResolution) {
-        return getDefaultResolutionWithDefaultFormat(context, defaultResolution, videoStreams);
-    }
 
     /**
      * @param context      Android app context
@@ -106,19 +94,6 @@ public final class ListHelper {
                                                      final List<VideoStream> videoStreams) {
         final String defaultResolution = computeDefaultResolution(context,
                 R.string.default_popup_resolution_key, R.string.default_popup_resolution_value);
-        return getDefaultResolutionWithDefaultFormat(context, defaultResolution, videoStreams);
-    }
-
-    /**
-     * @param context           Android app context
-     * @param videoStreams      list of the video streams to check
-     * @param defaultResolution the default resolution to look for
-     * @return index of the video stream with the default index
-     * @see #getDefaultResolutionIndex(String, String, MediaFormat, List)
-     */
-    public static int getPopupResolutionIndex(final Context context,
-                                              final List<VideoStream> videoStreams,
-                                              final String defaultResolution) {
         return getDefaultResolutionWithDefaultFormat(context, defaultResolution, videoStreams);
     }
 
@@ -634,7 +609,7 @@ public final class ListHelper {
      * @param videoStreams      the list of video streams to check
      * @return the index of the preferred video stream
      */
-    private static int getDefaultResolutionWithDefaultFormat(@NonNull final Context context,
+    public static int getDefaultResolutionWithDefaultFormat(@NonNull final Context context,
                                                              final String defaultResolution,
                                                              final List<VideoStream> videoStreams) {
         final MediaFormat defaultFormat = getDefaultFormat(context,
@@ -680,6 +655,14 @@ public final class ListHelper {
         return format;
     }
 
+    /** #Comparator for two resolution strings.
+     *
+     * See {@link #sortStreamList} for ordering.
+     *
+     * @param r1 first
+     * @param r2 second
+     * @return comparison int
+     */
     private static int compareVideoStreamResolution(@NonNull final String r1,
                                                     @NonNull final String r2) {
         try {
@@ -696,12 +679,17 @@ public final class ListHelper {
         }
     }
 
+    /** Does the application have a maximum resolution set?
+     *
+     * @param context App context
+     * @return whether a max resolution is set
+     */
     static boolean isLimitingDataUsage(@NonNull final Context context) {
         return getResolutionLimit(context) != null;
     }
 
     /**
-     * The maximum resolution allowed.
+     * The maximum resolution allowed by application settings.
      *
      * @param context App context
      * @return maximum resolution allowed or null if there is no maximum
@@ -720,7 +708,7 @@ public final class ListHelper {
     }
 
     /**
-     * The current network is metered (like mobile data)?
+     * Is the current network metered (like mobile data)?
      *
      * @param context App context
      * @return {@code true} if connected to a metered network

--- a/app/src/main/java/org/schabi/newpipe/util/SecondaryStreamHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/SecondaryStreamHelper.java
@@ -31,7 +31,7 @@ public class SecondaryStreamHelper<T extends Stream> {
      * Finds an audio stream compatible with the provided video-only stream, so that the two streams
      * can be combined in a single file by the downloader. If there are multiple available audio
      * streams, chooses either the highest or the lowest quality one based on
-     * {@link ListHelper#isLimitingDataUsage(Context)}.
+     * {@link ListHelper#isCurrentlyLimitingDataUsage(Context)}.
      *
      * @param context      Android context
      * @param audioStreams list of audio streams
@@ -56,7 +56,7 @@ public class SecondaryStreamHelper<T extends Stream> {
         }
 
         final boolean m4v = mediaFormat == MediaFormat.MPEG_4;
-        final boolean isLimitingDataUsage = ListHelper.isLimitingDataUsage(context);
+        final boolean isLimitingDataUsage = ListHelper.isCurrentlyLimitingDataUsage(context);
 
         Comparator<AudioStream> comparator = ListHelper.getAudioFormatComparator(
                 m4v ? MediaFormat.M4A : MediaFormat.WEBMA, isLimitingDataUsage);


### PR DESCRIPTION
I was trying to understand the logic here, and noticed the indirection via a QualityResolver interfaces is pretty unnecessary. Just branching directly makes the logic a lot easier to follow.

The `-999` sentinel value is a bit dumb, but java does not recognize that videoIndex is always initialized.

Nice side-effect, the `Resolver` interface was completely unused and can be dropped.

<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- record videos
- create clones
- take over the world


#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
