### PR TITLE
[Build] Make it possible control the version code and name

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,8 +20,15 @@ android {
         resValue "string", "app_name", "NewPipe"
         minSdk 21
         targetSdk 33
-        versionCode 999
+        if (System.properties.containsKey('versionCodeOverride')) {
+            versionCode System.getProperty('versionCodeOverride') as Integer
+        } else {
+            versionCode 999
+        }
         versionName "0.27.2"
+        if (System.properties.containsKey('versionNameSuffix')) {
+            versionNameSuffix System.getProperty('versionNameSuffix')
+        }
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
I'm currently experimenting with the [Nightly](https://github.com/TeamNewPipe/NewPipe-nightly) and how to get it into an F-Droid repo.
So far it looks quite good however all nightly builds have the same version and name which confuses F-Droid.

<details><summary>Example</summary>

![](https://github.com/user-attachments/assets/f14b256a-be59-4702-a847-b422fc31d267)

</details>

This PR make it possible to control the version code and name.
This makes it possible to e.g. set ``-DversionNameSuffix=-<nightlyBuildId>-<date> -DversionCodeOverride=<nightlyBuildId>`` which should then result in distinguishable versions.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
