### PR TITLE
Fix fullscreen eliciting "clear queue" prompt

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHolder.java
@@ -159,6 +159,11 @@ public final class PlayerHolder {
 
         private boolean playAfterConnect = false;
 
+        /**
+         * @param playAfterConnection Sets the value of `playAfterConnect` to pass to the {@link
+         * PlayerServiceExtendedEventListener#onPlayerConnected(Player, boolean)} the next time it
+         * is called. The value of `playAfterConnect` will be reset to false after that.
+         */
         public void doPlayAfterConnect(final boolean playAfterConnection) {
             this.playAfterConnect = playAfterConnection;
         }
@@ -183,7 +188,6 @@ public final class PlayerHolder {
             playerService = localBinder.getService();
             if (listener != null) {
                 listener.onServiceConnected(playerService);
-                getPlayer().ifPresent(p -> listener.onPlayerConnected(p, playAfterConnect));
             }
             startPlayerListener();
             // ^ will call listener.onPlayerConnected() down the line if there is an active player
@@ -357,6 +361,8 @@ public final class PlayerHolder {
                 listener.onPlayerDisconnected();
             } else {
                 listener.onPlayerConnected(player, serviceConnection.playAfterConnect);
+                // reset the value of playAfterConnect: if it was true before, it is now "consumed"
+                serviceConnection.playAfterConnect = false;
                 player.setFragmentListener(internalListener);
             }
         }


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR

Fixes #12297 by avoiding to pass `playAfterConnect=true` after toggling fullscreen.

This PR makes it so that `playAfterConnect` does not persist, and instead is reset to `false` after `onPlayerConnected` is used. Keeping it to `true` used to not cause issues before #12044, but commit a7a7dc53631579ea71baed0f097c0ef8638ae07b added more calls to `onPlayerConnected` to ensure the video detail fragment remains in sync with the current player. The whole logic around `playAfterConnect` is very bad, but hopefully this change does not create any problem, since there is no place where `playAfterConnect` is read other than `onPlayerConnected`.

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
