### PR TITLE
settings: add UI options to import/export subscriptions

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -862,4 +862,7 @@
     <string name="show_more">Show more</string>
     <string name="show_less">Show less</string>
     <string name="import_settings_vulnerable_format">The settings in the export being imported use a vulnerable format that was deprecated since NewPipe 0.27.0. Make sure the export being imported is from a trusted source, and prefer using only exports obtained from NewPipe 0.27.0 or newer in the future. Support for importing settings in this vulnerable format will soon be removed completely, and then old versions of NewPipe will not be able to import settings of exports from new versions anymore.</string>
+    <string name="exporting">Exporting subscriptions…</string>
+    <string name="importing">Importing subscriptions…</string>
+
 </resources>

--- a/app/src/main/res/xml/backup_restore_settings.xml
+++ b/app/src/main/res/xml/backup_restore_settings.xml
@@ -22,4 +22,18 @@
         android:summary="@string/reset_settings_summary"
         app:singleLineTitle="false"
         app:iconSpaceReserved="false" />
+
+    <Preference
+        android:key="export_subscriptions"
+        android:title="Export subscriptions"
+        android:summary="Export your subscriptions to a .json file"
+        app:singleLineTitle="false"
+        app:iconSpaceReserved="false" />
+
+    <Preference
+        android:key="import_subscriptions"
+        android:title="Import subscriptions"
+        android:summary="Import subscriptions from a previous .json export"
+        app:singleLineTitle="false"
+        app:iconSpaceReserved="false" />
 </PreferenceScreen>


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
Adds two new options to the Backup & Restore settings screen:
- "Export subscriptions": saves current subscriptions as a .json file
- "Import subscriptions": restores subscriptions from a previously exported .json file

Reuses existing import/export logic via SubscriptionsImportService and SubscriptionsExportService. These are 2 .json files created for testing the feature:

<img src="https://github.com/user-attachments/assets/478ff1b5-f918-4b2a-8e12-4ec170978287" width="300px"/>


#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/82b41206-314e-4425-8a29-43e12a1d0ebc" width="300px" alt="Before"/></td>
    <td><img src="https://github.com/user-attachments/assets/4bacfa54-26d7-4406-8cd4-3dfc5b8bcbfe" width="300px" alt="After"/></td>
  </tr>
</table>


#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #12026


#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
