### PR TITLE
Fix caption sizes not being changed

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
@@ -25,9 +25,7 @@ import android.graphics.Color;
 import android.os.Handler;
 import android.os.Looper;
 import android.provider.Settings;
-import android.util.DisplayMetrics;
 import android.util.Log;
-import android.util.TypedValue;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.ViewGroup;
@@ -44,6 +42,7 @@ import androidx.fragment.app.FragmentActivity;
 import androidx.recyclerview.widget.ItemTouchHelper;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.google.android.exoplayer2.ui.SubtitleView;
 import com.google.android.exoplayer2.video.VideoSize;
 
 import org.schabi.newpipe.R;
@@ -522,11 +521,8 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
 
     @Override
     protected void setupSubtitleView(final float captionScale) {
-        final DisplayMetrics metrics = context.getResources().getDisplayMetrics();
-        final int minimumLength = Math.min(metrics.heightPixels, metrics.widthPixels);
-        final float captionRatioInverse = 20f + 4f * (1.0f - captionScale);
-        binding.subtitleView.setFixedTextSize(
-                TypedValue.COMPLEX_UNIT_PX, minimumLength / captionRatioInverse);
+        binding.subtitleView.setFractionalTextSize(
+                SubtitleView.DEFAULT_TEXT_SIZE_FRACTION * captionScale);
     }
     //endregion
 

--- a/app/src/main/java/org/schabi/newpipe/player/ui/PopupPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/PopupPlayerUi.java
@@ -424,9 +424,8 @@ public final class PopupPlayerUi extends VideoPlayerUi {
 
     @Override
     protected void setupSubtitleView(final float captionScale) {
-        final float captionRatio = (captionScale - 1.0f) / 5.0f + 1.0f;
         binding.subtitleView.setFractionalTextSize(
-                SubtitleView.DEFAULT_TEXT_SIZE_FRACTION * captionRatio);
+                SubtitleView.DEFAULT_TEXT_SIZE_FRACTION * captionScale);
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
@@ -1414,6 +1414,10 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
         binding.subtitleView.setStyle(captionStyle);
     }
 
+    /**
+     *
+     * @param captionScale Value returned by {@link PlayerHelper#getCaptionScale}.
+     */
     protected abstract void setupSubtitleView(float captionScale);
     //endregion
 


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
The caption size setting now correctly applies to the main player. I have tested this on several (emulated) devices, but additional test are probably needed to ensure it works correctly on all devices. 
If I overlooked any aspects of the original implementation, I’m happy to adjust the code as needed.

Restarting the app is no longer required - only restarting the player is necessary. If this PR is accepted, the related strings in the settings should be updated to reflect this change.

#### Fixes the following issue(s)
- Fixes #9702

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
