### PR TITLE
Fixed resuming streams at the last playback position

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -2223,7 +2223,6 @@ public final class Player implements PlaybackListener, Listener {
             final SourceType sourceType = videoResolver.getStreamSourceType()
                     .orElse(SourceType.VIDEO_WITH_AUDIO_OR_AUDIO_ONLY);
 
-            setRecovery(); // making sure to save playback position before reloadPlayQueueManager()
             if (hasTimeline || !hasPendingRecovery) {
                 // making sure to save playback position before reloadPlayQueueManager()
                 setRecovery();
@@ -2240,7 +2239,6 @@ public final class Player implements PlaybackListener, Listener {
             Reload the play queue manager in this case, which is the behavior when we don't know the
             index of the video renderer or playQueueManagerReloadingNeeded returns true
             */
-            setRecovery(); // making sure to save playback position before reloadPlayQueueManager()
             if (hasTimeline || !hasPendingRecovery) {
                 // making sure to save playback position before reloadPlayQueueManager()
                 setRecovery();


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing) ⚠️ **Your PR must target the [`refactor`](https://github.com/TeamNewPipe/NewPipe/tree/refactor) branch**
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->

Reason for the bug is that https://github.com/TeamNewPipe/NewPipe/commit/1d8ea0181fc6a447153b0f1ffe4f27006bd1109a adds a call to `useVideoAndSubtitles` in the `initPlayback` overrides in the UI classes. This causes the recovery position for the queue item to be overridden due to the following flow:

- `Player.handleIntent` is called
- The `if (intent.getBooleanExtra(RESUME_PLAYBACK, false)` branch is reached
- It gets the playback position of the current queue item from the database via `loadStreamState`
- `newQueue.setRecovery(newQueue.getIndex(), state.getProgressMillis());` sets the recovery position to the value from DB
- Then calls `initPlayback(newQueue, playWhenReady);`
- `initPlayback` then calls `UIs.call(PlayerUi::initPlayback);`, which in turn calls `initPlayback` on one of `BackgroundPlayerUi`, `PopupPlayerUi`, `MainPlayerUi`
- `initPlayback` override in these classes calls `Player.useVideoAndSubtitles`
- `useVideoAndSubtitles` does `setRecovery()`
- This `setRecovery()` however gets the recovery position from `simpleExoPlayer.getCurrentPosition()` (which is effectively zero since we just started to resume playback), and this overwrites the previous recovery position we just set `setRecovery` in `handleIntent`
- `onPlaybackSynchronize` gets called at some point and seeks to the recovery position (which we just set to 0)
- And thus, it seeks to 0 instead of seeking to the saved playback position


The if conditions I added are supposed to ensure `setRecovery` is only called when there is no pending recovery (it won't be overwriting a recovery position that's already been set), or when exoplayer is far along in it's setup so that there's stuff to play (timeline is not empty).

I considered doing a proper refactor of this, because I don't really think calling `useVideoAndSubtitles` from the UIs is the best way to achieve the goal of minimizing bandwidth when playing in the background as it breaks separation of concerns, but I decided it's not worth it and can be tackled in NewPlayer at a later date.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
Maybe later

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #13139 

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
- [x] The proposed changes follow the [AI policy](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md#ai-policy).
- [x] I tested the changes using an emulator or a physical device.
