### PR TITLE
fix: support RTL usernames in comment header

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/info_list/holder/CommentInfoItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/holder/CommentInfoItemHolder.java
@@ -101,13 +101,15 @@ public class CommentInfoItemHolder extends InfoItemHolder {
         }
         itemThumbnailView.setOnClickListener(view -> openCommentAuthor(item));
 
-
         // setup the top row, with pinned icon, author name and comment date
         itemPinnedView.setVisibility(item.isPinned() ? View.VISIBLE : View.GONE);
-        itemTitleView.setText(Localization.concatenateStrings(item.getUploaderName(),
-                Localization.relativeTimeOrTextual(itemBuilder.getContext(), item.getUploadDate(),
+        final String uploaderName = Localization.localizeUserName(item.getUploaderName());
+        itemTitleView.setText(Localization.concatenateStrings(
+                uploaderName,
+                Localization.relativeTimeOrTextual(
+                        itemBuilder.getContext(),
+                        item.getUploadDate(),
                         item.getTextualUploadDate())));
-
 
         // setup bottom row, with likes, heart and replies button
         itemLikesCountView.setText(

--- a/app/src/main/java/org/schabi/newpipe/util/Localization.java
+++ b/app/src/main/java/org/schabi/newpipe/util/Localization.java
@@ -11,6 +11,7 @@ import android.icu.text.CompactDecimalFormat;
 import android.os.Build;
 import android.text.TextUtils;
 import android.text.format.DateUtils;
+import android.text.BidiFormatter;
 import android.util.DisplayMetrics;
 import android.util.Log;
 
@@ -83,6 +84,25 @@ public final class Localization {
         return strings.stream()
                 .filter(string -> !TextUtils.isEmpty(string))
                 .collect(Collectors.joining(delimiter));
+    }
+
+    /**
+     * Localize a user name like <code>@foobar</code>.
+     *
+     * Will correctly handle right-to-left usernames by using a {@link BidiFormatter}.
+     *
+     * @param plainName username, with an optional leading <code>@</code>
+     * @return a usernames that can include RTL-characters
+     */
+    @NonNull
+    public static String localizeUserName(final String plainName) {
+        final BidiFormatter bidi = BidiFormatter.getInstance();
+
+        if (plainName.startsWith("@")) {
+            return "@" + bidi.unicodeWrap(plainName.substring(1));
+        } else {
+            return bidi.unicodeWrap(plainName);
+        }
     }
 
     public static org.schabi.newpipe.extractor.localization.Localization getPreferredLocalization(


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
-  Wrapped  uploader's username using BidiFormatter to fix direction issues when combining RTL usernames with timestamps  in comment headers.

#### Before/After Screenshots/Screen Record
- Before:
![image](https://github.com/user-attachments/assets/16ff6ba5-e9e3-4020-8056-8c4c54631d2f)

- After:
![image](https://github.com/user-attachments/assets/d107e17a-8b9b-4ce4-af81-f82b027916ab)

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #12141 

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
