### PR TITLE
[Player] Use original audio language by default

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
@@ -806,7 +806,7 @@ public final class ListHelper {
         final Locale preferredLanguage = Localization.getPreferredLocale(context);
         final boolean preferOriginalAudio =
                 preferences.getBoolean(context.getString(R.string.prefer_original_audio_key),
-                        false);
+                        true);
         final boolean preferDescriptiveAudio =
                 preferences.getBoolean(context.getString(R.string.prefer_descriptive_audio_key),
                         false);

--- a/app/src/main/res/xml/video_audio_settings.xml
+++ b/app/src/main/res/xml/video_audio_settings.xml
@@ -62,7 +62,7 @@
         app:useSimpleSummaryProvider="true" />
 
     <SwitchPreferenceCompat
-        android:defaultValue="false"
+        android:defaultValue="true"
         android:key="@string/prefer_original_audio_key"
         android:summary="@string/prefer_original_audio_summary"
         android:title="@string/prefer_original_audio_title"


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)

#### Description of the changes in your PR
The palyer uses the original audio by default and not dubbed or auto-translated audio tracks.

#### ToDo

- [ ] wait for confirmation that this fixes the issue

#### Before/After Screenshots/Screen Record


#### Fixes the following issue(s)
- Fixes #12333


#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
