### PR TITLE
ci: fix shell injection in backport workflow

### DIFF
--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -25,9 +25,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Get backport metadata
         # the target branch is the first argument after `/backport`
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
           set -euo pipefail
-          body="${{ github.event.comment.body }}"
+          body="$COMMENT_BODY"
           
           line=${body%%$'\n'*} # Get the first line
           if [[ $line =~ ^/backport[[:space:]]+([^[:space:]]+) ]]; then


### PR DESCRIPTION
Found a potential shell injection point in `backport-pr.yml`. The workflow was directly interpolating `github.event.comment.body` into a run script, which is a bit risky if a comment contains backticks or other shell-sensitive characters.

I've refactored the "Get backport metadata" step to pass the comment body through an environment variable. This ensures the shell treats the input as a literal string and follows the official GitHub Actions security recommendations.