### PR TITLE
Allow starting the search fragment via intent

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -406,6 +406,14 @@
                 <data android:sspPattern="bandcamp.com/?show=*" />
             </intent-filter>
 
+            <!-- customized search URL filter -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="newpipe" android:host="search" />
+            </intent-filter>
+
         </activity>
         <service
             android:name=".RouterActivity$FetcherService"

--- a/app/src/main/java/org/schabi/newpipe/player/seekbarpreview/SeekbarPreviewThumbnailHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/player/seekbarpreview/SeekbarPreviewThumbnailHolder.java
@@ -132,8 +132,17 @@ public class SeekbarPreviewThumbnailHolder {
 
                 // Get the bounds where the frame is found
                 final int[] bounds = frameset.getFrameBoundsAt(currentPosMs);
-                generatedDataForUrl.put(currentPosMs,
-                                        createBitmapSupplier(srcBitMap, bounds, frameset));
+                generatedDataForUrl.put(currentPosMs, () -> {
+                    // It can happen, that the original bitmap could not be downloaded
+                    // In such a case - we don't want a NullPointer - simply return null
+                    if (srcBitMap == null) {
+                        return null;
+                    }
+
+                    // Cut out the corresponding bitmap form the "srcBitMap"
+                    return Bitmap.createBitmap(srcBitMap, bounds[1], bounds[2],
+                            frameset.getFrameWidth(), frameset.getFrameHeight());
+                });
 
                 currentPosMs += frameset.getDurationPerFrame();
                 pos++;

--- a/app/src/main/java/org/schabi/newpipe/util/ServiceHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ServiceHelper.java
@@ -121,6 +121,16 @@ public final class ServiceHelper {
                 .getServiceId();
     }
 
+    public static int getServiceIdByName(final String serviceName) throws IllegalArgumentException {
+        for (final StreamingService s : NewPipe.getServices()) {
+            if (s.getServiceInfo().getName().equalsIgnoreCase(serviceName)) {
+                return s.getServiceId();
+            }
+        }
+        throw new IllegalArgumentException("Invalid service name");
+    }
+
+
     @Nullable
     public static StreamingService getSelectedService(final Context context) {
         final String serviceName = PreferenceManager.getDefaultSharedPreferences(context)


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Extended custom URL scheme to include service selection: Implemented the ability for third-party apps to initiate a search in NewPipe on a specific service by using the custom URL scheme `newpipe://search?service=SERVICE_NAME\&q=YOUR_QUERY`.
- Added intent-filter to RouterActivity: Updated AndroidManifest.xml to include an intent-filter in RouterActivity to handle the custom URL scheme.
- Enhanced RouterActivity to handle 'service' parameter: Modified RouterActivity to parse the incoming service parameter from the intent, retrieve the corresponding service ID, and start MainActivity with the specified service and search query.
- Added error handling for invalid service names: Implemented validation for the service parameter to check if the provided service name is valid. If the service name is invalid, the app displays an error message to the user.
- Tested the implementation: Used ADB commands to send an intent with the custom URI and verified that NewPipe performs the search as expected, such as `adb shell am start -a android.intent.action.VIEW -d "newpipe://search?service=Soundcloud\&q=funny%20cats"`.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #3475


#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
