### PR TITLE
Initial setup for Settings page redesign with debug settings

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/settings/MainSettingsV2Fragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/MainSettingsV2Fragment.kt
@@ -1,0 +1,49 @@
+package org.schabi.newpipe.settings
+
+import android.os.Bundle
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import androidx.activity.ComponentActivity
+import androidx.core.view.MenuProvider
+import androidx.preference.Preference
+import org.schabi.newpipe.R
+
+/**
+ *  Provides main settings page, entry point to the NewPipe app settings.
+ */
+class MainSettingsV2Fragment : BasePreferenceFragment(), MenuProvider {
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        addPreferencesFromResourceRegistry()
+
+        (activity as? ComponentActivity)?.addMenuProvider(this, this)
+
+        // Hide debug preferences in RELEASE build variant
+        if (!DEBUG) {
+            findPreference<Preference>(getString(R.string.debug_pref_screen_key))?.let(
+                preferenceScreen::removePreference,
+            )
+        }
+    }
+
+    override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+        // -- Link settings activity and register menu --
+        menuInflater.inflate(R.menu.menu_settings_main_fragment, menu)
+        val menuSearchItem = menu.getItem(0)
+        (activity as? SettingsActivity)?.setMenuSearchItem(menuSearchItem)
+    }
+
+    override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+        if (menuItem.itemId == R.id.action_search) {
+            (activity as? SettingsActivity)?.setSearchActive(true)
+            return true
+        }
+        return false
+    }
+
+    override fun onDestroy() {
+        // Unlink activity so that we don't get memory problems
+        (activity as? SettingsActivity)?.setMenuSearchItem(null)
+        super.onDestroy()
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/settings/SettingsActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/SettingsActivity.java
@@ -20,6 +20,7 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
+import androidx.preference.PreferenceManager;
 
 import com.jakewharton.rxbinding4.widget.RxTextView;
 
@@ -112,8 +113,14 @@ public class SettingsActivity extends AppCompatActivity implements
                 }
             }
         } else {
+            final boolean shouldDisplaySettingsRedesign = PreferenceManager
+                    .getDefaultSharedPreferences(this)
+                    .getBoolean(getString(R.string.settings_layout_redesign_key), false);
+            final BasePreferenceFragment mainSettingsFragment =
+                    shouldDisplaySettingsRedesign
+                            ? new MainSettingsV2Fragment() : new MainSettingsFragment();
             getSupportFragmentManager().beginTransaction()
-                    .replace(R.id.settings_fragment_holder, new MainSettingsFragment())
+                    .replace(R.id.settings_fragment_holder, mainSettingsFragment)
                     .commit();
         }
 

--- a/app/src/main/java/org/schabi/newpipe/settings/SettingsResourceRegistry.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/SettingsResourceRegistry.java
@@ -29,6 +29,10 @@ public final class SettingsResourceRegistry {
     private final Set<SettingRegistryEntry> registeredEntries = new HashSet<>();
 
     private SettingsResourceRegistry() {
+        add(MainSettingsV2Fragment.class, R.xml.main_settings_v2).setSearchable(false);
+
+        // Before redesign settings arrangement. These should be cleared once the
+        // settings_layout_redesign_key is approved and enabled by default.
         add(MainSettingsFragment.class, R.xml.main_settings).setSearchable(false);
 
         add(AppearanceSettingsFragment.class, R.xml.appearance_settings);

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -245,6 +245,7 @@
     <string name="crash_the_app_key">crash_the_app_key</string>
     <string name="show_error_snackbar_key">show_error_snackbar_key</string>
     <string name="create_error_notification_key">create_error_notification_key</string>
+    <string name="settings_layout_redesign_key">settings_layout_redesign_key</string>
 
     <!-- THEMES -->
     <string name="theme_key">theme</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -491,6 +491,7 @@
     <string name="crash_the_app">Crash the app</string>
     <string name="show_error_snackbar">Show an error snackbar</string>
     <string name="create_error_notification">Create an error notification</string>
+    <string name="settings_layout_redesign">Enable the Redesigned Settings page</string>
     <!-- Subscriptions import/export -->
     <string name="import_title">Import</string>
     <string name="import_from">Import from</string>

--- a/app/src/main/res/xml/debug_settings.xml
+++ b/app/src/main/res/xml/debug_settings.xml
@@ -71,4 +71,11 @@
         android:title="@string/create_error_notification"
         app:singleLineTitle="false"
         app:iconSpaceReserved="false" />
+
+    <SwitchPreferenceCompat
+        android:defaultValue="false"
+        android:key="@string/settings_layout_redesign_key"
+        android:title="@string/settings_layout_redesign"
+        app:iconSpaceReserved="false"
+        app:singleLineTitle="false" />
 </PreferenceScreen>

--- a/app/src/main/res/xml/main_settings_v2.xml
+++ b/app/src/main/res/xml/main_settings_v2.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:key="general_preferences"
+    android:title="@string/settings">
+
+    <PreferenceScreen
+        android:fragment="org.schabi.newpipe.settings.DebugSettingsFragment"
+        android:key="@string/debug_pref_screen_key"
+        android:title="@string/settings_category_debug_title"
+        app:iconSpaceReserved="false" />
+</PreferenceScreen>


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Initial setup for Settings page redesign with debug settings

- Added a new settings option to enable the settings page redesign.
- This option allows us to integrate and test the new settings page gradually, minimizing disruptions to the current behavior.
- Reused the rest of the debug menu to reflect in the new settings page.
- Verified the functionality of all debug settings.

#### Next plan:
- Create PRs to gradually add all the subsections, as detailed in https://github.com/TeamNewPipe/NewPipe/issues/9587.

#### Note:
- This PR prepares for upcoming updates by setting up the necessary changes for follow-up PRs.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #9587

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
