### PR TITLE
Update NewPipe Extractor and add new proguard rules

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -208,7 +208,7 @@ dependencies {
     implementation 'com.github.TeamNewPipe:nanojson:1d9e1aea9049fc9f85e68b43ba39fe7be1c1f751'
     // WORKAROUND: if you get errors with the NewPipeExtractor dependency, replace `v0.24.3` with
     // the corresponding commit hash, since JitPack is sometimes buggy
-    implementation 'com.github.TeamNewPipe:NewPipeExtractor:9f83b385a'
+    implementation 'com.github.TeamNewPipe:NewPipeExtractor:0b99100db'
     implementation 'com.github.TeamNewPipe:NoNonsense-FilePicker:5.0.0'
 
 /** Checkstyle **/

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -5,10 +5,17 @@
 
 ## Rules for NewPipeExtractor
 -keep class org.schabi.newpipe.extractor.timeago.patterns.** { *; }
+## Rules for Rhino and Rhino Engine
+-keep class org.mozilla.javascript.* { *; }
 -keep class org.mozilla.javascript.** { *; }
+-keep class org.mozilla.javascript.engine.** { *; }
 -keep class org.mozilla.classfile.ClassFileWriter
 -dontwarn org.mozilla.javascript.JavaToJSONConverters
 -dontwarn org.mozilla.javascript.tools.**
+-keep class javax.script.** { *; }
+-dontwarn javax.script.**
+-keep class jdk.dynalink.** { *; }
+-dontwarn jdk.dynalink.**
 
 ## Rules for ExoPlayer
 -keep class com.google.android.exoplayer2.** { *; }


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [x] Meta improvement to the project (dev facing)

#### Description of the changes in your PR

This updates NewPipe Extractor to https://github.com/TeamNewPipe/NewPipeExtractor/commit/0b99100dbddeca2f27554620378f251afd66b30b.

I needed to add new Proguard rules to keep a few classes. The upgrade to Rhino 1.8.0 and the new dependency Rhino Engine 1.8.0 introduced in TeamNewPipe/NewPipeExtractor#1256 made this necessary. Otherwise `assembleRelease` would throw an error. I am unsure whether we could use stricter rules.


<details><summary>Build error</summary>


```
Missing class javax.script.AbstractScriptEngine (referenced from: void org.mozilla.javascript.engine.RhinoScriptEngine.<init>(org.mozilla.javascript.engine.RhinoScriptEngineFactory) and 1 other context)
Missing class javax.script.Bindings (referenced from: javax.script.Bindings org.mozilla.javascript.engine.BindingsObject.bindings and 8 other contexts)
Missing class javax.script.Compilable (referenced from: org.mozilla.javascript.engine.RhinoScriptEngine)
Missing class javax.script.CompiledScript (referenced from: void org.mozilla.javascript.engine.RhinoCompiledScript.<init>(org.mozilla.javascript.engine.RhinoScriptEngine, org.mozilla.javascript.Script) and 3 other contexts)
Missing class javax.script.Invocable (referenced from: org.mozilla.javascript.engine.RhinoScriptEngine)
Missing class javax.script.ScriptContext (referenced from: void org.mozilla.javascript.engine.Builtins.register(org.mozilla.javascript.Context, org.mozilla.javascript.ScriptableObject, javax.script.ScriptContext) and 6 other contexts)
Missing class javax.script.ScriptEngine (referenced from: javax.script.ScriptEngine org.mozilla.javascript.engine.RhinoCompiledScript.getEngine() and 1 other context)
Missing class javax.script.ScriptEngineFactory (referenced from: javax.script.ScriptEngineFactory org.mozilla.javascript.engine.RhinoScriptEngine.getFactory() and 1 other context)
Missing class javax.script.ScriptException (referenced from: javax.script.CompiledScript org.mozilla.javascript.engine.RhinoScriptEngine.compile(java.io.Reader) and 9 other contexts)
Missing class javax.script.SimpleBindings (referenced from: javax.script.Bindings org.mozilla.javascript.engine.RhinoScriptEngine.createBindings())
Missing class jdk.dynalink.CallSiteDescriptor (referenced from: jdk.dynalink.linker.GuardedInvocation org.mozilla.javascript.optimizer.BaseFunctionLinker.getGuardedInvocation(jdk.dynalink.linker.LinkRequest, jdk.dynalink.linker.LinkerServices) and 9 other contexts)
Missing class jdk.dynalink.DynamicLinker (referenced from: jdk.dynalink.DynamicLinker org.mozilla.javascript.optimizer.Bootstrapper.linker and 2 other contexts)
Missing class jdk.dynalink.DynamicLinkerFactory (referenced from: void org.mozilla.javascript.optimizer.Bootstrapper.<clinit>())
Missing class jdk.dynalink.NamedOperation (referenced from: jdk.dynalink.Operation org.mozilla.javascript.optimizer.Bootstrapper.parseOperation(java.lang.String) and 1 other context)
Missing class jdk.dynalink.Namespace (referenced from: jdk.dynalink.Namespace org.mozilla.javascript.optimizer.ParsedOperation.namespace and 4 other contexts)
Missing class jdk.dynalink.NamespaceOperation (referenced from: jdk.dynalink.Operation org.mozilla.javascript.optimizer.Bootstrapper.parseOperation(java.lang.String) and 1 other context)
Missing class jdk.dynalink.Operation (referenced from: jdk.dynalink.Operation org.mozilla.javascript.optimizer.ParsedOperation.operation and 17 other contexts)
Missing class jdk.dynalink.RelinkableCallSite (referenced from: java.lang.invoke.CallSite org.mozilla.javascript.optimizer.Bootstrapper.bootstrap(java.lang.invoke.MethodHandles$Lookup, java.lang.String, java.lang.invoke.MethodType))
Missing class jdk.dynalink.StandardNamespace (referenced from: jdk.dynalink.linker.GuardedInvocation org.mozilla.javascript.optimizer.DefaultLinker.getInvocation(java.lang.invoke.MethodHandles$Lookup, java.lang.invoke.MethodType, org.mozilla.javascript.optimizer.ParsedOperation))
Missing class jdk.dynalink.StandardOperation (referenced from: jdk.dynalink.Operation org.mozilla.javascript.optimizer.Bootstrapper.parseOperation(java.lang.String))
Missing class jdk.dynalink.linker.GuardedInvocation (referenced from: jdk.dynalink.linker.GuardedInvocation org.mozilla.javascript.optimizer.BaseFunctionLinker.getGuardedInvocation(jdk.dynalink.linker.LinkRequest, jdk.dynalink.linker.LinkerServices) and 12 other contexts)
Missing class jdk.dynalink.linker.GuardingDynamicLinker (referenced from: void org.mozilla.javascript.optimizer.Bootstrapper.<clinit>() and 1 other context)
Missing class jdk.dynalink.linker.LinkRequest (referenced from: jdk.dynalink.linker.GuardedInvocation org.mozilla.javascript.optimizer.BaseFunctionLinker.getGuardedInvocation(jdk.dynalink.linker.LinkRequest, jdk.dynalink.linker.LinkerServices) and 8 other contexts)
Missing class jdk.dynalink.linker.LinkerServices (referenced from: jdk.dynalink.linker.GuardedInvocation org.mozilla.javascript.optimizer.BaseFunctionLinker.getGuardedInvocation(jdk.dynalink.linker.LinkRequest, jdk.dynalink.linker.LinkerServices) and 8 other contexts)
Missing class jdk.dynalink.linker.TypeBasedGuardingDynamicLinker (referenced from: void org.mozilla.javascript.optimizer.Bootstrapper.<clinit>() and 8 other contexts)
Missing class jdk.dynalink.linker.support.CompositeTypeBasedGuardingDynamicLinker (referenced from: void org.mozilla.javascript.optimizer.Bootstrapper.<clinit>())
Missing class jdk.dynalink.linker.support.Guards (referenced from: jdk.dynalink.linker.GuardedInvocation org.mozilla.javascript.optimizer.BaseFunctionLinker.getGuardedInvocation(jdk.dynalink.linker.LinkRequest, jdk.dynalink.linker.LinkerServices) and 7 other contexts)
Missing class jdk.dynalink.support.ChainedCallSite (referenced from: java.lang.invoke.CallSite org.mozilla.javascript.optimizer.Bootstrapper.bootstrap(java.lang.invoke.MethodHandles$Lookup, java.lang.String, java.lang.invoke.MethodType))
```

</details>




#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
