### PR TITLE
Fix seekbar preview crashes

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/seekbarpreview/SeekbarPreviewThumbnailHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/player/seekbarpreview/SeekbarPreviewThumbnailHolder.java
@@ -109,6 +109,7 @@ public class SeekbarPreviewThumbnailHolder {
         final Stopwatch sw = Log.isLoggable(TAG, Log.DEBUG) ? Stopwatch.createStarted() : null;
 
         int currentPosMs = 0;
+        int pos = 1;
 
         final int urlFrameCount = frameset.getFramesPerPageX() * frameset.getFramesPerPageY();
 
@@ -116,14 +117,6 @@ public class SeekbarPreviewThumbnailHolder {
         for (final String url : frameset.getUrls()) {
             // get the bitmap
             final Bitmap srcBitMap = getBitMapFrom(url);
-
-            // It can happen, that the original bitmap could not be downloaded
-            // In such a case - we don't want a NullPointer - simply return null
-            // Recycled bitmaps can also not be created, so we also need to check for that
-            if (srcBitMap == null || srcBitMap.isRecycled()) {
-                Log.e(TAG, "Failed to retrieve or use bitmap from url: " + url);
-                continue;
-            }
 
             // The data is not added directly to "seekbarPreviewData" due to
             // concurrency and checks for "updateRequestIdentifier"
@@ -133,19 +126,34 @@ public class SeekbarPreviewThumbnailHolder {
             // foreach frame in the returned bitmap
             for (int i = 0; i < urlFrameCount; i++) {
                 // Frames outside the video length are skipped
-                if (i >= frameset.getTotalCount()) {
+                if (pos > frameset.getTotalCount()) {
                     break;
                 }
 
                 // Get the bounds where the frame is found
                 final int[] bounds = frameset.getFrameBoundsAt(currentPosMs);
                 generatedDataForUrl.put(currentPosMs, () -> {
+                    // It can happen, that the original bitmap could not be downloaded
+                    // In such a case - we don't want a NullPointer - simply return null;
+                    // Recycled bitmaps are also unusable here so we should check for that too
+                    if (srcBitMap == null || srcBitMap.isRecycled()) {
+                        return null;
+                    }
+
                     // Cut out the corresponding bitmap form the "srcBitMap"
-                    return Bitmap.createBitmap(srcBitMap, bounds[1], bounds[2],
+                    final Bitmap cutOutBitmap = Bitmap.createBitmap(srcBitMap, bounds[1], bounds[2],
                             frameset.getFrameWidth(), frameset.getFrameHeight());
+
+                    // We need to copy the bitmap to create a new instance since createBitmap
+                    // allows itself to return the original object that is was created with
+                    // this leads to recycled bitmaps being returned (if they are identical)
+                    // Reference: https://stackoverflow.com/a/23683075 + first comment
+                    // Fixes: https://github.com/TeamNewPipe/NewPipe/issues/11461
+                    return cutOutBitmap.copy(cutOutBitmap.getConfig(), true);
                 });
 
                 currentPosMs += frameset.getDurationPerFrame();
+                pos++;
             }
 
             // Check if we are still the latest request

--- a/app/src/main/java/org/schabi/newpipe/player/seekbarpreview/SeekbarPreviewThumbnailHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/player/seekbarpreview/SeekbarPreviewThumbnailHolder.java
@@ -172,12 +172,14 @@ public class SeekbarPreviewThumbnailHolder {
             final Bitmap cutOutBitmap = Bitmap.createBitmap(srcBitMap, bounds[1], bounds[2],
                     frameset.getFrameWidth(), frameset.getFrameHeight());
 
-            // We need to copy the bitmap to create a new instance since createBitmap
-            // allows itself to return the original object that is was created with
+            // If the cut out bitmap is identical to its source,
+            // we need to copy the bitmap to create a new instance.
+            // createBitmap allows itself to return the original object that is was created with
             // this leads to recycled bitmaps being returned (if they are identical)
             // Reference: https://stackoverflow.com/a/23683075 + first comment
             // Fixes: https://github.com/TeamNewPipe/NewPipe/issues/11461
-            return cutOutBitmap.copy(cutOutBitmap.getConfig(), true);
+            return cutOutBitmap == srcBitMap
+                    ? cutOutBitmap.copy(cutOutBitmap.getConfig(), true) : cutOutBitmap;
         };
     }
 


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Added error handling for recycled bitmaps and fixed the issue for specific videos crashing when the preview bar was pulled to the end twice.
`Bitmap.createBitmap` allows itself to NOT copy the bitmap if it is identical to the one it got passed. Since the same object is passed for bitmaps where nothing is cut out, recycling this bitmap leaves it unusable for later use.
Reference: https://stackoverflow.com/a/23683075 (the first comment to that answer)

#### Fixes the following issue(s)
- Fixes #11461

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
