### PR TITLE
Add option to make top bar completely black in Black Mode

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/settings/AppearanceSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/AppearanceSettingsFragment.java
@@ -8,6 +8,7 @@ import android.widget.Toast;
 
 import androidx.core.app.ActivityCompat;
 import androidx.preference.Preference;
+import androidx.preference.SwitchPreferenceCompat;
 
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.util.Constants;
@@ -52,6 +53,14 @@ public class AppearanceSettingsFragment extends BasePreferenceFragment {
                         getString(R.string.auto_device_theme_title)));
             }
         }
+
+        // Add preference for enabling completely black top bar
+        final SwitchPreferenceCompat blackTopBarPreference = new SwitchPreferenceCompat(getContext());
+        blackTopBarPreference.setKey(getString(R.string.black_top_bar_key));
+        blackTopBarPreference.setTitle(R.string.black_top_bar_title);
+        blackTopBarPreference.setSummary(R.string.black_top_bar_summary);
+        blackTopBarPreference.setDefaultValue(false);
+        getPreferenceScreen().addPreference(blackTopBarPreference);
     }
 
     @Override

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -16,7 +16,8 @@
 
         <include
             layout="@layout/toolbar_layout"
-            android:id="@+id/toolbar_layout"/>
+            android:id="@+id/toolbar_layout"
+            android:background="?attr/black_top_bar_color" />
 
         <androidx.fragment.app.FragmentContainerView
             android:id="@+id/fragment_player_holder"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -48,6 +48,7 @@
     <color name="black_card_item_background_color">#0F0F0F</color>
     <color name="black_card_item_contrast_color">#202020</color>
     <color name="black_border_color">#25FFFFFF</color>
+    <color name="black_top_bar_color">#000000</color>
 
     <!-- Miscellaneous -->
     <color name="queue_background_color">@color/dark_queue_background_color</color>


### PR DESCRIPTION
Fixes #11640

Add an option to make the top bar completely black in Black Mode.

* **colors.xml**: Add a new color resource `black_top_bar_color` with value `#000000`.
* **AppearanceSettingsFragment.java**: Add a new preference for enabling the completely black top bar option.
* **activity_main.xml**: Update the toolbar layout to use the new `black_top_bar_color` when the completely black top bar option is enabled.

