### PR TITLE
Add null-safe SharedPreferences.getStringSafe

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/ktx/SharedPreferences.kt
+++ b/app/src/main/java/org/schabi/newpipe/ktx/SharedPreferences.kt
@@ -1,0 +1,7 @@
+package org.schabi.newpipe.ktx
+
+import android.content.SharedPreferences
+
+fun SharedPreferences.getStringSafe(key: String, defValue: String): String {
+    return getString(key, null) ?: defValue
+}

--- a/app/src/main/java/org/schabi/newpipe/local/feed/service/FeedLoadManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/service/FeedLoadManager.kt
@@ -19,6 +19,7 @@ import org.schabi.newpipe.extractor.Info
 import org.schabi.newpipe.extractor.NewPipe
 import org.schabi.newpipe.extractor.feed.FeedInfo
 import org.schabi.newpipe.extractor.stream.StreamInfoItem
+import org.schabi.newpipe.ktx.getStringSafe
 import org.schabi.newpipe.local.feed.FeedDatabaseManager
 import org.schabi.newpipe.local.subscription.SubscriptionManager
 import org.schabi.newpipe.util.ChannelTabHelper
@@ -69,12 +70,10 @@ class FeedLoadManager(private val context: Context) {
         val outdatedThreshold = if (ignoreOutdatedThreshold) {
             OffsetDateTime.now(ZoneOffset.UTC)
         } else {
-            val thresholdOutdatedSeconds = (
-                defaultSharedPreferences.getString(
-                    context.getString(R.string.feed_update_threshold_key),
-                    context.getString(R.string.feed_update_threshold_default_value)
-                ) ?: context.getString(R.string.feed_update_threshold_default_value)
-                ).toInt()
+            val thresholdOutdatedSeconds = defaultSharedPreferences.getStringSafe(
+                context.getString(R.string.feed_update_threshold_key),
+                context.getString(R.string.feed_update_threshold_default_value)
+            ).toInt()
             OffsetDateTime.now(ZoneOffset.UTC).minusSeconds(thresholdOutdatedSeconds.toLong())
         }
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Add null-safe alternative to SharedPreferences.getString. Guarantees the return value is non-null when the provided default value is non-null.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Improvement for #11199

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
