### PR TITLE
Add separate message when download is rejected due to insufficient storage

### DIFF
--- a/app/src/main/java/us/shandian/giga/ui/adapter/MissionAdapter.java
+++ b/app/src/main/java/us/shandian/giga/ui/adapter/MissionAdapter.java
@@ -490,7 +490,7 @@ public class MissionAdapter extends Adapter<ViewHolder> implements Handler.Callb
                 showError(mission, UserAction.DOWNLOAD_POSTPROCESSING, R.string.error_postprocessing_failed);
                 return;
             case ERROR_INSUFFICIENT_STORAGE:
-                msg = R.string.error_insufficient_storage;
+                msg = R.string.error_insufficient_storage_left;
                 break;
             case ERROR_UNKNOWN_EXCEPTION:
                 if (mission.errObject != null) {

--- a/app/src/main/res/values-ar-rLY/strings.xml
+++ b/app/src/main/res/values-ar-rLY/strings.xml
@@ -271,7 +271,7 @@
     <string name="import_data_summary">يلغي السجل الحالي والاشتراكات وقوائم التشغيل والإعدادات (اختياريًا)</string>
     <string name="app_ui_crash">تعطل التطبيق / واجهة المستخدم</string>
     <string name="rename">إعادة التسمية</string>
-    <string name="error_insufficient_storage">لم يتبقى مساحة في الجهاز</string>
+    <string name="error_insufficient_storage_left">لم يتبقى مساحة في الجهاز</string>
     <string name="could_not_setup_download_menu">تعذر إعداد قائمة التنزيل</string>
     <string name="download_path_dialog_title">اختر مجلد التنزيل لملفات الفيديو</string>
     <string name="notifications_disabled">تم تعطيل الإشعارات</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -407,7 +407,7 @@
     <string name="overwrite_failed">لا يمكن الكتابة فوق الملف</string>
     <string name="download_already_pending">هناك تنزيل معلق بهذا الاسم</string>
     <string name="error_postprocessing_stopped">تم إغلاق NewPipe أثناء العمل على الملف</string>
-    <string name="error_insufficient_storage">لم يتبقى مساحة في الجهاز</string>
+    <string name="error_insufficient_storage_left">لم يتبقى مساحة في الجهاز</string>
     <string name="error_progress_lost">تم فقد التقدم بسبب حذف الملف</string>
     <string name="error_timeout">انتهى وقت الاتصال</string>
     <string name="confirm_prompt">هل تريد محو سجل التنزيل، أم تريد حذف جميع الملفات التي تم تنزيلها؟</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -548,7 +548,7 @@
     <string name="remove_watched">İzləniləni sil</string>
     <string name="downloads_storage_use_saf_title">Sistem qovluğu seçicisini (SAF) istifadə et</string>
     <string name="error_timeout">Bağlantı fasiləsi</string>
-    <string name="error_insufficient_storage">Cihazda yer qalmayıb</string>
+    <string name="error_insufficient_storage_left">Cihazda yer qalmayıb</string>
     <string name="error_postprocessing_stopped">Fayl üzərində işləyərkən NewPipe bağlandı</string>
     <string name="error_postprocessing_failed">Emaldan sonra uğursuz oldu</string>
     <string name="error_connect_host">Serverə qoşulmaq mümkün deyil</string>

--- a/app/src/main/res/values-b+ast/strings.xml
+++ b/app/src/main/res/values-b+ast/strings.xml
@@ -171,7 +171,7 @@
     <string name="overwrite_finished_warning">Yá esiste un ficheru baxáu con esti nome</string>
     <string name="overwrite_failed">nun pue sobrecribise\'l ficheru</string>
     <string name="download_already_pending">Hai una descarga pendiente con esti nome</string>
-    <string name="error_insufficient_storage">Nun queda espaciu nel preséu</string>
+    <string name="error_insufficient_storage_left">Nun queda espaciu nel preséu</string>
     <string name="error_timeout">Escosó\'l tiempu d\'espera de la conexón</string>
     <string name="subscriptions_import_unsuccessful">Nun pudieron importase les soscripciones</string>
     <string name="caption_setting_title">Sotítulos</string>

--- a/app/src/main/res/values-b+uz+Latn/strings.xml
+++ b/app/src/main/res/values-b+uz+Latn/strings.xml
@@ -416,7 +416,7 @@
     <string name="error_download_resource_gone">Ushbu yuklab olishni tiklab bo\'lmaydi</string>
     <string name="error_timeout">Ulanish vaqti tugadi</string>
     <string name="error_progress_lost">Siljish yo\'qoldi, chunki fayl o\'chirildi</string>
-    <string name="error_insufficient_storage">Qurilmada bo\'sh joy qolmadi</string>
+    <string name="error_insufficient_storage_left">Qurilmada bo\'sh joy qolmadi</string>
     <string name="error_postprocessing_stopped">NewPipe fayl ustida ishlash paytida yopilgan</string>
     <string name="error_postprocessing_failed">Keyingi ishlov berilmadi</string>
     <string name="error_http_not_found">Topilmadi</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -399,7 +399,7 @@
     <string name="overwrite_failed">немагчыма перазапісаць файл</string>
     <string name="download_already_pending">Ў чарзе ўжо ёсць загрузка з такім імем</string>
     <string name="error_postprocessing_stopped">NewPipe была зачынена падчас працы над файлам</string>
-    <string name="error_insufficient_storage">Скончылася вольнае месца на прыладзе</string>
+    <string name="error_insufficient_storage_left">Скончылася вольнае месца на прыладзе</string>
     <string name="error_progress_lost">Прагрэс страчаны, так як файл быў выдалены</string>
     <string name="error_timeout">Час злучэння выйшла</string>
     <string name="confirm_prompt">Вы ўпэўнены\?</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -467,7 +467,7 @@
     <string name="choose_instance_prompt">Изберете инстанция</string>
     <string name="comments_are_disabled">Коментарите са изключени</string>
     <string name="main_page_content_summary">Кои раздели се показват на началната страница</string>
-    <string name="error_insufficient_storage">Няма свободно място на устройството</string>
+    <string name="error_insufficient_storage_left">Няма свободно място на устройството</string>
     <plurals name="seconds">
         <item quantity="one">%d секунда</item>
         <item quantity="other">%d секунди</item>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -165,7 +165,7 @@
     <string name="stop">বন্ধ করুন</string>
     <string name="delete_downloaded_files">ডাউনলোড করা ফাইলগুলো ডিলিট করুন</string>
     <string name="clear_download_history">ডাওন লোড ইতিহাস মুছুন</string>
-    <string name="error_insufficient_storage">ডিভাইস এ স্পেস নেই</string>
+    <string name="error_insufficient_storage_left">ডিভাইস এ স্পেস নেই</string>
     <string name="error_http_not_found">পাওয়া যায় নি</string>
     <string name="error_unknown_host">সার্ভার পাওয়া যায় নি</string>
     <string name="show_error">এরর দেখান</string>

--- a/app/src/main/res/values-bn-rIN/strings.xml
+++ b/app/src/main/res/values-bn-rIN/strings.xml
@@ -141,7 +141,7 @@
     <string name="app_language_title">অ্যাপ এর ভাষা</string>
     <string name="stop">বন্ধ করুন</string>
     <string name="clear_download_history">ডাওন লোড ইতিহাস মুছুন</string>
-    <string name="error_insufficient_storage">ডিভাইস এ স্পেস নেই</string>
+    <string name="error_insufficient_storage_left">ডিভাইস এ স্পেস নেই</string>
     <string name="error_http_not_found">পাওয়া যায় নি</string>
     <string name="error_unknown_host">সার্ভার পাওয়া যায় নি</string>
     <string name="download_failed">ডাউন লোড হয় নি</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -10,7 +10,7 @@
     <string name="stop">বন্ধ করুন</string>
     <string name="delete_downloaded_files">ডাউনলোড করা ফাইলগুলো ডিলিট করুন</string>
     <string name="clear_download_history">ডাওন লোড ইতিহাস মুছুন</string>
-    <string name="error_insufficient_storage">ডিভাইস এ স্পেস নেই</string>
+    <string name="error_insufficient_storage_left">ডিভাইস এ স্পেস নেই</string>
     <string name="error_http_not_found">পাওয়া যায় নি</string>
     <string name="error_unknown_host">সার্ভার পাওয়া যায় নি</string>
     <string name="show_error">এরর দেখান</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -385,7 +385,7 @@
     <string name="enable_playback_resume_title">Reprèn la reproducció</string>
     <string name="overwrite_failed">No es pot sobreescriure el fitxer</string>
     <string name="download_already_pending">Hi ha una baixada pendent amb aquest nom</string>
-    <string name="error_insufficient_storage">No hi ha espai disponible al dispositiu</string>
+    <string name="error_insufficient_storage_left">No hi ha espai disponible al dispositiu</string>
     <string name="error_progress_lost">S\'ha perdut el progrés perquè s\'ha eliminat el fitxer</string>
     <string name="error_timeout">S\'ha excedit el temps d\'espera de la connexió</string>
     <string name="confirm_prompt">Esteu segurs que voleu esborrar el vostre historial de baixades o esborrar-ne tots els fitxers\?</string>

--- a/app/src/main/res/values-ckb/strings.xml
+++ b/app/src/main/res/values-ckb/strings.xml
@@ -21,7 +21,7 @@
     <string name="grid">هێڵەکی</string>
     <string name="auto_queue_summary">به‌رده‌وامبوون له‌ (به‌بێ دووباره‌كردنه‌وه‌) نۆبه‌تی کارپێکەر به‌پێی په‌خشی هاوشێوه‌</string>
     <string name="enable_queue_limit">سنووردانانی نۆرەی دابەزاندن</string>
-    <string name="error_insufficient_storage">بیرگەی ناوەکیت پڕ بووە</string>
+    <string name="error_insufficient_storage_left">بیرگەی ناوەکیت پڕ بووە</string>
     <string name="subscribers_count_not_available">ژمارەی بەژداری نادیارە</string>
     <string name="overwrite_failed">ناتوانرێت لەسەر ئەو فایله‌وه‌ جێگیر بکرێت</string>
     <string name="tab_choose">په‌ڕه‌ هەڵبژێرە</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -396,7 +396,7 @@
     <string name="overwrite_failed">soubor nelze přepsat</string>
     <string name="download_already_pending">Soubor s tímto názvem již čeká na stažení</string>
     <string name="error_postprocessing_stopped">NewPipe byl ukončen v průběhu zpracovávání souboru</string>
-    <string name="error_insufficient_storage">V zařízení nezbývá žádné místo</string>
+    <string name="error_insufficient_storage_left">V zařízení nezbývá žádné místo</string>
     <string name="error_progress_lost">Postup ztracen, protože soubor byl smazán</string>
     <string name="confirm_prompt">Jste si jisti smazáním své historie stahování nebo smazáním všech stažených souborů\?</string>
     <string name="enable_queue_limit">Omezit frontu stahování</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -633,7 +633,7 @@
     <string name="drawer_header_description">Skift service, nuværende valg:</string>
     <string name="comments_are_disabled">Kommentarer er slået fra</string>
     <string name="no_app_to_open_intent">Ingen apps på din enhed kan åbne dette</string>
-    <string name="error_insufficient_storage">Ingen ledig plads på enheden</string>
+    <string name="error_insufficient_storage_left">Ingen ledig plads på enheden</string>
     <string name="app_language_title">App sprog</string>
     <string name="remove_watched_popup_yes_and_partially_watched_videos">Ja, og delvist sete videoer</string>
     <string name="feed_load_error">Fejl ved indlæsning af feed</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -405,7 +405,7 @@
     <string name="overwrite_failed">Datei kann nicht überschrieben werden</string>
     <string name="download_already_pending">Es ist ein ausstehender Download mit diesem Namen vorhanden</string>
     <string name="error_postprocessing_stopped">NewPipe wurde während der Verarbeitung der Datei geschlossen</string>
-    <string name="error_insufficient_storage">Kein Speicherplatz mehr auf dem Gerät</string>
+    <string name="error_insufficient_storage_left">Kein Speicherplatz mehr auf dem Gerät</string>
     <string name="error_progress_lost">Vorgang abgebrochen, da die Datei gelöscht wurde</string>
     <string name="confirm_prompt">Möchtest du deinen Downloadverlauf oder alle heruntergeladenen Dateien löschen\?</string>
     <string name="enable_queue_limit">Downloadwarteschlange begrenzen</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -395,7 +395,7 @@
     <string name="overwrite_failed">δεν είναι δυνατή η αντικατάσταση του αρχείου</string>
     <string name="download_already_pending">Υπάρχει μια εκκρεμής λήψη με αυτό το όνομα</string>
     <string name="error_postprocessing_stopped">Το NewPipe τερματίστηκε ενώ επεξεργάζονταν το αρχείο</string>
-    <string name="error_insufficient_storage">Δεν υπάρχει αρκετός χώρος στη συσκευή</string>
+    <string name="error_insufficient_storage_left">Δεν υπάρχει αρκετός χώρος στη συσκευή</string>
     <string name="error_progress_lost">Η πρόοδος χάθηκε, επειδή το αρχείο διαγράφηκε</string>
     <string name="error_timeout">Λήξη χρονικού ορίου σύνδεσης</string>
     <string name="confirm_prompt">Θέλετε να διαγράψετε το ιστορικό λήψεων σας ή να διαγράψετε όλα τα αρχεία που έχετε λάβει;</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -406,7 +406,7 @@
     <string name="overwrite_finished_warning">Elŝutita dosieron kun ĉi tiu nomo jam ekzistas</string>
     <string name="download_already_pending">Estas pritraktata elŝuto kun ĉi tiu nomo</string>
     <string name="error_postprocessing_stopped">NewPipe estis fermita dum laborante sur la dosiero</string>
-    <string name="error_insufficient_storage">Neniu spaco havebla sur la aparato</string>
+    <string name="error_insufficient_storage_left">Neniu spaco havebla sur la aparato</string>
     <string name="error_progress_lost">Progreso perdita, ĉar la dosiero estis forviŝita</string>
     <string name="error_timeout">Eltempiĝo de Konekto</string>
     <string name="drawer_header_description">Ŝangi la servon, nuntempe elektita:</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -376,7 +376,7 @@
     <string name="error_http_not_found">No encontrado</string>
     <string name="error_postprocessing_failed">Falló el posprocesamiento</string>
     <string name="error_postprocessing_stopped">NewPipe se cerró mientras se trabajaba en el archivo</string>
-    <string name="error_insufficient_storage">No hay suficiente espacio disponible en el dispositivo</string>
+    <string name="error_insufficient_storage_left">No hay suficiente espacio disponible en el dispositivo</string>
     <string name="error_progress_lost">Progreso perdido, porque el archivo fue borrado</string>
     <string name="error_timeout">El tiempo de conexión expiro</string>
     <string name="error_download_resource_gone">No se puede recuperar esta descarga</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -505,7 +505,7 @@
     <string name="clear_download_history">Kustuta allalaadimiste ajalugu</string>
     <string name="error_download_resource_gone">Seda allalaadimist ei saa uuesti alustada</string>
     <string name="error_timeout">Ühendus aegus</string>
-    <string name="error_insufficient_storage">Seadmes pole enam ruumi</string>
+    <string name="error_insufficient_storage_left">Seadmes pole enam ruumi</string>
     <string name="download_already_pending">Sellise nimega allalaadimine on juba pooleli</string>
     <string name="overwrite_failed">faili asendamine ei õnnestu</string>
     <string name="feed_create_new_group_button_title">Uus</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -396,7 +396,7 @@
     <string name="overwrite_failed">Ezin da fitxategia gainidatzi</string>
     <string name="download_already_pending">Badago izen bereko deskarga bat burutzeke</string>
     <string name="error_postprocessing_stopped">NewPipe itxi egin da fitxategian lanean zegoela</string>
-    <string name="error_insufficient_storage">Ez dago lekurik gailuan</string>
+    <string name="error_insufficient_storage_left">Ez dago lekurik gailuan</string>
     <string name="error_progress_lost">Progresioa galdu da, fitxategia ezabatu delako</string>
     <string name="confirm_prompt">Zure deskargen historiala garbitu nahi duzu ala deskargatutako fitxategi guztiak ezabatu\?</string>
     <string name="enable_queue_limit">Mugatu deskargen ilara</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -384,7 +384,7 @@
     <string name="overwrite_failed">ناتوانی در بازنویسی پرونده</string>
     <string name="download_already_pending">یک بارگیری دیگر با همین نام در صف قرار دارد</string>
     <string name="error_postprocessing_stopped">نیوپایپ در خلال کار روی پرونده، بسته شد</string>
-    <string name="error_insufficient_storage">فضایی روی دستگاه باقی نمانده است</string>
+    <string name="error_insufficient_storage_left">فضایی روی دستگاه باقی نمانده است</string>
     <string name="error_progress_lost">پیشرفت کار متوفق شد زیرا پرونده پاک شده است</string>
     <string name="error_timeout">پایان زمان اتصال</string>
     <string name="confirm_prompt">می‌خواهید تاریخچه بارگیری را پاک کنید یا همه پرونده‌هایی که بارگیری شده‌اند؟</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -481,7 +481,7 @@
     <string name="error_download_resource_gone">Tätä latausta ei voi palauttaa</string>
     <string name="error_timeout">Yhteys aikakatkaistiin</string>
     <string name="error_progress_lost">Eteneminen menetettiin, koska tiedosto poistettiin</string>
-    <string name="error_insufficient_storage">Laitteella ei ole tilaa</string>
+    <string name="error_insufficient_storage_left">Laitteella ei ole tilaa</string>
     <string name="error_postprocessing_stopped">NewPipe suljettiin, kun se käsitteli tiedostoa</string>
     <string name="error_postprocessing_failed">Jälkikäsittely epäonnistui</string>
     <string name="error_http_not_found">Ei löytynyt</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -395,7 +395,7 @@
     <string name="overwrite_failed">impossible d’écraser le fichier</string>
     <string name="download_already_pending">Il y a un téléchargement en attente avec ce nom</string>
     <string name="error_postprocessing_stopped">NewPipe a été fermé alors qu’il travaillait sur le fichier</string>
-    <string name="error_insufficient_storage">Aucun espace disponible sur l’appareil</string>
+    <string name="error_insufficient_storage_left">Aucun espace disponible sur l’appareil</string>
     <string name="error_progress_lost">Progression perdue car le fichier a été supprimé</string>
     <string name="confirm_prompt">Voulez-vous effacer l’historique de téléchargement ou supprimer tous les fichiers téléchargés \?</string>
     <string name="enable_queue_limit">Limiter la file d’attente de téléchargement</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -419,7 +419,7 @@
     <string name="error_download_resource_gone">Non se pode recuperar esta descarga</string>
     <string name="error_timeout">O tempo de espera da conexión</string>
     <string name="error_progress_lost">Perdeuse o progreso porque se eliminou o ficheiro</string>
-    <string name="error_insufficient_storage">Non queda espazo no dispositivo</string>
+    <string name="error_insufficient_storage_left">Non queda espazo no dispositivo</string>
     <string name="error_postprocessing_stopped">NewPipe pechouse mentres se traballaba no ficheiro</string>
     <string name="error_postprocessing_failed">Fallou o post-procesamento</string>
     <string name="error_http_not_found">Non se atopou</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -401,7 +401,7 @@
     <string name="overwrite_failed">לא ניתן לשכתב את הקובץ</string>
     <string name="download_already_pending">כבר יש הורדה ממתינה בשם הזה</string>
     <string name="error_postprocessing_stopped">NewPipe נסגר בזמן העבודה על הקובץ</string>
-    <string name="error_insufficient_storage">לא נשאר מקום במכשיר</string>
+    <string name="error_insufficient_storage_left">לא נשאר מקום במכשיר</string>
     <string name="error_progress_lost">התהליך אבד כיוון שהקובץ נמחק</string>
     <string name="error_timeout">החיבור המתין זמן רב מדי</string>
     <string name="confirm_prompt">למחוק את היסטוריית ההורדות שלך או למחוק את כל הקבצים שהורדת\?</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -379,7 +379,7 @@
     <string name="overwrite_failed">फाइल को ओवरराइट नहीं कर सकते</string>
     <string name="download_already_pending">इस नाम का एक डाउनलोड बाकी है</string>
     <string name="error_postprocessing_stopped">फ़ाइल पर कार्य करते समय न्यूपाइप बंद किया गया</string>
-    <string name="error_insufficient_storage">डिवाइस पर जगह समाप्त</string>
+    <string name="error_insufficient_storage_left">डिवाइस पर जगह समाप्त</string>
     <string name="error_progress_lost">प्रगति खो गई, क्योंकि फ़ाइल मिटा दी गई थी</string>
     <string name="error_timeout">कनेक्शन का समय समाप्त</string>
     <string name="confirm_prompt">क्या आप अपना डाउनलोड इतिहास मिटाना चाहते हैं या सभी डाउनलोड की गई फ़ाइलों को हटाना चाहते हैं\?</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -426,7 +426,7 @@
     <string name="feed_update_threshold_option_always_update">Uvijek aktualiziraj</string>
     <string name="feed_use_dedicated_fetch_method_enable_button">Uključi brzi način</string>
     <string name="feed_use_dedicated_fetch_method_disable_button">Isključi brzi način</string>
-    <string name="error_insufficient_storage">Memorija uređaja je popunjena</string>
+    <string name="error_insufficient_storage_left">Memorija uređaja je popunjena</string>
     <string name="most_liked">Najomiljeniji</string>
     <string name="subtitle_activity_recaptcha">Pritisni „Gotovo” kad je riješeno</string>
     <string name="done">Gotovo</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -348,7 +348,7 @@
     <string name="error_download_resource_gone">A letöltést nem lehet helyrehozni</string>
     <string name="error_timeout">Kapcsolati időtúllépés</string>
     <string name="error_progress_lost">Az előrehaladás elveszett, mert a fájlt törölték</string>
-    <string name="error_insufficient_storage">Nincs hely az eszközön</string>
+    <string name="error_insufficient_storage_left">Nincs hely az eszközön</string>
     <string name="error_postprocessing_stopped">A NewPipe leállt a fájl feldolgozása közben</string>
     <string name="error_postprocessing_failed">Utófeldolgozás sikertelen</string>
     <string name="error_http_not_found">Nincs talalat</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -389,7 +389,7 @@
     <string name="overwrite_failed">tidak bisa menimpa ulang berkas</string>
     <string name="download_already_pending">Ada unduhan yang dijeda dengan nama ini</string>
     <string name="error_postprocessing_stopped">NewPipe telah ditutup saat sedang memproses berkas</string>
-    <string name="error_insufficient_storage">Tidak ada ruang kosong tersisa pada perangkat</string>
+    <string name="error_insufficient_storage_left">Tidak ada ruang kosong tersisa pada perangkat</string>
     <string name="error_progress_lost">Kehilangan laju, karena berkas telah dihapus</string>
     <string name="confirm_prompt">Apakah Anda yakin ingin menghapus semua riwayat unduhan dan berkas yang telah diunduh\?</string>
     <string name="enable_queue_limit">Batasi antrean unduhan</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -680,7 +680,7 @@
     <string name="error_http_no_content">Netþjónninn sendir ekki gögn</string>
     <string name="error_http_unsupported_range">Netþjónninn styður ekki fjölþráðuð niðurhöl, reyndu aftur með @string/msg_threads = 1</string>
     <string name="error_postprocessing_stopped">NewPipe var lokað á meðan unnið var að skrá</string>
-    <string name="error_insufficient_storage">Ekkert pláss eftir á tæki</string>
+    <string name="error_insufficient_storage_left">Ekkert pláss eftir á tæki</string>
     <string name="error_progress_lost">Framvinda tapaðist vegna þess að skránni var eytt</string>
     <string name="error_download_resource_gone">Get ekki endurheimt þetta niðurhal</string>
     <string name="clear_download_history">Hreinsa niðurhalsferil</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -399,7 +399,7 @@
     <string name="overwrite_failed">impossibile sovrascrivere il file</string>
     <string name="download_already_pending">C\'è un download in corso con questo nome</string>
     <string name="error_postprocessing_stopped">NewPipe è stato chiuso mentre lavorava sul file</string>
-    <string name="error_insufficient_storage">Spazio insufficiente sul dispositivo</string>
+    <string name="error_insufficient_storage_left">Spazio insufficiente sul dispositivo</string>
     <string name="error_progress_lost">Progresso perso poiché il file è stato eliminato</string>
     <string name="confirm_prompt">Vuoi cancellare la cronologia dei download o eliminare tutti i file scaricati\?</string>
     <string name="enable_queue_limit_desc">Sarà avviato un solo download per volta</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -390,7 +390,7 @@
     <string name="overwrite_failed">ファイルを上書きできません</string>
     <string name="download_already_pending">同じファイル名のダウンロードが既に進行中です</string>
     <string name="error_postprocessing_stopped">ファイルの作業中に NewPipe が閉じられました</string>
-    <string name="error_insufficient_storage">デバイスに空き容量がありません</string>
+    <string name="error_insufficient_storage_left">デバイスに空き容量がありません</string>
     <string name="error_progress_lost">ファイルが削除されたため、進行状況が失われました</string>
     <string name="confirm_prompt">ダウンロード履歴、またはダウンロードしたファイルを消去しますか\?</string>
     <string name="enable_queue_limit">ダウンロード キューの制限</string>

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -461,7 +461,7 @@
     <string name="error_http_unsupported_range">სერვერი არ იღებს მრავალ ნაკადის ჩამოტვირთვებს, ხელახლა სცადეთ @string/msg_threads = 1</string>
     <string name="error_http_not_found">არ მოიძებნა</string>
     <string name="error_postprocessing_failed">შემდგომი დამუშავება ვერ მოხერხდა</string>
-    <string name="error_insufficient_storage">მოწყობილობაზე არ არის დარჩენილი თავისუფალი ადგილი</string>
+    <string name="error_insufficient_storage_left">მოწყობილობაზე არ არის დარჩენილი თავისუფალი ადგილი</string>
     <string name="error_timeout">Კავშირის დრო ამოიწურა</string>
     <string name="error_download_resource_gone">ამ ჩამოტვირთვის აღდგენა შეუძლებელია</string>
     <string name="delete_downloaded_files">გადმოწერილი ფაილების წაშლა</string>

--- a/app/src/main/res/values-kmr/strings.xml
+++ b/app/src/main/res/values-kmr/strings.xml
@@ -388,7 +388,7 @@
     <string name="error_download_resource_gone">Vê dakêşanê nikare paşde bibe</string>
     <string name="error_timeout">Dema girêdanê</string>
     <string name="error_progress_lost">Pêşkeftin winda bû, ji ber ku pel hate jêbirin</string>
-    <string name="error_insufficient_storage">Cih li cîhazê namîne</string>
+    <string name="error_insufficient_storage_left">Cih li cîhazê namîne</string>
     <string name="error_postprocessing_stopped">Dema ku pel dixebitî NewPipe hate girtin</string>
     <string name="error_postprocessing_failed">Pêvajoya şûnda têk çû</string>
     <string name="error_http_not_found">Peyda nebû</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -389,7 +389,7 @@
     <string name="overwrite_failed">파일을 덮어쓰기할 수 없습니다</string>
     <string name="download_already_pending">해당 이름으로 대기된 다운로드가 있습니다</string>
     <string name="error_postprocessing_stopped">파일 작업 중에 Newpipe가 종료되었습니다</string>
-    <string name="error_insufficient_storage">남은 저장공간이 없습니다</string>
+    <string name="error_insufficient_storage_left">남은 저장공간이 없습니다</string>
     <string name="error_progress_lost">파일이 삭제되어 진행이 중지되었습니다</string>
     <string name="error_timeout">연결시간 초과</string>
     <string name="confirm_prompt">모든 다운로드 기록과 파일을 삭제합니다.확실합니까\?</string>

--- a/app/src/main/res/values-ku/strings.xml
+++ b/app/src/main/res/values-ku/strings.xml
@@ -418,7 +418,7 @@
     <string name="pause_downloads_on_mobile_desc">بەسوودە بۆ کاتی گۆڕینی هێڵ بۆ داتای مۆبایل, لەگەڵ ئەوەشدا زۆربەی دابەزاندنەکان ڕاناگرێت</string>
     <string name="close">داخستن</string>
     <string name="error_postprocessing_stopped">ئەپ داخرا لەکاتی کارکردن لەسەر ئەو پەڕگەیە</string>
-    <string name="error_insufficient_storage">بیرگەی ناوەکیت پڕبووە</string>
+    <string name="error_insufficient_storage_left">بیرگەی ناوەکیت پڕبووە</string>
     <string name="error_progress_lost">کردارەکە شکستی هێنا, چونکە ئەو پەڕگەیە سڕاوەتەوە</string>
     <string name="error_timeout">هێڵی ئینتەرنێت نەما</string>
     <string name="confirm_prompt">ئایا دەتەوێ مێژووی دابەزاندنەکانت بسڕدرێنەوە یان هەموو فایلە دابەزێنراوەکانت بسڕدرێنەوە؟</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -553,7 +553,7 @@
     <string name="show_original_time_ago_title">Elementams rodyti orginalų \"prieš\" laiką</string>
     <string name="error_connect_host">Nepavyksta prisijungti prie serverio</string>
     <string name="error_file_creation">Failo sukurti nepavyko</string>
-    <string name="error_insufficient_storage">Įrenginyje nebėra vietos</string>
+    <string name="error_insufficient_storage_left">Įrenginyje nebėra vietos</string>
     <string name="error_unknown_host">Nepavyko rasti serverio</string>
     <string name="permission_denied">Sistema uždraudė veiksmą</string>
     <string name="feed_group_show_only_ungrouped_subscriptions">Rodyti tik negrupuotas prenumeratas</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -371,7 +371,7 @@
     <string name="error_download_resource_gone">Nevar atgūt šo lejupielādi</string>
     <string name="error_timeout">Savienojums pārtraukts</string>
     <string name="error_progress_lost">Progress zaudēts, jo fails tika izdzēsts</string>
-    <string name="error_insufficient_storage">Ierīcē nav vietas</string>
+    <string name="error_insufficient_storage_left">Ierīcē nav vietas</string>
     <string name="error_postprocessing_stopped">Strādājot ar failu, NewPipe tika aizvērts</string>
     <string name="error_postprocessing_failed">Pēcapstrāde neizdevās</string>
     <string name="error_http_not_found">Nav atrasts</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -379,7 +379,7 @@
     <string name="overwrite_unrelated_warning">Ддотека со ова име веќе постои</string>
     <string name="overwrite_finished_warning">Преземената дадотека со ова име веќе постои</string>
     <string name="error_postprocessing_stopped">NewPipe беше затворен додека работеше на датотеката</string>
-    <string name="error_insufficient_storage">Не останува простор на уредот</string>
+    <string name="error_insufficient_storage_left">Не останува простор на уредот</string>
     <string name="error_timeout">Истечено време за поврзување</string>
     <string name="confirm_prompt">Дали си сигурен\?</string>
     <string name="enable_queue_limit">Ограничи ја редицата за преземање</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -494,7 +494,7 @@
     <string name="error_download_resource_gone">ഈ ഡൗൺലോഡ് വീണ്ടെടുക്കാനാവില്ല</string>
     <string name="error_timeout">കണക്ഷൻ കാലഹരണപ്പെട്ടു</string>
     <string name="error_progress_lost">ഫയൽ ഇല്ലാതാക്കിയതിനാൽ പുരോഗതി നഷ്‌ടപ്പെട്ടു</string>
-    <string name="error_insufficient_storage">ഉപകരണത്തിൽ ഇനിയൊരു സ്ഥലവും ബാക്കിയില്ല</string>
+    <string name="error_insufficient_storage_left">ഉപകരണത്തിൽ ഇനിയൊരു സ്ഥലവും ബാക്കിയില്ല</string>
     <string name="error_postprocessing_stopped">ഫയലിൽ പ്രവർത്തിക്കുമ്പോൾ ന്യൂപൈപ്പ് അടച്ചു</string>
     <string name="error_postprocessing_failed">പോസ്റ്റ്-പ്രോസസ്സിംഗ് പരാജയപ്പെട്ടു</string>
     <string name="error_http_not_found">കണ്ടെത്താനായില്ല</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -395,7 +395,7 @@
     <string name="overwrite_failed">Kan ikke overskrive filen</string>
     <string name="download_already_pending">Det finnes en ventende nedlasting ved dette navnet</string>
     <string name="error_postprocessing_stopped">NewPipe ble lukket under arbeid med filen</string>
-    <string name="error_insufficient_storage">Ingen ledig plass på enheten</string>
+    <string name="error_insufficient_storage_left">Ingen ledig plass på enheten</string>
     <string name="error_progress_lost">Framdrift gikk tapt, fordi filen ble slettet</string>
     <string name="error_timeout">Tilkoblingsavbrudd</string>
     <string name="confirm_prompt">Ønsker du å slette din nedlastingshistorikk eller slette alle nedlastede filer\?</string>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -389,7 +389,7 @@
     <string name="overwrite_failed">फाइल अधिलेखन गर्न सकिएन</string>
     <string name="download_already_pending">यसै नाम सितको एक फाइल डाउनलोड हुने प्रक्रियामा छ</string>
     <string name="error_postprocessing_stopped">फाइल मा काम गर्दा NewPipe बन्द भएको थियो</string>
-    <string name="error_insufficient_storage">उपकरणमा कुनै ठाउँ बाकी छैन</string>
+    <string name="error_insufficient_storage_left">उपकरणमा कुनै ठाउँ बाकी छैन</string>
     <string name="error_progress_lost">प्रगति हरायो, किनभने फाइल मेटिएको थियो</string>
     <string name="error_timeout">जडान समय सकियो</string>
     <string name="confirm_prompt">तपाईं आफ्नो डाउनलोड इतिहास वा डाउनलोड फाइल मेटाउन चाहनुहुन्छ\?</string>

--- a/app/src/main/res/values-nl-rBE/strings.xml
+++ b/app/src/main/res/values-nl-rBE/strings.xml
@@ -465,7 +465,7 @@
     <string name="clear_download_history">Download geschiedenis verwijderen</string>
     <string name="error_download_resource_gone">Kan deze download niet herstellen</string>
     <string name="error_timeout">Verbinding time-out</string>
-    <string name="error_insufficient_storage">Geen vrije ruimte meer op het apparaat</string>
+    <string name="error_insufficient_storage_left">Geen vrije ruimte meer op het apparaat</string>
     <string name="error_postprocessing_stopped">NewPipe werd gesloten terwijl het bezig was met het bestand</string>
     <string name="download_already_pending">Er staat al een download met deze naam in wacht</string>
     <string name="overwrite_failed">Kan bestand niet overschrijven</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -396,7 +396,7 @@
     <string name="overwrite_unrelated_warning">Een bestand met dezelfde naam bestaat al</string>
     <string name="overwrite_failed">Kan bestand niet overschrijven</string>
     <string name="download_already_pending">Er is al een download met deze naam bezig</string>
-    <string name="error_insufficient_storage">Geen vrije ruimte meer op het apparaat</string>
+    <string name="error_insufficient_storage_left">Geen vrije ruimte meer op het apparaat</string>
     <string name="error_progress_lost">Voortgang verloren, omdat bestand was verwijderd</string>
     <string name="confirm_prompt">Wilt u de downloadgeschiedenis of alle gedownloade bestanden verwijderen\?</string>
     <string name="enable_queue_limit">Download­wachtrij limiteren</string>

--- a/app/src/main/res/values-nqo/strings.xml
+++ b/app/src/main/res/values-nqo/strings.xml
@@ -517,7 +517,7 @@
     <string name="error_http_not_found">ߊ߬ ߕߍ߫ ߡߊߛߐ߬ߘߐ߲߬</string>
     <string name="error_postprocessing_failed">ߞߐߝߍ߫-ߦߙߍߞߍߟߌ ߓߘߊ߫ ߗߌߙߏ߲߫</string>
     <string name="error_postprocessing_stopped">ߣߌߎߔߌߔ ߘߊߕߎ߲߯ ߘߊ߫ ߟߋ߬ ߞߵߊ߬ ߕߘߍ߬ ߊ߬ ߦߋ߫ ߓߊ߯ߙߊ߫ ߟߊ߫ ߞߐߕߐ߮ ߞߊ߲߬</string>
-    <string name="error_insufficient_storage">ߜߍߞߣߍ߫ ߛߌ߫ ߕߍ߫ ߕߙߏߞߏ ߞߊ߲߬</string>
+    <string name="error_insufficient_storage_left">ߜߍߞߣߍ߫ ߛߌ߫ ߕߍ߫ ߕߙߏߞߏ ߞߊ߲߬</string>
     <string name="error_progress_lost">ߢߍߕߊ߮ ߓߘߊ߫ ߝߏ߫߸ ߓߊߏ߬ ߞߐߕߐ߮ ߓߘߊ߫ ߖߏ߬ߛߌ߫</string>
     <string name="error_download_resource_gone">ߟߊ߬ߖߌ߰ߟߌ ߣߌ߲߬ ߕߍ߫ ߛߋ߫ ߟߊߛߊ߬ߦߌ߬ ߟߊ߫</string>
     <string name="delete_downloaded_files">ߞߊ߬ ߞߐߕߐ߯ ߟߊߖߌ߰ߣߍ߲ ߠߎ߬ ߖߏ߬ߛߌ߫</string>

--- a/app/src/main/res/values-or/strings.xml
+++ b/app/src/main/res/values-or/strings.xml
@@ -378,7 +378,7 @@
     <string name="error_progress_lost">ପ୍ରଗତି ହଜିଗଲା, କାରଣ ଫାଇଲ୍ ଡିଲିଟ୍ ହେଲା</string>
     <string name="error_postprocessing_failed">ପରବର୍ତ୍ତୀ ପ୍ରକ୍ରିୟାକରଣ ବିଫଳ ହେଲା</string>
     <string name="error_postprocessing_stopped">ଫାଇଲରେ କାମ କରିବାବେଳେ ନ୍ୟୁ ପାଇପ୍ ବନ୍ଦ ହୋଇଯାଇଥିଲା</string>
-    <string name="error_insufficient_storage">ଡିଭାଇସରେ କୌଣସି ସ୍ଥାନ ବାକି ନାହିଁ</string>
+    <string name="error_insufficient_storage_left">ଡିଭାଇସରେ କୌଣସି ସ୍ଥାନ ବାକି ନାହିଁ</string>
     <string name="delete_downloaded_files_confirm">ଡିସ୍କରୁ ସମସ୍ତ ଡାଉନଲୋଡ୍ ହୋଇଥିବା ଫାଇଲଗୁଡ଼ିକୁ ଲିଭାନ୍ତୁ\?</string>
     <string name="stop">ବନ୍ଦ କର</string>
     <string name="max_retry_msg">ସର୍ବାଧିକ ପୁନଃଚେଷ୍ଟା</string>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -395,7 +395,7 @@
     <string name="overwrite_failed">ਫਾਈਲ ਓਵਰਰਾਈਟ ਨਹੀਂ ਹੋ ਸਕਦੀ</string>
     <string name="download_already_pending">ਇਸ ਨਾਮ ਦਾ ਇੱਕ ਡਾਊਨਲੋਡ ਬਕਾਇਆ ਹੈ</string>
     <string name="error_postprocessing_stopped">ਫਾਈਲ ਤੇ ਕੰਮ ਕਰਦੇ ਸਮੇਂ ਨਿਊਪਾਈਪ ਬੰਦ ਕੀਤੀ ਗਈ</string>
-    <string name="error_insufficient_storage">ਡਿਵਾਈਸ ਤੇ ਕੋਈ ਜਗ੍ਹਾ ਨਹੀਂ ਬਚੀ ਹੈ</string>
+    <string name="error_insufficient_storage_left">ਡਿਵਾਈਸ ਤੇ ਕੋਈ ਜਗ੍ਹਾ ਨਹੀਂ ਬਚੀ ਹੈ</string>
     <string name="error_progress_lost">ਪ੍ਰਗਤੀ ਖਤਮ ਹੋ ਗਈ, ਕਿਉਂਕਿ ਫਾਈਲ ਮਿਟਾਈ ਗਈ</string>
     <string name="error_timeout">ਕੁਨੈਕਸ਼ਨ ਦਾ ਸਮਾਂ ਸਮਾਪਤ</string>
     <string name="confirm_prompt">ਕੀ ਤੁਸੀਂ ਆਪਣਾ ਡਾਊਨਲੋਡ ਇਤਿਹਾਸ ਹਟਾਉਣਾ ਚਾਹੁੰਦੇ ਹੋ ਜਾਂ ਡਾਊਨਲੋਡ ਕੀਤੀਆਂ ਸਾਰੀਆਂ ਫ਼ਾਈਲਾਂ ਮਿਟਾਉਣਾ ਚਾਹੁੰਦੇ ਹੋ\?</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -401,7 +401,7 @@
     <string name="overwrite_failed">Nie udało się nadpisać pliku</string>
     <string name="download_already_pending">Plik o tej samej nazwie oczekuje na pobranie</string>
     <string name="error_postprocessing_stopped">NewPipe został zamknięty podczas pracy nad plikiem</string>
-    <string name="error_insufficient_storage">Brak miejsca na urządzeniu</string>
+    <string name="error_insufficient_storage_left">Brak miejsca na urządzeniu</string>
     <string name="error_progress_lost">Utracono postęp, ponieważ plik został usunięty</string>
     <string name="confirm_prompt">Czy chcesz wyczyścić historię pobierania, czy usunąć wszystkie pobrane pliki\?</string>
     <string name="enable_queue_limit">Ogranicz kolejkę pobierania</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -398,7 +398,7 @@
     <string name="overwrite_failed">O arquivo não pode ser sobrescrito</string>
     <string name="download_already_pending">Já existe um download pendente com este nome</string>
     <string name="error_postprocessing_stopped">O NewPipe foi fechado enquanto manipulava o arquivo</string>
-    <string name="error_insufficient_storage">Sem espaço disponível</string>
+    <string name="error_insufficient_storage_left">Sem espaço disponível</string>
     <string name="error_progress_lost">O progresso foi perdido pois o arquivo foi excluído</string>
     <string name="error_timeout">Tempo limite de conexão</string>
     <string name="confirm_prompt">Excluir todo o histórico de downloads ou excluir todos os arquivos baixados\?</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -221,7 +221,7 @@
     <string name="feed_oldest_subscription_update">Última atualização: %s</string>
     <string name="import_data_title">Importar base de dados</string>
     <string name="error_report_title">Relatório de erro</string>
-    <string name="error_insufficient_storage">Não há espaço livre no dispositivo</string>
+    <string name="error_insufficient_storage_left">Não há espaço livre no dispositivo</string>
     <string name="max_retry_desc">Número máximo de tentativas antes de cancelar a descarga</string>
     <string name="player_recoverable_failure">A recuperar de um erro do reprodutor</string>
     <string name="duration_live">Em direto</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -398,7 +398,7 @@
     <string name="overwrite_failed">Não foi possível substituir o ficheiro</string>
     <string name="download_already_pending">Existe uma descarga pendente com este nome</string>
     <string name="error_postprocessing_stopped">NewPipe foi fechado enquanto trabalhava no ficheiro</string>
-    <string name="error_insufficient_storage">Não há espaço livre no dispositivo</string>
+    <string name="error_insufficient_storage_left">Não há espaço livre no dispositivo</string>
     <string name="error_progress_lost">Progresso perdido, o ficheiro foi eliminado</string>
     <string name="error_timeout">Ligação expirada</string>
     <string name="confirm_prompt">Deseja limpar o histórico de descargas ou remover todos os ficheiros descarregados\?</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -475,7 +475,7 @@
     <string name="error_download_resource_gone">Nu se poate recupera această descărcare</string>
     <string name="error_timeout">Conexiunea a expirat</string>
     <string name="error_progress_lost">Progres pierdut, deoarece fișierul a fost șters</string>
-    <string name="error_insufficient_storage">Nu a mai rămas spațiu pe dispozitiv</string>
+    <string name="error_insufficient_storage_left">Nu a mai rămas spațiu pe dispozitiv</string>
     <string name="error_postprocessing_stopped">NewPipe a fost închis în timp ce lucra la fișier</string>
     <string name="error_postprocessing_failed">Post-procesarea a eșuat</string>
     <string name="error_http_not_found">Nu a fost găsit</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -405,7 +405,7 @@
     <string name="overwrite_failed">не удаётся перезаписать файл</string>
     <string name="download_already_pending">В очереди уже есть загрузка с таким именем</string>
     <string name="error_postprocessing_stopped">NewPipe была закрыта во время работы над файлом</string>
-    <string name="error_insufficient_storage">Закончилось свободное место на устройстве</string>
+    <string name="error_insufficient_storage_left">Закончилось свободное место на устройстве</string>
     <string name="error_progress_lost">Прогресс потерян, так как файл был удалён</string>
     <string name="confirm_prompt">Действительно удалить историю загрузок и загруженные файлы\?</string>
     <string name="enable_queue_limit">Ограничить очередь загрузки</string>

--- a/app/src/main/res/values-ryu/strings.xml
+++ b/app/src/main/res/values-ryu/strings.xml
@@ -392,7 +392,7 @@
     <string name="overwrite_failed">ファイルうわがきなやびらん</string>
     <string name="download_already_pending">いぬファイルめいぬダウンロードぬしでぃにしんこうちゅうやいびーん</string>
     <string name="error_postprocessing_stopped">ファイルぬさぎょうちゅうにNewPipeぬくーららりやびたん</string>
-    <string name="error_insufficient_storage">デバイスんかいにりらりょうぬあいびらん</string>
+    <string name="error_insufficient_storage_left">デバイスんかいにりらりょうぬあいびらん</string>
     <string name="error_progress_lost">ファイルぬさちゅるじょさったるたみ、しんこうじょうちゅーがうしならりやびたん</string>
     <string name="confirm_prompt">ダウンロードりりき、あらんでぃダウンロードさるファイルしーょうきょさびーが？</string>
     <string name="enable_queue_limit">ダウンロードキューぬせいぎん</string>

--- a/app/src/main/res/values-sat/strings.xml
+++ b/app/src/main/res/values-sat/strings.xml
@@ -708,7 +708,7 @@
     <string name="app_description">ᱟᱱᱰᱨᱚᱭᱮᱰ ᱨᱮ ᱞᱤᱵᱨᱮ ᱞᱟᱭᱤᱴᱣᱮᱴ ᱥᱴᱨᱤᱢᱤᱝ</string>
     <string name="metadata_tags">ᱴᱮᱜᱥ</string>
     <string name="metadata_privacy_public">ᱥᱚᱨᱠᱟᱨᱤ</string>
-    <string name="error_insufficient_storage">ᱚᱱᱚᱞ ᱨᱮ ᱡᱟᱭᱜᱟ ᱵᱟᱹᱱᱩᱜᱼᱟ</string>
+    <string name="error_insufficient_storage_left">ᱚᱱᱚᱞ ᱨᱮ ᱡᱟᱭᱜᱟ ᱵᱟᱹᱱᱩᱜᱼᱟ</string>
     <string name="detail_sub_channel_thumbnail_view_description">ᱪᱮᱱᱮᱞ ᱨᱮᱱᱟᱜ ᱟᱵᱟᱛᱟᱨ ᱛᱷᱩᱱᱤᱠᱟ</string>
     <string name="playlist_page_summary">ᱥᱮᱨᱮᱧ ᱞᱤᱥᱴᱤ ᱥᱟᱦᱴᱟ</string>
     <string name="never">ᱵᱟᱝ</string>

--- a/app/src/main/res/values-sc/strings.xml
+++ b/app/src/main/res/values-sc/strings.xml
@@ -316,7 +316,7 @@
     <string name="error_download_resource_gone">Impossìbile recuperare custu iscarrigamentu</string>
     <string name="error_timeout">Connessione iscadida</string>
     <string name="error_progress_lost">Su progressu s\'est pèrdidu, ca su documentu est istadu iscantzelladu</string>
-    <string name="error_insufficient_storage">Perunu ispàtziu abarradu in su dispositivu</string>
+    <string name="error_insufficient_storage_left">Perunu ispàtziu abarradu in su dispositivu</string>
     <string name="error_postprocessing_stopped">NewPipe est istadu serradu in su mentres chi fiat traballende a su documentu</string>
     <string name="error_postprocessing_failed">Post-protzessamentu fallidu</string>
     <string name="error_http_not_found">No agatadu</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -398,7 +398,7 @@
     <string name="overwrite_failed">súbor nemožno prepísať</string>
     <string name="download_already_pending">Súbor s rovnakým názvom už čaká na stiahnutie</string>
     <string name="error_postprocessing_stopped">NewPipe bol ukončený počas spracovávania súboru</string>
-    <string name="error_insufficient_storage">Máš plnú pamäť</string>
+    <string name="error_insufficient_storage_left">Máš plnú pamäť</string>
     <string name="error_progress_lost">Nemožno pokračovať, súbor bol vymazaný</string>
     <string name="error_timeout">Spojenie vypršalo</string>
     <string name="confirm_prompt">Chcete vymazať históriu sťahovania alebo odstrániť všetky stiahnuté súbory\?</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -211,7 +211,7 @@
     <string name="clear_download_history">Počisti zgodovino prenosa</string>
     <string name="error_download_resource_gone">Ni mogoče povrniti prenos</string>
     <string name="error_progress_lost">Napredek je izgubljen, ker je bila datoteka izbrisana</string>
-    <string name="error_insufficient_storage">Ni več prostora v vaši napravi</string>
+    <string name="error_insufficient_storage_left">Ni več prostora v vaši napravi</string>
     <string name="error_postprocessing_stopped">NewPipe se je zaprl medtem ko je delal z datoteko</string>
     <string name="error_http_not_found">Ni najden</string>
     <string name="error_http_no_content">Strežnik ne pošilja informacij</string>

--- a/app/src/main/res/values-so/strings.xml
+++ b/app/src/main/res/values-so/strings.xml
@@ -520,7 +520,7 @@
     <string name="error_download_resource_gone">Dajintan lama hagaajin karo</string>
     <string name="error_timeout">Ku xidhidii ayaa wakhtigii ka dhacay</string>
     <string name="error_progress_lost">Hawshii socotay way kala kacday, sababtoo ah shayga waa lala saaray</string>
-    <string name="error_insufficient_storage">Meel banaan oo wax lagu kaydiyo aalaada kuma hadhin</string>
+    <string name="error_insufficient_storage_left">Meel banaan oo wax lagu kaydiyo aalaada kuma hadhin</string>
     <string name="error_postprocessing_stopped">NewPipe waxaa la xidhay asagoo fayl ka shaqaynaya</string>
     <string name="error_postprocessing_failed">Habayntii way guuldareystay</string>
     <string name="error_http_not_found">Lama helin</string>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -82,7 +82,7 @@
     <string name="error_download_resource_gone">Nuk mund të rikuperohet ky shkarkim</string>
     <string name="error_timeout">Koha e lidhjes skadoi</string>
     <string name="error_progress_lost">Progresi humbi, pasi skedari është fshirë</string>
-    <string name="error_insufficient_storage">Nuk ka vend bosh në pajisje</string>
+    <string name="error_insufficient_storage_left">Nuk ka vend bosh në pajisje</string>
     <string name="error_postprocessing_stopped">NewPipe u mbyll ndërkohë që po punohej mbi skedarin</string>
     <string name="error_postprocessing_failed">Procesimi dështoi</string>
     <string name="error_http_not_found">Nuk u gjet</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -237,7 +237,7 @@
     <string name="error_download_resource_gone">Није могуће опоравити ово преузимање</string>
     <string name="error_timeout">Веза је истекла</string>
     <string name="error_progress_lost">Напредак је изгубљен, јер је фајл избрисан</string>
-    <string name="error_insufficient_storage">Недовољно меморије на уређају</string>
+    <string name="error_insufficient_storage_left">Недовољно меморије на уређају</string>
     <string name="error_postprocessing_stopped">NewPipe је затворен док је радио на фајлу</string>
     <string name="error_postprocessing_failed">Накнадна обрада није успела</string>
     <string name="error_http_not_found">Није пронађено</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -503,7 +503,7 @@
     <string name="error_download_resource_gone">Kan inte återställa den här hämtningen</string>
     <string name="error_timeout">Anslutnings avbrott</string>
     <string name="error_progress_lost">Framsteg förlorat, för att filen blev borttagen</string>
-    <string name="error_insufficient_storage">Inget utrymme kvar på enhet</string>
+    <string name="error_insufficient_storage_left">Inget utrymme kvar på enhet</string>
     <string name="error_postprocessing_stopped">NewPipe stängdes under arbete med en fil</string>
     <string name="error_report_open_github_notice">Vänligen kontrollera om en felrapport som tar upp din krasch redan finns. Att skapa ärenden när en felrapport redan finns, tar av den tid som vi annars kunde ha ägnat åt att fixa den faktiska buggen.</string>
     <string name="error_report_open_issue_button_text">Rapportera på GitHub</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -390,7 +390,7 @@
     <string name="overwrite_failed">dosyanın üzerine yazılamaz</string>
     <string name="download_already_pending">Bu isim ile bekleyen bir indirme var</string>
     <string name="error_postprocessing_stopped">NewPipe bu dosya üzerinde çalışırken kapandı</string>
-    <string name="error_insufficient_storage">Aygıt üzerinde yer yok</string>
+    <string name="error_insufficient_storage_left">Aygıt üzerinde yer yok</string>
     <string name="error_progress_lost">İlerleme kaybedildi, çünkü dosya silinmiş</string>
     <string name="error_timeout">Bağlantı zaman aşımı</string>
     <string name="confirm_prompt">İndirme geçmişinizi temizlemek veya indirilen tüm dosyaları silmek istiyor musunuz\?</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -398,7 +398,7 @@
     <string name="overwrite_failed">не можу перезаписати файл</string>
     <string name="download_already_pending">Завантаження з такою назвою вже додано в чергу</string>
     <string name="error_postprocessing_stopped">NewPipe був закритий під час роботи над файлом</string>
-    <string name="error_insufficient_storage">На пристрої не залишилося вільного місця</string>
+    <string name="error_insufficient_storage_left">На пристрої не залишилося вільного місця</string>
     <string name="error_progress_lost">Прогрес втрачено через видалення файлу</string>
     <string name="error_timeout">Час очікування з\'єднання вичерпано</string>
     <string name="confirm_prompt">Очистити історію завантажень чи завантажені файли\?</string>

--- a/app/src/main/res/values-ur/strings.xml
+++ b/app/src/main/res/values-ur/strings.xml
@@ -390,7 +390,7 @@
     <string name="overwrite_failed">فائل برتحریر نہیں کر سکتا</string>
     <string name="download_already_pending">اس نام کے ساتھ ڈاؤن لوڈ زیر التوا ہے</string>
     <string name="error_postprocessing_stopped">فائل پر کام کرنے کے دوران نیو پائپ بند کردی گئی تھی</string>
-    <string name="error_insufficient_storage">آلہ میں کوئی جگہ نہیں بچی</string>
+    <string name="error_insufficient_storage_left">آلہ میں کوئی جگہ نہیں بچی</string>
     <string name="error_progress_lost">پیشرفت ختم ہوگئی، کیونکہ فائل کو حذف کردیا گیا تھا</string>
     <string name="error_timeout">رابطے کا وقت ختم</string>
     <string name="confirm_prompt">کیا آپ اپنی ڈاؤن لوڈ کی سرگزشت کو صاف کرنا چاہتے ہیں یا ڈاؤن لوڈ کی گئی تمام فائلوں کو حذف کرنا چاہتے ہیں؟</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -392,7 +392,7 @@
     <string name="overwrite_failed">Không thể ghi đè lên tệp</string>
     <string name="download_already_pending">Có một bản tải xuống đang chờ xử lí với tên này</string>
     <string name="error_postprocessing_stopped">Newpipe đã bị đóng khi đang xử lí tệp</string>
-    <string name="error_insufficient_storage">Không đủ dung lượng trên máy</string>
+    <string name="error_insufficient_storage_left">Không đủ dung lượng trên máy</string>
     <string name="error_progress_lost">Quá trình tải bị hủy, vì tập tin đã bị xoá</string>
     <string name="error_timeout">Kết nối hết thời gian</string>
     <string name="confirm_prompt">Bạn muốn xóa lịch sử tải về hay xóa tất cả những file đã tải về\?</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -393,7 +393,7 @@
     <string name="overwrite_failed">无法覆盖文件</string>
     <string name="download_already_pending">已暂停下载包含此名称的任务</string>
     <string name="error_postprocessing_stopped">NewPipe 在处理文件时被关闭</string>
-    <string name="error_insufficient_storage">设备上没有剩余储存空间</string>
+    <string name="error_insufficient_storage_left">设备上没有剩余储存空间</string>
     <string name="error_progress_lost">进度丢失，文件已被删除</string>
     <string name="error_timeout">连接超时</string>
     <string name="confirm_prompt">是否清空下载记录或删除所有下载的文件？</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -454,7 +454,7 @@
     <string name="error_path_creation">建立唔到呢個目的地資料夾</string>
     <string name="error_ssl_exception">建立唔到安全連線</string>
     <string name="start_here_on_background">喺幕後開始播放</string>
-    <string name="error_insufficient_storage">部機冇晒位</string>
+    <string name="error_insufficient_storage_left">部機冇晒位</string>
     <string name="max_retry_msg">頂櫳重試幾多次</string>
     <string name="pause_downloads_on_mobile_desc">若然有機會用到流動數據嘅時候，可能會用得著，雖則有啲下載冇得暫停</string>
     <string name="enable_queue_limit">輪住嚟下載</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -390,7 +390,7 @@
     <string name="overwrite_failed">無法覆寫檔案</string>
     <string name="download_already_pending">已有擱置中的下載與此同名</string>
     <string name="error_postprocessing_stopped">NewPipe 在處理檔案時被關閉</string>
-    <string name="error_insufficient_storage">裝置上沒有剩餘的空間</string>
+    <string name="error_insufficient_storage_left">裝置上沒有剩餘的空間</string>
     <string name="error_progress_lost">進度遺失，因為檔案已被刪除</string>
     <string name="confirm_prompt">您想要清除您的下載歷史記錄，還是刪除所有已下載的檔案？</string>
     <string name="enable_queue_limit">限制下載佇列</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -616,7 +616,8 @@
     <string name="error_http_not_found">Not found</string>
     <string name="error_postprocessing_failed">Post-processing failed</string>
     <string name="error_postprocessing_stopped">NewPipe was closed while working on the file</string>
-    <string name="error_insufficient_storage">No space left on device</string>
+    <string name="error_insufficient_storage">Not enough free space on device</string>
+    <string name="error_insufficient_storage_left">No space left on device</string>
     <string name="error_progress_lost">Progress lost, because the file was deleted</string>
     <string name="error_timeout">Connection timeout</string>
     <string name="error_download_resource_gone">Cannot recover this download</string>


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Follow up to #10505 
Use a better fitting description of why a download was rejected.
Before: No space left on device
After: Not enough free space on device

#### Before/After Screenshots/Screen Record
Before:
<img src="https://github.com/TeamNewPipe/NewPipe/assets/76801836/6d5b09d6-4f29-4943-a328-a8a884fdde0a" alt="NO space left on device" width="200"/>


#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
