### PR TITLE
Improve and cleanup PlayerHelper formatters/localization

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
@@ -118,18 +118,6 @@ public final class PlayerHelper {
     }
 
     @NonNull
-    public static String subtitleMimeTypesOf(@NonNull final MediaFormat format) {
-        switch (format) {
-            case VTT:
-                return MimeTypes.TEXT_VTT;
-            case TTML:
-                return MimeTypes.APPLICATION_TTML;
-            default:
-                throw new IllegalArgumentException("Unrecognized mime type: " + format.name());
-        }
-    }
-
-    @NonNull
     public static String captionLanguageOf(@NonNull final Context context,
                                            @NonNull final SubtitlesStream subtitles) {
         final String displayName = subtitles.getDisplayLanguageName();

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
@@ -89,9 +89,7 @@ public final class PlayerHelper {
     private PlayerHelper() {
     }
 
-    ////////////////////////////////////////////////////////////////////////////
-    // Exposed helpers
-    ////////////////////////////////////////////////////////////////////////////
+    // region Exposed helpers
 
     @NonNull
     public static String getTimeString(final int milliSeconds) {
@@ -219,9 +217,8 @@ public final class PlayerHelper {
                 ? null : getAutoQueuedSinglePlayQueue(autoQueueItems.get(0));
     }
 
-    ////////////////////////////////////////////////////////////////////////////
-    // Settings Resolution
-    ////////////////////////////////////////////////////////////////////////////
+    // endregion
+    // region Resolution
 
     public static boolean isResumeAfterAudioFocusGain(@NonNull final Context context) {
         return getPreferences(context)
@@ -405,9 +402,8 @@ public final class PlayerHelper {
         return Integer.parseInt(preferredIntervalBytes) * 1024;
     }
 
-    ////////////////////////////////////////////////////////////////////////////
-    // Private helpers
-    ////////////////////////////////////////////////////////////////////////////
+    // endregion
+    // region Private helpers
 
     @NonNull
     private static SharedPreferences getPreferences(@NonNull final Context context) {
@@ -427,9 +423,8 @@ public final class PlayerHelper {
     }
 
 
-    ////////////////////////////////////////////////////////////////////////////
-    // Utils used by player
-    ////////////////////////////////////////////////////////////////////////////
+    // endregion
+    // region Utils used by player
 
     @RepeatMode
     public static int nextRepeatMode(@RepeatMode final int repeatMode) {
@@ -503,4 +498,6 @@ public final class PlayerHelper {
                 player.getContext().getString(R.string.seek_duration_key),
                 player.getContext().getString(R.string.seek_duration_default_value))));
     }
+
+    // endregion
 }

--- a/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
@@ -54,7 +54,6 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
                 final Intent intent = new Intent(Settings.ACTION_APP_LOCALE_SETTINGS)
                         .setData(Uri.fromParts("package", requireContext().getPackageName(), null));
                 startActivity(intent);
-                PlayerHelper.resetFormat();
                 return true;
             });
             newAppLanguagePref.setVisible(true);
@@ -66,7 +65,6 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
             final String systemLang = getString(R.string.default_localization_key);
             final String tag = systemLang.equals(language) ? null : language;
             AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags(tag));
-            PlayerHelper.resetFormat();
             return true;
         });
     }
@@ -110,5 +108,6 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
         NewPipe.setupLocalization(
             Localization.getPreferredLocalization(context),
             Localization.getPreferredContentCountry(context));
+        PlayerHelper.resetFormat();
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
@@ -16,6 +16,7 @@ import androidx.preference.Preference;
 import org.schabi.newpipe.DownloaderImpl;
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.extractor.NewPipe;
+import org.schabi.newpipe.player.helper.PlayerHelper;
 import org.schabi.newpipe.util.Localization;
 import org.schabi.newpipe.util.image.ImageStrategy;
 import org.schabi.newpipe.util.image.PicassoHelper;
@@ -53,6 +54,7 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
                 final Intent intent = new Intent(Settings.ACTION_APP_LOCALE_SETTINGS)
                         .setData(Uri.fromParts("package", requireContext().getPackageName(), null));
                 startActivity(intent);
+                PlayerHelper.resetFormat();
                 return true;
             });
             newAppLanguagePref.setVisible(true);
@@ -64,6 +66,7 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
             final String systemLang = getString(R.string.default_localization_key);
             final String tag = systemLang.equals(language) ? null : language;
             AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags(tag));
+            PlayerHelper.resetFormat();
             return true;
         });
     }

--- a/app/src/main/java/org/schabi/newpipe/util/Localization.java
+++ b/app/src/main/java/org/schabi/newpipe/util/Localization.java
@@ -127,14 +127,13 @@ public final class Localization {
     }
 
     public static String localizeNumber(final double number) {
-        final NumberFormat nf = NumberFormat.getInstance(getAppLocale());
-        return nf.format(number);
+        return NumberFormat.getInstance(getAppLocale()).format(number);
     }
 
     public static String formatDate(@NonNull final OffsetDateTime offsetDateTime) {
         return DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)
-                .withLocale(getAppLocale()).format(offsetDateTime
-                        .atZoneSameInstant(ZoneId.systemDefault()));
+            .withLocale(getAppLocale())
+            .format(offsetDateTime.atZoneSameInstant(ZoneId.systemDefault()));
     }
 
     @SuppressLint("StringFormatInvalid")


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR

Followup of https://github.com/TeamNewPipe/NewPipe/pull/12446

1. Contains some cleanup regarding the PlayerHelper localization and related code, removes dead code, etc.
2. If the language is changed via ContentSettingsFragment, PlayerHelper's formatters will be reset. If formatting is now requested next time it will be reinitialized and the correct format will be applied.

<details><summary>Here's an example</summary>

[Np12470Showcase1.webm](https://github.com/user-attachments/assets/9b6f3734-f192-4466-81f8-a7df6e9f4e20)

</details>

#### Fixes the following issue(s)
- Fixes #12441 (kind of, was already addressed mostly by https://github.com/TeamNewPipe/NewPipe/pull/12444)

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
