### PR TITLE
Don't write defaultFormat setting, use default value

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
@@ -643,6 +643,7 @@ public final class ListHelper {
                 context.getString(R.string.best_resolution_key), defaultFormat, videoStreams);
     }
 
+    @Nullable
     private static MediaFormat getDefaultFormat(@NonNull final Context context,
                                                 @StringRes final int defaultFormatKey,
                                                 @StringRes final int defaultFormatValueKey) {
@@ -651,18 +652,14 @@ public final class ListHelper {
 
         final String defaultFormat = context.getString(defaultFormatValueKey);
         final String defaultFormatString = preferences.getString(
-                context.getString(defaultFormatKey), defaultFormat);
+                context.getString(defaultFormatKey),
+                defaultFormat
+        );
 
-        MediaFormat defaultMediaFormat = getMediaFormatFromKey(context, defaultFormatString);
-        if (defaultMediaFormat == null) {
-            preferences.edit().putString(context.getString(defaultFormatKey), defaultFormat)
-                    .apply();
-            defaultMediaFormat = getMediaFormatFromKey(context, defaultFormat);
-        }
-
-        return defaultMediaFormat;
+        return getMediaFormatFromKey(context, defaultFormatString);
     }
 
+    @Nullable
     private static MediaFormat getMediaFormatFromKey(@NonNull final Context context,
                                                      @NonNull final String formatKey) {
         MediaFormat format = null;


### PR DESCRIPTION
Nowhere else does this (write a setting if it’s not set).

It took me a while to see that this code does not do what it intends, because `defaultFormat` is already the default value in the first `context.getString`, so calling `getMediaFormatFromKey` again is the exact same call (“do you know the definition of insanity…”) and will return `null` again …

So let’s drop the setting write and just rely on the default values.

<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
