### PR TITLE
fix: filter members-only videos from feeds

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/feed/service/FeedLoadManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/service/FeedLoadManager.kt
@@ -227,6 +227,7 @@ class FeedLoadManager(private val context: Context) {
                         }
                     }
                     .filterIsInstance<StreamInfoItem>()
+                    .filter { !it.requiresMembership() }
             }
 
             return Notification.createOnNext(


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
YouTube has started to mix members-only videos into the normal videos in the Videos tab. This filters them, as they cannot be watched without an account, leading to clutter in the feed.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
| Before                                                                                                            	| After                                                                                                                	|
|-------------------------------------------------------------------------------------------------------------------	|----------------------------------------------------------------------------------------------------------------------	|
| ![Feed with members-only videos](https://github.com/user-attachments/assets/4f26768f-ee83-4942-ae75-dff7b4f63aca) 	| ![Feed without members-only videos](https://github.com/user-attachments/assets/016bf29a-db50-4f8f-bc19-bb9999aa08f3) 	|

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
Closes: https://github.com/TeamNewPipe/NewPipe/issues/12011
Closes: https://github.com/TeamNewPipe/NewPipe/issues/12040

#### Relies on the following changes
<!-- Delete this if it doesn't apply to your PR. -->
https://github.com/TeamNewPipe/NewPipeExtractor/pull/1280.

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
