### PR TITLE
Add missing Peertube instance subscribeto.me to the links Newpipe han…

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -367,6 +367,7 @@
                 <data android:host="tilvids.com" />
                 <data android:host="video.lqdn.fr" />
                 <data android:host="video.ploud.fr" />
+                <data android:host="subscribeto.me" />
 
                 <data android:pathPrefix="/videos/" /> <!-- it contains playlists -->
                 <data android:pathPrefix="/w/" /> <!-- short video URLs -->


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This PR fixes the handling of subscribeto.me Peertube links on NewPipe.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before:



https://github.com/TeamNewPipe/NewPipe/assets/102914961/daf1a7a5-e4a1-4218-bc32-edd1c7b43c9d



- After:



https://github.com/TeamNewPipe/NewPipe/assets/102914961/d826fa98-9948-4afe-9418-2fc3925a09a2




#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
