### PR TITLE
Fix not considering nullability when comparing getAudioTrackType

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
@@ -874,6 +874,7 @@ public final class ListHelper {
 
         return Comparator.comparing(AudioStream::getAudioLocale, Comparator.nullsLast(
                         Comparator.comparing(locale -> locale.getDisplayName(appLoc))))
-                .thenComparing(AudioStream::getAudioTrackType);
+                .thenComparing(AudioStream::getAudioTrackType, Comparator.nullsLast(
+                        Comparator.naturalOrder()));
     }
 }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR

`AudioStream.getAudioTrackType()` is correctly marked as being `@Nullable` [in the extractor](https://github.com/TeamNewPipe/NewPipeExtractor/blob/fc67d49f59b7709ac1e61507167b0732c63a9403/extractor/src/main/java/org/schabi/newpipe/extractor/stream/AudioStream.java#L510). However, the nullability was not considered when comparing audio streams in `getAudioTrackNameComparator`. I fixed this and checked neighboring `get*Comparator` functions, but those were already correct.

To check that this is in fact working, use this video, as suggested in the issue: https://www.youtube.com/watch?v=mKdjycj-7eE

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #10883

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
