### PR TITLE
DownloadDialog: remove thread selector

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
@@ -22,7 +22,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.RadioGroup;
-import android.widget.SeekBar;
 import android.widget.Toast;
 
 import androidx.activity.result.ActivityResult;
@@ -65,7 +64,6 @@ import org.schabi.newpipe.util.FilenameUtils;
 import org.schabi.newpipe.util.ListHelper;
 import org.schabi.newpipe.util.PermissionHelper;
 import org.schabi.newpipe.util.SecondaryStreamHelper;
-import org.schabi.newpipe.util.SimpleOnSeekBarChangeListener;
 import org.schabi.newpipe.util.StreamItemAdapter;
 import org.schabi.newpipe.util.StreamItemAdapter.StreamInfoWrapper;
 import org.schabi.newpipe.util.AudioTrackAdapter;
@@ -323,21 +321,6 @@ public class DownloadDialog extends DialogFragment
 
         prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
 
-        final int threads = prefs.getInt(getString(R.string.default_download_threads), 3);
-        dialogBinding.threadsCount.setText(String.valueOf(threads));
-        dialogBinding.threads.setProgress(threads - 1);
-        dialogBinding.threads.setOnSeekBarChangeListener(new SimpleOnSeekBarChangeListener() {
-            @Override
-            public void onProgressChanged(@NonNull final SeekBar seekbar,
-                                          final int progress,
-                                          final boolean fromUser) {
-                final int newProgress = progress + 1;
-                prefs.edit().putInt(getString(R.string.default_download_threads), newProgress)
-                        .apply();
-                dialogBinding.threadsCount.setText(String.valueOf(newProgress));
-            }
-        });
-
         fetchStreamsSize();
     }
 
@@ -590,8 +573,6 @@ public class DownloadDialog extends DialogFragment
                 flag = false;
                 break;
         }
-
-        dialogBinding.threads.setEnabled(flag);
     }
 
     @Override
@@ -1051,7 +1032,7 @@ public class DownloadDialog extends DialogFragment
         final Stream selectedStream;
         Stream secondaryStream = null;
         final char kind;
-        int threads = dialogBinding.threads.getProgress() + 1;
+        int threads = 4;
         final String[] urls;
         final List<MissionRecoveryInfo> recoveryInfo;
         String psName = null;
@@ -1134,8 +1115,18 @@ public class DownloadDialog extends DialogFragment
             );
         }
 
-        DownloadManagerService.startMission(context, urls, storage, kind, threads,
-                currentInfo.getUrl(), psName, psArgs, nearLength, new ArrayList<>(recoveryInfo));
+        DownloadManagerService.startMission(
+                context,
+                urls,
+                storage,
+                kind,
+                threads,
+                currentInfo.getUrl(),
+                psName,
+                psArgs,
+                nearLength,
+                new ArrayList<>(recoveryInfo)
+        );
 
         Toast.makeText(context, getString(R.string.download_has_started),
                 Toast.LENGTH_SHORT).show();

--- a/app/src/main/res/layout/download_dialog.xml
+++ b/app/src/main/res/layout/download_dialog.xml
@@ -106,46 +106,9 @@
         android:textSize="12sp" />
 
     <org.schabi.newpipe.views.NewPipeTextView
-        android:id="@+id/threads_text_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@+id/audio_track_present_in_video_text"
-        android:layout_marginLeft="24dp"
-        android:layout_marginRight="24dp"
-        android:layout_marginBottom="6dp"
-        android:text="@string/msg_threads" />
-
-    <LinearLayout
-        android:id="@+id/threads_layout"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_below="@+id/threads_text_view"
-        android:layout_marginLeft="24dp"
-        android:layout_marginRight="24dp"
-        android:layout_marginBottom="12dp"
-        android:orientation="horizontal">
-
-        <org.schabi.newpipe.views.NewPipeTextView
-            android:id="@+id/threads_count"
-            android:layout_width="25dp"
-            android:layout_height="match_parent"
-            android:gravity="center_vertical"
-            android:paddingLeft="2dp"
-            tools:ignore="RtlHardcoded,RtlSymmetry"
-            tools:text="3" />
-
-        <SeekBar
-            android:id="@+id/threads"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:max="31"
-            android:progress="3" />
-    </LinearLayout>
-
-    <org.schabi.newpipe.views.NewPipeTextView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_below="@+id/threads_layout"
         android:layout_marginLeft="24dp"
         android:layout_marginRight="24dp"
         android:layout_marginBottom="12dp"

--- a/app/src/main/res/values-ar-rLY/strings.xml
+++ b/app/src/main/res/values-ar-rLY/strings.xml
@@ -634,7 +634,6 @@
     <string name="recent">حديثة</string>
     <string name="subscription_update_failed">تعذر تحديث الاشتراك</string>
     <string name="clear_queue_confirmation_description">سيتم استبدال قائمة انتظار للمشغل النشط</string>
-    <string name="msg_threads">التقسيم</string>
     <string name="subscribe_button_title">اشتراك</string>
     <string name="channel_created_by">أنشأها %s</string>
     <string name="settings_file_replacement_character_title">الحرف الإستبدالي</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -136,7 +136,6 @@
     <string name="checksum">التوقيع</string>
     <string name="ok">موافق</string>
     <string name="msg_name">اسم الملف</string>
-    <string name="msg_threads">التقسيم</string>
     <string name="msg_error">الخطأ</string>
     <string name="msg_running">يقوم نيوبايب بالتنزيل</string>
     <string name="msg_running_detail">انقر للحصول على التفاصيل</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -584,7 +584,6 @@
     <string name="msg_popup_permission">Bu icazə, ani görüntü rejimində
 \naçmaq üçün lazımdır</string>
     <string name="msg_copied">Buferə kopyalandı</string>
-    <string name="msg_threads">Parçalar</string>
     <string name="rename">Adını dəyişdir</string>
     <string name="create">Yarat</string>
     <plurals name="subscribers">

--- a/app/src/main/res/values-b+ast/strings.xml
+++ b/app/src/main/res/values-b+ast/strings.xml
@@ -36,7 +36,6 @@
     <string name="delete">Desaniciar</string>
     <string name="checksum">Suma de comprobación</string>
     <string name="ok">Aceutar</string>
-    <string name="msg_threads">Filos</string>
     <string name="msg_error">Fallu</string>
     <string name="msg_wait">Espera…</string>
     <string name="msg_copied">Copióse al cartafueyu</string>

--- a/app/src/main/res/values-b+uz+Latn/strings.xml
+++ b/app/src/main/res/values-b+uz+Latn/strings.xml
@@ -227,7 +227,6 @@
     <string name="msg_running_detail">Tafsilotlar uchun bosing</string>
     <string name="msg_running">NePipe yuklab olinmoqda</string>
     <string name="msg_error">Xato</string>
-    <string name="msg_threads">Iplar</string>
     <string name="msg_name">Faylnomi</string>
     <string name="ok">Ok</string>
     <string name="rename">Nomni o\'zgartirish</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -190,7 +190,6 @@
     <string name="rename">Перайменаваць</string>
     <string name="ok">ОК</string>
     <string name="msg_name">Імя файла</string>
-    <string name="msg_threads">Патокі</string>
     <string name="msg_error">Памылка</string>
     <string name="msg_running">NewPipe спампоўвае</string>
     <string name="msg_running_detail">Падрабязнасці</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -129,7 +129,6 @@
     <string name="checksum">Контролна сума</string>
     <string name="ok">ОК</string>
     <string name="msg_name">Име на файла</string>
-    <string name="msg_threads">Нишки</string>
     <string name="msg_error">Грешка</string>
     <string name="msg_running">NewPipe Изтегляне</string>
     <string name="msg_running_detail">Докосни за подробности</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -94,7 +94,6 @@
     <string name="ok">ঠিক আছে</string>
     <!-- Msg -->
     <string name="msg_name">ফাইলের নাম</string>
-    <string name="msg_threads">থ্রেড</string>
     <string name="msg_error">ত্রুটি</string>
     <string name="msg_running">NewPipe ডাউনলোড হচ্ছে</string>
     <string name="msg_running_detail">বিস্তারিত জানার জন্য আলতো চাপ</string>

--- a/app/src/main/res/values-bn-rIN/strings.xml
+++ b/app/src/main/res/values-bn-rIN/strings.xml
@@ -16,7 +16,6 @@
     <string name="msg_running_detail">বিস্তারিত জানার জন্য আলতো চাপ</string>
     <string name="msg_running">NewPipe ডাউনলোড হচ্ছে</string>
     <string name="msg_error">ত্রুটি</string>
-    <string name="msg_threads">থ্রেড</string>
     <string name="msg_name">ফাইলের নাম</string>
     <string name="ok">ঠিক আছে</string>
     <string name="rename">নাম পরিবর্তন করুন</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -90,7 +90,6 @@
     <string name="msg_running_detail">বিস্তারিত জানার জন্য আলতো চাপ</string>
     <string name="msg_running">NewPipe ডাউনলোড হচ্ছে</string>
     <string name="msg_error">ত্রুটি</string>
-    <string name="msg_threads">থ্রেড</string>
     <string name="msg_name">ফাইলের নাম</string>
     <string name="ok">ঠিক আছে</string>
     <string name="rename">নাম পরিবর্তন করুন</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -182,7 +182,6 @@
     <string name="checksum">Suma de verificació</string>
     <string name="dismiss">Tanca</string>
     <string name="rename">Canvia el nom</string>
-    <string name="msg_threads">Fils</string>
     <string name="msg_running">Baixada del NewPipe activa</string>
     <string name="msg_wait">Un moment…</string>
     <string name="msg_copied">S\'ha copiat al porta-retalls</string>

--- a/app/src/main/res/values-ckb/strings.xml
+++ b/app/src/main/res/values-ckb/strings.xml
@@ -100,7 +100,6 @@
     <string name="title_licenses">مۆڵەتنامەی لایەنی-سێیەم</string>
     <string name="app_license_title">مۆڵەتنامەی نیوپایپ</string>
     <string name="show_hold_to_append_title">پیشاندانی ڕێنمایی ”داگرتن تا پاشکۆ”</string>
-    <string name="msg_threads">دابەشکراوەکان</string>
     <string name="title_most_played">زۆرترین لێدراو</string>
     <string name="unbookmark_playlist">لادانی نیشانه‌كراو</string>
     <string name="tab_licenses">مۆڵەتەکان</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -55,7 +55,6 @@
     <string name="msg_running_detail">Klepněte pro podrobnosti</string>
     <string name="msg_error">Chyba</string>
     <string name="msg_name">Jméno souboru</string>
-    <string name="msg_threads">Vlákna</string>
     <string name="pause">Zastavit</string>
     <string name="delete">Smazat</string>
     <string name="start">Start</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -188,7 +188,6 @@
     <string name="rename">Omdøb</string>
     <string name="ok">OK</string>
     <string name="msg_name">Filnavn</string>
-    <string name="msg_threads">Tråde</string>
     <string name="msg_error">Fejl</string>
     <string name="msg_running">NewPiper downloader</string>
     <string name="msg_running_detail">Tryk for detaljer</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -81,7 +81,6 @@
     <string name="pause">Pause</string>
     <string name="ok">OK</string>
     <string name="app_ui_crash">App/UI abgestürzt</string>
-    <string name="msg_threads">Threads</string>
     <string name="msg_running">NewPipe lädt herunter</string>
     <string name="msg_running_detail">Für Details antippen</string>
     <string name="black_theme_title">Schwarz</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -193,7 +193,6 @@
     <string name="rename">Μετονομασία</string>
     <string name="ok">Εντάξει</string>
     <string name="msg_name">Όνομα αρχείου</string>
-    <string name="msg_threads">Νήματα</string>
     <string name="msg_running">Λήψη NewPipe</string>
     <string name="msg_wait">Παρακαλώ περιμένετε…</string>
     <string name="msg_copied">Αντιγράφηκε στο πρόχειρο</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -250,7 +250,6 @@
     <string name="checksum">Kontrolsumo</string>
     <string name="ok">Bone</string>
     <string name="msg_name">Dosiernomo</string>
-    <string name="msg_threads">Fadenoj</string>
     <string name="msg_error">Eraro</string>
     <string name="msg_running">NewPipe estas elŝutanta</string>
     <string name="msg_running_detail">Premu por detaladoj</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -70,7 +70,6 @@
     <string name="checksum">Suma de comprobación</string>
     <string name="ok">Aceptar</string>
     <string name="msg_name">Nombre del archivo</string>
-    <string name="msg_threads">Subprocesos</string>
     <string name="msg_error">Error</string>
     <string name="msg_running">NewPipe está descargando</string>
     <string name="msg_running_detail">Toca para ver detalles</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -181,7 +181,6 @@
     <string name="rename">Nimeta ümber</string>
     <string name="ok">OK</string>
     <string name="msg_name">Faili nimi</string>
-    <string name="msg_threads">Lõimed</string>
     <string name="msg_error">Viga</string>
     <string name="msg_running">NewPipe allalaadimine</string>
     <string name="msg_running_detail">Üksikasjade nägemiseks toksa</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -93,7 +93,6 @@
     <string name="checksum">Egiaztaketa-batura</string>
     <string name="ok">Ados</string>
     <string name="msg_name">Fitxategi-izena</string>
-    <string name="msg_threads">Hariak</string>
     <string name="msg_error">Errorea</string>
     <string name="msg_running">NewPipe deskargatzen</string>
     <string name="msg_running_detail">Ukitu xehetasunetarako</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -70,7 +70,6 @@
     <string name="checksum">مجموع مقابله‌ای</string>
     <string name="ok">قبول</string>
     <string name="msg_name">نام پرونده</string>
-    <string name="msg_threads">رشته‌ها</string>
     <string name="msg_error">خطا</string>
     <string name="msg_running">نیوپایپ در حال بارگیری است</string>
     <string name="msg_running_detail">برای جزییات، ضربه بزنید</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -126,7 +126,6 @@
     <string name="checksum">Tarkistussumma</string>
     <string name="ok">OK</string>
     <string name="msg_name">Tiedostonimi</string>
-    <string name="msg_threads">Säikeet</string>
     <string name="msg_error">Virhe</string>
     <string name="msg_running">NewPipe Lataus käynnissä</string>
     <string name="msg_running_detail">Napauta nähdäksesi lisää</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -72,7 +72,6 @@
     <string name="checksum">Somme de contrôle</string>
     <string name="ok">OK</string>
     <string name="msg_name">Nom du fichier</string>
-    <string name="msg_threads">Connexions simultanées</string>
     <string name="msg_error">Erreur</string>
     <string name="msg_running">NewPipe télécharge</string>
     <string name="msg_running_detail">Appuyer pour plus de détails</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -185,7 +185,6 @@
     <string name="rename">Renomear</string>
     <string name="ok">OK</string>
     <string name="msg_name">Nome do ficheiro</string>
-    <string name="msg_threads">Fios</string>
     <string name="msg_error">Erro</string>
     <string name="msg_running">Descarga do NewPipe</string>
     <string name="msg_running_detail">Toque para ver detalles</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -142,7 +142,6 @@
     <string name="checksum">גיבוב לאימות</string>
     <string name="ok">אישור</string>
     <string name="msg_name">שם קובץ</string>
-    <string name="msg_threads">תהליכי משנה</string>
     <string name="msg_error">שגיאה</string>
     <string name="msg_running">NewPipe בהורדה</string>
     <string name="msg_running_detail">יש לגעת לפרטים נוספים</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -148,7 +148,6 @@
     <string name="checksum">चेकसम</string>
     <string name="ok">ठीक है</string>
     <string name="msg_name">फाइल का नाम</string>
-    <string name="msg_threads">थ्रेड्स</string>
     <string name="msg_error">त्रुटी</string>
     <string name="msg_running">न्यूपाइप डाउनलोड कर रही है</string>
     <string name="msg_running_detail">विवरण के लिए टैप करें</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -106,7 +106,6 @@
     <string name="checksum">Kontrolni zbroj</string>
     <string name="ok">U redu</string>
     <string name="msg_name">Naziv datoteke</string>
-    <string name="msg_threads">Komponente procesa</string>
     <string name="msg_error">Greška</string>
     <string name="msg_running">NewPipe preuzimanje</string>
     <string name="msg_running_detail">Dodirni za prikaz detalja</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -70,7 +70,6 @@
     <string name="checksum">Ellenőrzőösszeg</string>
     <string name="ok">Rendben</string>
     <string name="msg_name">Fájlnév</string>
-    <string name="msg_threads">Szálak</string>
     <string name="msg_error">Hiba</string>
     <string name="msg_running">NewPipe letöltés folyamatban</string>
     <string name="msg_running_detail">Koppintson a részletekért</string>

--- a/app/src/main/res/values-hy/strings.xml
+++ b/app/src/main/res/values-hy/strings.xml
@@ -204,7 +204,6 @@
     <string name="app_language_title">Ափփի լեզու</string>
     <string name="notification_action_nothing">Ոչինչ</string>
     <string name="no_subscribers">Առանց հետևորդ</string>
-    <string name="msg_threads">Հոսքեր</string>
     <string name="add_to_playlist">Ավելացնել նվագացանկին</string>
     <string name="caption_none">Անենթագիր</string>
     <string name="caption_setting_title">Ենթագրեր</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -77,7 +77,6 @@
     <string name="no_player_found">Pemutar stream tidak ada. Pasang VLC?</string>
     <string name="app_ui_crash">App/UI rusak</string>
     <string name="info_labels">Apa:\\nPermintaan:\\nBahasa Konten:\\nNegara Konten:\\nBahasa Apl:\\nLayanan:\\nWaktu GMT:\\nPaket:\\nVersi:\\nVersi OS:</string>
-    <string name="msg_threads">Thread</string>
     <string name="title_activity_recaptcha">Tantangan reCAPTCHA</string>
     <string name="recaptcha_request_toast">Meminta kode reCAPTCHA</string>
     <string name="black_theme_title">Hitam</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -243,7 +243,6 @@
     <string name="no_comments">Engin ummæli</string>
     <string name="comments_are_disabled">Ummæli eru óvirk</string>
     <string name="checksum">Gátsumma</string>
-    <string name="msg_threads">Þræðir</string>
     <string name="msg_error">Villa</string>
     <string name="msg_running_detail">Pikkaðu á til að fá nánari upplýsingar</string>
     <string name="msg_wait">Bíddu aðeins…</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -70,7 +70,6 @@
     <string name="checksum">Checksum</string>
     <string name="ok">OK</string>
     <string name="msg_name">Nome del file</string>
-    <string name="msg_threads">Thread</string>
     <string name="msg_error">Errore</string>
     <string name="msg_running">NewPipe sta scaricando</string>
     <string name="msg_running_detail">Tocca per maggiori dettagli</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -67,7 +67,6 @@
     <string name="checksum">チェックサム</string>
     <string name="ok">OK</string>
     <string name="msg_name">ファイル名</string>
-    <string name="msg_threads">同時接続数</string>
     <string name="msg_error">エラー</string>
     <string name="msg_running">ダウンロード中 (NewPipe)</string>
     <string name="msg_running_detail">タップして詳細を表示</string>

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -278,7 +278,6 @@
     <string name="pause">პაუზა</string>
     <string name="rename">გადარქმევა</string>
     <string name="msg_name">ფაილის სახელი</string>
-    <string name="msg_threads">ძაფები</string>
     <string name="msg_error">შეცდომა</string>
     <string name="msg_running">NewPipe-ის ჩამოტვირთვა</string>
     <string name="msg_running_detail">შეეხეთ დეტალებისთვის</string>

--- a/app/src/main/res/values-kab/strings.xml
+++ b/app/src/main/res/values-kab/strings.xml
@@ -122,7 +122,6 @@
     <string name="share">Bḍu</string>
     <string name="donation_title">Tawsa</string>
     <string name="settings_category_debug_title">Débugger</string>
-    <string name="msg_threads">Threads</string>
     <string name="playback_pitch">Pas</string>
     <string name="systems_language">Amezwer n unagraw</string>
     <string name="rename">Snifel isem</string>

--- a/app/src/main/res/values-kmr/strings.xml
+++ b/app/src/main/res/values-kmr/strings.xml
@@ -9,7 +9,6 @@
     <string name="msg_running_detail">Ji bo hûrguliyan tap bikin</string>
     <string name="msg_running">Daxistina NewPipe</string>
     <string name="msg_error">Şaşî</string>
-    <string name="msg_threads">Mijar</string>
     <string name="msg_name">Navê pelê</string>
     <string name="ok">Baş e</string>
     <string name="rename">Navlêkirin</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -130,7 +130,6 @@
     <string name="no_videos">비디오 없음</string>
     <string name="ok">OK</string>
     <string name="msg_name">파일명</string>
-    <string name="msg_threads">스레드</string>
     <string name="msg_error">오류</string>
     <string name="msg_running">NewPipe 다운로드 중</string>
     <string name="msg_running_detail">터치해서 상세 정보 확인</string>

--- a/app/src/main/res/values-ku/strings.xml
+++ b/app/src/main/res/values-ku/strings.xml
@@ -160,7 +160,6 @@
     <string name="rename">ناو لێنانەوە</string>
     <string name="ok">باشە</string>
     <string name="msg_name">ناوی فایل</string>
-    <string name="msg_threads">دابەشکراوەکان</string>
     <string name="msg_error">کێشە ڕوویدا</string>
     <string name="msg_running">دابەزاندنەکانی ئەپ</string>
     <string name="msg_running_detail">کرتە بکە بۆ وردەکاری</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -100,7 +100,6 @@
     <string name="checksum">Kontrolinė suma</string>
     <string name="ok">Gerai</string>
     <string name="msg_name">Failo pavadinimas</string>
-    <string name="msg_threads">Gijos</string>
     <string name="msg_error">Klaida</string>
     <string name="msg_running">NewPipe atsisiunčiama</string>
     <string name="msg_running_detail">Bakstelėkite, kad peržiūrėtumėte išsamią informaciją</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -91,7 +91,6 @@
     <string name="msg_running_detail">Nospiediet priekš detaļām</string>
     <string name="msg_running">NewPipe lejupielādē</string>
     <string name="msg_error">Kļūda</string>
-    <string name="msg_threads">Procesi</string>
     <string name="msg_name">Faila nosaukums</string>
     <string name="ok">OK</string>
     <string name="rename">Pārsaukt</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -173,7 +173,6 @@
     <string name="rename">Прекрсти</string>
     <string name="ok">Готово</string>
     <string name="msg_name">Име на датотека</string>
-    <string name="msg_threads">Нишки</string>
     <string name="msg_error">Грешка</string>
     <string name="msg_running">NewPipe Превземање</string>
     <string name="msg_running_detail">Притисни за детали</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -144,7 +144,6 @@
     <string name="msg_running_detail">വിശദാംശങ്ങൾക്കായി തൊടൂ</string>
     <string name="msg_running">ന്യൂപൈപ്പ് ഡൗൺലോഡിങ്ങ്</string>
     <string name="msg_error">പിശക്</string>
-    <string name="msg_threads">ത്രെഡുകൾ</string>
     <string name="msg_name">ഫയൽനാമം</string>
     <string name="ok">ഓകെ</string>
     <string name="rename">പേരുമാറ്റുക</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -193,7 +193,6 @@
     <string name="rename">Namakan semula</string>
     <string name="ok">OK</string>
     <string name="msg_name">Nama fail</string>
-    <string name="msg_threads">Thread</string>
     <string name="msg_error">Ralat</string>
     <string name="msg_running">NewPipe sedang memuat turun</string>
     <string name="msg_running_detail">Ketuk untuk butiran</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -70,7 +70,6 @@
     <string name="checksum">Sjekksum</string>
     <string name="ok">OK</string>
     <string name="msg_name">Filnavn</string>
-    <string name="msg_threads">Tråder</string>
     <string name="msg_error">Feil</string>
     <string name="msg_running">NewPipe laster ned</string>
     <string name="msg_running_detail">Trykk for detaljer</string>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -201,7 +201,6 @@
     <string name="rename">पुनः नामकरण</string>
     <string name="ok">ठिक छ</string>
     <string name="msg_name">msg</string>
-    <string name="msg_threads">सूत्रहरू</string>
     <string name="msg_error">त्रुटि</string>
     <string name="msg_running">NewPipe डाउनलोड गर्दै</string>
     <string name="msg_running_detail">विवरण लागि ट्याप गर्नुहोस्</string>

--- a/app/src/main/res/values-nl-rBE/strings.xml
+++ b/app/src/main/res/values-nl-rBE/strings.xml
@@ -174,7 +174,6 @@
     <string name="rename">Hernoemen</string>
     <string name="ok">Oké</string>
     <string name="msg_name">Bestandsnaam</string>
-    <string name="msg_threads">Threads</string>
     <string name="msg_error">Fout</string>
     <string name="msg_running">NewPipe is aan het downloaden</string>
     <string name="msg_running_detail">Tik voor meer informatie</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -72,7 +72,6 @@
     <string name="checksum">Controlesom</string>
     <string name="ok">Oké</string>
     <string name="msg_name">Bestandsnaam</string>
-    <string name="msg_threads">Threads</string>
     <string name="msg_error">Fout</string>
     <string name="msg_running">NewPipe is aan het downloaden</string>
     <string name="msg_running_detail">Druk voor meer informatie</string>

--- a/app/src/main/res/values-nqo/strings.xml
+++ b/app/src/main/res/values-nqo/strings.xml
@@ -305,7 +305,6 @@
     <string name="dismiss">ߞߵߊ߬ ߟߊߓߌ߬ߟߊ߬</string>
     <string name="rename">ߞߵߊ߬ ߕߐ߯ߟߊ߫</string>
     <string name="msg_name">ߞߐߕߐ߯ ߕߐ߮</string>
-    <string name="msg_threads">ߜߊ߲߬ߞߎ߲߬ߠߌ߲߫ ߢߐ߲߰ߝߍ</string>
     <string name="msg_error">ߝߎ߬ߕߎ߲߬ߕߌ</string>
     <string name="msg_running">ߣߌߎߔߌߔ ߦߋ߫ ߟߊ߬ߖߌ߰ߟߌ ߟߊ߫</string>
     <string name="msg_running_detail">ߊ߬ ߛߐ߲߬ߞߌ߲߫ ߞߵߊ߬ ߕߐ߬ߝߍ߬ߦߊ߫</string>

--- a/app/src/main/res/values-or/strings.xml
+++ b/app/src/main/res/values-or/strings.xml
@@ -297,7 +297,6 @@
     <string name="checksum">ଚେକ୍ସମ୍</string>
     <string name="dismiss">ବରଖାସ୍ତ</string>
     <string name="msg_name">ଦସ୍ତାବିଜ୍ ର ନାମ</string>
-    <string name="msg_threads">ଥ୍ରେଡ୍</string>
     <string name="msg_error">ତ୍ରୁଟି</string>
     <string name="msg_running">ନୂତନ ପାଇପ୍ ଡାଉନଲୋଡ୍ କରୁଛି</string>
     <string name="msg_calculating_hash">ହ୍ୟାସ୍ ଗଣନା</string>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -180,7 +180,6 @@
     <string name="rename">ਨਾਮ ਬਦਲੋ</string>
     <string name="ok">ਠੀਕ ਹੈ</string>
     <string name="msg_name">ਫਾਈਲ ਦਾ ਨਾਮ</string>
-    <string name="msg_threads">ਥਰੈੱਡ</string>
     <string name="msg_error">ਤਰੁੱਟੀ</string>
     <string name="msg_running">ਨਿਊਪਾਈਪ ਡਾਊਨਲੋਡ ਕਰ ਰਹੀ ਹੈ</string>
     <string name="msg_running_detail">ਵੇਰਵਿਆਂ ਲਈ ਟੈਪ ਕਰੋ</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -70,7 +70,6 @@
     <string name="checksum">Suma kontrolna</string>
     <string name="ok">OK</string>
     <string name="msg_name">Nazwa pliku</string>
-    <string name="msg_threads">Wątki</string>
     <string name="msg_error">Błąd</string>
     <string name="msg_running">Pobieranie NewPipe</string>
     <string name="msg_running_detail">Naciśnij, aby zobaczyć szczegóły</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -70,7 +70,6 @@
     <string name="download_path_title">Pasta para vídeos baixados</string>
     <string name="kore_not_found">Instalar o aplicativo Kore\?</string>
     <string name="main_bg_subtitle">Toque na lupa para começar.</string>
-    <string name="msg_threads">Threads</string>
     <string name="no_available_dir">Por favor, defina uma pasta de download depois nas configurações</string>
     <string name="no_player_found">Sem reprodutor de transmissão. Instalar VLC?</string>
     <string name="parsing_error">O site não pôde ser analisado</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -7,7 +7,6 @@
 \nDeseja continuar\?</string>
     <string name="main_bg_subtitle">Toque na lupa para começar.</string>
     <string name="enable_playback_resume_title">Continuar reprodução</string>
-    <string name="msg_threads">Processos</string>
     <string name="settings_file_replacement_character_summary">Os carateres inválidos são substituídos por este valor</string>
     <string name="download">Descarregar</string>
     <string name="use_external_video_player_summary">Remove o áudio em algumas resoluções</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -75,7 +75,6 @@
     <string name="msg_copied">Copiado para a área de transferência</string>
     <string name="no_available_dir">Tem que definir, nas definições, uma pasta para as descargas</string>
     <string name="ok">OK</string>
-    <string name="msg_threads">Processos</string>
     <string name="msg_running">Descarga NewPipe</string>
     <string name="app_ui_crash">Aplicação terminou em erro</string>
     <string name="info_labels">O quê:\\nPedido:\\nIdioma do conteúdo:\\nPaís do conteúdo\\nIdioma da aplicação\\nServiço:\\nHora GMT:\\nPacote:\\nVersão:\\nSO Versão:</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -70,7 +70,6 @@
     <string name="checksum">Suma de control</string>
     <string name="ok">OK</string>
     <string name="msg_name">Numele fișierului</string>
-    <string name="msg_threads">Fire</string>
     <string name="msg_error">Eroare</string>
     <string name="msg_running">NewPipe descarcă</string>
     <string name="msg_running_detail">Atingeți pentru detalii</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -43,7 +43,6 @@
     <string name="download_path_audio_dialog_title">Введите путь к папке для скачивания аудио</string>
     <string name="main_bg_subtitle">Нажмите на лупу, чтобы начать.</string>
     <string name="msg_wait">Подождите…</string>
-    <string name="msg_threads">Потоки</string>
     <string name="ok">ОК</string>
     <string name="start">Начать</string>
     <string name="pause">Пауза</string>

--- a/app/src/main/res/values-ryu/strings.xml
+++ b/app/src/main/res/values-ryu/strings.xml
@@ -67,7 +67,6 @@
     <string name="checksum">チェックサム</string>
     <string name="ok">OK</string>
     <string name="msg_name">ファイルめい</string>
-    <string name="msg_threads">どうじらしみーちずくすん</string>
     <string name="msg_error">エラー</string>
     <string name="msg_running">ダウンロードちゅう（NewPipe）</string>
     <string name="msg_running_detail">タップししーょうさいをひょうじ</string>

--- a/app/src/main/res/values-sc/strings.xml
+++ b/app/src/main/res/values-sc/strings.xml
@@ -126,7 +126,6 @@
     <string name="msg_running_detail">Toca pro detàllios</string>
     <string name="msg_running">NewPipe est iscarrighende</string>
     <string name="msg_error">Errore</string>
-    <string name="msg_threads">Connessiones simultàneas</string>
     <string name="msg_name">Nùmene de su documentu</string>
     <string name="ok">AB</string>
     <string name="rename">Càmbia de nùmene</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -67,7 +67,6 @@
     <string name="checksum">Kontrolný súčet</string>
     <string name="ok">OK</string>
     <string name="msg_name">Názov súboru</string>
-    <string name="msg_threads">Vlákna</string>
     <string name="msg_error">Chyba</string>
     <string name="msg_running">NewPipe Preberanie</string>
     <string name="msg_running_detail">Dotykom zobraziť detaily</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -66,7 +66,6 @@
     <string name="delete">Izbriši</string>
     <string name="checksum">Nadzorna vsota</string>
     <string name="msg_name">Ime datoteke</string>
-    <string name="msg_threads">Nizi</string>
     <string name="msg_error">Napaka</string>
     <string name="msg_running">Prejemanje</string>
     <string name="msg_running_detail">Podrobnosti</string>

--- a/app/src/main/res/values-so/strings.xml
+++ b/app/src/main/res/values-so/strings.xml
@@ -203,7 +203,6 @@
     <string name="msg_running_detail">Faahfaahinta kusii dhufo</string>
     <string name="msg_running">NewPipe wuu dajinayaa</string>
     <string name="msg_error">Khalad</string>
-    <string name="msg_threads">Qaybaha</string>
     <string name="msg_name">Magaca shayga</string>
     <string name="ok">Hagaag</string>
     <string name="rename">Magaca ka baddal</string>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -268,7 +268,6 @@
     <string name="msg_running_detail">Shtyp për detajet</string>
     <string name="msg_running">NewPipe duke shkarkuar</string>
     <string name="msg_error">Gabim</string>
-    <string name="msg_threads">Veprimet paralele</string>
     <string name="msg_name">Emri i skedarit</string>
     <string name="ok">OK</string>
     <string name="rename">Riemërto</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -67,7 +67,6 @@
     <string name="checksum">Контролна сума</string>
     <string name="ok">У реду</string>
     <string name="msg_name">Назив фајла</string>
-    <string name="msg_threads">Нити</string>
     <string name="msg_error">Грешка</string>
     <string name="msg_running">NewPipe преузима</string>
     <string name="msg_running_detail">Додирните за детаље</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -136,7 +136,6 @@
     <string name="checksum">Kontrollsumma</string>
     <string name="ok">Okej</string>
     <string name="msg_name">Filnamn</string>
-    <string name="msg_threads">Trådar</string>
     <string name="msg_error">Fel</string>
     <string name="msg_running">NewPipe-hämtning</string>
     <string name="msg_running_detail">Tryck för detaljer</string>

--- a/app/src/main/res/values-te/strings.xml
+++ b/app/src/main/res/values-te/strings.xml
@@ -100,7 +100,6 @@
     <string name="delete">తొలగించు</string>
     <string name="ok">అలాగే</string>
     <string name="msg_name">ఫైలుపేరు</string>
-    <string name="msg_threads">థ్రెడ్లు</string>
     <string name="msg_error">లోపం</string>
     <string name="msg_running">న్యూపిప్ డౌన్లోడ్ అవుతంది</string>
     <string name="msg_running_detail">వివరాల కోసం నొక్కండి</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -69,7 +69,6 @@
     <string name="checksum">Doğrulama</string>
     <string name="ok">Tamam</string>
     <string name="msg_name">Dosya adı</string>
-    <string name="msg_threads">İş parçacığı</string>
     <string name="msg_error">Hata</string>
     <string name="msg_running">NewPipe İndiriliyor</string>
     <string name="msg_running_detail">Ayrıntılar için dokunun</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -74,7 +74,6 @@
     <string name="checksum">Контрольна сума</string>
     <string name="ok">Гаразд</string>
     <string name="msg_name">Назва файлу</string>
-    <string name="msg_threads">Потоки</string>
     <string name="msg_error">Помилка</string>
     <string name="msg_running">NewPipe завантажує</string>
     <string name="msg_running_detail">Деталі</string>

--- a/app/src/main/res/values-ur/strings.xml
+++ b/app/src/main/res/values-ur/strings.xml
@@ -173,7 +173,6 @@
     <string name="rename">نام تبدیل کریں</string>
     <string name="ok">ٹھيک ہے</string>
     <string name="msg_name">فائل کا نام</string>
-    <string name="msg_threads">موضوعات</string>
     <string name="msg_error">خرابی</string>
     <string name="msg_running">نیو پائپ ڈاؤن لوڈ ہو رہا ہے</string>
     <string name="msg_running_detail">تفصیلات کے لیے ٹیپ کریں</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -91,7 +91,6 @@
     <string name="checksum">Mã tổng kiểm (checksum)</string>
     <string name="ok">OK</string>
     <string name="msg_name">Tên file</string>
-    <string name="msg_threads">Chủ đề</string>
     <string name="msg_error">Lỗi</string>
     <string name="msg_running">NewPipe đang tải xuống</string>
     <string name="msg_running_detail">Chạm để biết chi tiết</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -79,7 +79,6 @@
     <string name="checksum">校验</string>
     <string name="ok">确定</string>
     <string name="msg_name">文件名</string>
-    <string name="msg_threads">线程数</string>
     <string name="msg_error">错误</string>
     <string name="msg_running_detail">点击了解详情</string>
     <string name="msg_wait">请稍候…</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -70,7 +70,6 @@
     <string name="checksum">校驗碼</string>
     <string name="ok">好</string>
     <string name="msg_name">檔案名稱</string>
-    <string name="msg_threads">執行緒數量</string>
     <string name="msg_error">錯誤</string>
     <string name="msg_running">NewPipe 下載緊</string>
     <string name="msg_running_detail">撳一下睇詳情</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -91,7 +91,6 @@
     <string name="checksum">檢查碼</string>
     <string name="ok">確定</string>
     <string name="msg_name">檔案名稱</string>
-    <string name="msg_threads">執行緒數目</string>
     <string name="msg_error">錯誤</string>
     <string name="msg_running">NewPipe 下載中</string>
     <string name="msg_running_detail">輕觸以顯示詳細資訊</string>

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -457,8 +457,6 @@
     <string name="downloads_cross_network">cross_network_downloads</string>
     <string name="downloads_queue_limit">downloads_queue_limit</string>
 
-    <string name="default_download_threads">default_download_threads</string>
-
     <!-- Preferred action on open (open from external app) -->
     <string name="preferred_open_action_key">preferred_open_action_key</string>
     <string name="preferred_open_action_default">@string/always_ask_open_action_key</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -332,7 +332,6 @@
     <string name="rename">Rename</string>
     <!-- Msg -->
     <string name="msg_name">Filename</string>
-    <string name="msg_threads">Threads</string>
     <string name="msg_error">Error</string>
     <string name="msg_running">NewPipe Downloading</string>
     <string name="msg_running_detail">Tap for details</string>


### PR DESCRIPTION
Exposing the number of download threads to users does not provide any value, because how should a user know how to set this value or what it means.

Instead, we just set the default to 4 threads for now (the previous default), with the possibility of improving the default later (e.g. depending on other running downloads or device speed).

#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR

![image](https://github.com/TeamNewPipe/NewPipe/assets/3153638/e35f91a7-1910-4b9f-9bfa-47781c89746e)

^ removes the threads slider on the bottom of the download popup

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
