### PR TITLE
Fix #1795: Persist shuffle and repeat mode across sessions

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -181,6 +181,8 @@ public final class Player implements PlaybackListener, Listener {
 
     public static final int RENDERER_UNAVAILABLE = -1;
     private static final String PICASSO_PLAYER_THUMBNAIL_TAG = "PICASSO_PLAYER_THUMBNAIL_TAG";
+    private static final String PREF_KEY_SHUFFLE_ENABLED = "player_shuffle_enabled";
+    private static final String PREF_KEY_REPEAT_MODE = "player_repeat_mode";
 
     /*//////////////////////////////////////////////////////////////////////////
     // Playback
@@ -616,6 +618,22 @@ public final class Player implements PlaybackListener, Listener {
         playQueue = queue;
         playQueue.init();
         reloadPlayQueueManager();
+
+        final int persistedRepeat = loadRepeatFromPrefs();
+        final boolean persistedShuffle = loadShuffleFromPrefs();
+
+        simpleExoPlayer.setRepeatMode(persistedRepeat);
+        simpleExoPlayer.setShuffleModeEnabled(persistedShuffle);
+
+        if (persistedShuffle && !playQueue.isShuffled()) {
+            playQueue.shuffle();
+        } else if (!persistedShuffle && playQueue.isShuffled()) {
+            playQueue.unshuffle();
+        }
+
+        UIs.call(ui -> ui.onRepeatModeChanged(persistedRepeat));
+        UIs.call(ui -> ui.onShuffleModeEnabledChanged(persistedShuffle));
+        notifyPlaybackUpdateToListeners();
 
         UIs.call(PlayerUi::initPlayback);
 
@@ -1263,6 +1281,23 @@ public final class Player implements PlaybackListener, Listener {
     //////////////////////////////////////////////////////////////////////////*/
     //region Repeat and shuffle
 
+    private void saveShuffleToPrefs(final boolean enabled) {
+        prefs.edit().putBoolean(PREF_KEY_SHUFFLE_ENABLED, enabled).apply();
+    }
+
+    private void saveRepeatToPrefs(@RepeatMode final int repeatMode) {
+        prefs.edit().putInt(PREF_KEY_REPEAT_MODE, repeatMode).apply();
+    }
+
+    private boolean loadShuffleFromPrefs() {
+        return prefs.getBoolean(PREF_KEY_SHUFFLE_ENABLED, false);
+    }
+
+    @RepeatMode
+    private int loadRepeatFromPrefs() {
+        return prefs.getInt(PREF_KEY_REPEAT_MODE, REPEAT_MODE_OFF);
+    }
+
     @RepeatMode
     public int getRepeatMode() {
         return exoPlayerIsNull() ? REPEAT_MODE_OFF : simpleExoPlayer.getRepeatMode();
@@ -1293,6 +1328,9 @@ public final class Player implements PlaybackListener, Listener {
             Log.d(TAG, "ExoPlayer - onRepeatModeChanged() called with: "
                     + "repeatMode = [" + repeatMode + "]");
         }
+
+        saveRepeatToPrefs(repeatMode);
+
         UIs.call(playerUi -> playerUi.onRepeatModeChanged(repeatMode));
         notifyPlaybackUpdateToListeners();
     }
@@ -1303,6 +1341,8 @@ public final class Player implements PlaybackListener, Listener {
             Log.d(TAG, "ExoPlayer - onShuffleModeEnabledChanged() called with: "
                     + "mode = [" + shuffleModeEnabled + "]");
         }
+
+        saveShuffleToPrefs(shuffleModeEnabled);
 
         if (playQueue != null) {
             if (shuffleModeEnabled) {


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [X] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
This PR adds persistence for the player’s **shuffle** and **repeat** modes, allowing users’ playback preferences to be saved and restored across app restarts.

**Details of the implementation:**
- Added helper methods for saving and loading playback modes using `SharedPreferences`:
  ```java
  private void saveShuffleToPrefs(final boolean enabled)
  private void saveRepeatToPrefs(@RepeatMode final int repeatMode)
  private boolean loadShuffleFromPrefs()
  private int loadRepeatFromPrefs()
  ```
- Restored persisted states during player initialization:
  ```java
  final int persistedRepeat = loadRepeatFromPrefs();
  final boolean persistedShuffle = loadShuffleFromPrefs();

  simpleExoPlayer.setRepeatMode(persistedRepeat);
  simpleExoPlayer.setShuffleModeEnabled(persistedShuffle);
  ```
- Synced UI and playback queue behavior with the restored states:
  ```java
  if (persistedShuffle && !playQueue.isShuffled()) {
      playQueue.shuffle();
  } else if (!persistedShuffle && playQueue.isShuffled()) {
      playQueue.unshuffle();
  }

  UIs.call(ui -> ui.onRepeatModeChanged(persistedRepeat));
  UIs.call(ui -> ui.onShuffleModeEnabledChanged(persistedShuffle));
  notifyPlaybackUpdateToListeners();
  ```
- Ensures the shuffle/repeat state remains consistent across app sessions and UI updates.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before:
https://github.com/user-attachments/assets/11dd1c36-e4c9-42ba-b6a9-8381f0debfbc
- After:
https://github.com/user-attachments/assets/ebb9486c-b916-4ab2-89c7-aa6b869d676d

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #1795

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The change was tested locally using the debug build from Android Studio.  
Shuffle and repeat modes were verified to persist correctly after restarting the app.  
No additional APK testing was performed via the CI artifacts.

#### Due diligence
- [X] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
