### PR TITLE
[Bug] Fix missing subtitle text in manually downloaded *.SRT files. (issue #10030)

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/streams/SrtFromTtmlWriter.java
+++ b/app/src/main/java/org/schabi/newpipe/streams/SrtFromTtmlWriter.java
@@ -54,6 +54,30 @@ public class SrtFromTtmlWriter {
         out.write(text.getBytes(charset));
     }
 
+    /*
+     *   Recursive method to extract text from all nodes
+     *   - This method processes TextNode and <br> tags, recursively
+     *     extracting text from nested tags.
+     *     For example: extract text from nested <span> tags
+     *   - Appends newlines for <br> tags.
+     */
+    private void extractText(final Node node, final StringBuilder text) {
+        if (node instanceof TextNode) {
+            text.append(((TextNode) node).text());
+        } else if (node instanceof Element) {
+            final Element element = (Element) node;
+            // <br> is a self-closing HTML tag used to insert a line break.
+            if (element.tagName().equalsIgnoreCase("br")) {
+                // Add a newline for <br> tags
+                text.append(NEW_LINE);
+            }
+        }
+        // Recursively process child nodes
+        for (final Node child : node.childNodes()) {
+            extractText(child, text);
+        }
+    }
+
     public void build(final SharpStream ttml) throws IOException {
         /*
          * TTML parser with BASIC support
@@ -81,14 +105,8 @@ public class SrtFromTtmlWriter {
         for (final Element paragraph : paragraphList) {
             text.setLength(0);
 
-            for (final Node children : paragraph.childNodes()) {
-                if (children instanceof TextNode) {
-                    text.append(((TextNode) children).text());
-                } else if (children instanceof Element
-                        && ((Element) children).tagName().equalsIgnoreCase("br")) {
-                    text.append(NEW_LINE);
-                }
-            }
+            // Recursively extract text from all child nodes
+            extractText(paragraph, text);
 
             if (ignoreEmptyFrames && text.length() < 1) {
                 continue;


### PR DESCRIPTION

<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [✔ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
##### Problem
Downloaded SRT subtitles for some videos are empty, containing only timestamps and sequence numbers, as reported in #10030. This affects videos with styled subtitles, such as:
- https://youtu.be/mtb-qa8xvFU(https://www.youtube.com/watch?v=mtb-qa8xvFU) (【HimeHina MV】Roki (Cover))
- https://www.youtube.com/watch?v=zbQRY8KSVbU (Ousama Ranking Opening 2 Full『Hadaka no Yuusha』by Vaundy)
- https://youtu.be/-eDYT_20YhM(https://www.youtube.com/watch?v=-eDYT_20YhM) (炜WARD ROMANCE ft. Feng Yi)
- https://www.youtube.com/watch?v=L-BgxLtMxh0 (Styled subtitles for YouTube demonstration)
- https://www.youtube.com/watch?v=Cc2nkx77U24 (Test: Rainbow Captions In Youtube)
- https://www.youtube.com/watch?v=lUDPjyfmJrs (【original anime MV】III【hololive/宝鐘マリン＆こぼ・かなえる】)

##### Problem Analysis
The issue occurs because some YouTube subtitles use TTML format with nested tags, which the original parser did not handle correctly.

###### Problematic TTML Example
```xml
<p begin="00:00:01.000" end="00:00:03.000">
  <span style="s4">Hello World!</span>
</p>

The text ("Hello World!") is nested inside a <span> tag for styling (e.g., colors or karaoke effects). The original parser only processed direct child nodes, missing the text inside <span>, resulting in empty SRT output.
Non-Problematic TTML Example
<p begin="00:00:01.000" end="00:00:03.000" style="s2">
  Hello World!
</p>

This TTML has text directly under <p>, which was parsed correctly by the original code.
Root Cause
The original SrtFromTtmlWriter.build method used a non-recursive loop, failing to extract text from nested tags like <span> in styled subtitles (e.g., rainbow or karaoke captions).
Solution

Added a new extractText method to recursively extract text from all nodes, including TextNode and <br> tags, handling nested tags like <span>.
Replaced the non-recursive loop in SrtFromTtmlWriter.build with a call to extractText().

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before:
- After:

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #10030

#### Relies on the following changes
<!-- Delete this if it doesn't apply to your PR. -->
- None

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).
- Fixed Cases (previously empty SRT files)

https://youtu.be/mtb-qa8xvFU (【HimeHina MV】Roki (Cover))
https://www.youtube.com/watch?v=zbQRY8KSVbU (Ousama Ranking Opening 2 Full『Hadaka no Yuusha』by Vaundy)
https://youtu.be/-eDYT_20YhM (炜WARD ROMANCE ft. Feng Yi)
https://www.youtube.com/watch?v=L-BgxLtMxh0 (Styled subtitles for YouTube demonstration)
https://www.youtube.com/watch?v=Cc2nkx77U24 (Test: Rainbow Captions In Youtube)
https://www.youtube.com/watch?v=lUDPjyfmJrs (【original anime MV】III【hololive/宝鐘マリン＆こぼ・かなえる】)

- Regression Testing

Tested a video with simple subtitles that downloaded correctly in the original NewPipe: https://www.youtube.com/watch?v=BVAIImxcv4g .
Confirmed SRT output remains correct after the fix, ensuring no regression.

All tested videos now produce correct SRT files with subtitle text.


#### Due diligence
- [ ✔] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
