### PR TITLE
Fix thumbnails appearing on Android Auto even if disabled

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/mediabrowser/MediaBrowserImpl.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/mediabrowser/MediaBrowserImpl.kt
@@ -8,6 +8,7 @@ import android.support.v4.media.MediaBrowserCompat
 import android.support.v4.media.MediaDescriptionCompat
 import android.util.Log
 import androidx.annotation.DrawableRes
+import androidx.core.net.toUri
 import androidx.media.MediaBrowserServiceCompat
 import androidx.media.MediaBrowserServiceCompat.Result
 import androidx.media.utils.MediaConstants
@@ -185,7 +186,7 @@ class MediaBrowserImpl(
         builder
             .setMediaId(createMediaIdForInfoItem(playlist is PlaylistRemoteEntity, playlist.uid))
             .setTitle(playlist.orderingName)
-            .setIconUri(playlist.thumbnailUrl?.let { Uri.parse(it) })
+            .setIconUri(imageUriOrNullIfDisabled(playlist.thumbnailUrl))
 
         val extras = Bundle()
         extras.putString(
@@ -212,7 +213,7 @@ class MediaBrowserImpl(
         }
 
         ImageStrategy.choosePreferredImage(item.thumbnails)?.let {
-            builder.setIconUri(Uri.parse(it))
+            builder.setIconUri(imageUriOrNullIfDisabled(it))
         }
 
         return MediaBrowserCompat.MediaItem(
@@ -258,7 +259,7 @@ class MediaBrowserImpl(
         builder.setMediaId(createMediaIdForPlaylistIndex(false, playlistId, index))
             .setTitle(item.streamEntity.title)
             .setSubtitle(item.streamEntity.uploader)
-            .setIconUri(Uri.parse(item.streamEntity.thumbnailUrl))
+            .setIconUri(imageUriOrNullIfDisabled(item.streamEntity.thumbnailUrl))
 
         return MediaBrowserCompat.MediaItem(
             builder.build(),
@@ -277,7 +278,7 @@ class MediaBrowserImpl(
             .setSubtitle(item.uploaderName)
 
         ImageStrategy.choosePreferredImage(item.thumbnails)?.let {
-            builder.setIconUri(Uri.parse(it))
+            builder.setIconUri(imageUriOrNullIfDisabled(it))
         }
 
         return MediaBrowserCompat.MediaItem(
@@ -316,7 +317,7 @@ class MediaBrowserImpl(
         builder.setMediaId(mediaId)
             .setTitle(streamHistoryEntry.streamEntity.title)
             .setSubtitle(streamHistoryEntry.streamEntity.uploader)
-            .setIconUri(Uri.parse(streamHistoryEntry.streamEntity.thumbnailUrl))
+            .setIconUri(imageUriOrNullIfDisabled(streamHistoryEntry.streamEntity.thumbnailUrl))
 
         return MediaBrowserCompat.MediaItem(
             builder.build(),
@@ -395,5 +396,13 @@ class MediaBrowserImpl(
 
     companion object {
         private val TAG: String = MediaBrowserImpl::class.java.getSimpleName()
+
+        fun imageUriOrNullIfDisabled(url: String?): Uri? {
+            return if (ImageStrategy.shouldLoadImages()) {
+                url?.toUri()
+            } else {
+                null
+            }
+        }
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/player/mediabrowser/MediaBrowserImpl.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/mediabrowser/MediaBrowserImpl.kt
@@ -104,7 +104,7 @@ class MediaBrowserImpl(
 
     private fun onLoadChildren(parentId: String): Single<List<MediaBrowserCompat.MediaItem>> {
         try {
-            val parentIdUri = Uri.parse(parentId)
+            val parentIdUri = parentId.toUri()
             val path = ArrayList(parentIdUri.pathSegments)
 
             if (path.isEmpty()) {

--- a/app/src/main/java/org/schabi/newpipe/player/mediabrowser/MediaBrowserPlaybackPreparer.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/mediabrowser/MediaBrowserPlaybackPreparer.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.os.ResultReceiver
 import android.support.v4.media.session.PlaybackStateCompat
 import android.util.Log
+import androidx.core.net.toUri
 import com.google.android.exoplayer2.Player
 import com.google.android.exoplayer2.ext.mediasession.MediaSessionConnector.PlaybackPreparer
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
@@ -137,7 +138,7 @@ class MediaBrowserPlaybackPreparer(
 
     private fun extractPlayQueueFromMediaId(mediaId: String): Single<PlayQueue> {
         try {
-            val mediaIdUri = Uri.parse(mediaId)
+            val mediaIdUri = mediaId.toUri()
             val path = ArrayList(mediaIdUri.pathSegments)
             if (path.isEmpty()) {
                 throw parseError(mediaId)


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR

In the Android Auto PR #12044 we forgot to disable thumbnails on Android Auto when the user disabled them from settings. This PR fixes that.

#### Screenshots

<table>
  <tr>
    <th>With high quality images</th>
    <th>Without images</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/b8ed5923-3893-47eb-9064-a5f974393729" width="400px" alt="Before"/></td>
    <td><img src="https://github.com/user-attachments/assets/21e0028f-a972-4ad3-8def-083b727afa01" width="400px" alt="After"/></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/ca2f28ba-da80-40b0-98b1-a6306f6a6d90" width="400px" alt="Before"/></td>
    <td><img src="https://github.com/user-attachments/assets/9cd7a6fc-5686-4297-82a1-e3811048996c" width="400px" alt="After"/></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/9cbb8c45-c982-4bb3-828c-448146c0531a" width="400px" alt="Before"/></td>
    <td><img src="https://github.com/user-attachments/assets/35d3d3a7-033a-4e12-aaa6-17031ae4256e" width="400px" alt="After"/></td>
  </tr>
</table>

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #12283

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
