### PR TITLE
Adapt header handling changes from other recyclerview adapters to fix…

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/BaseLocalListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/BaseLocalListFragment.java
@@ -28,6 +28,8 @@ import static org.schabi.newpipe.ktx.ViewUtils.animate;
 import static org.schabi.newpipe.ktx.ViewUtils.animateHideRecyclerViewAllowingScrolling;
 import static org.schabi.newpipe.util.ThemeHelper.getItemViewMode;
 
+import java.util.function.Supplier;
+
 /**
  * This fragment is design to be used with persistent data such as
  * {@link org.schabi.newpipe.database.LocalItem}, and does not cache the data contained
@@ -100,7 +102,7 @@ public abstract class BaseLocalListFragment<I, N> extends BaseStateFragment<I>
     //////////////////////////////////////////////////////////////////////////*/
 
     @Nullable
-    protected ViewBinding getListHeader() {
+    protected Supplier<View> getListHeaderSupplier() {
         return null;
     }
 
@@ -131,9 +133,9 @@ public abstract class BaseLocalListFragment<I, N> extends BaseStateFragment<I>
         itemsList = rootView.findViewById(R.id.items_list);
         refreshItemViewMode();
 
-        headerRootBinding = getListHeader();
-        if (headerRootBinding != null) {
-            itemListAdapter.setHeader(headerRootBinding.getRoot());
+        final Supplier<View> listHeaderSupplier = getListHeaderSupplier();
+        if (listHeaderSupplier != null) {
+            itemListAdapter.setHeaderSupplier(listHeaderSupplier);
         }
         footerRootBinding = getListFooter();
         itemListAdapter.setFooter(footerRootBinding.getRoot());

--- a/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
@@ -13,7 +13,6 @@ import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.viewbinding.ViewBinding;
 
 import com.evernote.android.state.State;
 import com.google.android.material.snackbar.Snackbar;
@@ -45,6 +44,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Supplier;
 
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 import io.reactivex.rxjava3.disposables.CompositeDisposable;
@@ -126,12 +126,12 @@ public class StatisticsPlaylistFragment
     }
 
     @Override
-    protected ViewBinding getListHeader() {
+    protected Supplier<View> getListHeaderSupplier() {
         headerBinding = StatisticPlaylistControlBinding.inflate(activity.getLayoutInflater(),
                 itemsList, false);
         playlistControlBinding = headerBinding.playlistControl;
 
-        return headerBinding;
+        return headerBinding::getRoot;
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
@@ -29,7 +29,6 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.recyclerview.widget.ItemTouchHelper;
 import androidx.recyclerview.widget.RecyclerView;
-import androidx.viewbinding.ViewBinding;
 
 import com.evernote.android.state.State;
 import org.reactivestreams.Subscriber;
@@ -67,6 +66,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
@@ -158,14 +158,14 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
     }
 
     @Override
-    protected ViewBinding getListHeader() {
+    protected Supplier<View> getListHeaderSupplier() {
         headerBinding = LocalPlaylistHeaderBinding.inflate(activity.getLayoutInflater(), itemsList,
-                false);
+            false);
         playlistControlBinding = headerBinding.playlistControl;
 
         headerBinding.playlistTitleView.setSelected(true);
 
-        return headerBinding;
+        return headerBinding::getRoot;
     }
 
     @Override


### PR DESCRIPTION
… issue #4475 in StatisticsPlaylistFragment

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
- Supply header to LocalItemListAdapter with a supplier
- Changes adapted from d3cd3d6

#### Before/After Screenshots/Screen Record
- Before:
![Screenshot_20250427_122720](https://github.com/user-attachments/assets/a0cec14f-020d-468f-a731-148b368ab024)
- After:
![Screenshot_20250427_124015](https://github.com/user-attachments/assets/19c0d6ec-401b-4744-87cc-342069e088fd)

#### Fixes the following issue(s)
- Fixes #4475
- This could be reproduced intermittently under these conditions:
    - Open the watch history list
    - Have video player drawer open and minimized
    - Scroll down far enough in the list so the header is not visible
    - Rotate the device until the bug happens
- The header would sometimes be drawn under the list items. If a user then scrolled back up to where the header was visible this would cause a crash when the RecyclerView tried to create the attached HeaderFooterHolder.
- Testing the above steps to reproduce the bug, I couldn't get the bug to happen again after these changes were applied.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
