### PR TITLE
Fixed playlist order

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/database/playlist/dao/PlaylistStreamDAO.java
+++ b/app/src/main/java/org/schabi/newpipe/database/playlist/dao/PlaylistStreamDAO.java
@@ -154,6 +154,6 @@ public interface PlaylistStreamDAO extends BasicDAO<PlaylistStreamEntity> {
             + " AND :streamUrl = :streamUrl"
 
             + " GROUP BY " + JOIN_PLAYLIST_ID
-            + " ORDER BY " + PLAYLIST_DISPLAY_INDEX)
+            + " ORDER BY " + PLAYLIST_DISPLAY_INDEX + ", " + PLAYLIST_NAME)
     Flowable<List<PlaylistDuplicatesEntry>> getPlaylistDuplicatesMetadata(String streamUrl);
 }


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
When user has not yet adjusted manually the playlists order the lists in "Bookmarked Playlists" and "add to playlist" dialog don't have the same order. Now in this phase both lists are sorted using case insensitive order. While after manual sorting from user both list keep the same order.  

#### Before/After Screenshots/Screen Record
- Before:

![Screenshot from 2024-09-26 14-02-30](https://github.com/user-attachments/assets/4b9ce814-3826-4525-b133-c3b36ce8cf4d)

![Screenshot from 2024-09-26 14-02-39](https://github.com/user-attachments/assets/aff41469-54ba-4c76-af47-c04dfdea9c39)

- After:

![Screenshot from 2024-09-26 14-16-34](https://github.com/user-attachments/assets/0b6847bf-46aa-4e68-8877-98c07e154ed5)


![Screenshot from 2024-09-26 14-16-41](https://github.com/user-attachments/assets/e7083566-fba0-4a14-a797-c6cf94cbf70d)


#### Fixes the following issue(s)
- Fixes #10993

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
