### PR TITLE
fix: handle nullable nextPage behavior when searching albums #12401

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/list/search/SearchFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/search/SearchFragment.java
@@ -1067,7 +1067,7 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
         infoListAdapter.addInfoItemList(result.getItems());
         nextPage = result.getNextPage();
 
-        if (!result.getErrors().isEmpty()) {
+        if (!result.getErrors().isEmpty() && nextPage != null) {
             showSnackBarError(new ErrorInfo(result.getErrors(), UserAction.SEARCHED,
                     "\"" + searchString + "\" → pageUrl: " + nextPage.getUrl() + ", "
                             + "pageIds: " + nextPage.getIds() + ", "


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
- Handle display search results when `nextPage` is null on Albums mode

#### Before/After Screenshots/Screen Record
- Before:

https://github.com/user-attachments/assets/0d4df6ca-25bc-4133-85a7-6bda199d870e

- After:

https://github.com/user-attachments/assets/cc46fe7d-7035-49af-88e9-e0e469c0fdfa

#### Fixes the following issue(s)
- Fixes #12401 

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
