### PR TITLE
[PlayQueue] Fix incorrect UI states of PlayQueue items

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueue.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueue.java
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 import io.reactivex.rxjava3.core.BackpressureStrategy;
 import io.reactivex.rxjava3.core.Flowable;
-import io.reactivex.rxjava3.subjects.BehaviorSubject;
+import io.reactivex.rxjava3.subjects.PublishSubject;
 
 /**
  * PlayQueue is responsible for keeping track of a list of streams and the index of
@@ -46,7 +46,7 @@ public abstract class PlayQueue implements Serializable {
     private List<PlayQueueItem> backup;
     private List<PlayQueueItem> streams;
 
-    private transient BehaviorSubject<PlayQueueEvent> eventBroadcast;
+    private transient PublishSubject<PlayQueueEvent> eventBroadcast;
     private transient Flowable<PlayQueueEvent> broadcastReceiver;
     private transient boolean disposed = false;
 
@@ -71,7 +71,7 @@ public abstract class PlayQueue implements Serializable {
      * </p>
      */
     public void init() {
-        eventBroadcast = BehaviorSubject.create();
+        eventBroadcast = PublishSubject.create();
 
         broadcastReceiver = eventBroadcast.toFlowable(BackpressureStrategy.BUFFER)
                 .observeOn(AndroidSchedulers.mainThread())


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)

#### Description of the changes in your PR
[`onNext()`](https://github.com/TeamNewPipe/NewPipe/blob/86fb618f616e51e42673a5358a93ca6aabf8736f/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueueAdapter.java#L85) is called after [`onSubscribe()`](https://github.com/TeamNewPipe/NewPipe/blob/86fb618f616e51e42673a5358a93ca6aabf8736f/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueueAdapter.java#L77)  when creating a `PlayQueueAdapter`. For that reason the last broadcasted event is applied to the UI state although it is already reflected in the PlayQueue that was used to initialize the adapter.
 
This is the intended behavior of the previously used event broadcaster of the type [`BehaviorSubject<>`](https://reactivex.io/RxJava/3.x/javadoc/io/reactivex/rxjava3/subjects/BehaviorSubject.html). The broadcaster's type was changed to [`PublishSubject<>`](https://reactivex.io/RxJava/3.x/javadoc/io/reactivex/rxjava3/subjects/PublishSubject.html) which does not emit the last event after `onSubscribe()`.

#### Before/After Screenshots/Screen Record
For screen records of the bugged behaviour, see #9669

[Screen_recording_20251220_181830.webm](https://github.com/user-attachments/assets/5277c177-2cce-4868-a3ee-e5aebcbd6816)

#### Review request
Help me identify why a `BehaviorSubject` was used in the first place. Is there a place where its functionality is needed?

#### Fixes the following issue(s)
Fixes https://github.com/TeamNewPipe/NewPipe/issues/9669

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
