### PR TITLE
Fix player resuming from start when clicking on a timestamp

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -462,7 +462,9 @@ public final class Player implements PlaybackListener, Listener {
         if (oldPlayerType != playerType && playQueue != null) {
             // If playerType changes from one to another we should reload the player
             // (to disable/enable video stream or to set quality)
-            setRecovery();
+            if (playerType != PlayerType.POPUP) {
+                setRecovery();
+            }
             reloadPlayQueueManager();
         }
 

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -462,9 +462,6 @@ public final class Player implements PlaybackListener, Listener {
         if (oldPlayerType != playerType && playQueue != null) {
             // If playerType changes from one to another we should reload the player
             // (to disable/enable video stream or to set quality)
-            if (playerType != PlayerType.POPUP) {
-                setRecovery();
-            }
             reloadPlayQueueManager();
         }
 


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Opening a timestamp from a comment (or somewhere else) started the pop-up player from the beginning instead of the timestamp (more details in the linked issue). Now it always opens the pop-up player at the specified time and not from start.
I am honestly unsure if this fix is acceptable since i don't fully understand the purpose of calling `setRecovery()` in this spot in the first place, so i am open to suggestions and/or help regarding this topic. I have not found any behavior that breaks with these changes though.

#### Fixes the following issue(s)
- Fixes #11302

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
