### PR TITLE
Fix local NewPipeExtractor build inclusion in settings.gradle.kts

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,8 +25,9 @@ include (":app")
 // We assume, that NewPipe and NewPipe Extractor have the same parent directory.
 // If this is not the case, please change the path in includeBuild().
 
-//includeBuild('../NewPipeExtractor') {
+//includeBuild("../NewPipeExtractor") {
 //    dependencySubstitution {
-//        substitute module('com.github.TeamNewPipe:NewPipeExtractor') using project(':extractor')
+//        substitute(module("com.github.TeamNewPipe:NewPipeExtractor"))
+//            .using(project(":extractor"))
 //    }
 //}


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [✓] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->

##### description
This PR updates the **commented example block** in `settings.gradle.kts` to fix the build error while including the `NewPipeExtractor` for local.

* Replaced single quotes (`'...'`) with double quotes (`"..."`)
* Updated the `substitute` syntax to the Kotlin DSL form, here is the new code:
  ```kotlin
  substitute(module("com.github.TeamNewPipe:NewPipeExtractor"))
      .using(project(":extractor"))
  ```
##### reason

This was caused by https://github.com/TeamNewPipe/NewPipe/pull/12706

- 1) Old file `settings.gradle` is coded with Groovy DSL syntax,
- 2) new file `settings.gradle.kts` is coded with Kotlin DSL
Here is the current comment block in the file:
```
//includeBuild('../NewPipeExtractor') {
//    dependencySubstitution {
//        substitute module('com.github.TeamNewPipe:NewPipeExtractor') using project(':extractor')
//    }
//}
```
However, since this file uses Kotlin DSL (.kts), the single quotes ('...') and the Groovy-style chained syntax are not valid in Kotlin.

I have written the details in the comment below.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before: Fail when trying to include a local NewPipeExtractor build in `settings.gradle.kts`.
- After: Succeed.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #12763


#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

* No functional or runtime changes.
* This only updates a commented-out example, so there’s **zero impact** on builds or dependencies.
* Tested successfully on the latest `dev` branch — project builds cleanly with the updated snippet.

#### Due diligence
- [ ✓] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
