### PR TITLE
add NP icon for Android Studio's NewUI

### DIFF
--- a/.idea/icon.svg
+++ b/.idea/icon.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg"  x="0px" y="0px"
+	 viewBox="0 0 100 100" style="enable-background:new 0 0 100 100;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#CD201F;}
+	.st1{fill:#FFFFFF;}
+</style>
+<g id="Alapkör">
+	<circle id="XMLID_23_" class="st0" cx="50" cy="50" r="50"/>
+</g>
+<g id="Elemek">
+	<path id="XMLID_19_" class="st1" d="M47,28.2c-9-5.3-15.3-9-15.3-9v61.7c0,0,30.4-18,52.3-30.9C72.1,43,57.7,34.5,47,28.2z"/>
+</g>
+<g id="Fedő">
+	<path id="XMLID_5_" class="st0" d="M48.4,40.1c-4.1-2.4-7-4.1-7-4.1V64c0,0,13.9-8.2,23.8-14C59.8,46.8,53.3,42.9,48.4,40.1z"/>
+	<rect id="XMLID_4_" x="41.4" y="55.6" class="st0" width="6.2" height="21"/>
+</g>
+<g id="Vonalak">
+</g>
+</svg>


### PR DESCRIPTION
This will add the NewPipe icon to the New UI of Android Studio.
This just makes development prettier.