### PR TITLE
Fix crash in MediaSessionPlayerUi while destroying player

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/mediasession/MediaSessionPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/mediasession/MediaSessionPlayerUi.java
@@ -38,7 +38,9 @@ public class MediaSessionPlayerUi extends PlayerUi
         implements SharedPreferences.OnSharedPreferenceChangeListener {
     private static final String TAG = "MediaSessUi";
 
+    @Nullable
     private MediaSessionCompat mediaSession;
+    @Nullable
     private MediaSessionConnector sessionConnector;
 
     private final String ignoreHardwareMediaButtonsKey;
@@ -195,6 +197,11 @@ public class MediaSessionPlayerUi extends PlayerUi
             // cause any trouble, it also doesn't seem to do anything, so we don't do anything to
             // save battery. Check out NotificationUtil.updateActions() to see what happens on
             // older android versions.
+            return;
+        }
+
+        if (sessionConnector == null) {
+            // sessionConnector will be null after destroyPlayer is called
             return;
         }
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This PR simply fixes the NullPointerException reported in #11029 by adding a null check and by adding `@Nullable` to the involved variables.

Note that the crash happened because in [Player::destroyPlayer()](https://github.com/TeamNewPipe/NewPipe/blob/0a8f28b1c6f804de22a1ee81fdc284e7725ef8cc/app/src/main/java/org/schabi/newpipe/player/Player.java#L566), first `PlayerUi::destroyPlayer` is called on every UI, and afterwards `simpleExoPlayer.removeListener(this)` causes a call to [onEvents()](https://github.com/TeamNewPipe/NewPipe/blob/0a8f28b1c6f804de22a1ee81fdc284e7725ef8cc/app/src/main/java/org/schabi/newpipe/player/Player.java#L1262) which in turn [calls](https://github.com/TeamNewPipe/NewPipe/blob/0a8f28b1c6f804de22a1ee81fdc284e7725ef8cc/app/src/main/java/org/schabi/newpipe/player/Player.java#L1801) `onMetadataChanged(info)` on every UI in an unexpected moment (i.e. after `PlayerUi::destroyPlayer()`), causing the crash inside `MediaSessionPlayerUi.onMetadataChanged()`.

I can consistently reproduce the crash in 0.27.0, while with this fix the crash does not happen anymore.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #11029

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
