### PR TITLE
Fix initial numbering of frames in TTML to SRT converter

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/streams/SrtFromTtmlWriter.java
+++ b/app/src/main/java/org/schabi/newpipe/streams/SrtFromTtmlWriter.java
@@ -24,7 +24,11 @@ public class SrtFromTtmlWriter {
     private final boolean ignoreEmptyFrames;
     private final Charset charset = StandardCharsets.UTF_8;
 
-    private int frameIndex = 0;
+    // According to the SubRip (.srt) specification, subtitle
+    // numbering must start from 1.
+    // Some players accept 0 or even negative indices,
+    // but to ensure compliance we start at 1.
+    private int frameIndex = 1;
 
     public SrtFromTtmlWriter(final SharpStream out, final boolean ignoreEmptyFrames) {
         this.out = out;
@@ -39,7 +43,8 @@ public class SrtFromTtmlWriter {
 
     private void writeFrame(final String begin, final String end, final StringBuilder text)
             throws IOException {
-        writeString(String.valueOf(frameIndex++));
+        writeString(String.valueOf(frameIndex));
+        frameIndex += 1;
         writeString(NEW_LINE);
         writeString(begin);
         writeString(" --> ");


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR

This PR fixes the numbering in .srt subtitle files generated from YouTube streams.
Previously, numbering started at 0, which is accepted by most players but does not comply with the SubRip specification. Now numbering starts at 1, ensuring strict compliance.

* **Spec reference**: [Wikipedia: SubRip](https://en.wikipedia.org/wiki/SubRip), and it says:  

> Subtitles are numbered sequentially, starting at 1.

* **Observed behavior**: numbering started at 0.
* **Tested players**:
  * mpv 0.37.0 ✅ works with 0
  * VLC 3.0.20 ✅ works with 0, even `-1`
  * MPlayer 1.5 ✅ works with 0
  * Totem 43.0 ✅ works with 0
* Even though playback worked fine, some stricter tools may reject such files.

Why not `i++` or `++i`?

Every time I see `i++` or `++i`, I need to pause and think:

* Is it “use first, then increment” (`i++`) or “increment first, then use” (`++i`)?
* Even after I've written the code, two or three days later, when I look at the modified code, I still find myself thinking about the same issue.

To avoid this confusion, I prefer splitting the current line `writeString(String.valueOf(frameIndex++));` into two lines: one to use current value of `frameIndex`, and the other to increment it.

#### Before/After Screenshots/Screen Record
- Before: Here is an example of YouTube video link (https://www.youtube.com/watch?v=Q8aPwoe_iMc), let's look at the beginning of a *.SRT file generated by NewPipe:

> a51x:/storage/emulated/0/Newpipe $ cat Bear\ Family\ Searches\ for\ Water\ _\ Wild\ Mexico\ _\ BBC\ Earth-en.srt               
> 0
> 00:00:00,640 --> 00:00:07,160
> This mother has three young cubs just 8
> 
> 1
> 00:00:03,840 --> 00:00:07,160
> months old.
> 
> 2
> 00:00:08,520 --> 00:00:22,899
> [Music]
> 
> 3
> 00:00:24,560 --> 00:00:29,039
> It's autumn and the family needs to
> 
> 4
> 00:00:27,119 --> 00:00:32,039
> flatten up before the winter

- After: Now numbering start at 1
<img width="600px" alt="start 1  2025-09-29 18-32-00" src="https://github.com/user-attachments/assets/2b16ea5a-4f54-45d7-aed4-0fda8bbc4506" />

#### Fixes the following issue(s)
Fixes #12670

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).