### PR TITLE
[SoundCloud] Fix soundcloud regression of expiring HLS streams after 5mins

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -125,7 +125,7 @@ ext {
     androidxWorkVersion = '2.8.1'
 
     stateSaverVersion = '1.4.1'
-    exoPlayerVersion = '2.18.7'
+    exoPlayerVersion = '2.19.1'
     googleAutoServiceVersion = '1.1.1'
     groupieVersion = '2.10.1'
     markwonVersion = '4.6.2'

--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -70,6 +70,8 @@ import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.comments.CommentsInfoItem;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.services.peertube.PeertubeInstance;
+import org.schabi.newpipe.extractor.utils.ExtractorLogger;
+import org.schabi.newpipe.extractor.utils.Logger;
 import org.schabi.newpipe.fragments.BackPressable;
 import org.schabi.newpipe.fragments.MainFragment;
 import org.schabi.newpipe.fragments.detail.VideoDetailFragment;
@@ -137,6 +139,29 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
         if (DEBUG) {
+            // Override Extractor to print to Logcat
+            ExtractorLogger.setLogger(new Logger() {
+                @Override
+                public void debug(final String tag, final String message) {
+                    Log.d(tag, message);
+                }
+
+                @Override
+                public void warn(final String tag, final String message) {
+                    Log.w(tag, message);
+                }
+
+                @Override
+                public void error(final String tag, final String message) {
+                    Log.e(tag, message);
+                }
+
+                @Override
+                public void error(final String tag, final String message, final Throwable t) {
+                    Log.e(tag, message, t);
+                }
+
+            });
             Log.d(TAG, "onCreate() called with: "
                     + "savedInstanceState = [" + savedInstanceState + "]");
         }

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -226,8 +226,8 @@ public final class Player implements PlaybackListener, Listener {
 
     // audio only mode does not mean that player type is background, but that the player was
     // minimized to background but will resume automatically to the original player type
-    private boolean isAudioOnly = false;
-    private boolean isPrepared = false;
+    private boolean isAudioOnly;
+    private boolean isPrepared;
 
     /*//////////////////////////////////////////////////////////////////////////
     // UIs, listeners and disposables
@@ -239,9 +239,9 @@ public final class Player implements PlaybackListener, Listener {
     private BroadcastReceiver broadcastReceiver;
     private IntentFilter intentFilter;
     @Nullable
-    private PlayerServiceEventListener fragmentListener = null;
+    private PlayerServiceEventListener fragmentListener;
     @Nullable
-    private PlayerEventListener activityListener = null;
+    private PlayerEventListener activityListener;
 
     @NonNull
     private final SerialDisposable progressUpdateDisposable = new SerialDisposable();
@@ -386,7 +386,7 @@ public final class Player implements PlaybackListener, Listener {
         final boolean playbackSkipSilence = getPrefs().getBoolean(getContext().getString(
                 R.string.playback_skip_silence_key), getPlaybackSkipSilence());
 
-        final boolean samePlayQueue = playQueue != null && playQueue.equalStreamsAndIndex(newQueue);
+        final boolean samePlayQueue = newQueue.equalStreamsAndIndex(playQueue);
         final int repeatMode = intent.getIntExtra(REPEAT_MODE, getRepeatMode());
         final boolean playWhenReady = intent.getBooleanExtra(PLAY_WHEN_READY, true);
         final boolean isMuted = intent.getBooleanExtra(IS_MUTED, isMuted());
@@ -636,7 +636,9 @@ public final class Player implements PlaybackListener, Listener {
         }
 
         if (DEBUG) {
-            Log.d(TAG, "Setting recovery, queue: " + queuePos + ", pos: " + windowPos);
+            final var currentTitle = currentItem != null ? currentItem.getTitle() : "";
+            Log.d(TAG, "Setting recovery, queue: "
+                       + queuePos + "[" + currentTitle + "], pos: " + windowPos);
         }
         playQueue.setRecovery(queuePos, windowPos);
     }
@@ -969,11 +971,39 @@ public final class Player implements PlaybackListener, Listener {
         updatePlaybackState(playWhenReady, playbackState);
     }
 
+    public static String exoplayerStateToString(final int playbackState) {
+        return switch (playbackState) {
+            case com.google.android.exoplayer2.Player.STATE_IDLE -> // 1
+                    "STATE_IDLE";
+            case com.google.android.exoplayer2.Player.STATE_BUFFERING -> // 2
+                    "STATE_BUFFERING";
+            case com.google.android.exoplayer2.Player.STATE_READY -> //3
+                    "STATE_READY";
+            case com.google.android.exoplayer2.Player.STATE_ENDED -> // 4
+                    "STATE_ENDED";
+            default ->
+                    throw new IllegalArgumentException("Unknown playback state " + playbackState);
+        };
+    }
+
+    public static String stateToString(final int state) {
+        return switch (state) {
+            case STATE_PREFLIGHT -> "STATE_PREFLIGHT";
+            case STATE_BLOCKED -> "STATE_BLOCKED";
+            case STATE_PLAYING -> "STATE_PLAYING";
+            case STATE_BUFFERING -> "STATE_BUFFERING";
+            case STATE_PAUSED -> "STATE_PAUSED";
+            case STATE_PAUSED_SEEK -> "STATE_PAUSED_SEEK";
+            case STATE_COMPLETED -> "STATE_COMPLETED";
+            default -> throw new IllegalArgumentException("Unknown playback state " + state);
+        };
+    }
+
     @Override
     public void onPlaybackStateChanged(final int playbackState) {
         if (DEBUG) {
             Log.d(TAG, "ExoPlayer - onPlaybackStateChanged() called with: "
-                    + "playbackState = [" + playbackState + "]");
+                    + "playbackState = [" + exoplayerStateToString(playbackState) + "]");
         }
         updatePlaybackState(getPlayWhenReady(), playbackState);
     }
@@ -1060,7 +1090,8 @@ public final class Player implements PlaybackListener, Listener {
 
     public void changeState(final int state) {
         if (DEBUG) {
-            Log.d(TAG, "changeState() called with: state = [" + state + "]");
+            Log.d(TAG,
+                  "changeState() called with: state = [" + stateToString(state) + "]");
         }
         currentState = state;
         switch (state) {
@@ -1770,7 +1801,7 @@ public final class Player implements PlaybackListener, Listener {
                     .observeOn(AndroidSchedulers.mainThread())
                     .doOnError(e -> {
                         if (DEBUG) {
-                            e.printStackTrace();
+                            Log.e(TAG, "Error saving stream state", e);
                         }
                     })
                     .onErrorComplete()

--- a/app/src/main/java/org/schabi/newpipe/player/datasource/LoggingHttpDataSource.java
+++ b/app/src/main/java/org/schabi/newpipe/player/datasource/LoggingHttpDataSource.java
@@ -1,0 +1,118 @@
+package org.schabi.newpipe.player.datasource;
+
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.google.android.exoplayer2.upstream.DataSpec;
+import com.google.android.exoplayer2.upstream.DefaultHttpDataSource;
+import com.google.android.exoplayer2.upstream.HttpDataSource;
+import com.google.android.exoplayer2.upstream.TransferListener;
+
+import org.schabi.newpipe.DownloaderImpl;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+public class LoggingHttpDataSource extends DefaultHttpDataSource {
+
+    public final String TAG = getClass().getSimpleName() + "@" + hashCode();
+
+    public LoggingHttpDataSource() { }
+
+    public LoggingHttpDataSource(@Nullable final String userAgent,
+                                 final int connectTimeoutMillis,
+                                 final int readTimeoutMillis,
+                                 final boolean allowCrossProtocolRedirects,
+                                 @Nullable final RequestProperties defaultRequestProperties) {
+        super(userAgent,
+              connectTimeoutMillis,
+              readTimeoutMillis,
+              allowCrossProtocolRedirects,
+              defaultRequestProperties);
+    }
+
+
+    @Override
+    public long open(final DataSpec dataSpec) throws HttpDataSourceException {
+        Log.d(TAG, "Request URL: " + dataSpec.uri);
+        try {
+            return super.open(dataSpec);
+        } catch (final HttpDataSource.InvalidResponseCodeException e) {
+            Log.e(TAG, "HTTP error for URL: " + dataSpec.uri);
+            Log.e(TAG, "Response code: " + e.responseCode);
+            Log.e(TAG, "Headers: " + e.headerFields);
+            Log.e(TAG, "Body: " + new String(e.responseBody, StandardCharsets.UTF_8));
+            throw e;
+        }
+    }
+
+    @SuppressWarnings("checkstyle:hiddenField")
+    public static class Factory implements HttpDataSource.Factory {
+
+        final RequestProperties defaultRequestProperties;
+
+        @Nullable
+        TransferListener transferListener;
+        @Nullable
+        String userAgent;
+        int connectTimeoutMs;
+        int readTimeoutMs;
+        boolean allowCrossProtocolRedirects;
+
+        public Factory() {
+            defaultRequestProperties = new RequestProperties();
+            connectTimeoutMs = DEFAULT_CONNECT_TIMEOUT_MILLIS;
+            readTimeoutMs = DEFAULT_READ_TIMEOUT_MILLIS;
+            userAgent = DownloaderImpl.USER_AGENT;
+        }
+
+        @NonNull
+        @Override
+        public HttpDataSource createDataSource() {
+            final var dataSource = new LoggingHttpDataSource(userAgent,
+                                                             connectTimeoutMs,
+                                                             readTimeoutMs,
+                                                             allowCrossProtocolRedirects,
+                                                             defaultRequestProperties);
+            if (transferListener != null) {
+                dataSource.addTransferListener(transferListener);
+            }
+            return dataSource;
+        }
+
+        @NonNull
+        @Override
+        public Factory setDefaultRequestProperties(
+                @NonNull final Map<String, String> defaultRequestProperties) {
+            this.defaultRequestProperties.clearAndSet(defaultRequestProperties);
+            return this;
+        }
+
+        public Factory setUserAgent(@Nullable final String userAgent) {
+            this.userAgent = userAgent;
+            return this;
+        }
+
+        public Factory setConnectTimeoutMs(final int connectTimeoutMs) {
+            this.connectTimeoutMs = connectTimeoutMs;
+            return this;
+        }
+
+        public Factory setReadTimeoutMs(final int readTimeoutMs) {
+            this.readTimeoutMs = readTimeoutMs;
+            return this;
+        }
+
+        public Factory setAllowCrossProtocolRedirects(final boolean allowCrossProtocolRedirects) {
+            this.allowCrossProtocolRedirects = allowCrossProtocolRedirects;
+            return this;
+        }
+
+        public Factory setTransferListener(@Nullable final TransferListener transferListener) {
+            this.transferListener = transferListener;
+            return this;
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/datasource/LoggingHttpDataSource.java
+++ b/app/src/main/java/org/schabi/newpipe/player/datasource/LoggingHttpDataSource.java
@@ -1,5 +1,7 @@
 package org.schabi.newpipe.player.datasource;
 
+import static org.schabi.newpipe.MainActivity.DEBUG;
+
 import android.util.Log;
 
 import androidx.annotation.NonNull;
@@ -36,6 +38,10 @@ public class LoggingHttpDataSource extends DefaultHttpDataSource {
 
     @Override
     public long open(final DataSpec dataSpec) throws HttpDataSourceException {
+        if (!DEBUG) {
+            return super.open(dataSpec);
+        }
+
         Log.d(TAG, "Request URL: " + dataSpec.uri);
         try {
             return super.open(dataSpec);

--- a/app/src/main/java/org/schabi/newpipe/player/datasource/NonUriHlsDataSourceFactory.java
+++ b/app/src/main/java/org/schabi/newpipe/player/datasource/NonUriHlsDataSourceFactory.java
@@ -112,7 +112,7 @@ public final class NonUriHlsDataSourceFactory implements HlsDataSourceFactory {
      * </p>
      *
      * <p>
-     * This change allow playback of non-URI HLS contents, when the manifest is not a master
+     * This change allows playback of non-URI HLS contents, when the manifest is not a master
      * manifest/playlist (otherwise, endless loops should be encountered because the
      * {@link DataSource}s created for media playlists should use the master playlist response
      * instead).

--- a/app/src/main/java/org/schabi/newpipe/player/datasource/RefreshableHlsHttpDataSource.java
+++ b/app/src/main/java/org/schabi/newpipe/player/datasource/RefreshableHlsHttpDataSource.java
@@ -1,0 +1,233 @@
+package org.schabi.newpipe.player.datasource;
+
+import android.net.Uri;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.google.android.exoplayer2.source.hls.playlist.HlsMediaPlaylist;
+import com.google.android.exoplayer2.source.hls.playlist.HlsPlaylistParser;
+import com.google.android.exoplayer2.upstream.DataSourceInputStream;
+import com.google.android.exoplayer2.upstream.DataSpec;
+import com.google.android.exoplayer2.upstream.HttpDataSource;
+
+import org.schabi.newpipe.extractor.exceptions.ExtractionException;
+import org.schabi.newpipe.extractor.stream.RefreshableStream;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class RefreshableHlsHttpDataSource extends LoggingHttpDataSource {
+
+    private final String TAG =
+            RefreshableHlsHttpDataSource.class.getSimpleName() + "@" + hashCode();
+    private final RefreshableStream refreshableStream;
+    private final String originalPlaylistUrl;
+    private final Map<String, String> chunkUrlMap = new LinkedHashMap<>();
+    private int readsCalled;
+    private boolean isError;
+
+    public RefreshableHlsHttpDataSource(final RefreshableStream refreshableStream) {
+        this.refreshableStream = refreshableStream;
+        originalPlaylistUrl = refreshableStream.initialUrl();
+    }
+
+    @SuppressWarnings("checkstyle:LineLength")
+    public RefreshableHlsHttpDataSource(final RefreshableStream refreshableStream,
+                                        @Nullable final String userAgent,
+                                        final int connectTimeoutMillis,
+                                        final int readTimeoutMillis,
+                                        final boolean allowCrossProtocolRedirects,
+                                        @Nullable final RequestProperties defaultRequestProperties) {
+        super(userAgent,
+              connectTimeoutMillis,
+              readTimeoutMillis,
+              allowCrossProtocolRedirects,
+              defaultRequestProperties);
+        this.refreshableStream = refreshableStream;
+        originalPlaylistUrl = refreshableStream.initialUrl();
+    }
+
+    @Override
+    public int read(@NonNull final byte[] buffer, final int offset, final int length)
+            throws HttpDataSourceException {
+        return super.read(buffer, offset, length);
+    }
+
+    @Override
+    public long open(final DataSpec dataSpec) throws HttpDataSourceException {
+        final var url = dataSpec.uri.toString();
+        Log.d(TAG, "called open(" + url + ")");
+        if (!url.contains(refreshableStream.playlistId())) {
+            // TODO: throw error or no?
+            Log.e(TAG, "Playlist id does not match");
+        }
+        return chunkUrlMap.isEmpty()
+                ? openInternal(dataSpec)
+                : openInternal(getUpdatedDataSpec(dataSpec));
+    }
+
+    private long openInternal(final DataSpec dataSpec) throws HttpDataSourceException {
+        try {
+            final var bytesToRead = super.open(dataSpec);
+            Log.d(TAG, "Bytes to read: " + bytesToRead);
+            isError = false; // if we got to this line there was no error
+            return bytesToRead;
+        } catch (final InvalidResponseCodeException e) {
+            // TODO: This assumes SoundCloud returning 403 when playlist expires
+            //  If we need to refresh playlists for other services at a later date then
+            //  need to generalize this class
+            if (isError || e.responseCode != 403) {
+                // Use isError to prevent infinite loop if playlist expires, we replace signature
+                // but then that one gives an error, and then we replace signature again, and so on
+                // The expectation is that no error will be thrown on the first recursion
+                throw e;
+            }
+
+            try {
+                refreshPlaylist();
+            } catch (final ExtractionException | IOException ex) {
+                // TODO: better error here
+                // TODO: so what happens when we throw exception here
+                //  and this method gets called again in this class?
+                //  if we want to prevent open being called again we need to throw a runtime
+                throw new HttpDataSourceException("Error refreshing Hls playlist: "
+                                                  + originalPlaylistUrl,
+                                                  new IOException(ex), dataSpec,
+                                                  HttpDataSourceException.TYPE_OPEN);
+            }
+            isError = true;
+            // Use recursion to reuse error handling without code duplication
+            return openInternal(getUpdatedDataSpec(dataSpec));
+        }
+    }
+
+    private void refreshPlaylist() throws ExtractionException, IOException {
+        Log.d(TAG, "refreshPlaylist() - originalPlaylistUrl " + originalPlaylistUrl);
+        final var newPlaylistUrl = refreshableStream.fetchLatestUrl();
+        Log.d(TAG, "New playlist url " + newPlaylistUrl);
+        Log.d(TAG, "Extracting new playlist Chunks");
+        final var newChunks = extractChunksFromPlaylist(newPlaylistUrl);
+
+        if (!chunkUrlMap.isEmpty()) {
+            updateChunkMap(chunkUrlMap, newChunks);
+        }
+        initializeChunkMappings(chunkUrlMap, newChunks);
+    }
+
+    private static void initializeChunkMappings(final Map<String, String> chunkMap,
+                                                final List<String> newChunks) {
+        for (int i = 0; i < newChunks.size(); ++i) {
+            final var newUrl = newChunks.get(i);
+            chunkMap.put(getBaseUrl(newUrl), newUrl);
+        }
+    }
+
+    private static void updateChunkMap(final Map<String, String> chunkMap,
+                                       final List<String> newChunks) throws IOException {
+        if (chunkMap.size() != newChunks.size()) {
+            throw new IOException("Error extracting chunks: chunks are not same size\n"
+                                  + "Expected " + chunkMap.size()
+                                  + " and got " + newChunks.size());
+        }
+
+        final var baseUrlIt = chunkMap.keySet().iterator();
+        final var newChunkUrlIt = newChunks.iterator();
+        while (baseUrlIt.hasNext()) {
+            chunkMap.put(baseUrlIt.next(), newChunkUrlIt.next());
+        }
+    }
+
+    private static String getBaseUrl(final String url) {
+        final int idx = url.indexOf('?');
+        return idx == -1 ? url : url.substring(0, idx);
+    }
+
+    // TODO: better name
+    private DataSpec getUpdatedDataSpec(final DataSpec dataSpec) {
+        final var currentUrl = dataSpec.uri.toString();
+        Log.d(TAG, "getUpdatedDataSpec(" + currentUrl + ')');
+        // Playlist has expired, so get mapping for new url
+        final var baseUrl = getBaseUrl(currentUrl);
+
+        if (baseUrl.equals(currentUrl)) {
+            Log.e(TAG, "Url has no query parameters");
+        }
+
+        final var updatedUrl = chunkUrlMap.get(baseUrl);
+        if (updatedUrl == null) {
+            throw new IllegalStateException("baseUrl not found in mappings: " + baseUrl);
+            // TODO: problemo
+        }
+        Log.d(TAG, "updated url:" + updatedUrl);
+        return dataSpec.buildUpon()
+                       .setUri(Uri.parse(updatedUrl))
+                       .build();
+    }
+
+    /**
+     * Extracts the chunks/segments from an m3u8 playlist using
+     * ExoPlayer's {@link HlsPlaylistParser}.
+     * @param playlistUrl url of m3u8 playlist to extract
+     * @return Urls for all the chunks/segments in the playlist
+     * @throws IOException If error extracting the chunks
+     */
+    private List<String> extractChunksFromPlaylist(final String playlistUrl)
+            throws IOException {
+        Log.d(TAG, "extractChunksFromPlaylist(" + playlistUrl + ')');
+        final var chunks = new ArrayList<String>();
+        final var parser = new HlsPlaylistParser();
+        final var dataSpec = new DataSpec(Uri.parse(playlistUrl));
+        final var httpDataSource = new LoggingHttpDataSource.Factory().createDataSource();
+
+        // Adapted from ParsingLoadable.load()
+        // DataSourceInputStream opens the data source internally on open()
+        // It passes dataSpec to data source
+        // httpDataSource is a DefaultHttpDataSource, and getUri will return dataSpec's uri
+        // which == playlistUrl
+        try (@SuppressWarnings("LocalCanBeFinal")
+             var inputStream = new DataSourceInputStream(httpDataSource, dataSpec)) {
+            inputStream.open();
+
+            final var playlist =
+                    parser.parse(Objects.requireNonNull(httpDataSource.getUri()), inputStream);
+
+            if (!(playlist instanceof final HlsMediaPlaylist hlsMediaPlaylist)) {
+                throw new IOException("Expected Hls playlist to be an HlsMediaPlaylist, but was a "
+                        + playlist.getClass().getSimpleName());
+            }
+            for (final var segment : hlsMediaPlaylist.segments) {
+                chunks.add(segment.url);
+            }
+            Log.d(TAG, "Extracted " + chunks.size() + " chunks");
+            chunks.stream().forEach(m -> Log.d(TAG, "Chunk " + m));
+            return chunks;
+        } finally {
+            httpDataSource.close();
+        }
+    }
+
+    public static class Factory extends LoggingHttpDataSource.Factory {
+        private final RefreshableStream refreshableStream;
+
+        public Factory(final RefreshableStream refreshableStream) {
+            this.refreshableStream = refreshableStream;
+        }
+
+        @NonNull
+        @Override
+        public HttpDataSource createDataSource() {
+            return new RefreshableHlsHttpDataSource(refreshableStream,
+                                                    userAgent,
+                                                    connectTimeoutMs,
+                                                    readTimeoutMs,
+                                                    allowCrossProtocolRedirects,
+                                                    defaultRequestProperties);
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerDataSource.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerDataSource.java
@@ -5,7 +5,7 @@ import static org.schabi.newpipe.MainActivity.DEBUG;
 import android.content.Context;
 import android.util.Log;
 
-import androidx.annotation.Nullable;
+import androidx.annotation.NonNull;
 
 import com.google.android.exoplayer2.database.StandaloneDatabaseProvider;
 import com.google.android.exoplayer2.source.ProgressiveMediaSource;
@@ -18,15 +18,15 @@ import com.google.android.exoplayer2.source.smoothstreaming.DefaultSsChunkSource
 import com.google.android.exoplayer2.source.smoothstreaming.SsMediaSource;
 import com.google.android.exoplayer2.upstream.DataSource;
 import com.google.android.exoplayer2.upstream.DefaultDataSource;
-import com.google.android.exoplayer2.upstream.DefaultHttpDataSource;
 import com.google.android.exoplayer2.upstream.TransferListener;
 import com.google.android.exoplayer2.upstream.cache.LeastRecentlyUsedCacheEvictor;
 import com.google.android.exoplayer2.upstream.cache.SimpleCache;
 
-import org.schabi.newpipe.DownloaderImpl;
+import org.jetbrains.annotations.Contract;
 import org.schabi.newpipe.extractor.services.youtube.dashmanifestcreators.YoutubeOtfDashManifestCreator;
 import org.schabi.newpipe.extractor.services.youtube.dashmanifestcreators.YoutubePostLiveStreamDvrDashManifestCreator;
 import org.schabi.newpipe.extractor.services.youtube.dashmanifestcreators.YoutubeProgressiveDashManifestCreator;
+import org.schabi.newpipe.player.datasource.LoggingHttpDataSource;
 import org.schabi.newpipe.player.datasource.NonUriHlsDataSourceFactory;
 import org.schabi.newpipe.player.datasource.YoutubeHttpDataSource;
 
@@ -78,27 +78,32 @@ public class PlayerDataSource {
     private final CacheFactory ytProgressiveDashCacheDataSourceFactory;
 
 
+    private final Context context;
+    private final TransferListener transferListener;
+
+
     public PlayerDataSource(final Context context,
                             final TransferListener transferListener) {
-
+        this.context = context;
+        this.transferListener = transferListener;
         progressiveLoadIntervalBytes = PlayerHelper.getProgressiveLoadIntervalBytes(context);
 
         // make sure the static cache was created: needed by CacheFactories below
         instantiateCacheIfNeeded(context);
 
-        // generic data source factories use DefaultHttpDataSource.Factory
+        // generic data source factories use LoggingHttpDataSource.Factory, which is a wrapper
+        // around DefaultHttpDataSource
         cachelessDataSourceFactory = new DefaultDataSource.Factory(context,
-                new DefaultHttpDataSource.Factory().setUserAgent(DownloaderImpl.USER_AGENT))
+                new LoggingHttpDataSource.Factory())
                 .setTransferListener(transferListener);
-        cacheDataSourceFactory = new CacheFactory(context, transferListener, cache,
-                new DefaultHttpDataSource.Factory().setUserAgent(DownloaderImpl.USER_AGENT));
+        cacheDataSourceFactory = createCacheDataSourceFactory(new LoggingHttpDataSource.Factory());
 
         // YouTube-specific data source factories use getYoutubeHttpDataSourceFactory()
-        ytHlsCacheDataSourceFactory = new CacheFactory(context, transferListener, cache,
+        ytHlsCacheDataSourceFactory = createCacheDataSourceFactory(
                 getYoutubeHttpDataSourceFactory(false, false));
-        ytDashCacheDataSourceFactory = new CacheFactory(context, transferListener, cache,
+        ytDashCacheDataSourceFactory = createCacheDataSourceFactory(
                 getYoutubeHttpDataSourceFactory(true, true));
-        ytProgressiveDashCacheDataSourceFactory = new CacheFactory(context, transferListener, cache,
+        ytProgressiveDashCacheDataSourceFactory = createCacheDataSourceFactory(
                 getYoutubeHttpDataSourceFactory(false, true));
 
         // set the maximum size to manifest creators
@@ -108,6 +113,11 @@ public class PlayerDataSource {
                 MAX_MANIFEST_CACHE_SIZE);
     }
 
+    @NonNull
+    @Contract(value = "_ -> new", pure = true)
+    private CacheFactory createCacheDataSourceFactory(final DataSource.Factory wrappedFactory) {
+        return new CacheFactory(context, transferListener, cache, wrappedFactory);
+    }
 
     //region Live media source factories
     public SsMediaSource.Factory getLiveSsMediaSourceFactory() {

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerDataSource.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerDataSource.java
@@ -26,8 +26,11 @@ import org.jetbrains.annotations.Contract;
 import org.schabi.newpipe.extractor.services.youtube.dashmanifestcreators.YoutubeOtfDashManifestCreator;
 import org.schabi.newpipe.extractor.services.youtube.dashmanifestcreators.YoutubePostLiveStreamDvrDashManifestCreator;
 import org.schabi.newpipe.extractor.services.youtube.dashmanifestcreators.YoutubeProgressiveDashManifestCreator;
+import org.schabi.newpipe.extractor.stream.RefreshableStream;
+import org.schabi.newpipe.extractor.stream.Stream;
 import org.schabi.newpipe.player.datasource.LoggingHttpDataSource;
 import org.schabi.newpipe.player.datasource.NonUriHlsDataSourceFactory;
+import org.schabi.newpipe.player.datasource.RefreshableHlsHttpDataSource;
 import org.schabi.newpipe.player.datasource.YoutubeHttpDataSource;
 
 import java.io.File;
@@ -144,12 +147,23 @@ public class PlayerDataSource {
 
     //region Generic media source factories
     public HlsMediaSource.Factory getHlsMediaSourceFactory(
-            @Nullable final NonUriHlsDataSourceFactory.Builder hlsDataSourceFactoryBuilder) {
-        if (hlsDataSourceFactoryBuilder != null) {
-            hlsDataSourceFactoryBuilder.setDataSourceFactory(cacheDataSourceFactory);
-            return new HlsMediaSource.Factory(hlsDataSourceFactoryBuilder.build());
-        }
+            @NonNull final NonUriHlsDataSourceFactory.Builder hlsDataSourceFactoryBuilder) {
+        hlsDataSourceFactoryBuilder.setDataSourceFactory(cacheDataSourceFactory);
+        return new HlsMediaSource.Factory(hlsDataSourceFactoryBuilder.build());
+    }
 
+    public HlsMediaSource.Factory getHlsMediaSourceFactory(final Stream stream) {
+        if (stream instanceof final RefreshableStream refreshableStream) {
+            return new HlsMediaSource.Factory(
+                createCacheDataSourceFactory(
+                        new RefreshableHlsHttpDataSource.Factory(refreshableStream)
+                )
+            );
+        }
+        return getHlsMediaSourceFactory();
+    }
+
+    public HlsMediaSource.Factory getHlsMediaSourceFactory() {
         return new HlsMediaSource.Factory(cacheDataSourceFactory);
     }
 

--- a/app/src/main/java/org/schabi/newpipe/player/mediasession/MediaSessionPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/mediasession/MediaSessionPlayerUi.java
@@ -36,7 +36,7 @@ import java.util.stream.IntStream;
 
 public class MediaSessionPlayerUi extends PlayerUi
         implements SharedPreferences.OnSharedPreferenceChangeListener {
-    private static final String TAG = "MediaSessUi";
+    private static final String TAG = MediaSessionPlayerUi.class.getSimpleName();
 
     @NonNull
     private final MediaSessionCompat mediaSession;

--- a/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueue.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueue.java
@@ -538,11 +538,8 @@ public abstract class PlayQueue implements Serializable {
     }
 
     public boolean equalStreamsAndIndex(@Nullable final PlayQueue other) {
-        if (equalStreams(other)) {
-            //noinspection ConstantConditions
-            return other.getIndex() == getIndex(); //NOSONAR: other is not null
-        }
-        return false;
+        //noinspection ConstantConditions
+        return equalStreams(other) && other.getIndex() == getIndex(); //NOSONAR: other is not null
     }
 
     public boolean isDisposed() {

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/PlaybackResolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/PlaybackResolver.java
@@ -343,8 +343,7 @@ public interface PlaybackResolver extends Resolver<StreamInfo, MediaSource> {
                             .build());
         }
 
-        final NonUriHlsDataSourceFactory.Builder hlsDataSourceFactoryBuilder =
-                new NonUriHlsDataSourceFactory.Builder();
+        final var hlsDataSourceFactoryBuilder = new NonUriHlsDataSourceFactory.Builder();
         hlsDataSourceFactoryBuilder.setPlaylistString(stream.getContent());
 
         return dataSource.getHlsMediaSourceFactory(hlsDataSourceFactoryBuilder)

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/PlaybackResolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/PlaybackResolver.java
@@ -335,7 +335,7 @@ public interface PlaybackResolver extends Resolver<StreamInfo, MediaSource> {
             throws ResolverException {
         if (stream.isUrl()) {
             throwResolverExceptionIfUrlNullOrEmpty(stream.getContent());
-            return dataSource.getHlsMediaSourceFactory(null).createMediaSource(
+            return dataSource.getHlsMediaSourceFactory(stream).createMediaSource(
                     new MediaItem.Builder()
                             .setTag(metadata)
                             .setUri(Uri.parse(stream.getContent()))

--- a/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
@@ -302,6 +302,9 @@ public final class ListHelper {
         final Comparator<AudioStream> cmp = getAudioFormatComparator(context);
 
         for (final AudioStream stream : audioStreams) {
+            // TODO: this doesn't add HLS OPUS streams, but soundcloud has that.
+            // Meaning it never actually plays the OPUS soundcloud streams, only
+            // progressive and hls mp3
             if (stream.getDeliveryMethod() == DeliveryMethod.TORRENT
                     || (stream.getDeliveryMethod() == DeliveryMethod.HLS
                     && stream.getFormat() == MediaFormat.OPUS)) {

--- a/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
@@ -293,7 +293,7 @@ public final class ListHelper {
     public static List<AudioStream> getFilteredAudioStreams(
             @NonNull final Context context,
             @Nullable final List<AudioStream> audioStreams) {
-        if (audioStreams == null) {
+        if (audioStreams == null || audioStreams.isEmpty()) {
             return Collections.emptyList();
         }
 

--- a/app/src/main/java/org/schabi/newpipe/util/SparseItemUtil.java
+++ b/app/src/main/java/org/schabi/newpipe/util/SparseItemUtil.java
@@ -32,7 +32,7 @@ public final class SparseItemUtil {
     }
 
     /**
-     * Use this to certainly obtain an single play queue with all of the data filled in when the
+     * Use this to certainly obtain a single play queue with all of the data filled in when the
      * stream info item you are handling might be sparse, e.g. because it was fetched via a {@link
      * org.schabi.newpipe.extractor.feed.FeedExtractor}. FeedExtractors provide a fast and
      * lightweight method to fetch info, but the info might be incomplete (see

--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -70,6 +70,8 @@
 
     <module name="SuppressWarningsFilter" />
 
+    <module name="SuppressWithPlainTextCommentFilter"/>
+
     <module name="TreeWalker">
         <module name="SuppressionCommentFilter"/>
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,6 +6,6 @@ include ':app'
 
 //includeBuild('../NewPipeExtractor') {
 //    dependencySubstitution {
-//        substitute module('com.github.TeamNewPipe:NewPipeExtractor') using project(':extractor')
+//        substitute module('com.github.TeamNewPipe.NewPipeExtractor:NewPipeExtractor') using project(':extractor')
 //    }
 //}


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Add refreshing of expired SoundCloud HLS playlists
- Bump ExoPlayer to latest version
- Add LoggingHttpDataSource to log ExoPlayer Http requests for non-YouTube streams
- Hook up Logcat to ExtractorLogger
- Allow comment suppression in checkstyle
- Fix incorrect module path name in settings.gradle
- Improve logging in various places
- Small refactors in various places

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #12109 

#### Relies on the following changes
<!-- Delete this if it doesn't apply to your PR. -->
- https://github.com/TeamNewPipe/NewPipeExtractor/pull/1325

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).

# Testing

Until we add tests, the simplest way to test this is to:

1. Load a SoundCloud track, preferably one 3-4mins long (https://soundcloud.com/minecraftwizards/18-c418-sweden)
2. Play it for 3s
3. Pause it for 5mins
4. Play it again for 2mins

If you get no error then it means it's working. You can also check Logcat and Ctrl+F for "refreshPlaylist" which should show up on step 4.

## Please Note

I have some TODOs that I haven't removed/solved yet but I am making this PR ahead of time for code review and can sort those out later.

# General rundown of the fix

As detailed in #12109, the cause of the bug is due to the HLS CDN urls expiring after 5 minutes.
Previously we would only retrieve Progressive MP3 streams which basically just downloaded the whole track outright so there was no opportunity for anything to expire since the full track gets buffered way quicker than 5 minutes.

The way we extract SoundCloud tracks in `SoundcloudStreamExtractor` is we call the API to get the JSON information for a `track`. The part of the `track` that has information for the actual audio track is `transcodings`.

Here's an example JSON object for the track https://soundcloud.com/jaronsteele/as-the-world-gets-smaller:


<details><summary><b>Example track JSON</b></summary><p>

```json
{
    "artwork_url": "https://i1.sndcdn.com/artworks-000606732097-86fmxf-large.jpg",
    "caption": null,
    "commentable": true,
    "comment_count": 92,
    "created_at": "2019-10-02T16:48:07Z",
    "description": "-\n1/6\nEverything in Between",
    "downloadable": false,
    "download_count": 0,
    "duration": 139892,
    "full_duration": 139923,
    "embeddable_by": "all",
    "genre": "Everything in Between",
    "has_downloads_left": false,
    "id": 690040873,
    "kind": "track",
    "label_name": null,
    "last_modified": "2022-04-30T15:11:44Z",
    "license": "all-rights-reserved",
    "likes_count": 2745,
    "permalink": "as-the-world-gets-smaller",
    "permalink_url": "https://soundcloud.com/jaronsteele/as-the-world-gets-smaller",
    "playback_count": 126750,
    "public": true,
    "publisher_metadata": {
        "id": 690040873,
        "urn": "soundcloud:tracks:690040873",
        "contains_music": true
    },
    "purchase_title": null,
    "purchase_url": null,
    "release_date": null,
    "reposts_count": 291,
    "secret_token": null,
    "sharing": "public",
    "state": "finished",
    "streamable": true,
    "tag_list": "Jaron",
    "title": "As The World Gets Smaller",
    "uri": "https://api.soundcloud.com/tracks/690040873",
    "urn": "soundcloud:tracks:690040873",
    "user_id": 232789711,
    "visuals": null,
    "waveform_url": "https://wave.sndcdn.com/jPI4kiRuqQ8N_m.json",
    "display_date": "2019-10-02T16:48:07Z",
    "media": {
        "transcodings": [
            {
                "url": "https://api-v2.soundcloud.com/media/soundcloud:tracks:690040873/67cae8d9-7363-4aff-8003-2e905b315f86/stream/hls",
                "preset": "aac_160k",
                "duration": 139892,
                "snipped": false,
                "format": {
                    "protocol": "hls",
                    "mime_type": "audio/mp4; codecs=\"mp4a.40.2\""
                },
                "quality": "sq",
                "is_legacy_transcoding": false
            },
            {
                "url": "https://api-v2.soundcloud.com/media/soundcloud:tracks:690040873/afed15d4-0bf0-48ec-a591-d356b13486c2/stream/hls",
                "preset": "abr_sq",
                "duration": 139892,
                "snipped": false,
                "format": {
                    "protocol": "hls",
                    "mime_type": "audio/mpegurl"
                },
                "quality": "sq",
                "is_legacy_transcoding": false
            },
            {
                "url": "https://api-v2.soundcloud.com/media/soundcloud:tracks:690040873/588daf99-dcfc-47cc-8350-8df87d23bc12/stream/hls",
                "preset": "mp3_0_0",
                "duration": 139923,
                "snipped": false,
                "format": {
                    "protocol": "hls",
                    "mime_type": "audio/mpeg"
                },
                "quality": "sq",
                "is_legacy_transcoding": true
            },
            {
                "url": "https://api-v2.soundcloud.com/media/soundcloud:tracks:690040873/588daf99-dcfc-47cc-8350-8df87d23bc12/stream/progressive",
                "preset": "mp3_0_0",
                "duration": 139923,
                "snipped": false,
                "format": {
                    "protocol": "progressive",
                    "mime_type": "audio/mpeg"
                },
                "quality": "sq",
                "is_legacy_transcoding": true
            },
            {
                "url": "https://api-v2.soundcloud.com/media/soundcloud:tracks:690040873/d9110040-fe52-4adb-84f0-7d672d7ab077/stream/hls",
                "preset": "opus_0_0",
                "duration": 139853,
                "snipped": false,
                "format": {
                    "protocol": "hls",
                    "mime_type": "audio/ogg; codecs=\"opus\""
                },
                "quality": "sq",
                "is_legacy_transcoding": true
            }
        ]
    },
    "station_urn": "soundcloud:system-playlists:track-stations:690040873",
    "station_permalink": "track-stations:690040873",
    "track_authorization": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJnZW8iOiJHQiIsInN1YiI6IiIsInJpZCI6IjhlNzIxMDhmLWRmNzctNDAwZC05OGM1LTQ0YzRhYjliZDJjOSIsImlhdCI6MTc0OTYzMjE1Mn0.d0DzxofzLlnLqiwSPEXwvuzundSHDbeLJQmYAIMbQ1U",
    "monetization_model": "BLACKBOX",
    "policy": "MONETIZE",
    "user": {
        "avatar_url": "https://i1.sndcdn.com/avatars-twmTztScdRSRjtfu-nIRvzg-large.jpg",
        "first_name": "\\__*",
        "followers_count": 21915,
        "full_name": "\\__*",
        "id": 232789711,
        "kind": "user",
        "last_modified": "2025-05-05T07:09:58Z",
        "last_name": "",
        "permalink": "jaronsteele",
        "permalink_url": "https://soundcloud.com/jaronsteele",
        "uri": "https://api.soundcloud.com/users/232789711",
        "urn": "soundcloud:users:232789711",
        "username": "jaron",
        "verified": true,
        "city": "",
        "country_code": null,
        "badges": {
            "pro": false,
            "creator_mid_tier": false,
            "pro_unlimited": false,
            "verified": true
        },
        "station_urn": "soundcloud:system-playlists:artist-stations:232789711",
        "station_permalink": "artist-stations:232789711"
    }
},

```
</details>
<hr>

`transcodings` is found in `track.media.transcodings`

Here is the `transcodings` array for this `track`:

<details><summary><b>Example transcodings JSON</b></summary><p>

```json
"media": {
    "transcodings": [
        {
            "url": "https://api-v2.soundcloud.com/media/soundcloud:tracks:690040873/67cae8d9-7363-4aff-8003-2e905b315f86/stream/hls",
            "preset": "aac_160k",
            "duration": 139892,
            "snipped": false,
            "format": {
                "protocol": "hls",
                "mime_type": "audio/mp4; codecs=\"mp4a.40.2\""
            },
            "quality": "sq",
            "is_legacy_transcoding": false
        },
        {
            "url": "https://api-v2.soundcloud.com/media/soundcloud:tracks:690040873/afed15d4-0bf0-48ec-a591-d356b13486c2/stream/hls",
            "preset": "abr_sq",
            "duration": 139892,
            "snipped": false,
            "format": {
                "protocol": "hls",
                "mime_type": "audio/mpegurl"
            },
            "quality": "sq",
            "is_legacy_transcoding": false
        },
        {
            "url": "https://api-v2.soundcloud.com/media/soundcloud:tracks:690040873/588daf99-dcfc-47cc-8350-8df87d23bc12/stream/hls",
            "preset": "mp3_0_0",
            "duration": 139923,
            "snipped": false,
            "format": {
                "protocol": "hls",
                "mime_type": "audio/mpeg"
            },
            "quality": "sq",
            "is_legacy_transcoding": true
        },
        {
            "url": "https://api-v2.soundcloud.com/media/soundcloud:tracks:690040873/588daf99-dcfc-47cc-8350-8df87d23bc12/stream/progressive",
            "preset": "mp3_0_0",
            "duration": 139923,
            "snipped": false,
            "format": {
                "protocol": "progressive",
                "mime_type": "audio/mpeg"
            },
            "quality": "sq",
            "is_legacy_transcoding": true
        },
        {
            "url": "https://api-v2.soundcloud.com/media/soundcloud:tracks:690040873/d9110040-fe52-4adb-84f0-7d672d7ab077/stream/hls",
            "preset": "opus_0_0",
            "duration": 139853,
            "snipped": false,
            "format": {
                "protocol": "hls",
                "mime_type": "audio/ogg; codecs=\"opus\""
            },
            "quality": "sq",
            "is_legacy_transcoding": true
        }
    ]
},

```
</details>
<hr>

Each `transcoding` in the array has a `url`, and we call that endpoint to get the direct CDN stream url we need to get the actual binary data which will be played by ExoPlayer. 

The CDN urls for each transcoding all have a different format for the base path of the URL, but they share some query parameters.

### Example Progressive MP3 URL


```markdown
https://cf-media.sndcdn.com/jPI4kiRuqQ8N.128.mp3?Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiKjovL2NmLW1lZGlhLnNuZGNkbi5jb20valBJNGtpUnVxUThOLjEyOC5tcDMqIiwiQ29uZGl0aW9uIjp7IkRhdGVMZXNzVGhhbiI6eyJBV1M6RXBvY2hUaW1lIjoxNzUwODk1ODU5fX19XX0_&Signature=dhm-WTxVYck7kCeqQpYS6LHblPqtwseUkzZ4hKjUnRnOQGwe~6hbgLMW~TE2l8QEiGlUFBMS4LsuDTH8sBCZzyjJ0vdOdHucphg9se-P8ZCUCjxVOfI16DLAMlb3KfSAkyeqZUWpuRf0Zq9AmdNRhBBKiexycruaQCYGMK~Qe9HaCCXWTYZamHSogitnif~r5ga5jeZs23FU30al6RzeKN64pwMnYdi1pnVixEykaQ5b4Zg6hLRZp~a7gqFqqyBX8PESzH2hJkV1rphNtnHIl0C1vgfxj9hltkrNhQDri~OD4e4a~nqTmnAkUFqSuCkVXWKyfIgICoMMX2~jdpoquQ__&Key-Pair-Id=APKAI6TU7MMXM5DG6EPQ
```

### Example HLS MP3 URL


```markdown
https://cf-hls-media.sndcdn.com/playlist/jPI4kiRuqQ8N.128.mp3/playlist.m3u8?Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiKjovL2NmLWhscy1tZWRpYS5zbmRjZG4uY29tL3BsYXlsaXN0L2pQSTRraVJ1cVE4Ti4xMjgubXAzL3BsYXlsaXN0Lm0zdTgqIiwiQ29uZGl0aW9uIjp7IkRhdGVMZXNzVGhhbiI6eyJBV1M6RXBvY2hUaW1lIjoxNzUwODk0OTE4fX19XX0_&Signature=BRwoetXgqu0HndAziOtz48aKzwH1uc07ruDeAECzSKGHN5XK2s20E4hQaLR4PzCix5AZn-GKsU5Myqz~wp2uhIWHKXfyhn4aQNTBxIIREfwR9wGTNKVcSA5IGjtmjJF37uVuAkxSwPSEg54I9MB6MvftSy4P5twTLEj~x3xfX9k6mxIaqoBqMP5TuuLFRqRnIBa~PEK~IfY~SKWH5swv9ZSQgbKSlm1bznb66SI189wMes1n1Z1UxaVEXn2-PCFHBPkaH--yFd-8U4QltBbAcyLllZzpp3kIxq9BNd2ff-k8p6pilnntTerMFuzg37PQkTw8-SKcApiqoDsr-Xhmng__&Key-Pair-Id=APKAI6TU7MMXM5DG6EPQ
```


### Example HLS AAC URL


```markdown
https://playback.media-streaming.soundcloud.cloud/jPI4kiRuqQ8N/aac_160k/67cae8d9-7363-4aff-8003-2e905b315f86/playlist.m3u8?expires=1750894776&Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cHM6Ly9wbGF5YmFjay5tZWRpYS1zdHJlYW1pbmcuc291bmRjbG91ZC5jbG91ZC9qUEk0a2lSdXFROE4vYWFjXzE2MGsvNjdjYWU4ZDktNzM2My00YWZmLTgwMDMtMmU5MDViMzE1Zjg2L3BsYXlsaXN0Lm0zdTg~ZXhwaXJlcz0xNzUwODk0Nzc2IiwiQ29uZGl0aW9uIjp7IkRhdGVMZXNzVGhhbiI6eyJBV1M6RXBvY2hUaW1lIjoxNzUwODk0Nzc2fX19XX0_&Signature=hYW9T6gng6ixxLnbhmGRpc-A2DDn3E~hamnzcOL893tkmRmlbirQElg9M40ylxJzIWGggLRMNadjBJPuvKU5mL59sWPzsgSKmS1WlPBjrs4ZCblSZBH2Y~XOPCJfZE2DH03O1DzNqY48PaTC2CO~n5I2h4mj0gTRDPRFMZz4xVYOqnOdAVCYdT3gXlSLVoUfR4WR6EiCNVC247uSb5Qed3C1f8FHbtrYzJ03EMoN6LZ0rW8yHMgsEIRvWAH408iRb-isjOs3hPHJMyiz8nF4ImnmxTrIY3DlKuoPbMjuEdkFlD5eoRT36oxRV8HOBOulsw~rtvidItq09kzxxoTDGA__&Key-Pair-Id=K34606QXLEIRF3
```


### Example HLS OPUS URL


```markdown
https://cf-hls-opus-media.sndcdn.com/playlist/d9110040-fe52-4adb-84f0-7d672d7ab077.64.opus/playlist.m3u8?Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiKjovL2NmLWhscy1vcHVzLW1lZGlhLnNuZGNkbi5jb20vcGxheWxpc3QvZDkxMTAwNDAtZmU1Mi00YWRiLTg0ZjAtN2Q2NzJkN2FiMDc3LjY0Lm9wdXMvcGxheWxpc3QubTN1OCoiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE3NTA5MTY3MTB9fX1dfQ__&Signature=clc5bSYK96w2VqMHraWqRtjOPEfMMwRJA1U1vCDRbfcwkOdrlMcoxCnW32uShymd0XsSmy0xdcgIASqE1xqjlGfa-aD~~3YEpoFYsiOj3rKPCQf2muowIe4YEj~yUzYm~8ktGA7epSQwLN~oZ5ER6H8vH4vVZP-CNQprNMMZGu0vNQj8TQH2-y0wyKQaN0GgKe1sGOmdyNpWnKAAtqIQvCaC7AoSwSqqMI0HP1rlCUCDtlLEPaXSjVih9SLCjAgNtAA1QTgNhRIfuuJn1AG4iMD4af6mJr5Lskrx90s6OKWcVoJY8Q9KpZo2lCwCK4AR4C7pynz5CqlIThTCBihaCw__&Key-Pair-Id=APKAI6TU7MMXM5DG6EPQ
```


If you look closely you can see they all share three query parameters:

- Policy
- Signature
- Key-Pair-Id


### `Policy`

This is a base64-encoded JSON object which contains information about the access rules for the resource. Here is one decoded:

```json
{
  "Statement": [
    {
      "Resource": "*/cf-hls-media.sndcdn.com/playlist/jPI4kiRuqQ8N.128.mp3/playlist.m3u8*",
      "Condition": {
        "DateLessThan": {
          "AWS:EpochTime": 1750894776
        }
      }
    }
  ]
}
```

`DateLessThan` is the expiry date as a Unix epoch timestamp. This is **always 5 minutes ahead** of when the url is called.

In the case of **AAC HLS** streams, there is also an `expires` query parameter in the URL, and it isidentical to the value in the `Policy` JSON.

### `Signature`

This is a cryptographic string used to validate the authenticity of the request. It’s essentially a **HMAC or RSA signature** applied to the Policy and/or the request URI using a private key. When the SoundCloud CDN receives the request, it uses the corresponding public key to verify the signature hasn’t been tampered with and that the request is within the allowed policy bounds.

If the `Signature` is incorrect, expired, or doesn’t match the policy, the CDN will reject the request with a 403 Forbidden.

### `Key-Pair-Id`

This is an identifier for the key pair used to sign the `Policy`. It tells the CDN which **public key** to use when verifying the signature. In SoundCloud’s case, the ID corresponds to one of their internal key sets.

* * *

## The problem

Let `apiStreamUrl` be the URL in `transcoding.url`, and let `contentUrl` be the actual CDN stream URL returned from calling `apiStreamUrl`.

Every time you call `apiStreamUrl`, it returns the **same base `contentUrl`**, but with a **different Policy, Signature**, and (for AAC) a different `expires` parameter.

For HLS streams, `contentUrl` is the m3u8 playlist.

Currently our code only calls `apiStreamUrl` once to get the m3u8 playlist for HLS streams, and that stays the same for the lifetime of the `AudioStream` object. The way m3u8 playlists work is that you fetch the m3u8 playlist from `contentUrl` which has the urls for each chunk of the playlist.

Here is an example:

<details><summary><b>Example M3U8 playlist</b></summary><p>

```
#EXTM3U
#EXT-X-VERSION:6
#EXT-X-PLAYLIST-TYPE:VOD
#EXT-X-TARGETDURATION:10
#EXT-X-MEDIA-SEQUENCE:0
#EXTINF:1.985272,
https://cf-hls-media.sndcdn.com/media/159660/0/31762/jPI4kiRuqQ8N.128.mp3?Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiKjovL2NmLWhscy1tZWRpYS5zbmRjZG4uY29tL21lZGlhLzE1OTY2MC8qLyovalBJNGtpUnVxUThOLjEyOC5tcDMiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE3NTA3ODI5OTh9fX1dfQ__&Signature=Y8mTNc0I4HJkSdxM7aw88PV-p~zAwTA7GrATlX7xiRcd8SsVX7HxLoJLGXQNHopavqiboDrM7wnDIMexriCZHHLfaS5C6xGnMSNFenDFw4GHoXZFahA6Sds05K-Isek3TBpZqOebrtwHJogbiF9fI1E88GrDnGtrdZhpcDct3Abjrhe9kWr~nwb9NEZjQxaUaRhnvRMvq-bs9NsLFNByv5Zk7tYIxgFHLDWfYuZAaTConvFelixiKfK4K5KUhZ7uE2wOPGvNJe1r6T02XgyhF9M7B88ERbxai-fkAodWMLqZhpev64davXfbT7axlB4ChvEXw3WSNtAIuUZlq2PUkQ__&Key-Pair-Id=APKAI6TU7MMXM5DG6EPQ
#EXTINF:2.977908,
https://cf-hls-media.sndcdn.com/media/159660/31763/79410/jPI4kiRuqQ8N.128.mp3?Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiKjovL2NmLWhscy1tZWRpYS5zbmRjZG4uY29tL21lZGlhLzE1OTY2MC8qLyovalBJNGtpUnVxUThOLjEyOC5tcDMiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE3NTA3ODI5OTh9fX1dfQ__&Signature=Y8mTNc0I4HJkSdxM7aw88PV-p~zAwTA7GrATlX7xiRcd8SsVX7HxLoJLGXQNHopavqiboDrM7wnDIMexriCZHHLfaS5C6xGnMSNFenDFw4GHoXZFahA6Sds05K-Isek3TBpZqOebrtwHJogbiF9fI1E88GrDnGtrdZhpcDct3Abjrhe9kWr~nwb9NEZjQxaUaRhnvRMvq-bs9NsLFNByv5Zk7tYIxgFHLDWfYuZAaTConvFelixiKfK4K5KUhZ7uE2wOPGvNJe1r6T02XgyhF9M7B88ERbxai-fkAodWMLqZhpev64davXfbT7axlB4ChvEXw3WSNtAIuUZlq2PUkQ__&Key-Pair-Id=APKAI6TU7MMXM5DG6EPQ
#EXTINF:4.989302,
https://cf-hls-media.sndcdn.com/media/159660/79411/159240/jPI4kiRuqQ8N.128.mp3?Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiKjovL2NmLWhscy1tZWRpYS5zbmRjZG4uY29tL21lZGlhLzE1OTY2MC8qLyovalBJNGtpUnVxUThOLjEyOC5tcDMiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE3NTA3ODI5OTh9fX1dfQ__&Signature=Y8mTNc0I4HJkSdxM7aw88PV-p~zAwTA7GrATlX7xiRcd8SsVX7HxLoJLGXQNHopavqiboDrM7wnDIMexriCZHHLfaS5C6xGnMSNFenDFw4GHoXZFahA6Sds05K-Isek3TBpZqOebrtwHJogbiF9fI1E88GrDnGtrdZhpcDct3Abjrhe9kWr~nwb9NEZjQxaUaRhnvRMvq-bs9NsLFNByv5Zk7tYIxgFHLDWfYuZAaTConvFelixiKfK4K5KUhZ7uE2wOPGvNJe1r6T02XgyhF9M7B88ERbxai-fkAodWMLqZhpev64davXfbT7axlB4ChvEXw3WSNtAIuUZlq2PUkQ__&Key-Pair-Id=APKAI6TU7MMXM5DG6EPQ
#EXTINF:9.978604,
https://cf-hls-media.sndcdn.com/media/159660/159241/318900/jPI4kiRuqQ8N.128.mp3?Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiKjovL2NmLWhscy1tZWRpYS5zbmRjZG4uY29tL21lZGlhLzE1OTY2MC8qLyovalBJNGtpUnVxUThOLjEyOC5tcDMiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE3NTA3ODI5OTh9fX1dfQ__&Signature=Y8mTNc0I4HJkSdxM7aw88PV-p~zAwTA7GrATlX7xiRcd8SsVX7HxLoJLGXQNHopavqiboDrM7wnDIMexriCZHHLfaS5C6xGnMSNFenDFw4GHoXZFahA6Sds05K-Isek3TBpZqOebrtwHJogbiF9fI1E88GrDnGtrdZhpcDct3Abjrhe9kWr~nwb9NEZjQxaUaRhnvRMvq-bs9NsLFNByv5Zk7tYIxgFHLDWfYuZAaTConvFelixiKfK4K5KUhZ7uE2wOPGvNJe1r6T02XgyhF9M7B88ERbxai-fkAodWMLqZhpev64davXfbT7axlB4ChvEXw3WSNtAIuUZlq2PUkQ__&Key-Pair-Id=APKAI6TU7MMXM5DG6EPQ
#EXTINF:9.978604,
https://cf-hls-media.sndcdn.com/media/159660/318901/478561/jPI4kiRuqQ8N.128.mp3?Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiKjovL2NmLWhscy1tZWRpYS5zbmRjZG4uY29tL21lZGlhLzE1OTY2MC8qLyovalBJNGtpUnVxUThOLjEyOC5tcDMiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE3NTA3ODI5OTh9fX1dfQ__&Signature=Y8mTNc0I4HJkSdxM7aw88PV-p~zAwTA7GrATlX7xiRcd8SsVX7HxLoJLGXQNHopavqiboDrM7wnDIMexriCZHHLfaS5C6xGnMSNFenDFw4GHoXZFahA6Sds05K-Isek3TBpZqOebrtwHJogbiF9fI1E88GrDnGtrdZhpcDct3Abjrhe9kWr~nwb9NEZjQxaUaRhnvRMvq-bs9NsLFNByv5Zk7tYIxgFHLDWfYuZAaTConvFelixiKfK4K5KUhZ7uE2wOPGvNJe1r6T02XgyhF9M7B88ERbxai-fkAodWMLqZhpev64davXfbT7axlB4ChvEXw3WSNtAIuUZlq2PUkQ__&Key-Pair-Id=APKAI6TU7MMXM5DG6EPQ
#EXTINF:9.978604,
https://cf-hls-media.sndcdn.com/media/159660/478562/638221/jPI4kiRuqQ8N.128.mp3?Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiKjovL2NmLWhscy1tZWRpYS5zbmRjZG4uY29tL21lZGlhLzE1OTY2MC8qLyovalBJNGtpUnVxUThOLjEyOC5tcDMiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE3NTA3ODI5OTh9fX1dfQ__&Signature=Y8mTNc0I4HJkSdxM7aw88PV-p~zAwTA7GrATlX7xiRcd8SsVX7HxLoJLGXQNHopavqiboDrM7wnDIMexriCZHHLfaS5C6xGnMSNFenDFw4GHoXZFahA6Sds05K-Isek3TBpZqOebrtwHJogbiF9fI1E88GrDnGtrdZhpcDct3Abjrhe9kWr~nwb9NEZjQxaUaRhnvRMvq-bs9NsLFNByv5Zk7tYIxgFHLDWfYuZAaTConvFelixiKfK4K5KUhZ7uE2wOPGvNJe1r6T02XgyhF9M7B88ERbxai-fkAodWMLqZhpev64davXfbT7axlB4ChvEXw3WSNtAIuUZlq2PUkQ__&Key-Pair-Id=APKAI6TU7MMXM5DG6EPQ
#EXTINF:9.978604,
https://cf-hls-media.sndcdn.com/media/159660/638222/797882/jPI4kiRuqQ8N.128.mp3?Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiKjovL2NmLWhscy1tZWRpYS5zbmRjZG4uY29tL21lZGlhLzE1OTY2MC8qLyovalBJNGtpUnVxUThOLjEyOC5tcDMiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE3NTA3ODI5OTh9fX1dfQ__&Signature=Y8mTNc0I4HJkSdxM7aw88PV-p~zAwTA7GrATlX7xiRcd8SsVX7HxLoJLGXQNHopavqiboDrM7wnDIMexriCZHHLfaS5C6xGnMSNFenDFw4GHoXZFahA6Sds05K-Isek3TBpZqOebrtwHJogbiF9fI1E88GrDnGtrdZhpcDct3Abjrhe9kWr~nwb9NEZjQxaUaRhnvRMvq-bs9NsLFNByv5Zk7tYIxgFHLDWfYuZAaTConvFelixiKfK4K5KUhZ7uE2wOPGvNJe1r6T02XgyhF9M7B88ERbxai-fkAodWMLqZhpev64davXfbT7axlB4ChvEXw3WSNtAIuUZlq2PUkQ__&Key-Pair-Id=APKAI6TU7MMXM5DG6EPQ
#EXTINF:9.978604,
https://cf-hls-media.sndcdn.com/media/159660/797883/957542/jPI4kiRuqQ8N.128.mp3?Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiKjovL2NmLWhscy1tZWRpYS5zbmRjZG4uY29tL21lZGlhLzE1OTY2MC8qLyovalBJNGtpUnVxUThOLjEyOC5tcDMiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE3NTA3ODI5OTh9fX1dfQ__&Signature=Y8mTNc0I4HJkSdxM7aw88PV-p~zAwTA7GrATlX7xiRcd8SsVX7HxLoJLGXQNHopavqiboDrM7wnDIMexriCZHHLfaS5C6xGnMSNFenDFw4GHoXZFahA6Sds05K-Isek3TBpZqOebrtwHJogbiF9fI1E88GrDnGtrdZhpcDct3Abjrhe9kWr~nwb9NEZjQxaUaRhnvRMvq-bs9NsLFNByv5Zk7tYIxgFHLDWfYuZAaTConvFelixiKfK4K5KUhZ7uE2wOPGvNJe1r6T02XgyhF9M7B88ERbxai-fkAodWMLqZhpev64davXfbT7axlB4ChvEXw3WSNtAIuUZlq2PUkQ__&Key-Pair-Id=APKAI6TU7MMXM5DG6EPQ
#EXTINF:9.978604,
https://cf-hls-media.sndcdn.com/media/159660/957543/1117202/jPI4kiRuqQ8N.128.mp3?Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiKjovL2NmLWhscy1tZWRpYS5zbmRjZG4uY29tL21lZGlhLzE1OTY2MC8qLyovalBJNGtpUnVxUThOLjEyOC5tcDMiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE3NTA3ODI5OTh9fX1dfQ__&Signature=Y8mTNc0I4HJkSdxM7aw88PV-p~zAwTA7GrATlX7xiRcd8SsVX7HxLoJLGXQNHopavqiboDrM7wnDIMexriCZHHLfaS5C6xGnMSNFenDFw4GHoXZFahA6Sds05K-Isek3TBpZqOebrtwHJogbiF9fI1E88GrDnGtrdZhpcDct3Abjrhe9kWr~nwb9NEZjQxaUaRhnvRMvq-bs9NsLFNByv5Zk7tYIxgFHLDWfYuZAaTConvFelixiKfK4K5KUhZ7uE2wOPGvNJe1r6T02XgyhF9M7B88ERbxai-fkAodWMLqZhpev64davXfbT7axlB4ChvEXw3WSNtAIuUZlq2PUkQ__&Key-Pair-Id=APKAI6TU7MMXM5DG6EPQ
#EXTINF:9.978604,
https://cf-hls-media.sndcdn.com/media/159660/1117203/1276863/jPI4kiRuqQ8N.128.mp3?Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiKjovL2NmLWhscy1tZWRpYS5zbmRjZG4uY29tL21lZGlhLzE1OTY2MC8qLyovalBJNGtpUnVxUThOLjEyOC5tcDMiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE3NTA3ODI5OTh9fX1dfQ__&Signature=Y8mTNc0I4HJkSdxM7aw88PV-p~zAwTA7GrATlX7xiRcd8SsVX7HxLoJLGXQNHopavqiboDrM7wnDIMexriCZHHLfaS5C6xGnMSNFenDFw4GHoXZFahA6Sds05K-Isek3TBpZqOebrtwHJogbiF9fI1E88GrDnGtrdZhpcDct3Abjrhe9kWr~nwb9NEZjQxaUaRhnvRMvq-bs9NsLFNByv5Zk7tYIxgFHLDWfYuZAaTConvFelixiKfK4K5KUhZ7uE2wOPGvNJe1r6T02XgyhF9M7B88ERbxai-fkAodWMLqZhpev64davXfbT7axlB4ChvEXw3WSNtAIuUZlq2PUkQ__&Key-Pair-Id=APKAI6TU7MMXM5DG6EPQ
#EXTINF:9.978604,
https://cf-hls-media.sndcdn.com/media/159660/1276864/1436523/jPI4kiRuqQ8N.128.mp3?Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiKjovL2NmLWhscy1tZWRpYS5zbmRjZG4uY29tL21lZGlhLzE1OTY2MC8qLyovalBJNGtpUnVxUThOLjEyOC5tcDMiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE3NTA3ODI5OTh9fX1dfQ__&Signature=Y8mTNc0I4HJkSdxM7aw88PV-p~zAwTA7GrATlX7xiRcd8SsVX7HxLoJLGXQNHopavqiboDrM7wnDIMexriCZHHLfaS5C6xGnMSNFenDFw4GHoXZFahA6Sds05K-Isek3TBpZqOebrtwHJogbiF9fI1E88GrDnGtrdZhpcDct3Abjrhe9kWr~nwb9NEZjQxaUaRhnvRMvq-bs9NsLFNByv5Zk7tYIxgFHLDWfYuZAaTConvFelixiKfK4K5KUhZ7uE2wOPGvNJe1r6T02XgyhF9M7B88ERbxai-fkAodWMLqZhpev64davXfbT7axlB4ChvEXw3WSNtAIuUZlq2PUkQ__&Key-Pair-Id=APKAI6TU7MMXM5DG6EPQ
#EXTINF:9.978604,
https://cf-hls-media.sndcdn.com/media/159660/1436524/1596184/jPI4kiRuqQ8N.128.mp3?Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiKjovL2NmLWhscy1tZWRpYS5zbmRjZG4uY29tL21lZGlhLzE1OTY2MC8qLyovalBJNGtpUnVxUThOLjEyOC5tcDMiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE3NTA3ODI5OTh9fX1dfQ__&Signature=Y8mTNc0I4HJkSdxM7aw88PV-p~zAwTA7GrATlX7xiRcd8SsVX7HxLoJLGXQNHopavqiboDrM7wnDIMexriCZHHLfaS5C6xGnMSNFenDFw4GHoXZFahA6Sds05K-Isek3TBpZqOebrtwHJogbiF9fI1E88GrDnGtrdZhpcDct3Abjrhe9kWr~nwb9NEZjQxaUaRhnvRMvq-bs9NsLFNByv5Zk7tYIxgFHLDWfYuZAaTConvFelixiKfK4K5KUhZ7uE2wOPGvNJe1r6T02XgyhF9M7B88ERbxai-fkAodWMLqZhpev64davXfbT7axlB4ChvEXw3WSNtAIuUZlq2PUkQ__&Key-Pair-Id=APKAI6TU7MMXM5DG6EPQ
#EXTINF:9.978604,
https://cf-hls-media.sndcdn.com/media/159660/1596185/1755844/jPI4kiRuqQ8N.128.mp3?Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiKjovL2NmLWhscy1tZWRpYS5zbmRjZG4uY29tL21lZGlhLzE1OTY2MC8qLyovalBJNGtpUnVxUThOLjEyOC5tcDMiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE3NTA3ODI5OTh9fX1dfQ__&Signature=Y8mTNc0I4HJkSdxM7aw88PV-p~zAwTA7GrATlX7xiRcd8SsVX7HxLoJLGXQNHopavqiboDrM7wnDIMexriCZHHLfaS5C6xGnMSNFenDFw4GHoXZFahA6Sds05K-Isek3TBpZqOebrtwHJogbiF9fI1E88GrDnGtrdZhpcDct3Abjrhe9kWr~nwb9NEZjQxaUaRhnvRMvq-bs9NsLFNByv5Zk7tYIxgFHLDWfYuZAaTConvFelixiKfK4K5KUhZ7uE2wOPGvNJe1r6T02XgyhF9M7B88ERbxai-fkAodWMLqZhpev64davXfbT7axlB4ChvEXw3WSNtAIuUZlq2PUkQ__&Key-Pair-Id=APKAI6TU7MMXM5DG6EPQ
#EXTINF:9.978604,
https://cf-hls-media.sndcdn.com/media/159660/1755845/1915505/jPI4kiRuqQ8N.128.mp3?Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiKjovL2NmLWhscy1tZWRpYS5zbmRjZG4uY29tL21lZGlhLzE1OTY2MC8qLyovalBJNGtpUnVxUThOLjEyOC5tcDMiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE3NTA3ODI5OTh9fX1dfQ__&Signature=Y8mTNc0I4HJkSdxM7aw88PV-p~zAwTA7GrATlX7xiRcd8SsVX7HxLoJLGXQNHopavqiboDrM7wnDIMexriCZHHLfaS5C6xGnMSNFenDFw4GHoXZFahA6Sds05K-Isek3TBpZqOebrtwHJogbiF9fI1E88GrDnGtrdZhpcDct3Abjrhe9kWr~nwb9NEZjQxaUaRhnvRMvq-bs9NsLFNByv5Zk7tYIxgFHLDWfYuZAaTConvFelixiKfK4K5KUhZ7uE2wOPGvNJe1r6T02XgyhF9M7B88ERbxai-fkAodWMLqZhpev64davXfbT7axlB4ChvEXw3WSNtAIuUZlq2PUkQ__&Key-Pair-Id=APKAI6TU7MMXM5DG6EPQ
#EXTINF:9.978604,
https://cf-hls-media.sndcdn.com/media/159660/1915506/2075165/jPI4kiRuqQ8N.128.mp3?Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiKjovL2NmLWhscy1tZWRpYS5zbmRjZG4uY29tL21lZGlhLzE1OTY2MC8qLyovalBJNGtpUnVxUThOLjEyOC5tcDMiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE3NTA3ODI5OTh9fX1dfQ__&Signature=Y8mTNc0I4HJkSdxM7aw88PV-p~zAwTA7GrATlX7xiRcd8SsVX7HxLoJLGXQNHopavqiboDrM7wnDIMexriCZHHLfaS5C6xGnMSNFenDFw4GHoXZFahA6Sds05K-Isek3TBpZqOebrtwHJogbiF9fI1E88GrDnGtrdZhpcDct3Abjrhe9kWr~nwb9NEZjQxaUaRhnvRMvq-bs9NsLFNByv5Zk7tYIxgFHLDWfYuZAaTConvFelixiKfK4K5KUhZ7uE2wOPGvNJe1r6T02XgyhF9M7B88ERbxai-fkAodWMLqZhpev64davXfbT7axlB4ChvEXw3WSNtAIuUZlq2PUkQ__&Key-Pair-Id=APKAI6TU7MMXM5DG6EPQ
#EXTINF:9.978604,
https://cf-hls-media.sndcdn.com/media/159660/2075166/2234825/jPI4kiRuqQ8N.128.mp3?Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiKjovL2NmLWhscy1tZWRpYS5zbmRjZG4uY29tL21lZGlhLzE1OTY2MC8qLyovalBJNGtpUnVxUThOLjEyOC5tcDMiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE3NTA3ODI5OTh9fX1dfQ__&Signature=Y8mTNc0I4HJkSdxM7aw88PV-p~zAwTA7GrATlX7xiRcd8SsVX7HxLoJLGXQNHopavqiboDrM7wnDIMexriCZHHLfaS5C6xGnMSNFenDFw4GHoXZFahA6Sds05K-Isek3TBpZqOebrtwHJogbiF9fI1E88GrDnGtrdZhpcDct3Abjrhe9kWr~nwb9NEZjQxaUaRhnvRMvq-bs9NsLFNByv5Zk7tYIxgFHLDWfYuZAaTConvFelixiKfK4K5KUhZ7uE2wOPGvNJe1r6T02XgyhF9M7B88ERbxai-fkAodWMLqZhpev64davXfbT7axlB4ChvEXw3WSNtAIuUZlq2PUkQ__&Key-Pair-Id=APKAI6TU7MMXM5DG6EPQ
#EXTINF:0.235098,
https://cf-hls-media.sndcdn.com/media/159660/2234826/2238587/jPI4kiRuqQ8N.128.mp3?Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiKjovL2NmLWhscy1tZWRpYS5zbmRjZG4uY29tL21lZGlhLzE1OTY2MC8qLyovalBJNGtpUnVxUThOLjEyOC5tcDMiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE3NTA3ODI5OTh9fX1dfQ__&Signature=Y8mTNc0I4HJkSdxM7aw88PV-p~zAwTA7GrATlX7xiRcd8SsVX7HxLoJLGXQNHopavqiboDrM7wnDIMexriCZHHLfaS5C6xGnMSNFenDFw4GHoXZFahA6Sds05K-Isek3TBpZqOebrtwHJogbiF9fI1E88GrDnGtrdZhpcDct3Abjrhe9kWr~nwb9NEZjQxaUaRhnvRMvq-bs9NsLFNByv5Zk7tYIxgFHLDWfYuZAaTConvFelixiKfK4K5KUhZ7uE2wOPGvNJe1r6T02XgyhF9M7B88ERbxai-fkAodWMLqZhpev64davXfbT7axlB4ChvEXw3WSNtAIuUZlq2PUkQ__&Key-Pair-Id=APKAI6TU7MMXM5DG6EPQ
#EXT-X-ENDLIST

```
</details>
<hr>

We pass `contentUrl` to ExoPlayer, and it fetches this playlist, parses it, and sequentially gets each chunk for playback (it will usually buffer like 10 chunks ahead of the current position).

When NewPipe extracts a SoundCloud stream, it stores it in a StreamInfo. it will also extract the track before and after it for seamless playback once the current song ends. Every time something is extracted it gets put into a cache, and SoundCloud streams have a cache expiry of 5 minutes.

The problem is we only get this playlist once, so the chunk urls are fixed and expire after 5 minutes. This means if you have tracks A, B and C, and you play track B, depending on the length of the tracks, or even if you just pause for more than 5 minutes, ExoPlayer will try to fetch a chunk after it's expired, get a 403 Forbidden, and playback stops and skips to the next track.

Our error handling doesn't handle errors well so it does not retry the track and just skips to the next song. (Reference Player.Java onPlayerError here)

ExoPlayer has no built-in support for refreshing expired HLS playlists. Calling `apiStreamUrl` returns a new `contentUrl` (i.e., a playlist URL) every time, and even calling `contentUrl` will return a fresh m3u8 playlist with updated URLs for each playlist segment; but `contentUrl` itself expires after 5 minutes.

There's no way to tell ExoPlayer to call `apiStreamUrl` and then call `contentUrl`, parse the playlist and update it's internal `HlsMediaPlaylist` after it is initially created. Even though we pass `contentUrl` to ExoPlayer for it to parse initially, it only calls it once and never calls it again, so the playlist never gets updated and expires after 5mins because the `Policy` and `Signature` are no longer valid.

## The Solution

I initially tried to find a solution within ExoPlayer that wouldn’t require changing much NewPipe code, but ExoPlayer exposes no API refresh playlists once they're created. The only way to do it would be to modify the ExoPlayer source code and use our own custom package, but that's too much (and would still be too complicated as well) 

So I used a custom `HttpDataSource`: `RefreshableHlsHttpDataSource`.

### How it works

- When a request to a playlist chunk fails with `403`, it means the `contentUrl` has expired, and all the chunk URLs in the playlist have also expired.
- At that point, we re-call `apiStreamUrl` to get a brand new `contentUrl`, which points to a fresh playlist with valid chunk URLs and updated `Policy`, `Signature`, etc.
- We parse this new playlist and construct a mapping between the **base paths** of the expired chunks and their new equivalents from the fresh playlist. All chunks have predictable, stable base paths; only the query parameters differ.
- From then on, whenever ExoPlayer tries to load a chunk using an expired URL, it gets mapped to an updated URL. This process repeats when the updated URLs expire.


