### PR TITLE
Fix background crash focus

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -233,7 +233,6 @@ dependencies {
     implementation 'androidx.fragment:fragment-ktx:1.6.2'
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:${androidxLifecycleVersion}"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:${androidxLifecycleVersion}"
-    implementation "androidx.lifecycle:lifecycle-process:${androidxLifecycleVersion}"
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.1.0'
     implementation 'androidx.media:media:1.7.0'
     implementation 'androidx.preference:preference:1.2.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -233,6 +233,7 @@ dependencies {
     implementation 'androidx.fragment:fragment-ktx:1.6.2'
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:${androidxLifecycleVersion}"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:${androidxLifecycleVersion}"
+    implementation "androidx.lifecycle:lifecycle-process:${androidxLifecycleVersion}"
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.1.0'
     implementation 'androidx.media:media:1.7.0'
     implementation 'androidx.preference:preference:1.2.1'

--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -126,7 +126,10 @@ public class MainActivity extends AppCompatActivity {
     private static final int ITEM_ID_ABOUT = 2;
 
     private static final int ORDER = 0;
+    public static final String KEY_IS_IN_BACKGROUND = "is_in_background";
 
+    private SharedPreferences sharedPreferences;
+    private SharedPreferences.Editor sharedPrefEditor;
     /*//////////////////////////////////////////////////////////////////////////
     // Activity's LifeCycle
     //////////////////////////////////////////////////////////////////////////*/
@@ -156,6 +159,8 @@ public class MainActivity extends AppCompatActivity {
 
         assureCorrectAppLanguage(this);
         super.onCreate(savedInstanceState);
+        sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
+        sharedPrefEditor = sharedPreferences.edit();
 
         mainBinding = ActivityMainBinding.inflate(getLayoutInflater());
         drawerLayoutBinding = mainBinding.drawerLayout;
@@ -199,16 +204,29 @@ public class MainActivity extends AppCompatActivity {
         super.onPostCreate(savedInstanceState);
 
         final App app = App.getApp();
-        final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(app);
 
-        if (prefs.getBoolean(app.getString(R.string.update_app_key), false)
-                && prefs.getBoolean(app.getString(R.string.update_check_consent_key), false)) {
+        if (sharedPreferences.getBoolean(app.getString(R.string.update_app_key), false)
+                && sharedPreferences
+                .getBoolean(app.getString(R.string.update_check_consent_key), false)) {
             // Start the worker which is checking all conditions
             // and eventually searching for a new version.
             NewVersionWorker.enqueueNewVersionCheckingWork(app, false);
         }
     }
 
+    @Override
+    protected void onStart() {
+        super.onStart();
+        sharedPrefEditor.putBoolean(KEY_IS_IN_BACKGROUND, false).apply();
+        Log.d(TAG, "App moved to foreground");
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        sharedPrefEditor.putBoolean(KEY_IS_IN_BACKGROUND, true).apply();
+        Log.d(TAG, "App moved to background");
+    }
     private void setupDrawer() throws ExtractionException {
         addDrawerMenuForCurrentService();
 
@@ -508,13 +526,11 @@ public class MainActivity extends AppCompatActivity {
             ErrorUtil.showUiErrorSnackbar(this, "Setting up service toggle", e);
         }
 
-        final SharedPreferences sharedPreferences =
-                PreferenceManager.getDefaultSharedPreferences(this);
         if (sharedPreferences.getBoolean(Constants.KEY_THEME_CHANGE, false)) {
             if (DEBUG) {
                 Log.d(TAG, "Theme has changed, recreating activity...");
             }
-            sharedPreferences.edit().putBoolean(Constants.KEY_THEME_CHANGE, false).apply();
+            sharedPrefEditor.putBoolean(Constants.KEY_THEME_CHANGE, false).apply();
             ActivityCompat.recreate(this);
         }
 
@@ -522,7 +538,7 @@ public class MainActivity extends AppCompatActivity {
             if (DEBUG) {
                 Log.d(TAG, "main page has changed, recreating main fragment...");
             }
-            sharedPreferences.edit().putBoolean(Constants.KEY_MAIN_PAGE_CHANGE, false).apply();
+            sharedPrefEditor.putBoolean(Constants.KEY_MAIN_PAGE_CHANGE, false).apply();
             NavigationHelper.openMainActivity(this);
         }
 

--- a/app/src/main/java/org/schabi/newpipe/error/ErrorUtil.kt
+++ b/app/src/main/java/org/schabi/newpipe/error/ErrorUtil.kt
@@ -11,7 +11,9 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.PendingIntentCompat
 import androidx.fragment.app.Fragment
+import androidx.preference.PreferenceManager
 import com.google.android.material.snackbar.Snackbar
+import org.schabi.newpipe.MainActivity
 import org.schabi.newpipe.R
 
 /**
@@ -35,12 +37,20 @@ class ErrorUtil {
          * activity (since the workflow would be interrupted anyway in that case). So never use this
          * for background services.
          *
+         * If the crashed occurred while the app was in the background open a notification instead
+         *
          * @param context the context to use to start the new activity
          * @param errorInfo the error info to be reported
          */
         @JvmStatic
         fun openActivity(context: Context, errorInfo: ErrorInfo) {
-            context.startActivity(getErrorActivityIntent(context, errorInfo))
+            if (PreferenceManager.getDefaultSharedPreferences(context)
+                .getBoolean(MainActivity.KEY_IS_IN_BACKGROUND, true)
+            ) {
+                createNotification(context, errorInfo)
+            } else {
+                context.startActivity(getErrorActivityIntent(context, errorInfo))
+            }
         }
 
         /**


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This PR addresses the issue of NewPipe stealing focus to report an error even while it is in the background.
To check if the app has been in the background a monitoring class (that could also be used for different purposes) and a shared preference have been introduced to ensure that the state is correctly remembered and can then handle the reporting accordingly e.g. only show a notification if the crash happened while in foreground and show a not.
This was tested via delayed test crashes: 
```
new Handler(Looper.getMainLooper()).postDelayed(() -> {
            // Deliberately throw a RuntimeException
            throw new RuntimeException("Simulated crash for testing purposes.");
        }, 20000);

```

Occasionally i have seen this misbehave seemingly when another crash occurred before with a different foreground/background state. Unfortunately i have not found a fix for this, if somebody wants to take a look or can reproduce it I would be grateful. I am also open to completely different approaches since this approach is of course not optimal. 

#### Fixes the following issue(s)
- Fixes #10135 

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
