### PR TITLE
Add workflow to backport PRs to another branch

### DIFF
--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -15,7 +15,7 @@ jobs:
     # everybody to trigger backports and create branches in our repository.
     if: >
         github.event.issue.pull_request &&
-        startsWith(github.event.comment.body, '/backport') &&
+        startsWith(github.event.comment.body, '/backport ') &&
         (
         github.event.comment.author_association == 'OWNER' ||
         github.event.comment.author_association == 'COLLABORATOR' ||
@@ -28,23 +28,19 @@ jobs:
         run: |
           set -euo pipefail
           body="${{ github.event.comment.body }}"
-          labels_json='${{ toJSON(github.event.pull_request.labels || github.event.issue.labels) }}'
-          target=$(echo "$body" | sed -n 's/.*\/backport[[:space:]]\+\([^[:space:]]\+\).*/\1/p')
-
-          if [ -z "$target" ]; then
-            echo "No backport target found in comment." >&2
+          
+          line=${body%%$'\n'*} # Get the first line
+          if [[ $line =~ ^/backport[[:space:]]+([^[:space:]]+) ]]; then
+            echo "BACKPORT_TARGET=${BASH_REMATCH[1]}" >> "$GITHUB_ENV"
+          else
+            echo "Usage: /backport <target-branch>" >&2
             exit 1
           fi
-          echo "BACKPORT_TARGET=$target" >> $GITHUB_ENV
 
-          labels=$(echo "$labels_json" | jq -r 'if . == null then "" else map(.name) | join(",") end')
-          if [ -z "$labels" ]; then
-            echo "BACKPORT_PR_LABELS=backport" >> $GITHUB_ENV
-          else
-            echo "BACKPORT_PR_LABELS=backport,$labels" >> $GITHUB_ENV
-          fi
       - name: Create backport pull request
         uses: korthout/backport-action@v4
         with:
-          add_labels: ${{ env.BACKPORT_PR_LABELS }}
+          add_labels: 'backport'
+          copy_labels_pattern: '.*'
+          label_pattern: ''
           target_branches: ${{ env.BACKPORT_TARGET }}


### PR DESCRIPTION
#### What is it?
- [x] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This adds a workflow to open backport PRs to another branch.
The workflow can be triggered by creating a comment on a closed PR: `/backport <TARGET_BRANCH>`
The backport can only be triggered by people with write access to the repository.

See this PR on my fork for a PR that was backported, has an invlaid and failed backport: https://github.com/TobiGr/NewPipe/pull/35

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
- [x] The proposed changes follow the [AI policy](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md#ai-policy).
- [x] I tested the changes using an emulator or a physical device.
