### PR TITLE
Add option to delete a download without also deleting file

### DIFF
--- a/app/src/main/java/us/shandian/giga/service/DownloadManager.java
+++ b/app/src/main/java/us/shandian/giga/service/DownloadManager.java
@@ -265,7 +265,7 @@ public class DownloadManager {
         }
     }
 
-    public void deleteMission(Mission mission) {
+    public void deleteMission(Mission mission, boolean alsoDeleteFile) {
         synchronized (this) {
             if (mission instanceof DownloadMission) {
                 mMissionsPending.remove(mission);
@@ -274,7 +274,9 @@ public class DownloadManager {
                 mFinishedMissionStore.deleteMission(mission);
             }
 
-            mission.delete();
+            if (alsoDeleteFile) {
+                mission.delete();
+            }
         }
     }
 

--- a/app/src/main/java/us/shandian/giga/ui/adapter/MissionAdapter.java
+++ b/app/src/main/java/us/shandian/giga/ui/adapter/MissionAdapter.java
@@ -614,7 +614,7 @@ public class MissionAdapter extends Adapter<ViewHolder> implements Handler.Callb
         while (i.hasNext()) {
             Mission mission = i.next();
             if (mission != null) {
-                mDownloadManager.deleteMission(mission);
+                mDownloadManager.deleteMission(mission, true);
                 mContext.sendBroadcast(new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE, mission.storage.getUri()));
             }
             i.remove();
@@ -667,7 +667,14 @@ public class MissionAdapter extends Adapter<ViewHolder> implements Handler.Callb
                 shareFile(h.item.mission);
                 return true;
             case R.id.delete:
-                mDeleter.append(h.item.mission);
+                // delete the entry and the file
+                mDeleter.append(h.item.mission, true);
+                applyChanges();
+                checkMasterButtonsVisibility();
+                return true;
+            case R.id.delete_entry:
+                // just delete the entry
+                mDeleter.append(h.item.mission, false);
                 applyChanges();
                 checkMasterButtonsVisibility();
                 return true;
@@ -676,7 +683,7 @@ public class MissionAdapter extends Adapter<ViewHolder> implements Handler.Callb
                 final StoredFileHelper storage = h.item.mission.storage;
                 if (!storage.existsAsFile()) {
                     Toast.makeText(mContext, R.string.missing_file, Toast.LENGTH_SHORT).show();
-                    mDeleter.append(h.item.mission);
+                    mDeleter.append(h.item.mission, true);
                     applyChanges();
                     return true;
                 }

--- a/app/src/main/res/menu/mission.xml
+++ b/app/src/main/res/menu/mission.xml
@@ -27,7 +27,11 @@
 
     <item
         android:id="@+id/delete"
-        android:title="@string/delete" />
+        android:title="@string/delete_file" />
+
+    <item
+        android:id="@+id/delete_entry"
+        android:title="@string/delete_entry" />
 
     <item
         android:id="@+id/error_message_view"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -333,6 +333,8 @@
     <string name="pause">Pause</string>
     <string name="create">Create</string>
     <string name="delete">Delete</string>
+    <string name="delete_file">Delete file</string>
+    <string name="delete_entry">Delete entry</string>
     <string name="checksum">Checksum</string>
     <string name="dismiss">Dismiss</string>
     <string name="rename">Rename</string>
@@ -872,4 +874,5 @@
     <string name="trending_podcasts">Trending podcasts</string>
     <string name="trending_movies">Trending movies and shows</string>
     <string name="trending_music">Trending music</string>
+    <string name="entry_deleted">Entry deleted</string>
 </resources>


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR

Some user at FrOSCon reported that the "Delete" button in the Download screen was confusing because they expected it to only delete the entry instead of also deleting the file, so I made that clearer by changing the string from "Delete" to "Delete file" and also added a "Delete entry" button that just deletes the entry.

#### Before/After Screenshots/Screen Record


<img width="462" height="420" alt="image" src="https://github.com/user-attachments/assets/3f01dbb5-a70f-45f6-bc93-29a21364ca12" />

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
