### PR TITLE
Adding Hash of Signing Key to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Also, since they are free and open source software, neither the app nor the Extr
 ## Installation and updates
 You can install NewPipe using one of the following methods:
  1. Add our custom repo to F-Droid and install it from there. The instructions are here: https://newpipe.net/FAQ/tutorials/install-add-fdroid-repo/
- 2. Download the APK from [GitHub Releases](https://github.com/TeamNewPipe/NewPipe/releases), [compare the signing key](#apk-info) and install it.</b>
+ 2. Download the APK from [GitHub Releases](https://github.com/TeamNewPipe/NewPipe/releases), [compare the signing key](#apk-info) and install it.
  3. Update via F-Droid. This is the slowest method of getting updates, as F-Droid must recognize changes, build the APK itself, sign it, and then push the update to users.
  4. Build a debug APK yourself. This is the fastest way to get new features on your device, but is much more complicated, so we recommend using one of the other methods.
  5. If you're interested in a specific feature or bugfix provided in a Pull Request in this repo, you can also download its APK from within the PR. Read the PR description for instructions. The great thing about PR-specific APKs is that they're installed side-by-side the official app, so you don't have to worry about losing your data or messing anything up.


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- Simple Security Addition

#### Description of the changes in your PR
For your consideration, I'm submitting a small edit to the README to add the hash of the signing key currently posted on the NewPipe website and bring it to the user's attention in installation method #2.

For android users looking to download the APK and install directly from Github, or using a different method like Obtainium, the responsibility of verifying the signing key of the downloaded APK is placed on the user. This is easily done with [AppVerifier](https://github.com/soupslurpr/AppVerifier). A signing certificate posted on both the website and in the README would improve user confidence in the download.

Thank you for your consideration.