### PR TITLE
Fix downloading/exporting when overwriting file would not truncate

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/subscription/services/SubscriptionsExportService.java
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/services/SubscriptionsExportService.java
@@ -76,7 +76,7 @@ public class SubscriptionsExportService extends BaseImportExportService {
 
         try {
             outFile = new StoredFileHelper(this, path, "application/json");
-            outputStream = new SharpOutputStream(outFile.getStream());
+            outputStream = new SharpOutputStream(outFile.openAndTruncateStream());
         } catch (final IOException e) {
             handleError(e);
             return START_NOT_STICKY;

--- a/app/src/main/java/org/schabi/newpipe/settings/export/ImportExportManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/export/ImportExportManager.kt
@@ -24,8 +24,7 @@ class ImportExportManager(private val fileLocator: BackupFileLocator) {
      */
     @Throws(Exception::class)
     fun exportDatabase(preferences: SharedPreferences, file: StoredFileHelper) {
-        file.create()
-        ZipOutputStream(SharpOutputStream(file.stream).buffered()).use { outZip ->
+        ZipOutputStream(SharpOutputStream(file.openAndTruncateStream()).buffered()).use { outZip ->
             // add the database
             ZipHelper.addFileToZip(
                 outZip,

--- a/app/src/main/java/org/schabi/newpipe/streams/io/StoredFileHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/streams/io/StoredFileHelper.java
@@ -189,6 +189,19 @@ public class StoredFileHelper implements Serializable {
         }
     }
 
+    public SharpStream openAndTruncateStream() throws IOException {
+        final SharpStream sharpStream = getStream();
+        try {
+            sharpStream.setLength(0);
+        } catch (final Throwable e) {
+            // we can't use try-with-resources here, since we only want to close the stream if an
+            // exception occurs, but leave it open if everything goes well
+            sharpStream.close();
+            throw e;
+        }
+        return sharpStream;
+    }
+
     /**
      * Indicates whether it's using the {@code java.io} API.
      *


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This PR adds a method to open a file and immediately truncate it: `openAndTruncateStream()`. Database and subscription exports previously did not truncate the file before writing to it, resulting in corrupted files like in #7802 when the new content is shorter than the previous content. I looked at how the Downloader interacts with files, but the downloader correctly sets the length of the file before writing to it, so I did not change anything there. I tested on my phone (Android 13 SAF) and on API 22 emulated (SAF and NNFP) and it worked in both.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #7802

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
