### PR TITLE
Fix not saving comment replies state on config change

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/list/comments/CommentRepliesFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/comments/CommentRepliesFragment.java
@@ -30,6 +30,7 @@ import org.schabi.newpipe.util.text.TextLinkifier;
 import java.util.Queue;
 import java.util.function.Supplier;
 
+import icepick.State;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.disposables.CompositeDisposable;
 
@@ -38,7 +39,8 @@ public final class CommentRepliesFragment
 
     public static final String TAG = CommentRepliesFragment.class.getSimpleName();
 
-    private CommentsInfoItem commentsInfoItem; // the comment to show replies of
+    @State
+    CommentsInfoItem commentsInfoItem; // the comment to show replies of
     private final CompositeDisposable disposables = new CompositeDisposable();
 
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
A `@State` annotation was missing from `CommentRepliesFragment.commentsInfoItem`, causing the value to be lost on configuration changes. This caused the NPE described [here](https://github.com/TeamNewPipe/NewPipe/issues/10930#issuecomment-2045910769). This PR just adds the `@State`. I tested and while I could reproduce consistently before, after this PR I can't reproduce the problem anymore.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes&nbsp;https://github.com/TeamNewPipe/NewPipe/issues/10930#issuecomment-2045910769

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
