### PR TITLE
Ask for consent before checking for updates

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/App.java
+++ b/app/src/main/java/org/schabi/newpipe/App.java
@@ -60,6 +60,8 @@ import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 public class App extends Application {
     public static final String PACKAGE_NAME = BuildConfig.APPLICATION_ID;
     private static final String TAG = App.class.toString();
+
+    private boolean isFirstRun = false;
     private static App app;
 
     @NonNull
@@ -85,7 +87,13 @@ public class App extends Application {
             return;
         }
 
-        // Initialize settings first because others inits can use its values
+        // check if the last used preference version is set
+        // to determine whether this is the first app run
+        final int lastUsedPrefVersion = PreferenceManager.getDefaultSharedPreferences(this)
+                .getInt(getString(R.string.last_used_preferences_version), -1);
+        isFirstRun = lastUsedPrefVersion == -1;
+
+        // Initialize settings first because other initializations can use its values
         NewPipeSettings.initSettings(this);
 
         NewPipe.init(getDownloader(),
@@ -255,4 +263,7 @@ public class App extends Application {
         return false;
     }
 
+    public boolean isFirstRun() {
+        return isFirstRun;
+    }
 }

--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -79,6 +79,7 @@ import org.schabi.newpipe.player.Player;
 import org.schabi.newpipe.player.event.OnKeyDownListener;
 import org.schabi.newpipe.player.helper.PlayerHolder;
 import org.schabi.newpipe.player.playqueue.PlayQueue;
+import org.schabi.newpipe.settings.UpdateSettingsFragment;
 import org.schabi.newpipe.util.Constants;
 import org.schabi.newpipe.util.DeviceUtils;
 import org.schabi.newpipe.util.KioskTranslator;
@@ -86,6 +87,7 @@ import org.schabi.newpipe.util.Localization;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.PeertubeHelper;
 import org.schabi.newpipe.util.PermissionHelper;
+import org.schabi.newpipe.util.ReleaseVersionUtil;
 import org.schabi.newpipe.util.SerializedCache;
 import org.schabi.newpipe.util.ServiceHelper;
 import org.schabi.newpipe.util.StateSaver;
@@ -166,6 +168,11 @@ public class MainActivity extends AppCompatActivity {
             // Schedule worker for checking for new streams and creating corresponding notifications
             // if this is enabled by the user.
             NotificationWorker.initialize(this);
+        }
+        if (!UpdateSettingsFragment.wasUserAskedForConsent(this)
+                && ReleaseVersionUtil.INSTANCE.isReleaseApk()
+                && !App.getApp().isFirstRun()) {
+            UpdateSettingsFragment.askForConsentToUpdateChecks(this);
         }
     }
 

--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -183,7 +183,7 @@ public class MainActivity extends AppCompatActivity {
         final App app = App.getApp();
         final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(app);
 
-        if (prefs.getBoolean(app.getString(R.string.update_app_key), true)) {
+        if (prefs.getBoolean(app.getString(R.string.update_app_key), false)) {
             // Start the worker which is checking all conditions
             // and eventually searching for a new version.
             NewVersionWorker.enqueueNewVersionCheckingWork(app, false);

--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -170,8 +170,8 @@ public class MainActivity extends AppCompatActivity {
             NotificationWorker.initialize(this);
         }
         if (!UpdateSettingsFragment.wasUserAskedForConsent(this)
-                && ReleaseVersionUtil.INSTANCE.isReleaseApk()
-                && !App.getApp().isFirstRun()) {
+                && !App.getApp().isFirstRun()
+                && ReleaseVersionUtil.INSTANCE.isReleaseApk()) {
             UpdateSettingsFragment.askForConsentToUpdateChecks(this);
         }
     }
@@ -183,7 +183,8 @@ public class MainActivity extends AppCompatActivity {
         final App app = App.getApp();
         final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(app);
 
-        if (prefs.getBoolean(app.getString(R.string.update_app_key), false)) {
+        if (prefs.getBoolean(app.getString(R.string.update_app_key), false)
+                && prefs.getBoolean(app.getString(R.string.update_check_consent_key), false)) {
             // Start the worker which is checking all conditions
             // and eventually searching for a new version.
             NewVersionWorker.enqueueNewVersionCheckingWork(app, false);

--- a/app/src/main/java/org/schabi/newpipe/settings/NewPipeSettings.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/NewPipeSettings.java
@@ -11,6 +11,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
 import androidx.preference.PreferenceManager;
 
+import org.schabi.newpipe.App;
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.util.DeviceUtils;
 
@@ -44,14 +45,8 @@ public final class NewPipeSettings {
     private NewPipeSettings() { }
 
     public static void initSettings(final Context context) {
-        // check if the last used preference version is set
-        // to determine whether this is the first app run
-        final int lastUsedPrefVersion = PreferenceManager.getDefaultSharedPreferences(context)
-                .getInt(context.getString(R.string.last_used_preferences_version), -1);
-        final boolean isFirstRun = lastUsedPrefVersion == -1;
-
         // first run migrations, then setDefaultValues, since the latter requires the correct types
-        SettingMigrations.runMigrationsIfNeeded(context, isFirstRun);
+        SettingMigrations.runMigrationsIfNeeded(context);
 
         // readAgain is true so that if new settings are added their default value is set
         PreferenceManager.setDefaultValues(context, R.xml.main_settings, true);
@@ -68,7 +63,7 @@ public final class NewPipeSettings {
         saveDefaultVideoDownloadDirectory(context);
         saveDefaultAudioDownloadDirectory(context);
 
-        disableMediaTunnelingIfNecessary(context, isFirstRun);
+        disableMediaTunnelingIfNecessary(context);
     }
 
     static void saveDefaultVideoDownloadDirectory(final Context context) {
@@ -146,8 +141,7 @@ public final class NewPipeSettings {
                 R.string.show_remote_search_suggestions_key);
     }
 
-    private static void disableMediaTunnelingIfNecessary(@NonNull final Context context,
-                                                         final boolean isFirstRun) {
+    private static void disableMediaTunnelingIfNecessary(@NonNull final Context context) {
         final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         final String disabledTunnelingKey = context.getString(R.string.disable_media_tunneling_key);
         final String disabledTunnelingAutomaticallyKey =
@@ -162,7 +156,7 @@ public final class NewPipeSettings {
                 prefs.getInt(disabledTunnelingAutomaticallyKey, -1) == 0
                         && !prefs.getBoolean(disabledTunnelingKey, false);
 
-        if (Boolean.TRUE.equals(isFirstRun)
+        if (App.getApp().isFirstRun()
                 || (wasDeviceBlacklistUpdated && !wasMediaTunnelingEnabledByUser)) {
             setMediaTunneling(context);
         }

--- a/app/src/main/java/org/schabi/newpipe/settings/SettingMigrations.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/SettingMigrations.java
@@ -7,6 +7,7 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.preference.PreferenceManager;
 
+import org.schabi.newpipe.App;
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.error.ErrorInfo;
 import org.schabi.newpipe.error.ErrorUtil;
@@ -163,15 +164,14 @@ public final class SettingMigrations {
     private static final int VERSION = 6;
 
 
-    public static void runMigrationsIfNeeded(@NonNull final Context context,
-                                             final boolean isFirstRun) {
+    public static void runMigrationsIfNeeded(@NonNull final Context context) {
         // setup migrations and check if there is something to do
         sp = PreferenceManager.getDefaultSharedPreferences(context);
         final String lastPrefVersionKey = context.getString(R.string.last_used_preferences_version);
         final int lastPrefVersion = sp.getInt(lastPrefVersionKey, 0);
 
         // no migration to run, already up to date
-        if (isFirstRun) {
+        if (App.getApp().isFirstRun()) {
             sp.edit().putInt(lastPrefVersionKey, VERSION).apply();
             return;
         } else if (lastPrefVersion == VERSION) {

--- a/app/src/main/java/org/schabi/newpipe/settings/UpdateSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/UpdateSettingsFragment.java
@@ -1,9 +1,12 @@
 package org.schabi.newpipe.settings;
 
+import android.app.AlertDialog;
+import android.content.Context;
 import android.os.Bundle;
 import android.widget.Toast;
 
 import androidx.preference.Preference;
+import androidx.preference.PreferenceManager;
 
 import org.schabi.newpipe.NewVersionWorker;
 import org.schabi.newpipe.R;
@@ -35,5 +38,39 @@ public class UpdateSettingsFragment extends BasePreferenceFragment {
                 .setOnPreferenceChangeListener(updatePreferenceChange);
         findPreference(getString(R.string.manual_update_key))
                 .setOnPreferenceClickListener(manualUpdateClick);
+    }
+
+    public static void askForConsentToUpdateChecks(final Context context) {
+        new AlertDialog.Builder(context)
+                .setTitle(context.getString(R.string.check_for_updates))
+                .setMessage(context.getString(R.string.auto_update_check_description))
+                .setPositiveButton(context.getString(R.string.yes), (d, w) -> {
+                    d.dismiss();
+                    setAutoUpdateCheckEnabled(context, true);
+                })
+                .setNegativeButton(R.string.no, (d, w) -> {
+                    d.dismiss();
+                    // set explicitly to false, since the default is true on previous versions
+                    setAutoUpdateCheckEnabled(context, false);
+                })
+                .show();
+    }
+
+    private static void setAutoUpdateCheckEnabled(final Context context, final boolean enabled) {
+        PreferenceManager.getDefaultSharedPreferences(context)
+                .edit()
+                .putBoolean(context.getString(R.string.update_app_key), enabled)
+                .putBoolean(context.getString(R.string.update_check_consent_key), true)
+                .apply();
+    }
+
+    /**
+     * Whether the user was asked for consent to automatically check for app updates.
+     * @param context
+     * @return true if the user was asked for consent, false otherwise
+     */
+    public static boolean wasUserAskedForConsent(final Context context) {
+        return PreferenceManager.getDefaultSharedPreferences(context)
+                .getBoolean(context.getString(R.string.update_check_consent_key), false);
     }
 }

--- a/app/src/main/res/values-ar-rLY/strings.xml
+++ b/app/src/main/res/values-ar-rLY/strings.xml
@@ -78,7 +78,7 @@
     <string name="short_billion">بليون</string>
     <string name="feed_load_error_account_info">تعذر تحميل موجز \'%s\'.</string>
     <string name="question_mark">؟</string>
-    <string name="manual_update_title">التحقق من وجود تحديثات</string>
+    <string name="check_for_updates">التحقق من وجود تحديثات</string>
     <string name="peertube_instance_url_title">مثيلات خوادم پيرتيوب</string>
     <string name="more_than_100_videos">+100 فيديو</string>
     <string name="short_thousand">ألف</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -700,7 +700,7 @@
     <string name="enqueue_next_stream">وضع التالي على قائمة الانتظار</string>
     <string name="enqueued_next">تم وضع التالي على قائمة الانتظار</string>
     <string name="processing_may_take_a_moment">جاري المعالجة ... قد يستغرق لحظة</string>
-    <string name="manual_update_title">التحقق من وجود تحديثات</string>
+    <string name="check_for_updates">التحقق من وجود تحديثات</string>
     <string name="manual_update_description">التحقق يدويا من وجود إصدارات جديدة</string>
     <string name="checking_updates_toast">جاري التحقق من وجود تحديثات…</string>
     <string name="feed_new_items">عناصر تغذية جديدة</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -448,7 +448,7 @@
         <item quantity="one">%s video</item>
         <item quantity="other">%s video</item>
     </plurals>
-    <string name="manual_update_title">Yeniləmələri yoxla</string>
+    <string name="check_for_updates">Yeniləmələri yoxla</string>
     <string name="seekbar_preview_thumbnail_title">Axtarış çubuğunun miniatür önizləməsi</string>
     <string name="permission_denied">Əməliyyat sistem tərəfindən ləğv edildi</string>
     <string name="auto">Avto</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -670,7 +670,7 @@
     <string name="enable_streams_notifications_summary">Апавяшчаць аб новых стрымах з падпісак</string>
     <string name="streams_notifications_interval_title">Частата праверкі</string>
     <string name="streams_notifications_network_title">Патрабуецца падключэнне да сеткі</string>
-    <string name="manual_update_title">Праверце наяўнасць абнаўленняў</string>
+    <string name="check_for_updates">Праверце наяўнасць абнаўленняў</string>
     <string name="manual_update_description">Праверце новыя версіі ўручную</string>
     <string name="autoplay_summary">Аўтаматычны запуск прайгравання — %s</string>
     <string name="card">Картка</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -548,7 +548,7 @@
     <string name="recaptcha_cookies_cleared">Бисквитките от reCAPTCHA бяха почистени</string>
     <string name="checking_updates_toast">Проверяване за актуализации…</string>
     <string name="enumeration_comma">,</string>
-    <string name="manual_update_title">Провери за актуализации</string>
+    <string name="check_for_updates">Провери за актуализации</string>
     <string name="percent">Процент</string>
     <string name="unknown_quality">Неизвестно качество</string>
     <string name="unknown_format">Неизвестен формат</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -401,7 +401,7 @@
     <string name="default_content_country_title">কনটেন্টের জন্য পূর্বনির্ধারিত দেশ</string>
     <string name="external_player_unsupported_link_type">বাইরের প্লেয়ারসমূহ এ ধরনের লিঙ্কসমূহ সমর্থন করে না</string>
     <string name="msg_calculating_hash">হ্যাশ হিসাব করা হচ্ছে</string>
-    <string name="manual_update_title">আপডেট চেক করো</string>
+    <string name="check_for_updates">আপডেট চেক করো</string>
     <plurals name="watching">
         <item quantity="one">%s জন দেখছে</item>
         <item quantity="other">%s জন দেখছে</item>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -596,7 +596,7 @@
     <string name="detail_pinned_comment_view_description">পিনকৃত মন্তব্য</string>
     <string name="notifications">বিজ্ঞপ্তি</string>
     <string name="checking_updates_toast">হালনাগাদ দেখা হচ্ছে …</string>
-    <string name="manual_update_title">হালনাগাদ আছে কিনা দেখো</string>
+    <string name="check_for_updates">হালনাগাদ আছে কিনা দেখো</string>
     <string name="start_main_player_fullscreen_title">মূল প্লেয়ার ফুল স্ক্রীন এ শুরু করুন</string>
     <string name="feed_new_items">ধারার নতুন ভুক্তি</string>
     <string name="error_report_channel_name">ত্রুটি প্রতিবেদন এর বিজ্ঞপ্তি</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -640,7 +640,7 @@
     <string name="start_main_player_fullscreen_summary">Si la rotació automàtica està bloquejada, no inicieu vídeos al mini reproductor, sinó que aneu directament al mode de pantalla completa. Podeu accedir igualment al mini reproductor sortint de pantalla completa</string>
     <string name="error_report_channel_name">Notificació d\'informe d\'error</string>
     <string name="crash_the_player">Tancar abruptament el reproductor</string>
-    <string name="manual_update_title">Comprovar si hi ha actualitzacions</string>
+    <string name="check_for_updates">Comprovar si hi ha actualitzacions</string>
     <string name="manual_update_description">Comprovar manualment si hi ha noves versions</string>
     <plurals name="download_finished_notification">
         <item quantity="one">Baixada finalitzada</item>

--- a/app/src/main/res/values-ckb/strings.xml
+++ b/app/src/main/res/values-ckb/strings.xml
@@ -658,7 +658,7 @@
     <string name="error_report_notification_title">نیوپایپ تووشی کێشەیەک بوو ، کرتە بکە بۆ سکاڵاکردن</string>
     <string name="show_crash_the_player_title">پیشاندانی ”کڕاش کردنی لێدەرەکە“</string>
     <string name="create_error_notification">سازاندنی پەیامی کێشەیەک</string>
-    <string name="manual_update_title">پشکنین بۆ نوێکردنەوە</string>
+    <string name="check_for_updates">پشکنین بۆ نوێکردنەوە</string>
     <string name="error_report_channel_name">کێشە لە سکاڵا کردنی پەیام</string>
     <string name="error_report_channel_description">پەیامەکانی سکاڵاکردن لە کێشەکان</string>
     <string name="feed_new_items">بابەتە نوێیەکانی فیید</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -665,7 +665,7 @@
     <string name="start_main_player_fullscreen_title">Spustit hlavní přehrávač na celé obrazovce</string>
     <string name="processing_may_take_a_moment">Zpracovávám... může trvat moment</string>
     <string name="manual_update_description">Ručně zkontrolovat zda je k dispozici nová verze</string>
-    <string name="manual_update_title">Kontrola aktualizací</string>
+    <string name="check_for_updates">Kontrola aktualizací</string>
     <string name="error_report_notification_title">NewPipe narazil na problém, klikněte pro nahlášení</string>
     <string name="error_report_notification_toast">Došlo k chybě, více v oznámení</string>
     <string name="create_error_notification">Vytvořit oznámení o chybě</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -526,7 +526,7 @@
     <string name="checking_updates_toast">Tjekker efter opdateringer…</string>
     <string name="recovering">gendanner</string>
     <string name="feed_load_error_fast_unknown">\"Hurtig feed\"-tilstand oplyser ikke mere info om dette.</string>
-    <string name="manual_update_title">Tjek efter opdateringer</string>
+    <string name="check_for_updates">Tjek efter opdateringer</string>
     <string name="remove_watched_popup_title">Fjern sete videoer\?</string>
     <string name="disable_media_tunneling_summary">Deaktivér medietunneling, hvis du oplever en sort skærm eller hakken ved videoafspilning.</string>
     <string name="error_report_open_github_notice">Tjek venligst, om der allerede findes et problem, der diskuterer dit nedbrud. Når du opretter flere tickets, tager du tid fra os, som vi kunne bruge på at løse den faktiske fejl.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -655,7 +655,7 @@
     <string name="enqueued_next">Als Nächstes eingereiht</string>
     <string name="enqueue_next_stream">Als Nächstes in Wiedergabe einreihen</string>
     <string name="processing_may_take_a_moment">Verarbeite … Kann einen Moment dauern</string>
-    <string name="manual_update_title">Nach Aktualisierungen suchen</string>
+    <string name="check_for_updates">Nach Aktualisierungen suchen</string>
     <string name="checking_updates_toast">Suche nach Aktualisierungen …</string>
     <string name="manual_update_description">Manuelle Prüfung auf neue Versionen</string>
     <string name="feed_new_items">Neue Feed-Elemente</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -654,7 +654,7 @@
     <string name="processing_may_take_a_moment">Επεξεργασία... Μπορεί να πάρει λίγο χρόνο</string>
     <string name="checking_updates_toast">Έλεγχος αναβάθμισης…</string>
     <string name="manual_update_description">Χειροκίνητος έλεγχος για νέα έκδοση</string>
-    <string name="manual_update_title">Έλεγχος αναβάθμισης</string>
+    <string name="check_for_updates">Έλεγχος αναβάθμισης</string>
     <string name="feed_new_items">Νέα αντικείμενα τροφοδοσίας</string>
     <string name="show_crash_the_player_title">Εμφάνιση «Κατάρρευσης αναπαραγωγέα»</string>
     <string name="show_crash_the_player_summary">Εμφανίζει μια επιλογή κατάρρευσης κατά τη χρήση του αναπαραγωγέα</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -667,7 +667,7 @@
     <string name="enqueued_next">Añadido el siguiente vídeo a la cola</string>
     <string name="enqueue_next_stream">Añadir el siguiente vídeo a la cola</string>
     <string name="processing_may_take_a_moment">Procesando… Podría tomar un momento</string>
-    <string name="manual_update_title">Buscar actualizaciones</string>
+    <string name="check_for_updates">Buscar actualizaciones</string>
     <string name="manual_update_description">Buscar nuevas versiones manualmente</string>
     <string name="checking_updates_toast">Buscando actualizaciones…</string>
     <string name="feed_new_items">Nuevos elementos en el muro</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -653,7 +653,7 @@
     <string name="enqueue_next_stream">Lisa esitamiseks järgmisena</string>
     <string name="processing_may_take_a_moment">Töötlen andmeid… Võib kuluda mõni hetk</string>
     <string name="checking_updates_toast">Kontrollin uuendusi…</string>
-    <string name="manual_update_title">Kontrolli uuendusi</string>
+    <string name="check_for_updates">Kontrolli uuendusi</string>
     <string name="manual_update_description">Kontrolli uuendusi käsitsi</string>
     <string name="feed_new_items">Uued andmevoo kirjed</string>
     <string name="show_crash_the_player_title">Näita „Jooksuta meediamängija kokku“ nupukest</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -657,7 +657,7 @@
     <string name="error_report_channel_description">Jakinarazpenak erroreen berri emateko</string>
     <string name="error_report_notification_title">NewPipe-k errore bat aurkitu du, sakatu berri emateko</string>
     <string name="error_report_notification_toast">Errore bat gertatu da, ikusi jakinarazpena</string>
-    <string name="manual_update_title">Bilatu eguneraketak</string>
+    <string name="check_for_updates">Bilatu eguneraketak</string>
     <string name="manual_update_description">Bilatu bertsio berriak eskuz</string>
     <string name="feed_new_items">Elementu berriak jarioan</string>
     <string name="no_appropriate_file_manager_message_android_10">Ez da fitxategi kudeatzaile bat aurkitu ekintza honetarako.

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -652,7 +652,7 @@
     <string name="enqueued_next">بعدی در صف گذاشته شد</string>
     <string name="enqueue_next_stream">در صف گذاشتن بعدی</string>
     <string name="processing_may_take_a_moment">در حال پردازش… ممکن است کمی طول بکشد</string>
-    <string name="manual_update_title">بررسی به‌روز رسانی‌ها</string>
+    <string name="check_for_updates">بررسی به‌روز رسانی‌ها</string>
     <string name="manual_update_description">بررسی دستی برای نگارش‌های جدید</string>
     <string name="checking_updates_toast">بررسی کردن به‌روز رسانی‌ها…</string>
     <string name="feed_new_items">موارد خوراک جدید</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -652,7 +652,7 @@
         <item quantity="other">Poistettu %1$s latausta</item>
     </plurals>
     <string name="processing_may_take_a_moment">Käsitellään… Voi kestää hetken</string>
-    <string name="manual_update_title">Tarkista päivitykset</string>
+    <string name="check_for_updates">Tarkista päivitykset</string>
     <string name="manual_update_description">Tarkista manuaalisesti onko uusia versioita saatavilla</string>
     <string name="checking_updates_toast">Tarkistetaan päivityksiä…</string>
     <string name="error_report_channel_description">Ilmoitukset, joilla raportoidaan virheistä</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -668,7 +668,7 @@
     <string name="processing_may_take_a_moment">Traitement en cours… Veuillez patienter</string>
     <string name="manual_update_description">Vérifier manuellement de nouvelles versions</string>
     <string name="checking_updates_toast">Vérification des mises à jour…</string>
-    <string name="manual_update_title">Vérifier les mises à jour</string>
+    <string name="check_for_updates">Vérifier les mises à jour</string>
     <string name="feed_new_items">Nouveaux éléments du flux</string>
     <string name="crash_the_player">Faire planter le lecteur</string>
     <string name="show_crash_the_player_title">Afficher « Faire planter le lecteur »</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -658,7 +658,7 @@
     <string name="error_report_notification_title">NewPipe atopou un erro, presione para reportar</string>
     <string name="detail_pinned_comment_view_description">Comentario fixado</string>
     <string name="enqueued_next">Enfileirado</string>
-    <string name="manual_update_title">Procurar actualizacións</string>
+    <string name="check_for_updates">Procurar actualizacións</string>
     <string name="manual_update_description">Procurar manualmente novas versións</string>
     <string name="checking_updates_toast">A procurar actualizacións…</string>
     <string name="downloads_storage_use_saf_summary_api_29">A partir do Android 10, só o \'Sistema de Acceso ao Almacenamento\' está soportado</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -676,7 +676,7 @@
     <string name="enqueued_next">נוסף כהבא בתור</string>
     <string name="enqueue_next_stream">הוספה כהבא בתור</string>
     <string name="processing_may_take_a_moment">מתבצע עיבוד… נא להמתין רגע קט</string>
-    <string name="manual_update_title">איתור עדכונים</string>
+    <string name="check_for_updates">איתור עדכונים</string>
     <string name="checking_updates_toast">מתבצע איתור עדכונים…</string>
     <string name="manual_update_description">לנסות לאתר גרסאות חדשות ידנית</string>
     <string name="feed_new_items">פריטים חדשים בהזנה</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -579,7 +579,7 @@
     <string name="streams_notifications_network_title">नेटवर्क कनेक्शन आवश्यक</string>
     <string name="enable_streams_notifications_title">नई स्ट्रीम अधिसूचनाएं</string>
     <string name="any_network">कोई भी नेटवर्क</string>
-    <string name="manual_update_title">अपडेट के लिए जाँच करें</string>
+    <string name="check_for_updates">अपडेट के लिए जाँच करें</string>
     <string name="low_quality_smaller">निम्न गुणवत्ता (छोटा)</string>
     <string name="seekbar_preview_thumbnail_title">सीकबार थंमनेल पूर्वावलोकन</string>
     <string name="high_quality_larger">उच्च गुणवत्ता (बड़ा)</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -665,7 +665,7 @@
     <string name="manual_update_description">Ručno traži nove verzije</string>
     <string name="checking_updates_toast">Traženje novih verzija …</string>
     <string name="local_search_suggestions">Prijedlozi lokalne pretrage</string>
-    <string name="manual_update_title">Traži nove verzije</string>
+    <string name="check_for_updates">Traži nove verzije</string>
     <string name="start_main_player_fullscreen_summary">Nemoj pokretati videa u mini playeru, već izravno pokreni cjeloekranski prikaz, ako je automatsko okretanje zaključano. Mini playeru i dalje možeš pristupiti napuštanjem cjeloekranskog prikaza</string>
     <string name="feed_new_items">Nove stavke feeda</string>
     <string name="error_report_channel_name">Obavijest o prijavi greške</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -661,7 +661,7 @@
     <string name="show_crash_the_player_title">A „lejátszó összeomlasztása” lehetőség megjelenítése</string>
     <string name="show_crash_the_player_summary">Megjeleníti az összeomlasztási lehetőséget a lejátszó használatakor</string>
     <string name="unhook_checkbox">Hangmagasság megtartása (torzítást okozhat)</string>
-    <string name="manual_update_title">Frissítések keresése</string>
+    <string name="check_for_updates">Frissítések keresése</string>
     <string name="dont_show">Ne jelenítse meg</string>
     <string name="remove_watched">Megnézettek eltávolítása</string>
     <string name="remove_watched_popup_title">Eltávolítja a megnézett videókat\?</string>

--- a/app/src/main/res/values-hy/strings.xml
+++ b/app/src/main/res/values-hy/strings.xml
@@ -151,7 +151,7 @@
     <string name="resize_zoom">Մեծացնել</string>
     <string name="caption_auto_generated">Գեներացված</string>
     <string name="import_file_title">Ներմուծել ֆայլ</string>
-    <string name="manual_update_title">Ստուգել թարմացումները</string>
+    <string name="check_for_updates">Ստուգել թարմացումները</string>
     <string name="auto">Ինքնին</string>
     <string name="high_quality_larger">Բարձր որակ (մեծ)</string>
     <string name="low_quality_smaller">Ցածր որակ (փոքր)</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -640,7 +640,7 @@
     <string name="show_image_indicators_summary">Tampilkan Ribon bewarna Picasso di atas gambar yang mengindikasikan asalnya: merah untuk jaringan, biru untuk disk dan hijau untuk memori</string>
     <string name="start_main_player_fullscreen_summary">Jangan memulai memutar video di mini player, tapi nyalakan langsung di mode layar penuh, jika rotasi otomatis terkunci. Anda tetap dapat mengakses mini player dengan keluar dari layar penuh</string>
     <string name="processing_may_take_a_moment">Memproses… Mungkin butuh waktu sebentar</string>
-    <string name="manual_update_title">Periksa Pembaruan</string>
+    <string name="check_for_updates">Periksa Pembaruan</string>
     <string name="manual_update_description">Periksa manual untuk versi baru</string>
     <string name="checking_updates_toast">Memeriksa pembaruan…</string>
     <string name="feed_new_items">Item feed baru</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -438,7 +438,7 @@
     <string name="streams_notifications_network_title">Tegund tengingar</string>
     <string name="any_network">Allar</string>
     <string name="updates_setting_description">Sýna tilkynningu þegar ný útgáfa er fáanleg</string>
-    <string name="manual_update_title">Leita að uppfærslum</string>
+    <string name="check_for_updates">Leita að uppfærslum</string>
     <string name="manual_update_description">Leita handvirkt fyrir uppfærslum</string>
     <string name="minimize_on_exit_title">Fela þegar skipt er um forrit</string>
     <string name="minimize_on_exit_background_description">Nota bakgrunnsspilara</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -664,7 +664,7 @@
     <string name="enqueued_next">Aggiunto alla coda come prossimo</string>
     <string name="enqueue_next_stream">Accoda come prossimo</string>
     <string name="processing_may_take_a_moment">Elaborazione… Potrebbe volerci un attimo</string>
-    <string name="manual_update_title">Controlla aggiornamenti</string>
+    <string name="check_for_updates">Controlla aggiornamenti</string>
     <string name="manual_update_description">Verifica manualmente la presenza di nuove versioni</string>
     <string name="checking_updates_toast">Controllo aggiornamenti…</string>
     <string name="feed_new_items">Nuovi elementi feed</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -639,7 +639,7 @@
     <string name="processing_may_take_a_moment">処理中… 少し時間がかかるかもしれません</string>
     <string name="manual_update_description">新しいバージョンを手動で確認します</string>
     <string name="checking_updates_toast">アップデートを確認中…</string>
-    <string name="manual_update_title">アップデートを確認</string>
+    <string name="check_for_updates">アップデートを確認</string>
     <string name="enqueue_next_stream">次をキューに追加</string>
     <string name="enqueued_next">次をキューに追加しました</string>
     <string name="detail_heart_img_view_description">クリエイターの心をこめて</string>

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -426,7 +426,7 @@
     <string name="any_network">ნებისმიერი ქსელი</string>
     <string name="updates_setting_title">განახლებები</string>
     <string name="updates_setting_description">მაჩვენე შეტყობინება აპის განახლების მოთხოვნით, როდესაც ხელმისაწვდომი იქნება ახალი ვერსია</string>
-    <string name="manual_update_title">Შეამოწმოთ განახლებები</string>
+    <string name="check_for_updates">Შეამოწმოთ განახლებები</string>
     <string name="manual_update_description">ხელით შეამოწმეთ ახალი ვერსიები</string>
     <string name="minimize_on_exit_title">მინიმიზაცია აპის გადამრთველზე</string>
     <string name="minimize_on_exit_summary">მოქმედება სხვა აპზე გადასვლისას მთავარი ვიდეო დამკვრელიდან — %s</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -557,7 +557,7 @@
     <string name="streams_notifications_interval_title">확인 빈도</string>
     <string name="streams_notifications_network_title">필요한 네트워크 연결</string>
     <string name="any_network">모든 네트워크</string>
-    <string name="manual_update_title">업데이트 확인</string>
+    <string name="check_for_updates">업데이트 확인</string>
     <string name="manual_update_description">새로운 버전을 수동으로 확인</string>
     <string name="autoplay_summary">자동으로 재생 시작 — %s</string>
     <string name="wifi_only">Wi-Fi에서만</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -664,7 +664,7 @@
     <string name="enqueued_next">Sekantis pridėtas į eilę</string>
     <string name="enqueue_next_stream">Įtraukti į eilę sekantį</string>
     <string name="processing_may_take_a_moment">Apdorojama… tai gali užtrukti</string>
-    <string name="manual_update_title">Tikrinti ar yra atnaujinimų</string>
+    <string name="check_for_updates">Tikrinti ar yra atnaujinimų</string>
     <string name="manual_update_description">Tikrinti ar yra atnaujinimų rankiniu būdu</string>
     <string name="checking_updates_toast">Tikrinti ar yra atnaujinimų…</string>
     <string name="feed_new_items">Nauji sklaidos kanalo elementai</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -632,7 +632,7 @@
     <string name="local_search_suggestions">Lokālie meklēšanas ieteikumi</string>
     <string name="show_image_indicators_title">Rādīt attēlu indikatorus</string>
     <string name="high_quality_larger">Augstas kvalitātes (lielāks)</string>
-    <string name="manual_update_title">Pārbaudīt atjauninājumus</string>
+    <string name="check_for_updates">Pārbaudīt atjauninājumus</string>
     <string name="manual_update_description">Manuāli pārbaudīt, vai ir atjauninājumi</string>
     <string name="seekbar_preview_thumbnail_title">Video atskaņošanas joslas sīktēla priekšskatījums</string>
     <string name="checking_updates_toast">Pārbauda, vai ir atjauninājumi…</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -651,7 +651,7 @@
     <string name="start_main_player_fullscreen_title">Start hovedspiller i fullskjerm</string>
     <string name="enqueue_next_stream">Still i kø neste</string>
     <string name="enqueued_next">I kø neste</string>
-    <string name="manual_update_title">Se etter oppdateringer</string>
+    <string name="check_for_updates">Se etter oppdateringer</string>
     <string name="processing_may_take_a_moment">Behandler … Kan ta sin tid</string>
     <string name="crash_the_player">Krasj avspilleren</string>
     <string name="show_crash_the_player_title">Vis \"Krasj spilleren\"</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -656,7 +656,7 @@
     <string name="show_crash_the_player_title">‘Speler crashen’ tonen</string>
     <string name="show_crash_the_player_summary">Toont een crash-optie bij gebruik van de speler</string>
     <string name="manual_update_description">Controleer handmatig op nieuwe versies</string>
-    <string name="manual_update_title">Controleren op updates</string>
+    <string name="check_for_updates">Controleren op updates</string>
     <string name="checking_updates_toast">Bezig met controleren op updates…</string>
     <string name="feed_new_items">Nieuwe feeditems</string>
     <string name="error_report_channel_name">Foutrapporten</string>

--- a/app/src/main/res/values-nqo/strings.xml
+++ b/app/src/main/res/values-nqo/strings.xml
@@ -482,7 +482,7 @@
     <string name="enable_streams_notifications_summary">ߞߊ߬ ߡߊ߬ߝߘߎ߬ߟߌ ߟߎ߬ ߟߊ߫ ߥߦߏ߬ ߞߎߘߊ ߟߎ߫ ߛߏߓߌ߬ߘߐ߬ߓߏ߲ ߠߎ߬ ߟߊߣߊ߬</string>
     <string name="any_network">ߞߙߏ߬ߝߏ߫ ߛߎ߮ ߓߍ߯</string>
     <string name="updates_setting_title">ߟߏ߲ߘߐߦߊߟߌ ߟߎ߬</string>
-    <string name="manual_update_title">ߟߏ߲ߘߐߦߊߟߌ ߟߎ߬ ߡߊߝߍߣߍ߲߫</string>
+    <string name="check_for_updates">ߟߏ߲ߘߐߦߊߟߌ ߟߎ߬ ߡߊߝߍߣߍ߲߫</string>
     <string name="manual_update_description">ߞߊ߬ ߓߐߞߏ߫ ߞߎߘߊ ߟߎ߫ ߕߎ߬ߢߊ߬ߟߐ߲߫ ߓߟߏ ߟߊ߫</string>
     <string name="minimize_on_exit_title">ߞߵߊ߬ ߡߊߖߌ߰ ߟߥߊߟߌߟߊ߲ ߘߐߦߟߍߡߊ߲߫ ߕߎߡߊ</string>
     <string name="minimize_on_exit_none_description">ߝߏߛߌ߬</string>

--- a/app/src/main/res/values-or/strings.xml
+++ b/app/src/main/res/values-or/strings.xml
@@ -410,7 +410,7 @@
     <string name="caption_auto_generated">ସ୍ଵତଃସୃଷ୍ଟ</string>
     <string name="content">ବିଷୟବସ୍ତୁ</string>
     <string name="enable_queue_limit">ଡାଉନଲୋଡ୍ ଧାଡି ସୀମିତ କରନ୍ତୁ</string>
-    <string name="manual_update_title">ଅଦ୍ୟତନ ପାଇଁ ଯାଞ୍ଚ କରନ୍ତୁ</string>
+    <string name="check_for_updates">ଅଦ୍ୟତନ ପାଇଁ ଯାଞ୍ଚ କରନ୍ତୁ</string>
     <string name="manual_update_description">ନୂତନ ସଂସ୍କରଣଗୁଡ଼ିକ ପାଇଁ ମାନୁଆଲ ଯାଞ୍ଚ କରନ୍ତୁ</string>
     <string name="missions_header_pending">ବିଚାରାଧୀନ ଅଛି</string>
     <string name="remove_watched_popup_title">ଦେଖାଯାଇଥିବା ଭିଡିଓଗୁଡିକ ଅପସାରଣ କରିବେ କି\?</string>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -669,7 +669,7 @@
     <string name="enable_streams_notifications_summary">ਸਬਸਕ੍ਰਾਈਬ ਕੀਤੇ ਚੈਨਲ ਉੱਪਰ ਨਵੀਂ ਸਟ੍ਰੀਮ ਉੱਪਲਬਧ ਹੋਣ ਤੇ ਨੋਟੀਫਿਕੇਸ਼ਨ ਰਾਹੀਂ ਸੂਚਿਤ ਕਰੋ</string>
     <string name="streams_notifications_interval_title">ਜਾਂਚ ਅਵਧੀ</string>
     <string name="any_network">ਕੋਈ ਵੀ ਨੈੱਟਵਰਕ</string>
-    <string name="manual_update_title">ਅੱਪਡੇਟ ਲਈ ਜਾਂਚ ਕਰੋ</string>
+    <string name="check_for_updates">ਅੱਪਡੇਟ ਲਈ ਜਾਂਚ ਕਰੋ</string>
     <string name="low_quality_smaller">ਘੱਟ ਗੁਣਵੱਤਾ (ਛੋਟਾ ਆਕਾਰ)</string>
     <string name="delete_downloaded_files_confirm">ਡਿਸਕ ਤੋਂ ਸਾਰੀਆਂ ਡਾਊਨਲੋਡ ਕੀਤੀਆਂ ਫਾਈਲਾਂ ਹਟਾਓ\?</string>
     <plurals name="deleted_downloads_toast">

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -673,7 +673,7 @@
     <string name="processing_may_take_a_moment">Przetwarzanie… Może to chwilę potrwać</string>
     <string name="checking_updates_toast">Sprawdzanie aktualizacji…</string>
     <string name="manual_update_description">Ręcznie sprawdź dostępność nowych wersji</string>
-    <string name="manual_update_title">Sprawdź dostępność aktualizacji</string>
+    <string name="check_for_updates">Sprawdź dostępność aktualizacji</string>
     <string name="feed_new_items">Nowe pozycje kanału</string>
     <string name="show_crash_the_player_summary">Pokazuje opcję psucia podczas korzystania z odtwarzacza</string>
     <string name="crash_the_player">Zepsuj odtwarzacz</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -664,7 +664,7 @@
     <string name="remote_search_suggestions">Sugestões de busca remotas</string>
     <string name="local_search_suggestions">Sugestões de busca locais</string>
     <string name="processing_may_take_a_moment">Processando… Pode demorar um pouco</string>
-    <string name="manual_update_title">Procurar por atualizações</string>
+    <string name="check_for_updates">Procurar por atualizações</string>
     <string name="manual_update_description">Procurar manualmente por novas versões</string>
     <string name="checking_updates_toast">Procurando por atualizações…</string>
     <string name="crash_the_player">Travar o reprodutor de vídeo</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -664,7 +664,7 @@
     <string name="enqueued_next">Enfileirado o próximo</string>
     <string name="enqueue_next_stream">Pôr na fila o próximo</string>
     <string name="processing_may_take_a_moment">A processar… Pode demorar um momento</string>
-    <string name="manual_update_title">Procurar atualizações</string>
+    <string name="check_for_updates">Procurar atualizações</string>
     <string name="manual_update_description">Verificar manualmente se existe uma nova versão</string>
     <string name="checking_updates_toast">A procurar atualizações…</string>
     <string name="feed_new_items">Novos itens</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -664,7 +664,7 @@
     <string name="enqueued_next">Seguinte colocado na fila</string>
     <string name="enqueue_next_stream">Colocar seguinte na fila</string>
     <string name="processing_may_take_a_moment">A processar… Pode levar algum tempo</string>
-    <string name="manual_update_title">Procurar atualizações</string>
+    <string name="check_for_updates">Procurar atualizações</string>
     <string name="manual_update_description">Verificar manualmente se existe uma nova versão</string>
     <string name="checking_updates_toast">A procurar atualizações…</string>
     <string name="feed_new_items">Novos itens</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -664,7 +664,7 @@
     <string name="show_image_indicators_title">Afișați indicatorii de imagine</string>
     <string name="disable_media_tunneling_summary">Dezactivați tunelarea media dacă întâmpinați un ecran negru sau blocaje la redarea video.</string>
     <string name="processing_may_take_a_moment">Procesarea.. Poate dura un moment</string>
-    <string name="manual_update_title">Verifică dacă există actualizări</string>
+    <string name="check_for_updates">Verifică dacă există actualizări</string>
     <string name="manual_update_description">Verifică manual dacă există versiuni noi</string>
     <string name="detail_pinned_comment_view_description">Comentariu lipit</string>
     <string name="error_report_channel_name">Notificare cu raport de eroare</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -675,7 +675,7 @@
     <string name="enqueue_next_stream">Добавить следующим</string>
     <string name="processing_may_take_a_moment">Обработка… Подождите немного</string>
     <string name="manual_update_description">Проверить обновления вручную</string>
-    <string name="manual_update_title">Проверить обновления</string>
+    <string name="check_for_updates">Проверить обновления</string>
     <string name="checking_updates_toast">Проверка обновлений…</string>
     <string name="feed_new_items">Новое на канале</string>
     <string name="notifications">Уведомления</string>

--- a/app/src/main/res/values-ryu/strings.xml
+++ b/app/src/main/res/values-ryu/strings.xml
@@ -651,7 +651,7 @@
     <string name="processing_may_take_a_moment">しーょりちゅう… くーてーんじがんがかかいんかむしりやびらん</string>
     <string name="manual_update_description">みーさるバージョンしーゅどうでぃかくにんさびーん</string>
     <string name="checking_updates_toast">アップデートかくにんちゅう…</string>
-    <string name="manual_update_title">アップデートかくにん</string>
+    <string name="check_for_updates">アップデートかくにん</string>
     <string name="enqueue_next_stream">ちぎキューんかいちちが</string>
     <string name="enqueued_next">ちぎキューんかいちいからさびたん</string>
     <string name="detail_heart_img_view_description">クリエイターぬちむくみてぃ</string>

--- a/app/src/main/res/values-sc/strings.xml
+++ b/app/src/main/res/values-sc/strings.xml
@@ -652,7 +652,7 @@
     <string name="enqueued_next">Postu in lista comente imbeniente</string>
     <string name="enqueue_next_stream">Pone in lista comente imbeniente</string>
     <string name="processing_may_take_a_moment">Protzessende… Bi diat pòdere chèrrere unu pagu de tempus</string>
-    <string name="manual_update_title">Chirca agiornamentos</string>
+    <string name="check_for_updates">Chirca agiornamentos</string>
     <string name="manual_update_description">Verìfica in manera manuale pro versiones noas</string>
     <string name="checking_updates_toast">Controllende sos agiornamentos…</string>
     <string name="error_report_notification_title">NewPipe at rilevadu un\'errore, toca pro lu sinnalare</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -664,7 +664,7 @@
     <string name="enqueue_next_stream">Pridať do zoznamu</string>
     <string name="enqueued_next">Ďaľší v poradí</string>
     <string name="processing_may_take_a_moment">Spracovávanie... môže to chvíľku trvať</string>
-    <string name="manual_update_title">Skontrolovať aktualizácie</string>
+    <string name="check_for_updates">Skontrolovať aktualizácie</string>
     <string name="manual_update_description">Ručne skontrolovať nové verzie</string>
     <string name="checking_updates_toast">Kontrolujú sa aktualizácie…</string>
     <string name="feed_new_items">Nové položky informačného kanála</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -715,7 +715,7 @@
     <string name="duplicate_in_playlist">Плејлисте које су затамњене већ садрже ову ставку.</string>
     <string name="leak_canary_not_available">LeakCanary није доступан</string>
     <string name="app_update_available_notification_text">Додирните да бисте преузели %s</string>
-    <string name="manual_update_title">Провери ажурирања</string>
+    <string name="check_for_updates">Провери ажурирања</string>
     <string name="seekbar_preview_thumbnail_title">Преглед сличице траке за претрагу</string>
     <string name="feed_hide_streams_title">Прикажи следеће стримове</string>
     <string name="feed_show_hide_streams">Прикажи/сакриј стримове</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -652,7 +652,7 @@
     <string name="remote_search_suggestions">Förslag via fjärrsökning</string>
     <string name="start_main_player_fullscreen_summary">Starta inte videor i minispelaren, utan byt till helskärmsläge direkt, om automatisk rotation är låst. Du kan fortfarande komma åt minispelaren genom att gå ut ur helskärmsläge</string>
     <string name="show_image_indicators_summary">Visa Picasso färgade band ovanpå bilderna som anger deras källa: rött för nätverk, blått för disk och grönt för minne</string>
-    <string name="manual_update_title">Sök efter uppdateringar</string>
+    <string name="check_for_updates">Sök efter uppdateringar</string>
     <string name="manual_update_description">Kolla manuellt efter nya versioner</string>
     <string name="checking_updates_toast">Söker efter uppdateringar…</string>
     <string name="feed_new_items">Nya flödes objekt</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -651,7 +651,7 @@
     <string name="enqueue_next_stream">Sonrakini sıraya ekle</string>
     <string name="enqueued_next">Sonraki sıraya eklendi</string>
     <string name="processing_may_take_a_moment">İşleniyor… Biraz zaman alabilir</string>
-    <string name="manual_update_title">Güncellemeleri denetle</string>
+    <string name="check_for_updates">Güncellemeleri denetle</string>
     <string name="manual_update_description">Yeni sürümleri el ile denetleyin</string>
     <string name="checking_updates_toast">Güncellemeler denetleniyor…</string>
     <string name="feed_new_items">Yeni akış ögeleri</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -668,7 +668,7 @@
     <string name="enqueued_next">Заплановано наступним</string>
     <string name="enqueue_next_stream">Запланувати наступним</string>
     <string name="processing_may_take_a_moment">Обробка… Трохи заждіть</string>
-    <string name="manual_update_title">Перевірити наявність оновлень</string>
+    <string name="check_for_updates">Перевірити наявність оновлень</string>
     <string name="manual_update_description">Перевірка нових версій вручну</string>
     <string name="checking_updates_toast">Перевірка оновлень…</string>
     <string name="feed_new_items">Нові записи стрічки</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -648,7 +648,7 @@
     <string name="show_crash_the_player_summary">Hiện tùy chọn dừng đột ngột khi sử dụng trình phát</string>
     <string name="show_error_snackbar">Hiện thanh báo lỗi</string>
     <string name="create_error_notification">Tạo thông báo lỗi</string>
-    <string name="manual_update_title">Kiểm tra cập nhật</string>
+    <string name="check_for_updates">Kiểm tra cập nhật</string>
     <string name="manual_update_description">Kiểm tra phiên bản mới theo cách thủ công</string>
     <string name="checking_updates_toast">Đang kiểm tra cập nhật…</string>
     <string name="feed_new_items">Mục nguồn cấp dữ liệu mới</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -642,7 +642,7 @@
     <string name="processing_may_take_a_moment">处理中…可能需要一些时间</string>
     <string name="manual_update_description">手动检查新版本</string>
     <string name="checking_updates_toast">检查更新中…</string>
-    <string name="manual_update_title">检查更新</string>
+    <string name="check_for_updates">检查更新</string>
     <string name="feed_new_items">新订阅源条目</string>
     <string name="show_crash_the_player_title">显示\"使播放器崩溃\"</string>
     <string name="show_crash_the_player_summary">在使用播放器时显示一个崩溃选项</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -288,7 +288,7 @@
     <string name="playback_tempo">節奏</string>
     <string name="playback_speed_control">播放速度控掣</string>
     <string name="systems_language">系統預設</string>
-    <string name="manual_update_title">檢查有冇更新</string>
+    <string name="check_for_updates">檢查有冇更新</string>
     <string name="app_language_title">個 App 用咩語言</string>
     <string name="remove_watched">睇咗嗰啲剷咗佢</string>
     <string name="remove_watched_popup_title">係咪要剷走睇咗嘅影片？</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -640,7 +640,7 @@
     <string name="enqueued_next">已將下一個加入佇列</string>
     <string name="enqueue_next_stream">將下一個加入佇列</string>
     <string name="processing_may_take_a_moment">正在處理……可能需要一點時間</string>
-    <string name="manual_update_title">檢查更新</string>
+    <string name="check_for_updates">檢查更新</string>
     <string name="manual_update_description">手動檢查新版本</string>
     <string name="checking_updates_toast">正在檢查更新……</string>
     <string name="feed_new_items">新 feed 項目</string>

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -494,6 +494,7 @@
     </string-array>
 
     <!-- Updates -->
+    <string name="update_check_consent_key">update_check_consent_key</string>
     <string name="update_app_key">update_app_key</string>
     <string name="manual_update_key">manual_update_key</string>
     <string name="update_pref_screen_key">update_pref_screen_key</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,8 @@
     <string name="install">Install</string>
     <string name="cancel">Cancel</string>
     <string name="ok">OK</string>
+    <string name="yes">Yes</string>
+    <string name="no">No</string>
     <string name="open_in_browser">Open in browser</string>
     <string name="mark_as_watched">Mark as watched</string>
     <string name="open_in_popup_mode">Open in popup mode</string>
@@ -557,8 +559,10 @@
     <string name="updates_setting_title">Updates</string>
     <string name="updates_setting_description">Show a notification to prompt app update when a new version is available</string>
     <string name="check_for_updates">Check for updates</string>
+    <string name="auto_update_check_description">NewPipe can automatically check for new versions from time to time and notify you once they are available.\nDo you want to enable this?</string>
     <string name="manual_update_title" translatable="false">@string/check_for_updates</string>
     <string name="manual_update_description">Manually check for new versions</string>
+
     <!-- Minimize to exit action -->
     <string name="minimize_on_exit_title">Minimize on app switch</string>
     <string name="minimize_on_exit_summary">Action when switching to other app from main video player — %s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -556,7 +556,8 @@
     <!-- Updates Settings -->
     <string name="updates_setting_title">Updates</string>
     <string name="updates_setting_description">Show a notification to prompt app update when a new version is available</string>
-    <string name="manual_update_title">Check for updates</string>
+    <string name="check_for_updates">Check for updates</string>
+    <string name="manual_update_title" translatable="false">@string/check_for_updates</string>
     <string name="manual_update_description">Manually check for new versions</string>
     <!-- Minimize to exit action -->
     <string name="minimize_on_exit_title">Minimize on app switch</string>

--- a/app/src/main/res/xml/update_settings.xml
+++ b/app/src/main/res/xml/update_settings.xml
@@ -4,7 +4,7 @@
     android:title="@string/settings_category_updates_title">
 
     <SwitchPreferenceCompat
-        android:defaultValue="true"
+        android:defaultValue="false"
         android:key="@string/update_app_key"
         android:summary="@string/updates_setting_description"
         android:title="@string/updates_setting_title"


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Ask for consent before enabling auto update check.

NewPipe is contacting its servers without asking for the users' consent. This is categorized as "tracking" by F-Droid (see https://github.com/TeamNewPipe/NewPipe/discussions/10785).

This PR disables checking for updates by default and adds a dialog asking for the user's consent to automatically check for updates if the app version is eligible for them. After upgrading to a version containing this commit the user is asked directly on the first app start. On fresh installs however, showing it on the first app start contributes to a bad onboarding an welcoming experience. Therefore, the dialog is shown at the second app start.

#### To Do

- [x] Implement settings migration triggering the consent check on update
- [x] Refactor the `App.isFirstRun` to be set inside App and read only (~~**should the variable be static?~~**)
- [x] Provide testing APK which does not rely on release signature check to ask for consent
- [x] Do testing

#### Before/After Screenshots/Screen Record
<img alt="grafik" src="https://github.com/TeamNewPipe/NewPipe/assets/17365767/f5307e73-6283-4669-9245-21a8fd4fc861" width=337 />

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Closes https://github.com/TeamNewPipe/NewPipe/discussions/10785

#### APK testing
Install this release APK for testing, singed by my dev key:
[NewPipe-check-consent.zip](https://github.com/TeamNewPipe/NewPipe/files/14692892/NewPipe-check-consent.zip)

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
