### PR TITLE
player.xml: Rename fullscreen buttons & separate enter/exit

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.kt
@@ -991,7 +991,7 @@ class VideoDetailFragment :
             // restored (i.e. bottomSheetState) to STATE_EXPANDED.
             updateBottomSheetState(BottomSheetBehavior.STATE_EXPANDED)
             // toggle landscape in order to open directly in fullscreen
-            onScreenRotationButtonClicked()
+            onFullscreenToggleButtonClicked()
         }
 
         if (PreferenceManager.getDefaultSharedPreferences(activity)
@@ -1726,7 +1726,7 @@ class VideoDetailFragment :
         tryAddVideoPlayerView()
     }
 
-    override fun onScreenRotationButtonClicked() {
+    override fun onFullscreenToggleButtonClicked() {
         // In tablet user experience will be better if screen will not be rotated
         // from landscape to portrait every time.
         // Just turn on fullscreen mode in landscape orientation

--- a/app/src/main/java/org/schabi/newpipe/player/event/PlayerServiceEventListener.java
+++ b/app/src/main/java/org/schabi/newpipe/player/event/PlayerServiceEventListener.java
@@ -10,7 +10,7 @@ public interface PlayerServiceEventListener extends PlayerEventListener {
 
     void onFullscreenStateChanged(boolean fullscreen);
 
-    void onScreenRotationButtonClicked();
+    void onFullscreenToggleButtonClicked();
 
     void onMoreOptionsLongClicked();
 

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHolder.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHolder.kt
@@ -243,8 +243,8 @@ object PlayerHolder {
             listener?.onFullscreenStateChanged(fullscreen)
         }
 
-        override fun onScreenRotationButtonClicked() {
-            listener?.onScreenRotationButtonClicked()
+        override fun onFullscreenToggleButtonClicked() {
+            listener?.onFullscreenToggleButtonClicked()
         }
 
         override fun onMoreOptionsLongClicked() {

--- a/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
@@ -154,7 +154,7 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
     protected void initListeners() {
         super.initListeners();
 
-        binding.screenRotationButton.setOnClickListener(makeOnClickListener(() -> {
+        binding.fullscreenToggleButton.setOnClickListener(makeOnClickListener(() -> {
             // Only if it's not a vertical video or vertical video but in landscape with locked
             // orientation a screen orientation can be changed automatically
             if (!isVerticalVideo || (isLandscape() && globalScreenOrientationLocked(context))) {
@@ -270,7 +270,7 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
 
         closeItemsList();
         showHideKodiButton();
-        binding.fullScreenButton.setVisibility(View.GONE);
+        binding.fullscreenToggleButtonSecondaryMenu.setVisibility(View.GONE);
         setupScreenRotationButton();
         binding.resizeTextView.setVisibility(View.VISIBLE);
         binding.getRoot().findViewById(R.id.metadataView).setVisibility(View.VISIBLE);
@@ -885,10 +885,10 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
     //region Video size, orientation, fullscreen
 
     private void setupScreenRotationButton() {
-        binding.screenRotationButton.setVisibility(globalScreenOrientationLocked(context)
+        binding.fullscreenToggleButton.setVisibility(globalScreenOrientationLocked(context)
                 || isVerticalVideo || DeviceUtils.isTablet(context)
                 ? View.VISIBLE : View.GONE);
-        binding.screenRotationButton.setImageDrawable(AppCompatResources.getDrawable(context,
+        binding.fullscreenToggleButton.setImageDrawable(AppCompatResources.getDrawable(context,
                 isFullscreen ? R.drawable.ic_fullscreen_exit
                         : R.drawable.ic_fullscreen));
     }

--- a/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
@@ -122,7 +122,7 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
                 && DeviceUtils.isTablet(player.getService())
                 && PlayerHelper.globalScreenOrientationLocked(player.getService())) {
             player.getFragmentListener().ifPresent(
-                    PlayerServiceEventListener::onScreenRotationButtonClicked);
+                    PlayerServiceEventListener::onFullscreenToggleButtonClicked);
         }
     }
 
@@ -159,7 +159,7 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
             // orientation a screen orientation can be changed automatically
             if (!isVerticalVideo || (isLandscape() && globalScreenOrientationLocked(context))) {
                 player.getFragmentListener()
-                        .ifPresent(PlayerServiceEventListener::onScreenRotationButtonClicked);
+                        .ifPresent(PlayerServiceEventListener::onFullscreenToggleButtonClicked);
             } else {
                 toggleFullscreen();
             }
@@ -233,7 +233,7 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
 
         // Exit from fullscreen when user closes the player via notification
         if (isFullscreen) {
-            toggleFullscreen();
+            exitFullscreen();
         }
 
         removeViewFromParent();
@@ -414,7 +414,7 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
     public void onCompleted() {
         super.onCompleted();
         if (isFullscreen) {
-            toggleFullscreen();
+            exitFullscreen();
         }
     }
     //endregion
@@ -905,7 +905,7 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
                 && !DeviceUtils.isTablet(context)) {
             // set correct orientation
             player.getFragmentListener().ifPresent(
-                    PlayerServiceEventListener::onScreenRotationButtonClicked);
+                    PlayerServiceEventListener::onFullscreenToggleButtonClicked);
         }
 
         setupScreenRotationButton();
@@ -915,28 +915,54 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
         if (DEBUG) {
             Log.d(TAG, "toggleFullscreen() called");
         }
+
+        if (isFullscreen) {
+            exitFullscreen();
+        } else {
+            enterFullscreen();
+        }
+
+    }
+
+    public void enterFullscreen() {
+        if (DEBUG) {
+            Log.d(TAG, "enterFullscreen() called");
+        }
         final PlayerServiceEventListener fragmentListener = player.getFragmentListener()
                 .orElse(null);
         if (fragmentListener == null || player.exoPlayerIsNull()) {
             return;
         }
+        isFullscreen = true;
+        // Android needs tens milliseconds to send new insets but a user is able to see
+        // how controls changes it's position from `0` to `nav bar height` padding.
+        // So just hide the controls to hide this visual inconsistency
+        hideControls(0, 0);
+        fragmentListener.onFullscreenStateChanged(true);
+        setupFullscreenButtons(true);
+    }
 
-        isFullscreen = !isFullscreen;
-        if (isFullscreen) {
-            // Android needs tens milliseconds to send new insets but a user is able to see
-            // how controls changes it's position from `0` to `nav bar height` padding.
-            // So just hide the controls to hide this visual inconsistency
-            hideControls(0, 0);
-        } else {
-            // Apply window insets because Android will not do it when orientation changes
-            // from landscape to portrait (open vertical video to reproduce)
-            binding.playbackControlRoot.setPadding(0, 0, 0, 0);
+    public void exitFullscreen() {
+        if (DEBUG) {
+            Log.d(TAG, "exitFullscreen() called");
         }
-        fragmentListener.onFullscreenStateChanged(isFullscreen);
+        final PlayerServiceEventListener fragmentListener = player.getFragmentListener()
+                .orElse(null);
+        if (fragmentListener == null || player.exoPlayerIsNull()) {
+            return;
+        }
+        isFullscreen = false;
+        // Apply window insets because Android will not do it when orientation changes
+        // from landscape to portrait (open vertical video to reproduce)
+        binding.playbackControlRoot.setPadding(0, 0, 0, 0);
+        fragmentListener.onFullscreenStateChanged(false);
+        setupFullscreenButtons(false);
+    }
 
-        binding.titleTextView.setVisibility(isFullscreen ? View.VISIBLE : View.GONE);
-        binding.channelTextView.setVisibility(isFullscreen ? View.VISIBLE : View.GONE);
-        binding.playerCloseButton.setVisibility(isFullscreen ? View.GONE : View.VISIBLE);
+    private void setupFullscreenButtons(final boolean fullscreen) {
+        binding.titleTextView.setVisibility(fullscreen ? View.VISIBLE : View.GONE);
+        binding.channelTextView.setVisibility(fullscreen ? View.VISIBLE : View.GONE);
+        binding.playerCloseButton.setVisibility(fullscreen ? View.GONE : View.VISIBLE);
         setupScreenRotationButton();
     }
 
@@ -951,7 +977,7 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
         if (videoInLandscapeButNotInFullscreen
                 && notPaused
                 && !DeviceUtils.isTablet(context)) {
-            toggleFullscreen();
+            enterFullscreen();
         }
     }
     //endregion

--- a/app/src/main/java/org/schabi/newpipe/player/ui/PopupPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/PopupPlayerUi.java
@@ -153,8 +153,8 @@ public final class PopupPlayerUi extends VideoPlayerUi {
 
     @Override
     protected void setupElementsVisibility() {
-        binding.fullScreenButton.setVisibility(View.VISIBLE);
-        binding.screenRotationButton.setVisibility(View.GONE);
+        binding.fullscreenToggleButtonSecondaryMenu.setVisibility(View.VISIBLE);
+        binding.fullscreenToggleButton.setVisibility(View.GONE);
         binding.resizeTextView.setVisibility(View.GONE);
         binding.getRoot().findViewById(R.id.metadataView).setVisibility(View.GONE);
         binding.queueButton.setVisibility(View.GONE);

--- a/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
@@ -234,7 +234,7 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
             ShareUtils.copyToClipboard(context, player.getVideoUrlAtCurrentTime());
             return true;
         });
-        binding.fullScreenButton.setOnClickListener(makeOnClickListener(() -> {
+        binding.fullscreenToggleButtonSecondaryMenu.setOnClickListener(makeOnClickListener(() -> {
             player.setRecovery();
             NavigationHelper.playOnMainPlayer(context,
                     Objects.requireNonNull(player.getPlayQueue()), true);
@@ -301,8 +301,8 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
         binding.moreOptionsButton.setOnLongClickListener(null);
         binding.share.setOnClickListener(null);
         binding.share.setOnLongClickListener(null);
-        binding.fullScreenButton.setOnClickListener(null);
-        binding.screenRotationButton.setOnClickListener(null);
+        binding.fullscreenToggleButtonSecondaryMenu.setOnClickListener(null);
+        binding.fullscreenToggleButton.setOnClickListener(null);
         binding.playWithKodi.setOnClickListener(null);
         binding.openInBrowser.setOnClickListener(null);
         binding.playerCloseButton.setOnClickListener(null);
@@ -1455,7 +1455,7 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
                         if (player.getCurrentState() == STATE_PLAYING && !isSomePopupMenuVisible) {
                             if (v == binding.playPauseButton
                                     // Hide controls in fullscreen immediately
-                                    || (v == binding.screenRotationButton && isFullscreen())) {
+                                    || (v == binding.fullscreenToggleButton && isFullscreen())) {
                                 hideControls(0, 0);
                             } else {
                                 hideControls(DEFAULT_CONTROLS_DURATION, DEFAULT_CONTROLS_HIDE_TIME);

--- a/app/src/main/res/layout/player.xml
+++ b/app/src/main/res/layout/player.xml
@@ -363,7 +363,7 @@
                         tools:ignore="RtlHardcoded" />
 
                     <androidx.appcompat.widget.AppCompatImageButton
-                        android:id="@+id/fullScreenButton"
+                        android:id="@+id/fullscreenToggleButtonSecondaryMenu"
                         android:layout_width="40dp"
                         android:layout_height="40dp"
                         android:background="?attr/selectableItemBackgroundBorderless"
@@ -457,7 +457,7 @@
                     android:layout_gravity="center"
                     android:layout_marginTop="2dp"
                     android:layout_weight="1"
-                    android:nextFocusDown="@id/screenRotationButton"
+                    android:nextFocusDown="@id/fullscreenToggleButton"
                     tools:progress="25"
                     tools:secondaryProgress="50" />
 
@@ -486,7 +486,7 @@
                     tools:ignore="HardcodedText,RtlHardcoded,RtlSymmetry" />
 
                 <androidx.appcompat.widget.AppCompatImageButton
-                    android:id="@+id/screenRotationButton"
+                    android:id="@+id/fullscreenToggleButton"
                     android:layout_width="40dp"
                     android:layout_height="40dp"
                     android:layout_marginStart="4dp"


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR

Their names must have come from a very old version of the app, they both toggle the fullscreen mode and rotate the screen depending on circumstances.

So `fullscreenButton` -> `fullscreenToggleButtonSecondaryMenu` because it is only visible in the secondary video menu on some configurations and `screenRotationButton` -> `fullscreenToggleButton` because it is the main fullscreen button next to the video progress bar.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).