### PR TITLE
Fix stream notification grouping

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/feed/notifications/NotificationHelper.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/notifications/NotificationHelper.kt
@@ -88,7 +88,7 @@ class NotificationHelper(val context: Context) {
 
                 // Show individual stream notifications, set channel icon only if there is actually
                 // one
-                showStreamNotifications(newStreams, data.serviceId, bitmap)
+                showStreamNotifications(newStreams, data.serviceId, data.url, bitmap)
                 // Show summary notification
                 manager.notify(data.pseudoId, summaryBuilder.build())
 
@@ -97,7 +97,7 @@ class NotificationHelper(val context: Context) {
 
             override fun onBitmapFailed(e: Exception, errorDrawable: Drawable) {
                 // Show individual stream notifications
-                showStreamNotifications(newStreams, data.serviceId, null)
+                showStreamNotifications(newStreams, data.serviceId, data.url, null)
                 // Show summary notification
                 manager.notify(data.pseudoId, summaryBuilder.build())
                 iconLoadingTargets.remove(this) // allow it to be garbage-collected
@@ -118,10 +118,11 @@ class NotificationHelper(val context: Context) {
     private fun showStreamNotifications(
         newStreams: List<StreamInfoItem>,
         serviceId: Int,
+        channelUrl: String,
         channelIcon: Bitmap?
     ) {
         for (stream in newStreams) {
-            val notification = createStreamNotification(stream, serviceId, channelIcon)
+            val notification = createStreamNotification(stream, serviceId, channelUrl, channelIcon)
             manager.notify(stream.url.hashCode(), notification)
         }
     }
@@ -129,6 +130,7 @@ class NotificationHelper(val context: Context) {
     private fun createStreamNotification(
         item: StreamInfoItem,
         serviceId: Int,
+        channelUrl: String,
         channelIcon: Bitmap?
     ): Notification {
         return NotificationCompat.Builder(
@@ -139,7 +141,7 @@ class NotificationHelper(val context: Context) {
             .setLargeIcon(channelIcon)
             .setContentTitle(item.name)
             .setContentText(item.uploaderName)
-            .setGroup(item.uploaderUrl)
+            .setGroup(channelUrl)
             .setColor(ContextCompat.getColor(context, R.color.ic_launcher_background))
             .setColorized(true)
             .setAutoCancel(true)


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- It is possible for the stream uploader URL to be different from the channel URL, thus resulting in the notifications not being grouped by the channel. This change fixes that.

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
