### PR TITLE
Fix retrieving incomplete data for SubscriptionEntity

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/database/subscription/SubscriptionEntity.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/subscription/SubscriptionEntity.kt
@@ -55,8 +55,8 @@ data class SubscriptionEntity(
     fun toChannelInfoItem(): ChannelInfoItem {
         return ChannelInfoItem(this.serviceId, this.url, this.name).apply {
             thumbnails = ImageStrategy.dbUrlToImageList(this@SubscriptionEntity.avatarUrl)
-            subscriberCount = this.subscriberCount
-            description = this.description
+            subscriberCount = this@SubscriptionEntity.subscriberCount ?: -1
+            description = this@SubscriptionEntity.description
         }
     }
 


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)

#### Description of the changes in your PR
This fixes a visual bug in which the channels reported the the subscriber count was unavailable although stored in the db.
this was used with the wrong scope.

Regression was introduced in #12746 

#### Fixes the following issue(s)
- Fixes #12953 

#### APK testing

The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
- [x] The proposed changes follow the [AI policy](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md#ai-policy).
- [x] I tested the changes using an emulator or a physical device.
