### PR TITLE
Fix Long Audio/Dubs text label puses UI Controls on Player Off Screen in Portrait mode. 

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
@@ -289,6 +289,7 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
         binding.topControls.setClickable(true);
         binding.topControls.setFocusable(true);
 
+        binding.metadataView.setVisibility(isFullscreen ? View.VISIBLE : View.GONE);
         binding.titleTextView.setVisibility(isFullscreen ? View.VISIBLE : View.GONE);
         binding.channelTextView.setVisibility(isFullscreen ? View.VISIBLE : View.GONE);
     }
@@ -934,6 +935,7 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
         }
         fragmentListener.onFullscreenStateChanged(isFullscreen);
 
+        binding.metadataView.setVisibility(isFullscreen ? View.VISIBLE : View.GONE);
         binding.titleTextView.setVisibility(isFullscreen ? View.VISIBLE : View.GONE);
         binding.channelTextView.setVisibility(isFullscreen ? View.VISIBLE : View.GONE);
         binding.playerCloseButton.setVisibility(isFullscreen ? View.GONE : View.VISIBLE);

--- a/app/src/main/res/layout/player.xml
+++ b/app/src/main/res/layout/player.xml
@@ -160,12 +160,15 @@
 
                     <org.schabi.newpipe.views.NewPipeTextView
                         android:id="@+id/audioTrackTextView"
-                        android:layout_width="wrap_content"
+                        android:layout_width="0dp"
                         android:layout_height="35dp"
                         android:layout_marginEnd="8dp"
+                        android:layout_weight="1"
                         android:background="?attr/selectableItemBackground"
                         android:gravity="center"
                         android:minWidth="0dp"
+                        android:singleLine="true"
+                        android:ellipsize="end"
                         android:padding="@dimen/player_main_buttons_padding"
                         android:textColor="@android:color/white"
                         android:textStyle="bold"


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [X] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
Constrain audioTrackTextView width (maxWidth="110dp") and single line + ellipsize="end" + scrollHorizontally="true", so it never wraps or steals too much space.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before: With long English/Spanish labels, the More options button could be pushed off-screen
<img width="627" height="387" alt="3b1144a61388ff6c1bd9799c790d77b4" src="https://github.com/user-attachments/assets/c837d973-5451-4399-abce-942b1c5c2aa0" />
<img width="624" height="402" alt="bcc59b3d652669fb7cdc6a1da62c89ef" src="https://github.com/user-attachments/assets/b8b53152-4866-4670-ae7b-523c68242de1" />

- After: Right-side controls remain visible; the audio track label stays on a single line with ellipsis
<img width="696" height="573" alt="image" src="https://github.com/user-attachments/assets/889614ba-85bb-4f66-82a9-be65dad72276" />
<img width="675" height="567" alt="image" src="https://github.com/user-attachments/assets/f221afd0-58ea-4a47-bc1b-446ac16b4097" />


#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #12499 

#### Relies on the following changes
<!-- Delete this if it doesn't apply to your PR. -->
- `android:singleLine="true"`
    `android:ellipsize="end"`
    `android:scrollHorizontally="true"`
   `android:maxWidth="110dp"`

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [X] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
