### PR TITLE
[Build] Fix Extractor dependency substitution after settings.gradle conversion

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,8 +25,8 @@ include (":app")
 // We assume, that NewPipe and NewPipe Extractor have the same parent directory.
 // If this is not the case, please change the path in includeBuild().
 
-//includeBuild('../NewPipeExtractor') {
+//includeBuild("../NewPipeExtractor") {
 //    dependencySubstitution {
-//        substitute module('com.github.TeamNewPipe:NewPipeExtractor') using project(':extractor')
+//        substitute(module("com.github.TeamNewPipe:NewPipeExtractor")).using(project(":extractor"))
 //    }
 //}


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [x] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Convert commented out dependency substitution for NewPipe Extractor in settings.gradle.kts
Introduced by #12706

#### Fixes the following issue(s)
A Gradle sync issue complaining about wrong syntax

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
