### PR TITLE
Migrate to non-transitive R classes

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/error/ErrorUtil.kt
+++ b/app/src/main/java/org/schabi/newpipe/error/ErrorUtil.kt
@@ -54,7 +54,7 @@ class ErrorUtil {
          */
         @JvmStatic
         fun showSnackbar(context: Context, errorInfo: ErrorInfo) {
-            val rootView = if (context is Activity) context.findViewById<View>(R.id.content) else null
+            val rootView = (context as? Activity)?.findViewById<View>(android.R.id.content)
             showSnackbar(context, rootView, errorInfo)
         }
 
@@ -71,7 +71,7 @@ class ErrorUtil {
         fun showSnackbar(fragment: Fragment, errorInfo: ErrorInfo) {
             var rootView = fragment.view
             if (rootView == null && fragment.activity != null) {
-                rootView = fragment.requireActivity().findViewById(R.id.content)
+                rootView = fragment.requireActivity().findViewById(android.R.id.content)
             }
             showSnackbar(fragment.requireContext(), rootView, errorInfo)
         }

--- a/app/src/main/java/org/schabi/newpipe/fragments/MainFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/MainFragment.java
@@ -245,10 +245,10 @@ public class MainFragment extends BaseFragment implements TabLayout.OnTabSelecte
         // change the background and icon color of the tab layout:
         // service-colored at the top, app-background-colored at the bottom
         tabLayout.setBackgroundColor(ThemeHelper.resolveColorFromAttr(requireContext(),
-                bottom ? R.attr.colorSecondary : R.attr.colorPrimary));
+                bottom ? android.R.attr.windowBackground : R.attr.colorPrimary));
 
         @ColorInt final int iconColor = bottom
-                ? ThemeHelper.resolveColorFromAttr(requireContext(), R.attr.colorAccent)
+                ? ThemeHelper.resolveColorFromAttr(requireContext(), android.R.attr.colorAccent)
                 : Color.WHITE;
         tabLayout.setTabRippleColor(ColorStateList.valueOf(iconColor).withAlpha(32));
         tabLayout.setTabIconTint(ColorStateList.valueOf(iconColor));

--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
@@ -549,7 +549,7 @@ class FeedFragment : BaseStateFragment<FeedState>() {
 
             var typeface = Typeface.DEFAULT
             var backgroundSupplier = { ctx: Context ->
-                resolveDrawable(ctx, R.attr.selectableItemBackground)
+                resolveDrawable(ctx, android.R.attr.selectableItemBackground)
             }
             if (doCheck) {
                 // If the uploadDate is null or true we should highlight the item
@@ -562,7 +562,7 @@ class FeedFragment : BaseStateFragment<FeedState>() {
                         LayerDrawable(
                             arrayOf(
                                 resolveDrawable(ctx, R.attr.dashed_border),
-                                resolveDrawable(ctx, R.attr.selectableItemBackground)
+                                resolveDrawable(ctx, android.R.attr.selectableItemBackground)
                             )
                         )
                     }

--- a/app/src/main/java/org/schabi/newpipe/player/PlayQueueActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayQueueActivity.java
@@ -569,16 +569,16 @@ public final class PlayQueueActivity extends AppCompatActivity
     private void onPlayModeChanged(final int repeatMode, final boolean shuffled) {
         switch (repeatMode) {
             case com.google.android.exoplayer2.Player.REPEAT_MODE_OFF:
-                queueControlBinding.controlRepeat
-                        .setImageResource(R.drawable.exo_controls_repeat_off);
+                queueControlBinding.controlRepeat.setImageResource(
+                        com.google.android.exoplayer2.ui.R.drawable.exo_controls_repeat_off);
                 break;
             case com.google.android.exoplayer2.Player.REPEAT_MODE_ONE:
-                queueControlBinding.controlRepeat
-                        .setImageResource(R.drawable.exo_controls_repeat_one);
+                queueControlBinding.controlRepeat.setImageResource(
+                        com.google.android.exoplayer2.ui.R.drawable.exo_controls_repeat_one);
                 break;
             case com.google.android.exoplayer2.Player.REPEAT_MODE_ALL:
-                queueControlBinding.controlRepeat
-                        .setImageResource(R.drawable.exo_controls_repeat_all);
+                queueControlBinding.controlRepeat.setImageResource(
+                        com.google.android.exoplayer2.ui.R.drawable.exo_controls_repeat_all);
                 break;
         }
 

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlaybackParameterDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlaybackParameterDialog.java
@@ -342,14 +342,14 @@ public class PlaybackParameterDialog extends DialogFragment {
         final Map<Boolean, TextView> pitchCtrlModeComponentMapping =
                 getPitchControlModeComponentMappings();
         pitchCtrlModeComponentMapping.forEach((v, textView) -> textView.setBackground(
-                resolveDrawable(requireContext(), R.attr.selectableItemBackground)));
+                resolveDrawable(requireContext(), android.R.attr.selectableItemBackground)));
 
         // Mark the selected textview
         final TextView textView = pitchCtrlModeComponentMapping.get(semitones);
         if (textView != null) {
             textView.setBackground(new LayerDrawable(new Drawable[]{
                     resolveDrawable(requireContext(), R.attr.dashed_border),
-                    resolveDrawable(requireContext(), R.attr.selectableItemBackground)
+                    resolveDrawable(requireContext(), android.R.attr.selectableItemBackground)
             }));
         }
 
@@ -415,14 +415,14 @@ public class PlaybackParameterDialog extends DialogFragment {
         // Bring all textviews into a normal state
         final Map<Double, TextView> stepSiteComponentMapping = getStepSizeComponentMappings();
         stepSiteComponentMapping.forEach((v, textView) -> textView.setBackground(
-                resolveDrawable(requireContext(), R.attr.selectableItemBackground)));
+                resolveDrawable(requireContext(), android.R.attr.selectableItemBackground)));
 
         // Mark the selected textview
         final TextView textView = stepSiteComponentMapping.get(newStepSize);
         if (textView != null) {
             textView.setBackground(new LayerDrawable(new Drawable[]{
                     resolveDrawable(requireContext(), R.attr.dashed_border),
-                    resolveDrawable(requireContext(), R.attr.selectableItemBackground)
+                    resolveDrawable(requireContext(), android.R.attr.selectableItemBackground)
             }));
         }
 

--- a/app/src/main/java/org/schabi/newpipe/player/notification/NotificationActionData.java
+++ b/app/src/main/java/org/schabi/newpipe/player/notification/NotificationActionData.java
@@ -69,41 +69,48 @@ public final class NotificationActionData {
         switch (selectedAction) {
             case NotificationConstants.PREVIOUS:
                 return new NotificationActionData(ACTION_PLAY_PREVIOUS,
-                        ctx.getString(R.string.exo_controls_previous_description), baseActionIcon);
+                        ctx.getString(com.google.android.exoplayer2.ui.R.string
+                                .exo_controls_previous_description), baseActionIcon);
 
             case NotificationConstants.NEXT:
                 return new NotificationActionData(ACTION_PLAY_NEXT,
-                        ctx.getString(R.string.exo_controls_next_description), baseActionIcon);
+                        ctx.getString(com.google.android.exoplayer2.ui.R.string
+                                .exo_controls_next_description), baseActionIcon);
 
             case NotificationConstants.REWIND:
                 return new NotificationActionData(ACTION_FAST_REWIND,
-                        ctx.getString(R.string.exo_controls_rewind_description), baseActionIcon);
+                        ctx.getString(com.google.android.exoplayer2.ui.R.string
+                                .exo_controls_rewind_description), baseActionIcon);
 
             case NotificationConstants.FORWARD:
                 return new NotificationActionData(ACTION_FAST_FORWARD,
-                        ctx.getString(R.string.exo_controls_fastforward_description),
-                        baseActionIcon);
+                        ctx.getString(com.google.android.exoplayer2.ui.R.string
+                                .exo_controls_fastforward_description), baseActionIcon);
 
             case NotificationConstants.SMART_REWIND_PREVIOUS:
                 if (player.getPlayQueue() != null && player.getPlayQueue().size() > 1) {
                     return new NotificationActionData(ACTION_PLAY_PREVIOUS,
-                            ctx.getString(R.string.exo_controls_previous_description),
-                            R.drawable.exo_notification_previous);
+                            ctx.getString(com.google.android.exoplayer2.ui.R.string
+                                    .exo_controls_previous_description),
+                            com.google.android.exoplayer2.ui.R.drawable.exo_notification_previous);
                 } else {
                     return new NotificationActionData(ACTION_FAST_REWIND,
-                            ctx.getString(R.string.exo_controls_rewind_description),
-                            R.drawable.exo_controls_rewind);
+                            ctx.getString(com.google.android.exoplayer2.ui.R.string
+                                    .exo_controls_rewind_description),
+                            com.google.android.exoplayer2.ui.R.drawable.exo_controls_rewind);
                 }
 
             case NotificationConstants.SMART_FORWARD_NEXT:
                 if (player.getPlayQueue() != null && player.getPlayQueue().size() > 1) {
                     return new NotificationActionData(ACTION_PLAY_NEXT,
-                            ctx.getString(R.string.exo_controls_next_description),
-                            R.drawable.exo_notification_next);
+                            ctx.getString(com.google.android.exoplayer2.ui.R.string
+                                    .exo_controls_next_description),
+                            com.google.android.exoplayer2.ui.R.drawable.exo_notification_next);
                 } else {
                     return new NotificationActionData(ACTION_FAST_FORWARD,
-                            ctx.getString(R.string.exo_controls_fastforward_description),
-                            R.drawable.exo_controls_fastforward);
+                            ctx.getString(com.google.android.exoplayer2.ui.R.string
+                                    .exo_controls_fastforward_description),
+                            com.google.android.exoplayer2.ui.R.drawable.exo_controls_fastforward);
                 }
 
             case NotificationConstants.PLAY_PAUSE_BUFFERING:
@@ -119,45 +126,56 @@ public final class NotificationActionData {
             case NotificationConstants.PLAY_PAUSE:
                 if (player.getCurrentState() == Player.STATE_COMPLETED) {
                     return new NotificationActionData(ACTION_PLAY_PAUSE,
-                            ctx.getString(R.string.exo_controls_pause_description),
+                            ctx.getString(com.google.android.exoplayer2.ui.R.string
+                                    .exo_controls_pause_description),
                             R.drawable.ic_replay);
                 } else if (player.isPlaying()
                         || player.getCurrentState() == Player.STATE_PREFLIGHT
                         || player.getCurrentState() == Player.STATE_BLOCKED
                         || player.getCurrentState() == Player.STATE_BUFFERING) {
                     return new NotificationActionData(ACTION_PLAY_PAUSE,
-                            ctx.getString(R.string.exo_controls_pause_description),
-                            R.drawable.exo_notification_pause);
+                            ctx.getString(com.google.android.exoplayer2.ui.R.string
+                                    .exo_controls_pause_description),
+                            com.google.android.exoplayer2.ui.R.drawable.exo_notification_pause);
                 } else {
                     return new NotificationActionData(ACTION_PLAY_PAUSE,
-                            ctx.getString(R.string.exo_controls_play_description),
-                            R.drawable.exo_notification_play);
+                            ctx.getString(com.google.android.exoplayer2.ui.R.string
+                                    .exo_controls_play_description),
+                            com.google.android.exoplayer2.ui.R.drawable.exo_notification_play);
                 }
 
             case NotificationConstants.REPEAT:
                 if (player.getRepeatMode() == REPEAT_MODE_ALL) {
                     return new NotificationActionData(ACTION_REPEAT,
-                            ctx.getString(R.string.exo_controls_repeat_all_description),
-                            R.drawable.exo_media_action_repeat_all);
+                            ctx.getString(com.google.android.exoplayer2.ui.R.string
+                                    .exo_controls_repeat_all_description),
+                            com.google.android.exoplayer2.ext.mediasession.R.drawable
+                                    .exo_media_action_repeat_all);
                 } else if (player.getRepeatMode() == REPEAT_MODE_ONE) {
                     return new NotificationActionData(ACTION_REPEAT,
-                            ctx.getString(R.string.exo_controls_repeat_one_description),
-                            R.drawable.exo_media_action_repeat_one);
+                            ctx.getString(com.google.android.exoplayer2.ui.R.string
+                                    .exo_controls_repeat_one_description),
+                            com.google.android.exoplayer2.ext.mediasession.R.drawable
+                                    .exo_media_action_repeat_one);
                 } else /* player.getRepeatMode() == REPEAT_MODE_OFF */ {
                     return new NotificationActionData(ACTION_REPEAT,
-                            ctx.getString(R.string.exo_controls_repeat_off_description),
-                            R.drawable.exo_media_action_repeat_off);
+                            ctx.getString(com.google.android.exoplayer2.ui.R.string
+                                    .exo_controls_repeat_off_description),
+                            com.google.android.exoplayer2.ext.mediasession.R.drawable
+                                    .exo_media_action_repeat_off);
                 }
 
             case NotificationConstants.SHUFFLE:
                 if (player.getPlayQueue() != null && player.getPlayQueue().isShuffled()) {
                     return new NotificationActionData(ACTION_SHUFFLE,
-                            ctx.getString(R.string.exo_controls_shuffle_on_description),
-                            R.drawable.exo_controls_shuffle_on);
+                            ctx.getString(com.google.android.exoplayer2.ui.R.string
+                                    .exo_controls_shuffle_on_description),
+                            com.google.android.exoplayer2.ui.R.drawable.exo_controls_shuffle_on);
                 } else {
                     return new NotificationActionData(ACTION_SHUFFLE,
-                            ctx.getString(R.string.exo_controls_shuffle_off_description),
-                            R.drawable.exo_controls_shuffle_off);
+                            ctx.getString(com.google.android.exoplayer2.ui.R.string
+                                    .exo_controls_shuffle_off_description),
+                            com.google.android.exoplayer2.ui.R.drawable.exo_controls_shuffle_off);
                 }
 
             case NotificationConstants.CLOSE:

--- a/app/src/main/java/org/schabi/newpipe/player/notification/NotificationConstants.java
+++ b/app/src/main/java/org/schabi/newpipe/player/notification/NotificationConstants.java
@@ -78,16 +78,16 @@ public final class NotificationConstants {
     @DrawableRes
     public static final int[] ACTION_ICONS = {
             0,
-            R.drawable.exo_icon_previous,
-            R.drawable.exo_icon_next,
-            R.drawable.exo_icon_rewind,
-            R.drawable.exo_icon_fastforward,
-            R.drawable.exo_icon_previous,
-            R.drawable.exo_icon_next,
+            com.google.android.exoplayer2.ui.R.drawable.exo_icon_previous,
+            com.google.android.exoplayer2.ui.R.drawable.exo_icon_next,
+            com.google.android.exoplayer2.ui.R.drawable.exo_icon_rewind,
+            com.google.android.exoplayer2.ui.R.drawable.exo_icon_fastforward,
+            com.google.android.exoplayer2.ui.R.drawable.exo_icon_previous,
+            com.google.android.exoplayer2.ui.R.drawable.exo_icon_next,
             R.drawable.ic_pause,
             R.drawable.ic_hourglass_top,
-            R.drawable.exo_icon_repeat_all,
-            R.drawable.exo_icon_shuffle_on,
+            com.google.android.exoplayer2.ui.R.drawable.exo_icon_repeat_all,
+            com.google.android.exoplayer2.ui.R.drawable.exo_icon_shuffle_on,
             R.drawable.ic_close,
     };
 
@@ -122,29 +122,41 @@ public final class NotificationConstants {
     public static String getActionName(@NonNull final Context context, @Action final int action) {
         switch (action) {
             case PREVIOUS:
-                return context.getString(R.string.exo_controls_previous_description);
+                return context.getString(com.google.android.exoplayer2.ui.R.string
+                        .exo_controls_previous_description);
             case NEXT:
-                return context.getString(R.string.exo_controls_next_description);
+                return context.getString(com.google.android.exoplayer2.ui.R.string
+                        .exo_controls_next_description);
             case REWIND:
-                return context.getString(R.string.exo_controls_rewind_description);
+                return context.getString(com.google.android.exoplayer2.ui.R.string
+                        .exo_controls_rewind_description);
             case FORWARD:
-                return context.getString(R.string.exo_controls_fastforward_description);
+                return context.getString(com.google.android.exoplayer2.ui.R.string
+                        .exo_controls_fastforward_description);
             case SMART_REWIND_PREVIOUS:
                 return Localization.concatenateStrings(
-                        context.getString(R.string.exo_controls_rewind_description),
-                        context.getString(R.string.exo_controls_previous_description));
+                        context.getString(com.google.android.exoplayer2.ui.R.string
+                                .exo_controls_rewind_description),
+                        context.getString(com.google.android.exoplayer2.ui.R.string
+                                .exo_controls_previous_description));
             case SMART_FORWARD_NEXT:
                 return Localization.concatenateStrings(
-                        context.getString(R.string.exo_controls_fastforward_description),
-                        context.getString(R.string.exo_controls_next_description));
+                        context.getString(com.google.android.exoplayer2.ui.R.string
+                                .exo_controls_fastforward_description),
+                        context.getString(com.google.android.exoplayer2.ui.R.string
+                                .exo_controls_next_description));
             case PLAY_PAUSE:
                 return Localization.concatenateStrings(
-                        context.getString(R.string.exo_controls_play_description),
-                        context.getString(R.string.exo_controls_pause_description));
+                        context.getString(com.google.android.exoplayer2.ui.R.string
+                                .exo_controls_play_description),
+                        context.getString(com.google.android.exoplayer2.ui.R.string
+                                .exo_controls_pause_description));
             case PLAY_PAUSE_BUFFERING:
                 return Localization.concatenateStrings(
-                        context.getString(R.string.exo_controls_play_description),
-                        context.getString(R.string.exo_controls_pause_description),
+                        context.getString(com.google.android.exoplayer2.ui.R.string
+                                .exo_controls_play_description),
+                        context.getString(com.google.android.exoplayer2.ui.R.string
+                                .exo_controls_pause_description),
                         context.getString(R.string.notification_action_buffering));
             case REPEAT:
                 return context.getString(R.string.notification_action_repeat);

--- a/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
@@ -952,11 +952,14 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
         super.onRepeatModeChanged(repeatMode);
 
         if (repeatMode == REPEAT_MODE_ALL) {
-            binding.repeatButton.setImageResource(R.drawable.exo_controls_repeat_all);
+            binding.repeatButton.setImageResource(
+                    com.google.android.exoplayer2.ui.R.drawable.exo_controls_repeat_all);
         } else if (repeatMode == REPEAT_MODE_ONE) {
-            binding.repeatButton.setImageResource(R.drawable.exo_controls_repeat_one);
+            binding.repeatButton.setImageResource(
+                    com.google.android.exoplayer2.ui.R.drawable.exo_controls_repeat_one);
         } else /* repeatMode == REPEAT_MODE_OFF */ {
-            binding.repeatButton.setImageResource(R.drawable.exo_controls_repeat_off);
+            binding.repeatButton.setImageResource(
+                    com.google.android.exoplayer2.ui.R.drawable.exo_controls_repeat_off);
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 android.defaults.buildfeatures.buildconfig=true
 android.enableJetifier=false
 android.nonFinalResIds=false
-android.nonTransitiveRClass=false
+android.nonTransitiveRClass=true
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx2048M --add-opens jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
 systemProp.file.encoding=utf-8


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Replaces #10077.
- Switch to [non-transitive R classes](https://blog.blundellapps.co.uk/speed-up-your-build-non-transitive-r-files/), which became the default starting in Android Gradle plugin 8.0. This fixes build issues with the CI pipeline and helps speed up the build process.
- These were the cases where `R.id.*` did not exist anymore and had to be replaced by the fully-qualified path.
  - `R.id.content` -> `android.R.id.content` to find the root view of an activity. I tested this manually and it works.
  - `R.attr.colorSecondary` -> `android.R.attr.windowBackground` as the bottom toolbar background color. I don't know why it was `colorSecondary` before, but `windowBackground` yields the same color as before, I tested on API 33 and API 22 on all themes. Moreover `windowBackground` is defined directly [in styles.xml](https://github.com/TeamNewPipe/NewPipe/blob/9648525ac19207643c18d85c5b1afef8dfd21b08/app/src/main/res/values/styles.xml#L30), so it should be correct.
  - `R.attr.colorAccent` -> `android.R.attr.colorAccent` as the bottom toolbar foreground color. Again, I tested on API 33 and API 22 on all themes and noticed no difference.
  - `R.attr.selectableItemBackground` -> `android.R.attr.selectableItemBackground`
  - all exoplayer string/drawable resources (which btw are all private and are not meant to be used ;-) )

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
