### PR TITLE
Disable video and text tracks in background player and prefer DASH manifests over HLS ones for livestreams

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -2096,7 +2096,7 @@ public final class Player implements PlaybackListener, Listener {
     }
 
     public void useVideoAndSubtitles(final boolean videoAndSubtitlesEnabled) {
-        if (playQueue == null || audioPlayerSelected()) {
+        if (playQueue == null) {
             return;
         }
 
@@ -2108,17 +2108,11 @@ public final class Player implements PlaybackListener, Listener {
             final SourceType sourceType = videoResolver.getStreamSourceType()
                     .orElse(SourceType.VIDEO_WITH_AUDIO_OR_AUDIO_ONLY);
 
+            setRecovery();
+
             if (playQueueManagerReloadingNeeded(sourceType, info, getVideoRendererIndex())) {
                 reloadPlayQueueManager();
             }
-
-            setRecovery();
-
-            // Disable or enable video and subtitles renderers depending of the
-            // videoAndSubtitlesEnabled value
-            trackSelector.setParameters(trackSelector.buildUponParameters()
-                    .setTrackTypeDisabled(C.TRACK_TYPE_TEXT, !videoAndSubtitlesEnabled)
-                    .setTrackTypeDisabled(C.TRACK_TYPE_VIDEO, !videoAndSubtitlesEnabled));
         }, () -> {
             /*
             The current metadata may be null sometimes (for e.g. when using an unstable connection
@@ -2127,9 +2121,15 @@ public final class Player implements PlaybackListener, Listener {
             Reload the play queue manager in this case, which is the behavior when we don't know the
             index of the video renderer or playQueueManagerReloadingNeeded returns true
             */
-            reloadPlayQueueManager();
             setRecovery();
+            reloadPlayQueueManager();
         });
+
+        // Disable or enable video and subtitles renderers depending of the
+        // videoAndSubtitlesEnabled value
+        trackSelector.setParameters(trackSelector.buildUponParameters()
+                .setTrackTypeDisabled(C.TRACK_TYPE_TEXT, !videoAndSubtitlesEnabled)
+                .setTrackTypeDisabled(C.TRACK_TYPE_VIDEO, !videoAndSubtitlesEnabled));
     }
 
     /**

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -2095,12 +2095,12 @@ public final class Player implements PlaybackListener, Listener {
         }
     }
 
-    public void useVideoSource(final boolean videoEnabled) {
+    public void useVideoAndSubtitles(final boolean videoAndSubtitlesEnabled) {
         if (playQueue == null || audioPlayerSelected()) {
             return;
         }
 
-        isAudioOnly = !videoEnabled;
+        isAudioOnly = !videoAndSubtitlesEnabled;
 
         getCurrentStreamInfo().ifPresentOrElse(info -> {
             // In case we don't know the source type, fall back to either video-with-audio, or
@@ -2114,10 +2114,11 @@ public final class Player implements PlaybackListener, Listener {
 
             setRecovery();
 
-            // Disable or enable video and subtitles renderers depending of the videoEnabled value
+            // Disable or enable video and subtitles renderers depending of the
+            // videoAndSubtitlesEnabled value
             trackSelector.setParameters(trackSelector.buildUponParameters()
-                    .setTrackTypeDisabled(C.TRACK_TYPE_TEXT, !videoEnabled)
-                    .setTrackTypeDisabled(C.TRACK_TYPE_VIDEO, !videoEnabled));
+                    .setTrackTypeDisabled(C.TRACK_TYPE_TEXT, !videoAndSubtitlesEnabled)
+                    .setTrackTypeDisabled(C.TRACK_TYPE_VIDEO, !videoAndSubtitlesEnabled));
         }, () -> {
             /*
             The current metadata may be null sometimes (for e.g. when using an unstable connection

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -112,6 +112,7 @@ import org.schabi.newpipe.player.playqueue.PlayQueueItem;
 import org.schabi.newpipe.player.resolver.AudioPlaybackResolver;
 import org.schabi.newpipe.player.resolver.VideoPlaybackResolver;
 import org.schabi.newpipe.player.resolver.VideoPlaybackResolver.SourceType;
+import org.schabi.newpipe.player.ui.BackgroundPlayerUi;
 import org.schabi.newpipe.player.ui.MainPlayerUi;
 import org.schabi.newpipe.player.ui.PlayerUi;
 import org.schabi.newpipe.player.ui.PlayerUiList;
@@ -265,6 +266,7 @@ public final class Player implements PlaybackListener, Listener {
     @NonNull
     private final HistoryRecordManager recordManager;
 
+    private boolean screenOn = true;
 
     /*//////////////////////////////////////////////////////////////////////////
     // Constructor
@@ -500,14 +502,17 @@ public final class Player implements PlaybackListener, Listener {
         switch (playerType) {
             case MAIN:
                 UIs.destroyAll(PopupPlayerUi.class);
+                UIs.destroyAll(BackgroundPlayerUi.class);
                 UIs.addAndPrepare(new MainPlayerUi(this, binding));
                 break;
             case POPUP:
                 UIs.destroyAll(MainPlayerUi.class);
+                UIs.destroyAll(BackgroundPlayerUi.class);
                 UIs.addAndPrepare(new PopupPlayerUi(this, binding));
                 break;
             case AUDIO:
                 UIs.destroyAll(VideoPlayerUi.class);
+                UIs.addAndPrepare(new BackgroundPlayerUi(this));
                 break;
         }
     }
@@ -751,6 +756,12 @@ public final class Player implements PlaybackListener, Listener {
                 break;
             case ACTION_SHUFFLE:
                 toggleShuffleModeEnabled();
+                break;
+            case Intent.ACTION_SCREEN_OFF:
+                screenOn = false;
+                break;
+            case Intent.ACTION_SCREEN_ON:
+                screenOn = true;
                 break;
             case Intent.ACTION_CONFIGURATION_CHANGED:
                 if (DEBUG) {
@@ -2362,4 +2373,11 @@ public final class Player implements PlaybackListener, Listener {
                 .orElse(RENDERER_UNAVAILABLE);
     }
     //endregion
+
+    /**
+     * @return whether the device screen is turned on.
+     */
+    public boolean isScreenOn() {
+        return screenOn;
+    }
 }

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerDataSource.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerDataSource.java
@@ -129,6 +129,13 @@ public class PlayerDataSource {
                 getDefaultDashChunkSourceFactory(cachelessDataSourceFactory),
                 cachelessDataSourceFactory);
     }
+
+    public DashMediaSource.Factory getLiveYoutubeDashMediaSourceFactory() {
+        return new DashMediaSource.Factory(
+                getDefaultDashChunkSourceFactory(cachelessDataSourceFactory),
+                cachelessDataSourceFactory)
+                .setManifestParser(new YoutubeDashLiveManifestParser());
+    }
     //endregion
 
 

--- a/app/src/main/java/org/schabi/newpipe/player/helper/YoutubeDashLiveManifestParser.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/YoutubeDashLiveManifestParser.java
@@ -1,0 +1,68 @@
+package org.schabi.newpipe.player.helper;
+
+import android.net.Uri;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.google.android.exoplayer2.source.dash.manifest.DashManifest;
+import com.google.android.exoplayer2.source.dash.manifest.DashManifestParser;
+import com.google.android.exoplayer2.source.dash.manifest.Period;
+import com.google.android.exoplayer2.source.dash.manifest.ProgramInformation;
+import com.google.android.exoplayer2.source.dash.manifest.ServiceDescriptionElement;
+import com.google.android.exoplayer2.source.dash.manifest.UtcTimingElement;
+
+import java.util.List;
+
+/**
+ * A {@link DashManifestParser} fixing YouTube DASH manifests to allow starting playback from the
+ * newest period available instead of the earliest one in some cases.
+ *
+ * <p>
+ * It changes the {@code availabilityStartTime} passed to a custom value doing the workaround.
+ * A better approach to fix the issue should be investigated and used in the future.
+ * </p>
+ */
+public class YoutubeDashLiveManifestParser extends DashManifestParser {
+
+    // Result of Util.parseXsDateTime("1970-01-01T00:00:00Z")
+    private static final long AVAILABILITY_START_TIME_TO_USE = 0;
+
+    // There is no computation made with the availabilityStartTime value in the
+    // parseMediaPresentationDescription method itself, so we can just override methods called in
+    // this method using the workaround value
+    // Overriding parsePeriod does not seem to be needed
+
+    @SuppressWarnings("checkstyle:ParameterNumber")
+    @NonNull
+    @Override
+    protected DashManifest buildMediaPresentationDescription(
+            final long availabilityStartTime,
+            final long durationMs,
+            final long minBufferTimeMs,
+            final boolean dynamic,
+            final long minUpdateTimeMs,
+            final long timeShiftBufferDepthMs,
+            final long suggestedPresentationDelayMs,
+            final long publishTimeMs,
+            @Nullable final ProgramInformation programInformation,
+            @Nullable final UtcTimingElement utcTiming,
+            @Nullable final ServiceDescriptionElement serviceDescription,
+            @Nullable final Uri location,
+            @NonNull final List<Period> periods) {
+        return super.buildMediaPresentationDescription(
+                AVAILABILITY_START_TIME_TO_USE,
+                durationMs,
+                minBufferTimeMs,
+                dynamic,
+                minUpdateTimeMs,
+                timeShiftBufferDepthMs,
+                suggestedPresentationDelayMs,
+                publishTimeMs,
+                programInformation,
+                utcTiming,
+                serviceDescription,
+                location,
+                periods);
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/PlaybackResolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/PlaybackResolver.java
@@ -201,11 +201,12 @@ public interface PlaybackResolver extends Resolver<StreamInfo, MediaSource> {
 
         try {
             final StreamInfoTag tag = StreamInfoTag.of(info);
-            if (!info.getHlsUrl().isEmpty()) {
-                return buildLiveMediaSource(dataSource, info.getHlsUrl(), C.CONTENT_TYPE_HLS, tag);
-            } else if (!info.getDashMpdUrl().isEmpty()) {
+            if (!info.getDashMpdUrl().isEmpty()) {
                 return buildLiveMediaSource(
                         dataSource, info.getDashMpdUrl(), C.CONTENT_TYPE_DASH, tag);
+            }
+            if (!info.getHlsUrl().isEmpty()) {
+                return buildLiveMediaSource(dataSource, info.getHlsUrl(), C.CONTENT_TYPE_HLS, tag);
             }
         } catch (final Exception e) {
             Log.w(TAG, "Error when generating live media source, falling back to standard sources",
@@ -225,7 +226,11 @@ public interface PlaybackResolver extends Resolver<StreamInfo, MediaSource> {
                 factory = dataSource.getLiveSsMediaSourceFactory();
                 break;
             case C.CONTENT_TYPE_DASH:
-                factory = dataSource.getLiveDashMediaSourceFactory();
+                if (metadata.getServiceId() == ServiceList.YouTube.getServiceId()) {
+                    factory = dataSource.getLiveYoutubeDashMediaSourceFactory();
+                } else {
+                    factory = dataSource.getLiveDashMediaSourceFactory();
+                }
                 break;
             case C.CONTENT_TYPE_HLS:
                 factory = dataSource.getLiveHlsMediaSourceFactory();

--- a/app/src/main/java/org/schabi/newpipe/player/ui/BackgroundPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/BackgroundPlayerUi.java
@@ -1,0 +1,29 @@
+package org.schabi.newpipe.player.ui;
+
+import androidx.annotation.NonNull;
+
+import org.schabi.newpipe.player.Player;
+
+/**
+ * This is not a real UI for the background player, it used to disable fetching video and text
+ * tracks with it.
+ *
+ * <p>
+ * This allows reducing data usage for manifest sources with demuxed audio and video,
+ * such as livestreams.
+ * </p>
+ */
+public class BackgroundPlayerUi extends PlayerUi {
+
+    public BackgroundPlayerUi(@NonNull final Player player) {
+        super(player);
+    }
+
+    @Override
+    public void initPlayback() {
+        super.initPlayback();
+
+        // Make sure to disable video and subtitles track types
+        player.useVideoAndSubtitles(false);
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
@@ -216,6 +216,10 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
         playQueueAdapter = new PlayQueueAdapter(context,
                 Objects.requireNonNull(player.getPlayQueue()));
         segmentAdapter = new StreamSegmentAdapter(getStreamSegmentListener());
+
+        // Make sure video and text tracks are enabled if the user is in the app, in the case user
+        // switched from background player to main player
+        player.useVideoAndSubtitles(fragmentIsVisible);
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
@@ -329,7 +329,7 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
         } else if (VideoDetailFragment.ACTION_VIDEO_FRAGMENT_RESUMED.equals(intent.getAction())) {
             // Restore video source when user returns to the fragment
             fragmentIsVisible = true;
-            player.useVideoSource(true);
+            player.useVideoAndSubtitles(true);
 
             // When a user returns from background, the system UI will always be shown even if
             // controls are invisible: hide it in that case
@@ -368,7 +368,7 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
         if (player.isPlaying() || player.isLoading()) {
             switch (getMinimizeOnExitAction(context)) {
                 case MINIMIZE_ON_EXIT_MODE_BACKGROUND:
-                    player.useVideoSource(false);
+                    player.useVideoAndSubtitles(false);
                     break;
                 case MINIMIZE_ON_EXIT_MODE_POPUP:
                     getParentActivity().ifPresent(activity -> {

--- a/app/src/main/java/org/schabi/newpipe/player/ui/PopupPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/PopupPlayerUi.java
@@ -152,6 +152,14 @@ public final class PopupPlayerUi extends VideoPlayerUi {
     }
 
     @Override
+    public void initPlayback() {
+        super.initPlayback();
+        // Make sure video and text tracks are enabled if the screen is turned on (which should
+        // always be the case), in the case user switched from background player to popup player
+        player.useVideoAndSubtitles(player.isScreenOn());
+    }
+
+    @Override
     protected void setupElementsVisibility() {
         binding.fullScreenButton.setVisibility(View.VISIBLE);
         binding.screenRotationButton.setVisibility(View.GONE);

--- a/app/src/main/java/org/schabi/newpipe/player/ui/PopupPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/PopupPlayerUi.java
@@ -216,10 +216,10 @@ public final class PopupPlayerUi extends VideoPlayerUi {
         } else if (player.isPlaying() || player.isLoading()) {
             if (Intent.ACTION_SCREEN_OFF.equals(intent.getAction())) {
                 // Use only audio source when screen turns off while popup player is playing
-                player.useVideoSource(false);
+                player.useVideoAndSubtitles(false);
             } else if (Intent.ACTION_SCREEN_ON.equals(intent.getAction())) {
                 // Restore video source when screen turns on and user was watching video in popup
-                player.useVideoSource(true);
+                player.useVideoAndSubtitles(true);
             }
         }
     }


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)

#### Description of the changes in your PR

This PR prioritizes DASH manifests over HLS ones for live sources, and works around bugged YouTube DASH manifests in order to use them. This workaround has been only tested for running livestreams and not running premieres (i.e. in the time the video can be played as a livestream during its release), so please test if you can get a running premiere. YouTube DASH manifests allow to rewind up to 4 hours to the current live time.

It also disables fetching video and text tracks in background player, in order to reduce data usage for livestreams on services on which we can get DASH manifests. When there are only HLS ones, nothing will change, at least for video track fetching, due to an ExoPlayer bug which still fetches video (and subtitles?), even if it has been disabled with the track selector (a low priority has been given by the ExoPlayer team to this bug for several years without any change).

#### Fixes the following issue(s)
Fixes #12024 and fixes #11756 (for non-HLS sources).
Related issue: #10158

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).