### PR TITLE
Fix seekbar crashing on drag with faulty frameset

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/seekbarpreview/SeekbarPreviewThumbnailHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/player/seekbarpreview/SeekbarPreviewThumbnailHolder.java
@@ -133,7 +133,7 @@ public class SeekbarPreviewThumbnailHolder {
                 // Get the bounds where the frame is found
                 final int[] bounds = frameset.getFrameBoundsAt(currentPosMs);
                 generatedDataForUrl.put(currentPosMs,
-                        createBitmapSupplier(srcBitMap, bounds, frameset));
+                                        createBitmapSupplier(srcBitMap, bounds, frameset));
 
                 currentPosMs += frameset.getDurationPerFrame();
                 pos++;

--- a/app/src/main/java/org/schabi/newpipe/player/seekbarpreview/SeekbarPreviewThumbnailHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/player/seekbarpreview/SeekbarPreviewThumbnailHolder.java
@@ -133,7 +133,7 @@ public class SeekbarPreviewThumbnailHolder {
                 // Get the bounds where the frame is found
                 final int[] bounds = frameset.getFrameBoundsAt(currentPosMs);
                 generatedDataForUrl.put(currentPosMs,
-                                        createBitmapSupplier(srcBitMap, bounds, frameset));
+                        createBitmapSupplier(srcBitMap, bounds, frameset));
 
                 currentPosMs += frameset.getDurationPerFrame();
                 pos++;
@@ -166,6 +166,18 @@ public class SeekbarPreviewThumbnailHolder {
             // "cannot use a recycled source in createBitmap" Exception -> simply return null
             if (srcBitMap == null || srcBitMap.isRecycled()) {
                 return null;
+            }
+
+            // Under some rare circumstances the YouTube API returns slightly too small storyboards,
+            // (or not the matching frame width/height)
+            // This would lead to createBitmap cutting out a bitmap that is out of bounds,
+            // so we need to adjust the bounds accordingly
+            if (srcBitMap.getWidth() < bounds[1] + frameset.getFrameWidth()) {
+                bounds[1] = srcBitMap.getWidth() - frameset.getFrameWidth();
+            }
+
+            if (srcBitMap.getHeight() < bounds[2] + frameset.getFrameHeight()) {
+                bounds[2] = srcBitMap.getHeight() - frameset.getFrameHeight();
             }
 
             // Cut out the corresponding bitmap form the "srcBitMap"


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Youtubes api seems to have VERY rarely "broken" preview storyboards i.e. storyboards that are too small for the given amount of frames on the x axis and width of frames. In the linked issue only the width seems to be affected but i assume the same could happen to the height.
As an example for this video https://www.youtube.com/watch?v=sxl4DJXCDzA (jumpscare/loud sound warning) the api returns this storyboard https://i.ytimg.com/sb/sxl4DJXCDzA/storyboard3_L2/M0.jpg?sqp=-oaymwENSDfyq4qpAwVwAcABBqLzl_8DBgiPyu6jBg==&sigh=rs$AOn4CLD0HwvNS2nXMr9JYlzeuRbC1ubbtg which should have 5 160 pixel wide frames (which is 800 pixels). The image is only 795 pixels wide so it breaks at some point when trying to create a bitmap for the preview.
For this video https://www.youtube.com/watch?v=CH50zuS8DD0 the storyboard is correctly sized: https://i.ytimg.com/sb/CH50zuS8DD0/storyboard3_L2/M0.jpg?sqp=-oaymwENSDfyq4qpAwVwAcABBqLzl_8DBgikqp23Bg==&sigh=rs$AOn4CLBG_KgXP0R2Z1DI9hg-Ntn7xCnrXA.
Seems to be a youtube sided thing, i don't see any issues on the extractor side (but I could be wrong about that of course). The only "solution" i found was to catch these cases and "manually" and adjust the bounds of the preview, even though i am not super happy with that approach. There seems to be no pattern (same video length for example) behind this behaviour but this statement comes with a very small sample size so I might have missed something.

#### Fixes the following issue(s)
- Fixes #10477

#### Relies on the following changes
- https://github.com/TeamNewPipe/NewPipe/pull/11584 (could also be added to this PR if you prefer that)
For this PR only line 171-181 are relevant

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
