### PR TITLE
Fix the issue of getting the checksum of a removed file

### DIFF
--- a/app/src/main/java/us/shandian/giga/ui/adapter/MissionAdapter.java
+++ b/app/src/main/java/us/shandian/giga/ui/adapter/MissionAdapter.java
@@ -664,6 +664,13 @@ public class MissionAdapter extends Adapter<ViewHolder> implements Handler.Callb
                 return true;
             case R.id.md5:
             case R.id.sha1:
+                final StoredFileHelper storage = h.item.mission.storage;
+                if (!storage.existsAsFile()) {
+                    Toast.makeText(mContext, R.string.missing_file, Toast.LENGTH_SHORT).show();
+                    mDeleter.append(h.item.mission);
+                    applyChanges();
+                    return true;
+                }
                 final NotificationManager notificationManager
                         = ContextCompat.getSystemService(mContext, NotificationManager.class);
                 final NotificationCompat.Builder progressNotificationBuilder
@@ -678,7 +685,6 @@ public class MissionAdapter extends Adapter<ViewHolder> implements Handler.Callb
 
                 notificationManager.notify(HASH_NOTIFICATION_ID, progressNotificationBuilder
                         .build());
-                final StoredFileHelper storage = h.item.mission.storage;
                 compositeDisposable.add(
                         Observable.fromCallable(() -> Utility.checksum(storage, id))
                                 .subscribeOn(Schedulers.computation())


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- In the current implementation, there is nothing preventing the user from calculating the checksum of a file that was deleted from the file manager, even though it doesn't work.
- I added a condition to check if the file does exist, and if not deleting it from the list of downloaded medias as well as showing an error message to the user.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #5038 

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
