### PR TITLE
MainActivity: Fix onBackPressed handling for open player

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -569,8 +569,8 @@ public class MainActivity extends AppCompatActivity {
             if (player instanceof BackPressable backPressable && !backPressable.onBackPressed()) {
                 BottomSheetBehavior.from(mainBinding.fragmentPlayerHolder)
                         .setState(BottomSheetBehavior.STATE_COLLAPSED);
-                return;
             }
+            return;
         }
 
         if (fragmentManager.getBackStackEntryCount() == 1) {


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
The change
https://github.com/TeamNewPipe/NewPipe/commit/b9dd7078ad3ae2ac1c20969fdd8b97736026b7dc
accidentally moved the `return` into the `{}`, so the logic would fall
through to

```
if (fragmentManager.getBackStackEntryCount() == 1) {`
```

and close the app even though there are still items on the
`VideoFragmentDetail` stack.

To reproduce:
Start video, enqueue another video, then start a third video (which
adds one entry to the stack), and press `back` on the expanded video.

This should keep the player open and go back to the first 2-video
queue, but it actually closes the app before this fix.
