### PR TITLE
Refactor Settings Compose Setup

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/SettingsScreen.kt
@@ -6,17 +6,18 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import org.schabi.newpipe.R
+import org.schabi.newpipe.ui.SettingsRoutes
 import org.schabi.newpipe.ui.TextPreference
 
 @Composable
 fun SettingsScreen(
-    onSelectSettingOption: (SettingsScreenKey) -> Unit,
+    onSelectSettingOption: (settingsRoute: SettingsRoutes) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(modifier = modifier) {
         TextPreference(
             title = R.string.settings_category_debug_title,
-            onClick = { onSelectSettingOption(SettingsScreenKey.DEBUG) }
+            onClick = { onSelectSettingOption(SettingsRoutes.SettingsDebugRoute) }
         )
         HorizontalDivider(color = Color.Black)
     }

--- a/app/src/main/java/org/schabi/newpipe/settings/SettingsV2Activity.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/SettingsV2Activity.kt
@@ -10,20 +10,18 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
-import androidx.navigation.navArgument
 import dagger.hilt.android.AndroidEntryPoint
 import org.schabi.newpipe.R
 import org.schabi.newpipe.settings.viewmodel.SettingsViewModel
+import org.schabi.newpipe.ui.SettingsRoutes
 import org.schabi.newpipe.ui.Toolbar
 import org.schabi.newpipe.ui.theme.AppTheme
-
-const val SCREEN_TITLE_KEY = "SCREEN_TITLE_KEY"
 
 @AndroidEntryPoint
 class SettingsV2Activity : ComponentActivity() {
@@ -35,37 +33,41 @@ class SettingsV2Activity : ComponentActivity() {
 
         setContent {
             val navController = rememberNavController()
-            var screenTitle by remember { mutableIntStateOf(SettingsScreenKey.ROOT.screenTitle) }
-            navController.addOnDestinationChangedListener { _, _, arguments ->
-                screenTitle =
-                    arguments?.getInt(SCREEN_TITLE_KEY) ?: SettingsScreenKey.ROOT.screenTitle
+            val navBackStackEntry by navController.currentBackStackEntryAsState()
+            @StringRes val screenTitleRes by remember(navBackStackEntry) {
+                mutableIntStateOf(
+                    when (navBackStackEntry?.destination?.route) {
+                        SettingsRoutes.SettingsMainRoute::class.java.canonicalName -> SettingsRoutes.SettingsMainRoute.screenTitleRes
+                        SettingsRoutes.SettingsDebugRoute::class.java.canonicalName -> SettingsRoutes.SettingsDebugRoute.screenTitleRes
+                        else -> R.string.settings
+                    }
+                )
             }
 
             AppTheme {
                 Scaffold(topBar = {
                     Toolbar(
-                        title = stringResource(id = screenTitle),
+                        title = stringResource(screenTitleRes),
+                        onNavigateBack = {
+                            if (!navController.popBackStack()) {
+                                finish()
+                            }
+                        },
                         hasSearch = true,
                         onSearchQueryChange = null // TODO: Add suggestions logic
                     )
                 }) { padding ->
                     NavHost(
                         navController = navController,
-                        startDestination = SettingsScreenKey.ROOT.name,
+                        startDestination = SettingsRoutes.SettingsMainRoute,
                         modifier = Modifier.padding(padding)
                     ) {
-                        composable(
-                            SettingsScreenKey.ROOT.name,
-                            listOf(createScreenTitleArg(SettingsScreenKey.ROOT.screenTitle))
-                        ) {
-                            SettingsScreen(onSelectSettingOption = { screen ->
-                                navController.navigate(screen.name)
+                        composable<SettingsRoutes.SettingsMainRoute> {
+                            SettingsScreen(onSelectSettingOption = { route ->
+                                navController.navigate(route)
                             })
                         }
-                        composable(
-                            SettingsScreenKey.DEBUG.name,
-                            listOf(createScreenTitleArg(SettingsScreenKey.DEBUG.screenTitle))
-                        ) {
+                        composable<SettingsRoutes.SettingsDebugRoute> {
                             DebugScreen(settingsViewModel)
                         }
                     }
@@ -73,13 +75,4 @@ class SettingsV2Activity : ComponentActivity() {
             }
         }
     }
-}
-
-fun createScreenTitleArg(@StringRes screenTitle: Int) = navArgument(SCREEN_TITLE_KEY) {
-    defaultValue = screenTitle
-}
-
-enum class SettingsScreenKey(@StringRes val screenTitle: Int) {
-    ROOT(R.string.settings),
-    DEBUG(R.string.settings_category_debug_title)
 }

--- a/app/src/main/java/org/schabi/newpipe/ui/SettingsRoutes.kt
+++ b/app/src/main/java/org/schabi/newpipe/ui/SettingsRoutes.kt
@@ -1,0 +1,17 @@
+package org.schabi.newpipe.ui
+
+import androidx.annotation.StringRes
+import kotlinx.serialization.Serializable
+import org.schabi.newpipe.R
+
+// Settings screens
+@Serializable
+sealed class SettingsRoutes(
+    @get:StringRes
+    val screenTitleRes: Int
+) {
+    @Serializable
+    object SettingsMainRoute : SettingsRoutes(R.string.settings)
+    @Serializable
+    object SettingsDebugRoute : SettingsRoutes(R.string.settings_category_debug_title)
+}

--- a/app/src/main/java/org/schabi/newpipe/ui/Toolbar.kt
+++ b/app/src/main/java/org/schabi/newpipe/ui/Toolbar.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SearchBar
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -35,11 +36,13 @@ fun TextAction(text: String, modifier: Modifier = Modifier) {
 }
 
 @Composable
-fun NavigationIcon() {
-    Icon(
-        imageVector = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back",
-        modifier = Modifier.padding(horizontal = SizeTokens.SpacingExtraSmall)
-    )
+fun NavigationIcon(navigateBack: () -> Unit) {
+    IconButton(onClick = navigateBack) {
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back",
+            modifier = Modifier.padding(horizontal = SizeTokens.SpacingExtraSmall)
+        )
+    }
 }
 
 @Composable
@@ -53,7 +56,8 @@ fun SearchSuggestionItem(text: String) {
 fun Toolbar(
     title: String,
     modifier: Modifier = Modifier,
-    hasNavigationIcon: Boolean = true,
+    // TODO: Handle search in toolbar in a better way.
+    onNavigateBack: (() -> Unit)? = null,
     hasSearch: Boolean = false,
     onSearchQueryChange: ((String) -> List<String>)? = null,
     actions: @Composable RowScope.() -> Unit = {}
@@ -65,7 +69,14 @@ fun Toolbar(
         TopAppBar(
             title = { Text(text = title) },
             modifier = modifier,
-            navigationIcon = { if (hasNavigationIcon) NavigationIcon() },
+            colors = TopAppBarDefaults.topAppBarColors(
+                containerColor = MaterialTheme.colorScheme.primaryContainer,
+                titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                actionIconContentColor = MaterialTheme.colorScheme.onPrimaryContainer
+            ),
+            navigationIcon = {
+                onNavigateBack?.let { NavigationIcon(onNavigateBack) }
+            },
             actions = {
                 actions()
                 if (hasSearch) {

--- a/app/src/main/java/org/schabi/newpipe/ui/theme/Color.kt
+++ b/app/src/main/java/org/schabi/newpipe/ui/theme/Color.kt
@@ -1,5 +1,8 @@
 package org.schabi.newpipe.ui.theme
 
+// Color.kt is generated using the Material theme builder https://material-foundation.github.io/material-theme-builder/
+// TODO: Update the colors to properly match the existing color scheme + also add colors schemes for other services
+
 import androidx.compose.ui.graphics.Color
 
 val primaryLight = Color(0xFF904A45)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,7 @@ markwon = "4.6.2"
 material = "1.11.0"
 media = "1.7.0"
 mockitoCore = "5.6.0"
-navigationCompose = "2.8.3"
+navigationCompose = "2.9.0"
 okhttp = "4.12.0"
 pagingCompose = "3.3.2"
 preference = "1.2.1"
@@ -137,7 +137,7 @@ kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-p
 kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
 kotlinx-coroutines-rx3 = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-rx3", version.ref = "kotlinxCoroutinesRx3" }
 kotlinx-serialization = { group = "org.jetbrains.kotlin", name = "kotlin-serialization", version.ref = "kotlin" }
-kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 lazycolumnscrollbar = { group = "com.github.nanihadesuka", name = "LazyColumnScrollbar", version.ref = "lazycolumnscrollbar" }
 leakcanary-android-core = { module = "com.squareup.leakcanary:leakcanary-android-core", version.ref = "leakcanary" }
 leakcanary-object-watcher = { group = "com.squareup.leakcanary", name = "leakcanary-object-watcher-android", version.ref = "leakcanary" }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This PR refines the Settings screen setup using Jetpack Compose:

* **Navigation Routing**: Updated navigation logic to use **Serialized Routes**, as recommended in the [official Compose navigation documentation](https://developer.android.com/develop/ui/compose/navigation).
* **Screen Title Management**: Migrated screen title handling to a Compose-native approach instead of using `addOnDestinationChangedListener`.
* **Toolbar Enhancements**:
  * Refined the toolbar layout and styling to improve alignment with Material theming.
  * Implemented proper ripple effects and consistent color usage.
  * Fixed back navigation behavior to align with Compose conventions.
* **Theming Note**: The current Compose-based theme system does not yet fully replicate the color palette used in the legacy (pre-Compose) implementation, especially across different services. A `TODO` has been added in code, and a separate task will be created to address this comprehensively.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before:
- After:

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #

#### Relies on the following changes
<!-- Delete this if it doesn't apply to your PR. -->
- N/A

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
