### PR TITLE
Fix image-minimizer on lines containing multiple images

### DIFF
--- a/.github/workflows/image-minimizer.js
+++ b/.github/workflows/image-minimizer.js
@@ -32,8 +32,8 @@ module.exports = async ({github, context}) => {
     }
 
     // Regex for finding images (simple variant) ![ALT_TEXT](https://*.githubusercontent.com/<number>/<variousHexStringsAnd->.<fileExtension>)
-    const REGEX_USER_CONTENT_IMAGE_LOOKUP = /\!\[(.*)\]\((https:\/\/[-a-z0-9]+\.githubusercontent\.com\/\d+\/[-0-9a-f]{32,512}\.(jpg|gif|png))\)/gm;
-    const REGEX_ASSETS_IMAGE_LOCKUP = /\!\[(.*)\]\((https:\/\/github\.com\/[-\w\d]+\/[-\w\d]+\/assets\/\d+\/[\-0-9a-f]{32,512})\)/gm;
+    const REGEX_USER_CONTENT_IMAGE_LOOKUP = /\!\[([^\]]*)\]\((https:\/\/[-a-z0-9]+\.githubusercontent\.com\/\d+\/[-0-9a-f]{32,512}\.(jpg|gif|png))\)/gm;
+    const REGEX_ASSETS_IMAGE_LOCKUP = /\!\[([^\]]*)\]\((https:\/\/github\.com\/[-\w\d]+\/[-\w\d]+\/assets\/\d+\/[\-0-9a-f]{32,512})\)/gm;
 
     // Check if we found something
     let foundSimpleImages = REGEX_USER_CONTENT_IMAGE_LOOKUP.test(initialBody)


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

<!-- custom option -->
- [x] **Bugfix (dev facing)**

#### Description of the changes in your PR
It is legal to have multiple images on a single line in Markdown. The previous regex did not handle that correctly. This PR fixes the regex.

#### Fixes the following issue(s)
- (Not tracked)

#### Testing

```js
var exampleBody = "![image-1](https://x.githubusercontent.com/1/11111111111111111111111111111111.png) ![image-2](https://x.githubusercontent.com/2/22222222222222222222222222222222.png)";
await replaceAsync(exampleBody, REGEX_USER_CONTENT_IMAGE_LOOKUP, match => `<<${match}>>`);
// previous output (incorrect):
"<<![image-1](https://x.githubusercontent.com/1/11111111111111111111111111111111.png) ![image-2](https://x.githubusercontent.com/2/22222222222222222222222222222222.png)>>"
// output with the fix:
"<<![image-1](https://x.githubusercontent.com/1/11111111111111111111111111111111.png)>> <<![image-2](https://x.githubusercontent.com/2/22222222222222222222222222222222.png)>>" 
```

#### APK testing
N/A

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
