### PR TITLE
Add more specific error messages and deduplicate their handling

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -214,7 +214,7 @@ dependencies {
     // the corresponding commit hash, since JitPack sometimes deletes artifacts.
     // If there’s already a git hash, just add more of it to the end (or remove a letter)
     // to cause jitpack to regenerate the artifact.
-    implementation 'com.github.TeamNewPipe:NewPipeExtractor:7adbc48a0aa872c016b8ec089e278d5e12772054'
+    implementation 'com.github.Stypox:NewPipeExtractor:1c04bd88c3f1e6b1e0c912814035745e61bb9aba'
     implementation 'com.github.TeamNewPipe:NoNonsense-FilePicker:5.0.0'
 
 /** Checkstyle **/

--- a/app/src/main/java/org/schabi/newpipe/RouterActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/RouterActivity.java
@@ -58,20 +58,13 @@ import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.StreamingService.LinkType;
 import org.schabi.newpipe.extractor.channel.ChannelInfo;
-import org.schabi.newpipe.extractor.exceptions.AgeRestrictedContentException;
 import org.schabi.newpipe.extractor.exceptions.ContentNotAvailableException;
 import org.schabi.newpipe.extractor.exceptions.ContentNotSupportedException;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
-import org.schabi.newpipe.extractor.exceptions.GeographicRestrictionException;
-import org.schabi.newpipe.extractor.exceptions.PaidContentException;
-import org.schabi.newpipe.extractor.exceptions.PrivateContentException;
 import org.schabi.newpipe.extractor.exceptions.ReCaptchaException;
-import org.schabi.newpipe.extractor.exceptions.SoundCloudGoPlusContentException;
-import org.schabi.newpipe.extractor.exceptions.YoutubeMusicPremiumContentException;
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
 import org.schabi.newpipe.extractor.playlist.PlaylistInfo;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
-import org.schabi.newpipe.ktx.ExceptionUtils;
 import org.schabi.newpipe.local.dialog.PlaylistDialog;
 import org.schabi.newpipe.player.PlayerType;
 import org.schabi.newpipe.player.helper.PlayerHelper;
@@ -279,28 +272,11 @@ public class RouterActivity extends AppCompatActivity {
             final Intent intent = new Intent(context, ReCaptchaActivity.class);
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             context.startActivity(intent);
-        } else if (errorInfo.getThrowable() != null
-                && ExceptionUtils.isNetworkRelated(errorInfo.getThrowable())) {
-            Toast.makeText(context, R.string.network_error, Toast.LENGTH_LONG).show();
-        } else if (errorInfo.getThrowable() instanceof AgeRestrictedContentException) {
-            Toast.makeText(context, R.string.restricted_video_no_stream,
-                    Toast.LENGTH_LONG).show();
-        } else if (errorInfo.getThrowable() instanceof GeographicRestrictionException) {
-            Toast.makeText(context, R.string.georestricted_content, Toast.LENGTH_LONG).show();
-        } else if (errorInfo.getThrowable() instanceof PaidContentException) {
-            Toast.makeText(context, R.string.paid_content, Toast.LENGTH_LONG).show();
-        } else if (errorInfo.getThrowable() instanceof PrivateContentException) {
-            Toast.makeText(context, R.string.private_content, Toast.LENGTH_LONG).show();
-        } else if (errorInfo.getThrowable() instanceof SoundCloudGoPlusContentException) {
-            Toast.makeText(context, R.string.soundcloud_go_plus_content,
-                    Toast.LENGTH_LONG).show();
-        } else if (errorInfo.getThrowable() instanceof YoutubeMusicPremiumContentException) {
-            Toast.makeText(context, R.string.youtube_music_premium_content,
-                    Toast.LENGTH_LONG).show();
-        } else if (errorInfo.getThrowable() instanceof ContentNotAvailableException) {
-            Toast.makeText(context, R.string.content_not_available, Toast.LENGTH_LONG).show();
-        } else if (errorInfo.getThrowable() instanceof ContentNotSupportedException) {
-            Toast.makeText(context, R.string.content_not_supported, Toast.LENGTH_LONG).show();
+        } else if (errorInfo.getThrowable() instanceof ContentNotAvailableException
+                || errorInfo.getThrowable() instanceof ContentNotSupportedException) {
+            // this exception does not usually indicate a problem that should be reported,
+            // so just show a toast instead of the notification
+            Toast.makeText(context, errorInfo.getMessageStringId(), Toast.LENGTH_LONG).show();
         } else {
             ErrorUtil.createNotification(context, errorInfo);
         }

--- a/app/src/main/java/org/schabi/newpipe/error/ErrorInfo.kt
+++ b/app/src/main/java/org/schabi/newpipe/error/ErrorInfo.kt
@@ -104,28 +104,8 @@ class ErrorInfo(
             action: UserAction?
         ): Int {
             return when {
-                // content not available exceptions
-                throwable is AccountTerminatedException -> R.string.account_terminated
-                throwable is AgeRestrictedContentException -> R.string.restricted_video_no_stream
-                throwable is GeographicRestrictionException -> R.string.georestricted_content
-                throwable is PaidContentException -> R.string.paid_content
-                throwable is PrivateContentException -> R.string.private_content
-                throwable is SoundCloudGoPlusContentException -> R.string.soundcloud_go_plus_content
-                throwable is UnsupportedContentInCountryException -> R.string.unsupported_content_in_country
-                throwable is YoutubeMusicPremiumContentException -> R.string.youtube_music_premium_content
-                throwable is YoutubeSignInConfirmNotBotException -> R.string.youtube_sign_in_confirm_not_bot_error
-                throwable is ContentNotAvailableException -> R.string.content_not_available
-
-                // ReCaptchas should have already been handled elsewhere,
-                // but return an error message here just in case
-                throwable is ReCaptchaException -> R.string.recaptcha_request_toast
-
-                // other extractor exceptions
-                throwable is ContentNotSupportedException -> R.string.content_not_supported
-                throwable != null && throwable.isNetworkRelated -> R.string.network_error
-                throwable is ExtractionException -> R.string.parsing_error
-
                 // player exceptions
+                // some may be IOException, so do these checks before isNetworkRelated!
                 throwable is ExoPlaybackException -> {
                     val cause = throwable.cause
                     when {
@@ -139,7 +119,30 @@ class ErrorInfo(
                 throwable is FailedMediaSource.FailedMediaSourceException -> getMessageStringId(throwable.cause, action)
                 throwable is PlaybackResolver.ResolverException -> R.string.player_stream_failure
 
-                // user actions (in case the exception is unrecognizable)
+                // content not available exceptions
+                throwable is AccountTerminatedException -> R.string.account_terminated
+                throwable is AgeRestrictedContentException -> R.string.restricted_video_no_stream
+                throwable is GeographicRestrictionException -> R.string.georestricted_content
+                throwable is PaidContentException -> R.string.paid_content
+                throwable is PrivateContentException -> R.string.private_content
+                throwable is SoundCloudGoPlusContentException -> R.string.soundcloud_go_plus_content
+                throwable is UnsupportedContentInCountryException -> R.string.unsupported_content_in_country
+                throwable is YoutubeMusicPremiumContentException -> R.string.youtube_music_premium_content
+                throwable is YoutubeSignInConfirmNotBotException -> R.string.youtube_sign_in_confirm_not_bot_error
+                throwable is ContentNotAvailableException -> R.string.content_not_available
+
+                // other extractor exceptions
+                throwable is ContentNotSupportedException -> R.string.content_not_supported
+                // ReCaptchas should have already been handled elsewhere,
+                // but return an error message here just in case
+                throwable is ReCaptchaException -> R.string.recaptcha_request_toast
+                // test this at the end as many exceptions could be a subclass of IOException
+                throwable != null && throwable.isNetworkRelated -> R.string.network_error
+                // an extraction exception unrelated to the network
+                // is likely an issue with parsing the website
+                throwable is ExtractionException -> R.string.parsing_error
+
+                // user actions (in case the exception is null or unrecognizable)
                 action == UserAction.UI_ERROR -> R.string.app_ui_crash
                 action == UserAction.REQUESTED_COMMENTS -> R.string.error_unable_to_load_comments
                 action == UserAction.SUBSCRIPTION_CHANGE -> R.string.subscription_change_failed

--- a/app/src/main/java/org/schabi/newpipe/error/ErrorPanelHelper.kt
+++ b/app/src/main/java/org/schabi/newpipe/error/ErrorPanelHelper.kt
@@ -15,19 +15,12 @@ import io.reactivex.rxjava3.disposables.Disposable
 import org.schabi.newpipe.MainActivity
 import org.schabi.newpipe.R
 import org.schabi.newpipe.extractor.exceptions.AccountTerminatedException
-import org.schabi.newpipe.extractor.exceptions.AgeRestrictedContentException
 import org.schabi.newpipe.extractor.exceptions.ContentNotAvailableException
 import org.schabi.newpipe.extractor.exceptions.ContentNotSupportedException
-import org.schabi.newpipe.extractor.exceptions.GeographicRestrictionException
-import org.schabi.newpipe.extractor.exceptions.PaidContentException
-import org.schabi.newpipe.extractor.exceptions.PrivateContentException
 import org.schabi.newpipe.extractor.exceptions.ReCaptchaException
-import org.schabi.newpipe.extractor.exceptions.SoundCloudGoPlusContentException
-import org.schabi.newpipe.extractor.exceptions.YoutubeMusicPremiumContentException
 import org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty
 import org.schabi.newpipe.ktx.animate
 import org.schabi.newpipe.ktx.isInterruptedCaused
-import org.schabi.newpipe.ktx.isNetworkRelated
 import org.schabi.newpipe.util.ServiceHelper
 import org.schabi.newpipe.util.external_communication.ShareUtils
 import java.util.concurrent.TimeUnit
@@ -127,7 +120,7 @@ class ErrorPanelHelper(
                 ErrorUtil.openActivity(context, errorInfo)
             }
 
-            errorTextView.setText(getExceptionDescription(errorInfo.throwable))
+            errorTextView.setText(errorInfo.messageStringId)
 
             if (errorInfo.throwable !is ContentNotAvailableException &&
                 errorInfo.throwable !is ContentNotSupportedException
@@ -192,27 +185,5 @@ class ErrorPanelHelper(
     companion object {
         val TAG: String = ErrorPanelHelper::class.simpleName!!
         val DEBUG: Boolean = MainActivity.DEBUG
-
-        @StringRes
-        fun getExceptionDescription(throwable: Throwable?): Int {
-            return when (throwable) {
-                is AgeRestrictedContentException -> R.string.restricted_video_no_stream
-                is GeographicRestrictionException -> R.string.georestricted_content
-                is PaidContentException -> R.string.paid_content
-                is PrivateContentException -> R.string.private_content
-                is SoundCloudGoPlusContentException -> R.string.soundcloud_go_plus_content
-                is YoutubeMusicPremiumContentException -> R.string.youtube_music_premium_content
-                is ContentNotAvailableException -> R.string.content_not_available
-                is ContentNotSupportedException -> R.string.content_not_supported
-                else -> {
-                    // show retry button only for content which is not unavailable or unsupported
-                    if (throwable != null && throwable.isNetworkRelated) {
-                        R.string.network_error
-                    } else {
-                        R.string.error_snackbar_message
-                    }
-                }
-            }
-        }
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/error/ErrorUtil.kt
+++ b/app/src/main/java/org/schabi/newpipe/error/ErrorUtil.kt
@@ -153,7 +153,7 @@ class ErrorUtil {
                 // fallback to showing a notification if no root view is available
                 createNotification(context, errorInfo)
             } else {
-                Snackbar.make(rootView, R.string.error_snackbar_message, Snackbar.LENGTH_LONG)
+                Snackbar.make(rootView, errorInfo.messageStringId, Snackbar.LENGTH_LONG)
                     .setActionTextColor(Color.YELLOW)
                     .setAction(context.getString(R.string.error_snackbar_action).uppercase()) {
                         openActivity(context, errorInfo)

--- a/app/src/main/java/org/schabi/newpipe/error/UserAction.java
+++ b/app/src/main/java/org/schabi/newpipe/error/UserAction.java
@@ -33,7 +33,8 @@ public enum UserAction {
     SHARE_TO_NEWPIPE("share to newpipe"),
     CHECK_FOR_NEW_APP_VERSION("check for new app version"),
     OPEN_INFO_ITEM_DIALOG("open info item dialog"),
-    GETTING_MAIN_SCREEN_TAB("getting main screen tab");
+    GETTING_MAIN_SCREEN_TAB("getting main screen tab"),
+    PLAY_ON_POPUP("play on popup");
 
     private final String message;
 

--- a/app/src/main/java/org/schabi/newpipe/player/mediabrowser/MediaBrowserPlaybackPreparer.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/mediabrowser/MediaBrowserPlaybackPreparer.kt
@@ -17,6 +17,7 @@ import io.reactivex.rxjava3.schedulers.Schedulers
 import org.schabi.newpipe.MainActivity
 import org.schabi.newpipe.NewPipeDatabase
 import org.schabi.newpipe.R
+import org.schabi.newpipe.error.ErrorInfo
 import org.schabi.newpipe.extractor.InfoItem.InfoType
 import org.schabi.newpipe.extractor.exceptions.ContentNotAvailableException
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler
@@ -84,7 +85,7 @@ class MediaBrowserPlaybackPreparer(
                 },
                 { throwable ->
                     Log.e(TAG, "Failed to start playback of media ID [$mediaId]", throwable)
-                    onPrepareError()
+                    onPrepareError(throwable)
                 }
             )
     }
@@ -115,9 +116,9 @@ class MediaBrowserPlaybackPreparer(
         )
     }
 
-    private fun onPrepareError() {
+    private fun onPrepareError(throwable: Throwable) {
         setMediaSessionError.accept(
-            ContextCompat.getString(context, R.string.error_snackbar_message),
+            ContextCompat.getString(context, ErrorInfo.getMessageStringId(throwable, null)),
             PlaybackStateCompat.ERROR_CODE_APP_ERROR
         )
     }

--- a/app/src/main/java/org/schabi/newpipe/util/text/InternalUrlsHandler.java
+++ b/app/src/main/java/org/schabi/newpipe/util/text/InternalUrlsHandler.java
@@ -1,14 +1,13 @@
 package org.schabi.newpipe.util.text;
 
 import android.content.Context;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
-import androidx.appcompat.app.AlertDialog;
 
 import org.schabi.newpipe.MainActivity;
-import org.schabi.newpipe.R;
-import org.schabi.newpipe.error.ErrorPanelHelper;
+import org.schabi.newpipe.error.ErrorInfo;
+import org.schabi.newpipe.error.ErrorUtil;
+import org.schabi.newpipe.error.UserAction;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
@@ -158,19 +157,13 @@ public final class InternalUrlsHandler {
         disposables.add(single.subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(info -> {
-                    final PlayQueue playQueue =
-                            new SinglePlayQueue(info, seconds * 1000L);
+                    final PlayQueue playQueue = new SinglePlayQueue(info, seconds * 1000L);
                     NavigationHelper.playOnPopupPlayer(context, playQueue, false);
                 }, throwable -> {
-                    if (DEBUG) {
-                        Log.e(TAG, "Could not play on popup: " + url, throwable);
-                    }
-                    new AlertDialog.Builder(context)
-                            .setTitle(R.string.player_stream_failure)
-                            .setMessage(
-                                    ErrorPanelHelper.Companion.getExceptionDescription(throwable))
-                            .setPositiveButton(R.string.ok, null)
-                            .show();
+                    final var errorInfo = new ErrorInfo(throwable, UserAction.PLAY_ON_POPUP, url);
+                    // This will only show a snackbar if the passed context has a root view:
+                    // otherwise it will resort to showing a notification, so we are safe here.
+                    ErrorUtil.showSnackbar(context, errorInfo);
                 }));
         return true;
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -866,4 +866,6 @@
     <string name="import_settings_vulnerable_format">The settings in the export being imported use a vulnerable format that was deprecated since NewPipe 0.27.0. Make sure the export being imported is from a trusted source, and prefer using only exports obtained from NewPipe 0.27.0 or newer in the future. Support for importing settings in this vulnerable format will soon be removed completely, and then old versions of NewPipe will not be able to import settings of exports from new versions anymore.</string>
     <string name="migration_info_6_7_title">SoundCloud Top 50 page removed</string>
     <string name="migration_info_6_7_message">SoundCloud has discontinued the original Top 50 charts. The corresponding tab has been removed from your main page.</string>
+    <string name="youtube_sign_in_confirm_not_bot_error">YouTube refused to provide data, asking for a login.\n\nYour IP might have been temporarily banned by YouTube, you can wait some time or switch to a different IP (for example by turning on/off a VPN, or by switching from WiFi to mobile data).</string>
+    <string name="unsupported_content_in_country">This content is not available for the currently selected content country.\n\nChange your selection from \"Settings > Content > Default content country\".</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -866,6 +866,7 @@
     <string name="import_settings_vulnerable_format">The settings in the export being imported use a vulnerable format that was deprecated since NewPipe 0.27.0. Make sure the export being imported is from a trusted source, and prefer using only exports obtained from NewPipe 0.27.0 or newer in the future. Support for importing settings in this vulnerable format will soon be removed completely, and then old versions of NewPipe will not be able to import settings of exports from new versions anymore.</string>
     <string name="migration_info_6_7_title">SoundCloud Top 50 page removed</string>
     <string name="migration_info_6_7_message">SoundCloud has discontinued the original Top 50 charts. The corresponding tab has been removed from your main page.</string>
+    <string name="player_error_403">HTTP error 403 occurred while playing, likely caused by an IP ban or streaming URL deobfuscation issues</string>
     <string name="youtube_sign_in_confirm_not_bot_error">YouTube refused to provide data, asking for a login.\n\nYour IP might have been temporarily banned by YouTube, you can wait some time or switch to a different IP (for example by turning on/off a VPN, or by switching from WiFi to mobile data).</string>
     <string name="unsupported_content_in_country">This content is not available for the currently selected content country.\n\nChange your selection from \"Settings > Content > Default content country\".</string>
 </resources>


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR

This PR deduplicates the decision of which error message to show for which throwable (it was done in 3 different places previously). It also adds some nice new error messages for specific errors, so users understand better what is going on (and maybe complain less when YouTube breaks something ;-) ).
- In `RouterActivity`, a toast is shown like before if the error is not something that usually needs to be reported, as to not distract the user with a notification.
- Make error snackbar display the actual error that has occurred, instead of showing "Sorry, something went wrong" every time. For example, "Could not parse website" is much more explanatory as the snackbar description when some item in a list can not be extracted (this is already shown in the error panel).
- All subclasses of `ContentNotAvailableException` now have nice specific error messages, and in particular this PR adds `UnsupportedContentInCountryException` (from @AudricV's new Youtube trending implementation) and `YoutubeSignInConfirmNotBotException` (https://github.com/TeamNewPipe/NewPipeExtractor/pull/1352). The latter in particular will hopefully help reduce the amount of duplicate comments in https://github.com/TeamNewPipe/NewPipe/issues/11139.
- Various player-related exceptions are now inspected to extract the original cause and show that to the user instead of always saying "Could not play this stream". In particular, 403 errors are detected and a custom error message is shown for them: "HTTP error 403 occurred while playing, likely caused by an IP ban or streaming URL deobfuscation issues" (this message was inspired by [FreeTube's](https://github.com/FreeTubeApp/FreeTube/issues/6834)). This should also help reduce the amount of duplicates we get related to 403 errors.

#### Relies on the following changes
<!-- Delete this if it doesn't apply to your PR. -->
- https://github.com/TeamNewPipe/NewPipeExtractor/pull/1352
- @AudricV's new Youtube trending implementation

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
