### PR TITLE
Ugly fix for broken text colors in dark mode

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -147,7 +147,7 @@ public class MainActivity extends AppCompatActivity {
         if (DeviceUtils.supportsWebView()) {
             try {
                 new WebView(this);
-            } catch (final Exception e) {
+            } catch (final Throwable e) {
                 if (DEBUG) {
                     Log.e(TAG, "Failed to create WebView", e);
                 }

--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -144,7 +144,15 @@ public class MainActivity extends AppCompatActivity {
         // Fixes text color turning black in dark/black mode:
         // https://github.com/TeamNewPipe/NewPipe/issues/12016
         // For further reference see: https://issuetracker.google.com/issues/37124582
-        new WebView(this);
+        if (DeviceUtils.supportsWebView()) {
+            try {
+                new WebView(this);
+            } catch (final Exception e) {
+                if (DEBUG) {
+                    Log.e(TAG, "Failed to create WebView", e);
+                }
+            }
+        }
 
         assureCorrectAppLanguage(this);
         super.onCreate(savedInstanceState);

--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -38,6 +38,7 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.webkit.WebView;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.FrameLayout;
@@ -139,6 +140,7 @@ public class MainActivity extends AppCompatActivity {
 
         ThemeHelper.setDayNightMode(this);
         ThemeHelper.setTheme(this, ServiceHelper.getSelectedServiceId(this));
+        new WebView(this);
 
         assureCorrectAppLanguage(this);
         super.onCreate(savedInstanceState);

--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -140,6 +140,10 @@ public class MainActivity extends AppCompatActivity {
 
         ThemeHelper.setDayNightMode(this);
         ThemeHelper.setTheme(this, ServiceHelper.getSelectedServiceId(this));
+
+        // Fixes text color turning black in dark/black mode:
+        // https://github.com/TeamNewPipe/NewPipe/issues/12016
+        // For further reference see: https://issuetracker.google.com/issues/37124582
         new WebView(this);
 
         assureCorrectAppLanguage(this);


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
An ugly fix for the issue that the text color is black in dark/black mode. WebView is unfortunately messing with the theme with no real way to prevent it (at least from my observation). 
For some further reference: https://issuetracker.google.com/issues/37124582. 
I am not entirely sure why this exactly helps but it seems like the first WebView instantiated sets the theme/context and following ones don't change it again? 
If there is some other change that directly prevents this bug from occurring it should definitely be preferred.

#### Fixes the following issue(s)
- Fixes #12016

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
