### PR TITLE
Add support for secondary audio track type

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
@@ -48,10 +48,12 @@ public final class ListHelper {
     private static final Set<String> HIGH_RESOLUTION_LIST = Set.of("1440p", "2160p");
     // Audio track types in order of priority. 0=lowest, n=highest
     private static final List<AudioTrackType> AUDIO_TRACK_TYPE_RANKING =
-            List.of(AudioTrackType.DESCRIPTIVE, AudioTrackType.DUBBED, AudioTrackType.ORIGINAL);
+            List.of(AudioTrackType.DESCRIPTIVE, AudioTrackType.SECONDARY, AudioTrackType.DUBBED,
+                    AudioTrackType.ORIGINAL);
     // Audio track types in order of priority when descriptive audio is preferred.
     private static final List<AudioTrackType> AUDIO_TRACK_TYPE_RANKING_DESCRIPTIVE =
-            List.of(AudioTrackType.ORIGINAL, AudioTrackType.DUBBED, AudioTrackType.DESCRIPTIVE);
+            List.of(AudioTrackType.SECONDARY, AudioTrackType.DUBBED, AudioTrackType.ORIGINAL,
+                    AudioTrackType.DESCRIPTIVE);
 
     /**
      * List of supported YouTube Itag ids.

--- a/app/src/main/java/org/schabi/newpipe/util/Localization.java
+++ b/app/src/main/java/org/schabi/newpipe/util/Localization.java
@@ -327,25 +327,20 @@ public final class Localization {
 
         if (track.getAudioTrackType() != null) {
             final String trackType = audioTrackType(context, track.getAudioTrackType());
-            if (trackType != null) {
-                return context.getString(R.string.audio_track_name, name, trackType);
-            }
+            return context.getString(R.string.audio_track_name, name, trackType);
         }
         return name;
     }
 
-    @Nullable
+    @NonNull
     private static String audioTrackType(@NonNull final Context context,
-                                         final AudioTrackType trackType) {
-        switch (trackType) {
-            case ORIGINAL:
-                return context.getString(R.string.audio_track_type_original);
-            case DUBBED:
-                return context.getString(R.string.audio_track_type_dubbed);
-            case DESCRIPTIVE:
-                return context.getString(R.string.audio_track_type_descriptive);
-        }
-        return null;
+                                         @NonNull final AudioTrackType trackType) {
+        return switch (trackType) {
+            case ORIGINAL -> context.getString(R.string.audio_track_type_original);
+            case DUBBED -> context.getString(R.string.audio_track_type_dubbed);
+            case DESCRIPTIVE -> context.getString(R.string.audio_track_type_descriptive);
+            case SECONDARY -> context.getString(R.string.audio_track_type_secondary);
+        };
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -816,6 +816,7 @@
     <string name="audio_track_type_original">original</string>
     <string name="audio_track_type_dubbed">dubbed</string>
     <string name="audio_track_type_descriptive">descriptive</string>
+    <string name="audio_track_type_secondary">secondary</string>
     <string name="channel_tab_videos">Videos</string>
     <string name="channel_tab_tracks">Tracks</string>
     <string name="channel_tab_shorts">Shorts</string>


### PR DESCRIPTION
#### What is it?
- [x] Feature (user facing)

#### Description of the changes in your PR
This PR adds support for secondary audio track type added in TeamNewPipe/NewPipeExtractor#1237.

These tracks have been given an higher priority than dubbed tracks when non-descriptive tracks are preferred, and a lower one than dubbed tracks when descriptive tracks are preferred. I don't know if that the right way to do this so the order should reviewed carefully.

Test videos are available in the extractor PR linked.

#### Fixes the following issue(s)
No issue found.

#### Relies on the following changes
- TeamNewPipe/NewPipeExtractor#1237

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).