### PR TITLE
Download fixes

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
@@ -7,8 +7,6 @@ import static org.schabi.newpipe.util.Localization.assureCorrectAppLanguage;
 import android.app.Activity;
 import android.content.ComponentName;
 import android.content.Context;
-import android.content.DialogInterface;
-import android.content.DialogInterface.OnDismissListener;
 import android.content.Intent;
 import android.content.ServiceConnection;
 import android.content.SharedPreferences;
@@ -113,9 +111,6 @@ public class DownloadDialog extends DialogFragment
     @State
     int selectedSubtitleIndex = 0; // default to the first item
 
-    @Nullable
-    private OnDismissListener onDismissListener = null;
-
     private StoredDirectoryHelper mainStorageAudio = null;
     private StoredDirectoryHelper mainStorageVideo = null;
     private DownloadManager downloadManager = null;
@@ -193,13 +188,6 @@ public class DownloadDialog extends DialogFragment
                 getStreamsOfSpecifiedDelivery(info.getSubtitles(), PROGRESSIVE_HTTP), context);
 
         this.selectedVideoIndex = ListHelper.getDefaultResolutionIndex(context, videoStreams);
-    }
-
-    /**
-     * @param onDismissListener the listener to call in {@link #onDismiss(DialogInterface)}
-     */
-    public void setOnDismissListener(@Nullable final OnDismissListener onDismissListener) {
-        this.onDismissListener = onDismissListener;
     }
 
 
@@ -362,14 +350,6 @@ public class DownloadDialog extends DialogFragment
             }
             return false;
         });
-    }
-
-    @Override
-    public void onDismiss(@NonNull final DialogInterface dialog) {
-        super.onDismiss(dialog);
-        if (onDismissListener != null) {
-            onDismissListener.onDismiss(dialog);
-        }
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
@@ -115,7 +115,7 @@ public class DownloadDialog extends DialogFragment
     private StoredDirectoryHelper mainStorageVideo = null;
     private DownloadManager downloadManager = null;
     private ActionMenuItemView okButton = null;
-    private Context context;
+    private Context context = null;
     private boolean askForSavePath;
 
     private AudioTrackAdapter audioTrackAdapter;
@@ -209,6 +209,8 @@ public class DownloadDialog extends DialogFragment
             return;
         }
 
+        // context will remain null if dismiss() was called above, allowing to check whether the
+        // dialog is being dismissed in onViewCreated()
         context = getContext();
 
         setStyle(STYLE_NO_TITLE, ThemeHelper.getDialogTheme(context));
@@ -293,6 +295,9 @@ public class DownloadDialog extends DialogFragment
                               @Nullable final Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         dialogBinding = DownloadDialogBinding.bind(view);
+        if (context == null) {
+            return; // the dialog is being dismissed, see the call to dismiss() in onCreate()
+        }
 
         dialogBinding.fileName.setText(FilenameUtils.createFilename(getContext(),
                 currentInfo.getName()));

--- a/app/src/main/java/us/shandian/giga/service/DownloadManagerService.java
+++ b/app/src/main/java/us/shandian/giga/service/DownloadManagerService.java
@@ -411,7 +411,7 @@ public class DownloadManagerService extends Service {
         mission.threadCount = threads;
         mission.source = source;
         mission.nearLength = nearLength;
-        mission.recoveryInfo = recovery.toArray(MissionRecoveryInfo[]::new);
+        mission.recoveryInfo = recovery.toArray(new MissionRecoveryInfo[0]);
 
         if (ps != null)
             ps.setTemporalDir(DownloadManager.pickAvailableTemporalDir(this));


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR

This PR contains 4 commits:
- The non-desugared `toArray(IntFunction)` method was being used when loading download missions. The [desugaring documentation](https://developer.android.com/studio/write/java8-support-table) reports it as "Not supported at all minSDK levels". This bug was introduced by f9fc1cd817ce989db6a636d973f09417c1ff0153. I checked and there no other places where `toArray(IntFunction)` is used.
- There were some logical flaws in the `getAudioStreamFor` function, which is used to choose the audio stream to mux with a video-only stream when downloading. [Before](https://github.com/TeamNewPipe/NewPipe/blob/cdb79ef78a54e57121e5627ea03dbaaa6c52b1ba/app/src/main/java/org/schabi/newpipe/util/SecondaryStreamHelper.java#L35) the code correctly chose WEBMA or WEBMA_OPUS audio for WEBM videos, and M4A audio for MPEG_4 videos. But [after](https://github.com/TeamNewPipe/NewPipe/blob/77bbbc88f8e1cefca0a4d2ec9b1a6a0c6a592637/app/src/main/java/org/schabi/newpipe/util/SecondaryStreamHelper.java#L39) commit 77bbbc88f8e1cefca0a4d2ec9b1a6a0c6a592637 the code only "prefers" choosing the correct format, but can still return an invalid audio format for a specific video format, since only Comparators are used with no filtering. This is fixed by basically restoring the previous behavior (but without discarding the improvements in 77bbbc88f8e1cefca0a4d2ec9b1a6a0c6a592637 related to `isLimitingDataUsage`), that is:
  - an MPEG4 video can only be muxed with an M4A audio
  - a WEBM video can only be muxed with either a WEBMA audio, or a WEBMA_OPUS audio

  Now if there is no valid audio format corresponding to a video format, the video will be downloaded without audio:
  ![image](https://github.com/TeamNewPipe/NewPipe/assets/36421898/43e80ea0-38a6-45ad-bbc2-b0fea16dd4b6)
- `DownloadDialog.onDismissListener` was not used anymore, so I removed it
- When `DownloadDialog.onCreate()` is called, if there is no storage permission on old Android versions, the dialog is dismissed without continuing initialization. However, for some reason, Android still calls `DownloadDialog.onViewCreated()` afterwards, which obviously requires the initialization in `onCreate()` to have completed, thus causing a NPE. This is fixed by adding a check to detect if the dialog was dismissed before initializing.


#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #10868
- Fixes #10696
- Fixes #9154

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
