### PR TITLE
Use groupingBy collector in ListHelper

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
@@ -28,6 +28,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -338,18 +339,9 @@ public final class ListHelper {
             return Collections.emptyList();
         }
 
-        final HashMap<String, List<AudioStream>> collectedStreams = new HashMap<>();
-
-        for (final AudioStream stream : audioStreams) {
-            final String trackId = Objects.toString(stream.getAudioTrackId(), "");
-            if (collectedStreams.containsKey(trackId)) {
-                collectedStreams.get(trackId).add(stream);
-            } else {
-                final List<AudioStream> list = new ArrayList<>();
-                list.add(stream);
-                collectedStreams.put(trackId, list);
-            }
-        }
+        final Map<String, List<AudioStream>> collectedStreams = audioStreams.stream()
+                .collect(Collectors.groupingBy(stream ->
+                        Objects.requireNonNullElse(stream.getAudioTrackId(), "")));
 
         // Filter unknown audio tracks if there are multiple tracks
         if (collectedStreams.size() > 1) {


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Codebase improvement (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Use the [`groupingBy`](https://docs.oracle.com/javase/8/docs/api/java/util/stream/Collectors.html#groupingBy-java.util.function.Function-) collector in the `ListHelper` class.

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
