### PR TITLE
Fix: Issue where upon video completion in fullscreen landscape, the device does not revert back to portrait mode

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
@@ -87,6 +87,8 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
     private static final int DETAIL_TITLE_TEXT_SIZE_TV = 16; // sp
     private static final int DETAIL_TITLE_TEXT_SIZE_TABLET = 15; // sp
 
+    private boolean portraitBefore = false;
+    private boolean isOnScreenRotationButtonClicked = false;
     private boolean isFullscreen = false;
     private boolean isVerticalVideo = false;
     private boolean fragmentIsVisible = false;
@@ -138,6 +140,9 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
         // Android TV: without it focus will frame the whole player
         binding.playPauseButton.requestFocus();
 
+        // Tracks the orientation if it's portrait. See #13057
+        portraitBefore =  !isLandscape();
+
         // Note: This is for automatically playing (when "Resume playback" is off), see #6179
         if (player.getPlayWhenReady()) {
             player.play();
@@ -158,6 +163,7 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
         binding.screenRotationButton.setOnClickListener(makeOnClickListener(() -> {
             // Only if it's not a vertical video or vertical video but in landscape with locked
             // orientation a screen orientation can be changed automatically
+            isOnScreenRotationButtonClicked = true;
             if (!isVerticalVideo || (isLandscape() && globalScreenOrientationLocked(context))) {
                 player.getFragmentListener()
                         .ifPresent(PlayerServiceEventListener::onScreenRotationButtonClicked);
@@ -235,7 +241,6 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
     @Override
     public void destroy() {
         super.destroy();
-
         // Exit from fullscreen when user closes the player via notification
         if (isFullscreen) {
             toggleFullscreen();
@@ -920,6 +925,18 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
         }
 
         isFullscreen = !isFullscreen;
+
+        // If toggleFullscreen was called without the fullscreen button clicked,
+        // then it means the user changed the orientation of the device to landscape,
+        // and portraitBefore should be false.
+        // If the fullscreen button was clicked and it's no longer in fullscreen,
+        // then portraitBefore should be set depending on the orientation.
+        // See #13057 and below.
+        if ((!isOnScreenRotationButtonClicked || !isFullscreen)
+                && player.getCurrentState() != STATE_COMPLETED) {
+            portraitBefore = !isLandscape();
+        }
+
         if (isFullscreen) {
             // Android needs tens milliseconds to send new insets but a user is able to see
             // how controls changes it's position from `0` to `nav bar height` padding.
@@ -930,11 +947,27 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
             // from landscape to portrait (open vertical video to reproduce)
             binding.playbackControlRoot.setPadding(0, 0, 0, 0);
         }
+
+        // When the video ends, the orientation remains in landscape
+        // although it was in portrait when fullscreen was clicked.
+        // This corrects the orientation back to portrait. See #13057.
+        if (player.getCurrentState() == STATE_COMPLETED
+                && !DeviceUtils.isTablet(context)
+                && !DeviceUtils.isTv(context)
+                && portraitBefore
+                && !isVerticalVideo
+                && isLandscape()
+                && globalScreenOrientationLocked(context)) {
+            fragmentListener.onScreenRotationButtonClicked();
+        }
+
         fragmentListener.onFullscreenStateChanged(isFullscreen);
 
         binding.metadataView.setVisibility(isFullscreen ? View.VISIBLE : View.GONE);
         binding.playerCloseButton.setVisibility(isFullscreen ? View.GONE : View.VISIBLE);
         setupScreenRotationButton();
+
+        isOnScreenRotationButtonClicked = false;
     }
 
     public void checkLandscape() {


### PR DESCRIPTION

<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)


#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
Bug fix with the player in fullscreen landscape. When the video ends, the player now exits fullscreen mode with the correct orientation.


#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #13057 


#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
- [x] The proposed changes follow the [AI policy](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md#ai-policy).
- [x] I tested the changes using an emulator or a physical device.
