### PR TITLE
BaseDescriptionFragment: Assert member is initialized

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/BaseDescriptionFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/BaseDescriptionFragment.java
@@ -64,7 +64,7 @@ public abstract class BaseDescriptionFragment extends BaseFragment {
 
     /**
      * Get the description to display.
-     * @return description object
+     * @return description object, if available
      */
     @Nullable
     protected abstract Description getDescription();
@@ -73,7 +73,7 @@ public abstract class BaseDescriptionFragment extends BaseFragment {
      * Get the streaming service. Used for generating description links.
      * @return streaming service
      */
-    @Nullable
+    @NonNull
     protected abstract StreamingService getService();
 
     /**
@@ -93,7 +93,7 @@ public abstract class BaseDescriptionFragment extends BaseFragment {
      * Get the list of tags to display below the description.
      * @return tag list
      */
-    @Nullable
+    @NonNull
     public abstract List<String> getTags();
 
     /**
@@ -158,7 +158,7 @@ public abstract class BaseDescriptionFragment extends BaseFragment {
                                    final LinearLayout layout,
                                    final boolean linkifyContent,
                                    @StringRes final int type,
-                                   @Nullable final String content) {
+                                   @NonNull final String content) {
         if (isBlank(content)) {
             return;
         }
@@ -221,16 +221,12 @@ public abstract class BaseDescriptionFragment extends BaseFragment {
                 urls.append(imageSizeToText(image.getWidth()));
             } else {
                 switch (image.getEstimatedResolutionLevel()) {
-                    case LOW:
-                        urls.append(getString(R.string.image_quality_low));
-                        break;
-                    default: // unreachable, Image.ResolutionLevel.UNKNOWN is already filtered out
-                    case MEDIUM:
-                        urls.append(getString(R.string.image_quality_medium));
-                        break;
-                    case HIGH:
-                        urls.append(getString(R.string.image_quality_high));
-                        break;
+                    case LOW -> urls.append(getString(R.string.image_quality_low));
+                    case MEDIUM -> urls.append(getString(R.string.image_quality_medium));
+                    case HIGH -> urls.append(getString(R.string.image_quality_high));
+                    default -> {
+                        // unreachable, Image.ResolutionLevel.UNKNOWN is already filtered out
+                    }
                 }
             }
 
@@ -255,7 +251,7 @@ public abstract class BaseDescriptionFragment extends BaseFragment {
     private void addTagsMetadataItem(final LayoutInflater inflater, final LinearLayout layout) {
         final List<String> tags = getTags();
 
-        if (tags != null && !tags.isEmpty()) {
+        if (!tags.isEmpty()) {
             final var itemBinding = ItemMetadataTagsBinding.inflate(inflater, layout, false);
 
             tags.stream().sorted(String.CASE_INSENSITIVE_ORDER).forEach(tag -> {

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/DescriptionFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/DescriptionFragment.java
@@ -7,6 +7,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.LinearLayout;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 
@@ -23,10 +24,8 @@ import icepick.State;
 public class DescriptionFragment extends BaseDescriptionFragment {
 
     @State
-    StreamInfo streamInfo = null;
+    StreamInfo streamInfo;
 
-    public DescriptionFragment() {
-    }
 
     public DescriptionFragment(final StreamInfo streamInfo) {
         this.streamInfo = streamInfo;
@@ -35,44 +34,29 @@ public class DescriptionFragment extends BaseDescriptionFragment {
     @Nullable
     @Override
     protected Description getDescription() {
-        if (streamInfo == null) {
-            return null;
-        }
         return streamInfo.getDescription();
     }
 
-    @Nullable
+    @NonNull
     @Override
     protected StreamingService getService() {
-        if (streamInfo == null) {
-            return null;
-        }
         return streamInfo.getService();
     }
 
     @Override
     protected int getServiceId() {
-        if (streamInfo == null) {
-            return -1;
-        }
         return streamInfo.getServiceId();
     }
 
-    @Nullable
+    @NonNull
     @Override
     protected String getStreamUrl() {
-        if (streamInfo == null) {
-            return null;
-        }
         return streamInfo.getUrl();
     }
 
-    @Nullable
+    @NonNull
     @Override
     public List<String> getTags() {
-        if (streamInfo == null) {
-            return null;
-        }
         return streamInfo.getTags();
     }
 

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/DescriptionFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/DescriptionFragment.java
@@ -26,10 +26,10 @@ public class DescriptionFragment extends BaseDescriptionFragment {
     @State
     StreamInfo streamInfo;
 
-
     public DescriptionFragment(final StreamInfo streamInfo) {
         this.streamInfo = streamInfo;
     }
+
 
     @Nullable
     @Override

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelAboutFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelAboutFragment.java
@@ -2,12 +2,12 @@ package org.schabi.newpipe.fragments.list.channel;
 
 import static org.schabi.newpipe.extractor.stream.StreamExtractor.UNKNOWN_SUBSCRIBER_COUNT;
 
-import android.content.Context;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.LinearLayout;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import org.schabi.newpipe.R;
@@ -26,15 +26,12 @@ public class ChannelAboutFragment extends BaseDescriptionFragment {
     @State
     protected ChannelInfo channelInfo;
 
-    public static ChannelAboutFragment getInstance(final ChannelInfo channelInfo) {
+    public static ChannelAboutFragment getInstance(final @NonNull ChannelInfo channelInfo) {
         final ChannelAboutFragment fragment = new ChannelAboutFragment();
         fragment.channelInfo = channelInfo;
         return fragment;
     }
 
-    public ChannelAboutFragment() {
-        super();
-    }
 
     @Override
     protected void initViews(final View rootView, final Bundle savedInstanceState) {
@@ -45,26 +42,20 @@ public class ChannelAboutFragment extends BaseDescriptionFragment {
     @Nullable
     @Override
     protected Description getDescription() {
-        if (channelInfo == null) {
-            return null;
-        }
-        return new Description(channelInfo.getDescription(), Description.PLAIN_TEXT);
+        return new Description(
+                channelInfo.getDescription(),
+                Description.PLAIN_TEXT
+        );
     }
 
-    @Nullable
+    @NonNull
     @Override
     protected StreamingService getService() {
-        if (channelInfo == null) {
-            return null;
-        }
         return channelInfo.getService();
     }
 
     @Override
     protected int getServiceId() {
-        if (channelInfo == null) {
-            return -1;
-        }
         return channelInfo.getServiceId();
     }
 
@@ -74,12 +65,9 @@ public class ChannelAboutFragment extends BaseDescriptionFragment {
         return null;
     }
 
-    @Nullable
+    @NonNull
     @Override
     public List<String> getTags() {
-        if (channelInfo == null) {
-            return null;
-        }
         return channelInfo.getTags();
     }
 
@@ -93,10 +81,11 @@ public class ChannelAboutFragment extends BaseDescriptionFragment {
             return;
         }
 
-        final Context context = getContext();
         if (channelInfo.getSubscriberCount() != UNKNOWN_SUBSCRIBER_COUNT) {
             addMetadataItem(inflater, layout, false, R.string.metadata_subscribers,
-                    Localization.localizeNumber(context, channelInfo.getSubscriberCount()));
+                    Localization.localizeNumber(
+                            requireContext(),
+                            channelInfo.getSubscriberCount()));
         }
 
         addImagesMetadataItem(inflater, layout, R.string.metadata_avatars,

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelAboutFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelAboutFragment.java
@@ -26,10 +26,8 @@ public class ChannelAboutFragment extends BaseDescriptionFragment {
     @State
     protected ChannelInfo channelInfo;
 
-    public static ChannelAboutFragment getInstance(final @NonNull ChannelInfo channelInfo) {
-        final ChannelAboutFragment fragment = new ChannelAboutFragment();
-        fragment.channelInfo = channelInfo;
-        return fragment;
+    ChannelAboutFragment(@NonNull final ChannelInfo channelInfo) {
+        this.channelInfo = channelInfo;
     }
 
 
@@ -42,10 +40,7 @@ public class ChannelAboutFragment extends BaseDescriptionFragment {
     @Nullable
     @Override
     protected Description getDescription() {
-        return new Description(
-                channelInfo.getDescription(),
-                Description.PLAIN_TEXT
-        );
+        return new Description(channelInfo.getDescription(), Description.PLAIN_TEXT);
     }
 
     @NonNull

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
@@ -474,7 +474,7 @@ public class ChannelFragment extends BaseStateFragment<ChannelInfo>
             if (ChannelTabHelper.showChannelTab(
                     context, preferences, R.string.show_channel_tabs_about)) {
                 tabAdapter.addFragment(
-                        ChannelAboutFragment.getInstance(currentInfo),
+                        new ChannelAboutFragment(currentInfo),
                         context.getString(R.string.channel_tab_about));
             }
         }


### PR DESCRIPTION
`streamInfo` and `channelInfo` have to be initialized, since the only way to construct the class it to pass them. So we can remove the null check boilerplate and make some of the accessors `NonNull`.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
