### PR TITLE
[YouTube] Access first element if array size is one

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/util/potoken/JavaScriptUtil.kt
+++ b/app/src/main/java/org/schabi/newpipe/util/potoken/JavaScriptUtil.kt
@@ -17,7 +17,7 @@ fun parseChallengeData(rawChallengeData: String): String {
         val descrambled = descramble(scrambled.getString(1))
         JsonParser.array().from(descrambled)
     } else {
-        scrambled.getArray(1)
+        scrambled.getArray(0)
     }
 
     val messageId = challengeData.getString(0)


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR

If the challenge data array is of size one, the second element is accessed, leading to an `IndexOutOfBoundsException`. I assume, that this is a typo, as the [JS version](https://github.com/Stypox/NewPipe/blob/2b183a057651a79aa826a110e3eebf126befdd6c/app/src/main/assets/po_token.html#L100) did correctly access the first element.


#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
