### PR TITLE
Fix subtitle post-processing error losing original exception

### DIFF
--- a/app/src/main/java/us/shandian/giga/postprocessing/TtmlConverter.java
+++ b/app/src/main/java/us/shandian/giga/postprocessing/TtmlConverter.java
@@ -29,9 +29,12 @@ class TtmlConverter extends Postprocessing {
 
             try {
                 writer.build(sources[0]);
+            } catch (IOException err) {
+                Log.e(TAG, "subtitle conversion failed due to I/O error", err);
+                throw err;
             } catch (Exception err) {
-                Log.e(TAG, "subtitle parse failed", err);
-                return err instanceof IOException ? 1 : 8;
+                Log.e(TAG, "subtitle conversion failed", err);
+                throw new IOException("TTML to SRT conversion failed", err);
             }
 
             return OK_RESULT;


### PR DESCRIPTION
## What is this?

This PR fixes the error reporting in subtitle (TTML → SRT) post-processing, addressing **#13206**.

## The problem

When subtitle post-processing fails, users see a generic error:

```
RuntimeException: post-processing algorithm returned 8
```

This happens because `TtmlConverter.process()` catches all exceptions and returns opaque integer error codes (1 for IOException, 8 for anything else). `Postprocessing.run()` then wraps this code into a new `RuntimeException`, **discarding the original exception and its stack trace entirely**.

This makes it impossible to diagnose the actual root cause of subtitle download failures.

## The fix

Instead of catching exceptions and returning error codes, the exceptions are now propagated properly:

- **IOExceptions** are re-thrown directly
- **Other exceptions** are wrapped in an `IOException` with the original exception preserved as the cause

This allows `DownloadMission.doPostprocessing()` to catch and report the actual error with its full stack trace, which will appear in user crash reports.

## Why this approach

The `process()` method's return-code-based error handling was designed for cases where partial recovery is possible (like in muxers). For `TtmlConverter`, there is no partial recovery — a parse failure is fatal. Propagating the exception is more idiomatic and preserves diagnostic information that is critical for debugging issues like #13206.

## APK testing

This is a minimal, low-risk change to error handling only — no behavioral change when conversion succeeds.