### PR TITLE
Fix download resume corruption when server returns HTTP 200

### DIFF
--- a/app/src/main/java/us/shandian/giga/get/DownloadRunnableFallback.java
+++ b/app/src/main/java/us/shandian/giga/get/DownloadRunnableFallback.java
@@ -85,6 +85,7 @@ public class DownloadRunnableFallback extends Thread {
             if (mMission.unknownLength || mConn.getResponseCode() == 200) {
                 // restart amount of bytes downloaded
                 mMission.done = mMission.offsets[mMission.current] - mMission.offsets[0];
+                start = 0; // reset position to avoid writing at wrong offset
             }
 
             mF = mMission.storage.getStream();


### PR DESCRIPTION
## What it does

When resuming a download and the server returns HTTP 200 (instead of 206), `mMission.done` is reset but `start` is not. This causes the file seek at line 91 to use a stale offset, writing data at the wrong position.

Related issue #12874

## The fix

Reset `start = 0` when HTTP 200 is received, so the write position correctly restarts from the beginning of the current resource.

## Testing

Verified fix by downloading a large file, interrupting, and resuming. Seeking works correctly after the fix.

## APK tested?

Yes - built and tested on physical device.