### PR TITLE
Fix NPE if avatarUrl is null when reloading feed

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/database/subscription/SubscriptionEntity.java
+++ b/app/src/main/java/org/schabi/newpipe/database/subscription/SubscriptionEntity.java
@@ -1,6 +1,7 @@
 package org.schabi.newpipe.database.subscription;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.room.ColumnInfo;
 import androidx.room.Entity;
 import androidx.room.Ignore;
@@ -95,11 +96,12 @@ public class SubscriptionEntity {
         this.name = name;
     }
 
+    @Nullable
     public String getAvatarUrl() {
         return avatarUrl;
     }
 
-    public void setAvatarUrl(final String avatarUrl) {
+    public void setAvatarUrl(@Nullable final String avatarUrl) {
         this.avatarUrl = avatarUrl;
     }
 

--- a/app/src/main/java/org/schabi/newpipe/local/feed/service/FeedUpdateInfo.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/service/FeedUpdateInfo.kt
@@ -18,7 +18,7 @@ data class FeedUpdateInfo(
     @NotificationMode
     val notificationMode: Int,
     val name: String,
-    val avatarUrl: String,
+    val avatarUrl: String?,
     val url: String,
     val serviceId: Int,
     // description and subscriberCount are null if the constructor info is from the fast feed method

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionManager.kt
@@ -100,7 +100,9 @@ class SubscriptionManager(context: Context) {
         val subscriptionEntity = subscriptionTable.getSubscription(info.uid)
 
         subscriptionEntity.name = info.name
-        subscriptionEntity.avatarUrl = info.avatarUrl
+
+        // some services do not provide an avatar URL
+        info.avatarUrl?.let { subscriptionEntity.avatarUrl = it }
 
         // these two fields are null if the feed info was fetched using the fast feed method
         info.description?.let { subscriptionEntity.description = it }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This PR fixes a NPE by simply making sure avatarUrl is `@Nullable` everywhere, and is also treated as so.
I tested and before this fix I could reproduce the crash in 

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #10863
- Fixes&nbsp;https://github.com/TeamNewPipe/NewPipe/issues/10930#issuecomment-2042808053

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
