### PR TITLE
Fix audio ducking issue by using ExoPlayer's automatic audio focus management

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -1328,7 +1328,34 @@ public final class Player implements PlaybackListener, Listener {
 
     public void toggleMute() {
         final boolean wasMuted = isMuted();
+        final boolean wasPlaying = simpleExoPlayer.isPlaying();
+        Log.d(TAG, "toggleMute: wasMuted=" + wasMuted + ", wasPlaying=" + wasPlaying);
         simpleExoPlayer.setVolume(wasMuted ? 1 : 0);
+        if (wasMuted) {
+            Log.d(TAG, "toggleMute: enabling audio focus, willPlay=" + wasPlaying);
+            simpleExoPlayer.setAudioAttributes(
+                new com.google.android.exoplayer2.audio.AudioAttributes.Builder()
+                    .setUsage(C.USAGE_MEDIA)
+                    .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
+                    .build(),
+                true  // handleAudioFocus = true - ExoPlayer handles focus automatically
+            );
+            if (wasPlaying) {
+                Log.d(TAG, "toggleMute: calling play(), isPlaying=" + simpleExoPlayer.isPlaying());
+                simpleExoPlayer.play();
+                Log.d(TAG, "toggleMute: after play(), isPlaying=" + simpleExoPlayer.isPlaying());
+            }
+        } else {
+            Log.d(TAG, "toggleMute: disabling audio focus, abandoning focus");
+            simpleExoPlayer.setAudioAttributes(
+                new com.google.android.exoplayer2.audio.AudioAttributes.Builder()
+                    .setUsage(C.USAGE_MEDIA)
+                    .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
+                    .build(),
+                false  // handleAudioFocus = false
+            );
+            audioReactor.abandonAudioFocus();
+        }
         UIs.call(playerUi -> playerUi.onMuteUnmuteChanged(!wasMuted));
         notifyPlaybackUpdateToListeners();
     }

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -634,14 +634,13 @@ public final class Player implements PlaybackListener, Listener {
         simpleExoPlayer.setWakeMode(C.WAKE_MODE_NETWORK);
         simpleExoPlayer.setHandleAudioBecomingNoisy(true);
 
-        // Enable automatic audio focus management - let Android handle ducking automatically
+        // Enable ExoPlayer automatic audio focus management
         simpleExoPlayer.setAudioAttributes(
             new com.google.android.exoplayer2.audio.AudioAttributes.Builder()
                 .setUsage(C.USAGE_MEDIA)
                 .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
                 .build(),
-            true  // handleAudioFocus = true for automatic management
-        );
+            true);
 
         audioReactor = new AudioReactor(context, simpleExoPlayer);
 
@@ -1328,34 +1327,19 @@ public final class Player implements PlaybackListener, Listener {
 
     public void toggleMute() {
         final boolean wasMuted = isMuted();
-        final boolean wasPlaying = simpleExoPlayer.isPlaying();
-        Log.d(TAG, "toggleMute: wasMuted=" + wasMuted + ", wasPlaying=" + wasPlaying);
         simpleExoPlayer.setVolume(wasMuted ? 1 : 0);
-        if (wasMuted) {
-            Log.d(TAG, "toggleMute: enabling audio focus, willPlay=" + wasPlaying);
-            simpleExoPlayer.setAudioAttributes(
+
+        // Update audio focus
+        // When wasMuted is true, we want to play sound, so ExoPlayer has to handle audio focus in
+        // this case; when wasMuted is false, we don't want to play sound, so no audio focus should
+        // be done
+        simpleExoPlayer.setAudioAttributes(
                 new com.google.android.exoplayer2.audio.AudioAttributes.Builder()
-                    .setUsage(C.USAGE_MEDIA)
-                    .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
-                    .build(),
-                true  // handleAudioFocus = true - ExoPlayer handles focus automatically
-            );
-            if (wasPlaying) {
-                Log.d(TAG, "toggleMute: calling play(), isPlaying=" + simpleExoPlayer.isPlaying());
-                simpleExoPlayer.play();
-                Log.d(TAG, "toggleMute: after play(), isPlaying=" + simpleExoPlayer.isPlaying());
-            }
-        } else {
-            Log.d(TAG, "toggleMute: disabling audio focus, abandoning focus");
-            simpleExoPlayer.setAudioAttributes(
-                new com.google.android.exoplayer2.audio.AudioAttributes.Builder()
-                    .setUsage(C.USAGE_MEDIA)
-                    .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
-                    .build(),
-                false  // handleAudioFocus = false
-            );
-            audioReactor.abandonAudioFocus();
-        }
+                        .setUsage(C.USAGE_MEDIA)
+                        .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
+                        .build(),
+                wasMuted);
+
         UIs.call(playerUi -> playerUi.onMuteUnmuteChanged(!wasMuted));
         notifyPlaybackUpdateToListeners();
     }

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -634,6 +634,15 @@ public final class Player implements PlaybackListener, Listener {
         simpleExoPlayer.setWakeMode(C.WAKE_MODE_NETWORK);
         simpleExoPlayer.setHandleAudioBecomingNoisy(true);
 
+        // Enable automatic audio focus management - let Android handle ducking automatically
+        simpleExoPlayer.setAudioAttributes(
+            new com.google.android.exoplayer2.audio.AudioAttributes.Builder()
+                .setUsage(C.USAGE_MEDIA)
+                .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
+                .build(),
+            true  // handleAudioFocus = true for automatic management
+        );
+
         audioReactor = new AudioReactor(context, simpleExoPlayer);
 
         registerBroadcastReceiver();
@@ -1173,10 +1182,6 @@ public final class Player implements PlaybackListener, Listener {
         }
 
         UIs.call(PlayerUi::onPrepared);
-
-        if (playWhenReady && !isMuted()) {
-            audioReactor.requestAudioFocus();
-        }
     }
 
     private void onBlocked() {
@@ -1324,11 +1329,6 @@ public final class Player implements PlaybackListener, Listener {
     public void toggleMute() {
         final boolean wasMuted = isMuted();
         simpleExoPlayer.setVolume(wasMuted ? 1 : 0);
-        if (wasMuted) {
-            audioReactor.requestAudioFocus();
-        } else {
-            audioReactor.abandonAudioFocus();
-        }
         UIs.call(playerUi -> playerUi.onMuteUnmuteChanged(!wasMuted));
         notifyPlaybackUpdateToListeners();
     }
@@ -1740,10 +1740,6 @@ public final class Player implements PlaybackListener, Listener {
             return;
         }
 
-        if (!isMuted()) {
-            audioReactor.requestAudioFocus();
-        }
-
         if (currentState == STATE_COMPLETED) {
             if (playQueue.getIndex() == 0) {
                 seekToDefault();
@@ -1771,7 +1767,6 @@ public final class Player implements PlaybackListener, Listener {
             return;
         }
 
-        audioReactor.abandonAudioFocus();
         simpleExoPlayer.pause();
         saveStreamProgressState();
     }

--- a/app/src/main/java/org/schabi/newpipe/player/helper/AudioReactor.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/AudioReactor.java
@@ -1,37 +1,26 @@
 package org.schabi.newpipe.player.helper;
 
-import android.animation.Animator;
-import android.animation.AnimatorListenerAdapter;
-import android.animation.ValueAnimator;
 import android.content.Context;
 import android.content.Intent;
 import android.media.AudioManager;
 import android.media.audiofx.AudioEffect;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
-import androidx.media.AudioFocusRequestCompat;
 import androidx.media.AudioManagerCompat;
 
 import com.google.android.exoplayer2.ExoPlayer;
 import com.google.android.exoplayer2.analytics.AnalyticsListener;
 
-public class AudioReactor implements AudioManager.OnAudioFocusChangeListener, AnalyticsListener {
+public class AudioReactor implements AnalyticsListener {
 
     private static final String TAG = "AudioFocusReactor";
 
-    private static final int DUCK_DURATION = 1500;
-    private static final float DUCK_AUDIO_TO = .2f;
-
-    private static final int FOCUS_GAIN_TYPE = AudioManagerCompat.AUDIOFOCUS_GAIN;
     private static final int STREAM_TYPE = AudioManager.STREAM_MUSIC;
 
     private final ExoPlayer player;
     private final Context context;
     private final AudioManager audioManager;
-
-    private final AudioFocusRequestCompat request;
 
     public AudioReactor(@NonNull final Context context,
                         @NonNull final ExoPlayer player) {
@@ -39,16 +28,9 @@ public class AudioReactor implements AudioManager.OnAudioFocusChangeListener, An
         this.context = context;
         this.audioManager = ContextCompat.getSystemService(context, AudioManager.class);
         player.addAnalyticsListener(this);
-
-        request = new AudioFocusRequestCompat.Builder(FOCUS_GAIN_TYPE)
-                //.setAcceptsDelayedFocusGain(true)
-                .setWillPauseWhenDucked(true)
-                .setOnAudioFocusChangeListener(this)
-                .build();
     }
 
     public void dispose() {
-        abandonAudioFocus();
         player.removeAnalyticsListener(this);
         notifyAudioSessionUpdate(false, player.getAudioSessionId());
     }
@@ -56,14 +38,6 @@ public class AudioReactor implements AudioManager.OnAudioFocusChangeListener, An
     /*//////////////////////////////////////////////////////////////////////////
     // Audio Manager
     //////////////////////////////////////////////////////////////////////////*/
-
-    public void requestAudioFocus() {
-        AudioManagerCompat.requestAudioFocus(audioManager, request);
-    }
-
-    public void abandonAudioFocus() {
-        AudioManagerCompat.abandonAudioFocusRequest(audioManager, request);
-    }
 
     public int getVolume() {
         return audioManager.getStreamVolume(STREAM_TYPE);
@@ -75,73 +49,6 @@ public class AudioReactor implements AudioManager.OnAudioFocusChangeListener, An
 
     public int getMaxVolume() {
         return AudioManagerCompat.getStreamMaxVolume(audioManager, STREAM_TYPE);
-    }
-
-    /*//////////////////////////////////////////////////////////////////////////
-    // AudioFocus
-    //////////////////////////////////////////////////////////////////////////*/
-
-    @Override
-    public void onAudioFocusChange(final int focusChange) {
-        Log.d(TAG, "onAudioFocusChange() called with: focusChange = [" + focusChange + "]");
-        switch (focusChange) {
-            case AudioManager.AUDIOFOCUS_GAIN:
-                onAudioFocusGain();
-                break;
-            case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK:
-                onAudioFocusLossCanDuck();
-                break;
-            case AudioManager.AUDIOFOCUS_LOSS:
-            case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
-                onAudioFocusLoss();
-                break;
-        }
-    }
-
-    private void onAudioFocusGain() {
-        Log.d(TAG, "onAudioFocusGain() called");
-        player.setVolume(DUCK_AUDIO_TO);
-        animateAudio(DUCK_AUDIO_TO, 1.0f);
-
-        if (PlayerHelper.isResumeAfterAudioFocusGain(context)) {
-            player.play();
-        }
-    }
-
-    private void onAudioFocusLoss() {
-        Log.d(TAG, "onAudioFocusLoss() called");
-        player.pause();
-    }
-
-    private void onAudioFocusLossCanDuck() {
-        Log.d(TAG, "onAudioFocusLossCanDuck() called");
-        // Set the volume to 1/10 on ducking
-        player.setVolume(DUCK_AUDIO_TO);
-    }
-
-    private void animateAudio(final float from, final float to) {
-        final ValueAnimator valueAnimator = new ValueAnimator();
-        valueAnimator.setFloatValues(from, to);
-        valueAnimator.setDuration(AudioReactor.DUCK_DURATION);
-        valueAnimator.addListener(new AnimatorListenerAdapter() {
-            @Override
-            public void onAnimationStart(final Animator animation) {
-                player.setVolume(from);
-            }
-
-            @Override
-            public void onAnimationCancel(final Animator animation) {
-                player.setVolume(to);
-            }
-
-            @Override
-            public void onAnimationEnd(final Animator animation) {
-                player.setVolume(to);
-            }
-        });
-        valueAnimator.addUpdateListener(animation ->
-                player.setVolume(((float) animation.getAnimatedValue())));
-        valueAnimator.start();
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/app/src/main/java/org/schabi/newpipe/player/helper/AudioReactor.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/AudioReactor.java
@@ -4,11 +4,9 @@ import android.content.Context;
 import android.content.Intent;
 import android.media.AudioManager;
 import android.media.audiofx.AudioEffect;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
-import androidx.media.AudioFocusRequestCompat;
 import androidx.media.AudioManagerCompat;
 
 import com.google.android.exoplayer2.ExoPlayer;
@@ -16,15 +14,11 @@ import com.google.android.exoplayer2.analytics.AnalyticsListener;
 
 public class AudioReactor implements AnalyticsListener {
 
-    private static final String TAG = "AudioFocusReactor";
-
-    private static final int FOCUS_GAIN_TYPE = AudioManagerCompat.AUDIOFOCUS_GAIN;
     private static final int STREAM_TYPE = AudioManager.STREAM_MUSIC;
 
     private final ExoPlayer player;
     private final Context context;
     private final AudioManager audioManager;
-    private final AudioFocusRequestCompat request;
 
     public AudioReactor(@NonNull final Context context,
                         @NonNull final ExoPlayer player) {
@@ -32,32 +26,11 @@ public class AudioReactor implements AnalyticsListener {
         this.context = context;
         this.audioManager = ContextCompat.getSystemService(context, AudioManager.class);
         player.addAnalyticsListener(this);
-
-        request = new AudioFocusRequestCompat.Builder(FOCUS_GAIN_TYPE)
-                .setWillPauseWhenDucked(true)
-                .setOnAudioFocusChangeListener(focusChange -> {
-                })
-                .build();
     }
 
     public void dispose() {
-        abandonAudioFocus();
         player.removeAnalyticsListener(this);
         notifyAudioSessionUpdate(false, player.getAudioSessionId());
-    }
-
-    /*//////////////////////////////////////////////////////////////////////////
-    // Audio Focus
-    //////////////////////////////////////////////////////////////////////////*/
-
-    public void requestAudioFocus() {
-        Log.d(TAG, "requestAudioFocus() called");
-        AudioManagerCompat.requestAudioFocus(audioManager, request);
-    }
-
-    public void abandonAudioFocus() {
-        Log.d(TAG, "abandonAudioFocus() called");
-        AudioManagerCompat.abandonAudioFocusRequest(audioManager, request);
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/app/src/main/java/org/schabi/newpipe/player/helper/AudioReactor.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/AudioReactor.java
@@ -4,9 +4,11 @@ import android.content.Context;
 import android.content.Intent;
 import android.media.AudioManager;
 import android.media.audiofx.AudioEffect;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
+import androidx.media.AudioFocusRequestCompat;
 import androidx.media.AudioManagerCompat;
 
 import com.google.android.exoplayer2.ExoPlayer;
@@ -16,11 +18,13 @@ public class AudioReactor implements AnalyticsListener {
 
     private static final String TAG = "AudioFocusReactor";
 
+    private static final int FOCUS_GAIN_TYPE = AudioManagerCompat.AUDIOFOCUS_GAIN;
     private static final int STREAM_TYPE = AudioManager.STREAM_MUSIC;
 
     private final ExoPlayer player;
     private final Context context;
     private final AudioManager audioManager;
+    private final AudioFocusRequestCompat request;
 
     public AudioReactor(@NonNull final Context context,
                         @NonNull final ExoPlayer player) {
@@ -28,11 +32,32 @@ public class AudioReactor implements AnalyticsListener {
         this.context = context;
         this.audioManager = ContextCompat.getSystemService(context, AudioManager.class);
         player.addAnalyticsListener(this);
+
+        request = new AudioFocusRequestCompat.Builder(FOCUS_GAIN_TYPE)
+                .setWillPauseWhenDucked(true)
+                .setOnAudioFocusChangeListener(focusChange -> {
+                })
+                .build();
     }
 
     public void dispose() {
+        abandonAudioFocus();
         player.removeAnalyticsListener(this);
         notifyAudioSessionUpdate(false, player.getAudioSessionId());
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+    // Audio Focus
+    //////////////////////////////////////////////////////////////////////////*/
+
+    public void requestAudioFocus() {
+        Log.d(TAG, "requestAudioFocus() called");
+        AudioManagerCompat.requestAudioFocus(audioManager, request);
+    }
+
+    public void abandonAudioFocus() {
+        Log.d(TAG, "abandonAudioFocus() called");
+        AudioManagerCompat.abandonAudioFocusRequest(audioManager, request);
     }
 
     /*//////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)

#### Description of the changes in your PR
Fix audio ducking issue by using Android's automatic audio focus management

Previously, manual audio focus handling caused volume to not be restored after transient ducking on some devices.

This change removes manual AudioFocusRequest management and relies on ExoPlayer's built-in audio focus handling (handleAudioFocus=true), which properly manages automatic ducking as recommended in: https://developer.android.com/media/optimize/audio-focus#automatic-ducking

#### Fixes the following issue(s)
- Fixes #9710 

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
- [x] The proposed changes follow the [AI policy](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md#ai-policy).
- [x] I tested the changes using an emulator or a physical device.
    - I tested with my phone.