### PR TITLE
Fix background play notification volume adjustment

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/helper/AudioReactor.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/AudioReactor.java
@@ -1,8 +1,5 @@
 package org.schabi.newpipe.player.helper;
 
-import android.animation.Animator;
-import android.animation.AnimatorListenerAdapter;
-import android.animation.ValueAnimator;
 import android.content.Context;
 import android.content.Intent;
 import android.media.AudioManager;
@@ -21,7 +18,6 @@ public class AudioReactor implements AudioManager.OnAudioFocusChangeListener, An
 
     private static final String TAG = "AudioFocusReactor";
 
-    private static final int DUCK_DURATION = 1500;
     private static final float DUCK_AUDIO_TO = .2f;
 
     private static final int FOCUS_GAIN_TYPE = AudioManagerCompat.AUDIOFOCUS_GAIN;
@@ -42,7 +38,6 @@ public class AudioReactor implements AudioManager.OnAudioFocusChangeListener, An
 
         request = new AudioFocusRequestCompat.Builder(FOCUS_GAIN_TYPE)
                 //.setAcceptsDelayedFocusGain(true)
-                .setWillPauseWhenDucked(true)
                 .setOnAudioFocusChangeListener(this)
                 .build();
     }
@@ -100,8 +95,7 @@ public class AudioReactor implements AudioManager.OnAudioFocusChangeListener, An
 
     private void onAudioFocusGain() {
         Log.d(TAG, "onAudioFocusGain() called");
-        player.setVolume(DUCK_AUDIO_TO);
-        animateAudio(DUCK_AUDIO_TO, 1.0f);
+        player.setVolume(1.0f);
 
         if (PlayerHelper.isResumeAfterAudioFocusGain(context)) {
             player.play();
@@ -117,31 +111,6 @@ public class AudioReactor implements AudioManager.OnAudioFocusChangeListener, An
         Log.d(TAG, "onAudioFocusLossCanDuck() called");
         // Set the volume to 1/10 on ducking
         player.setVolume(DUCK_AUDIO_TO);
-    }
-
-    private void animateAudio(final float from, final float to) {
-        final ValueAnimator valueAnimator = new ValueAnimator();
-        valueAnimator.setFloatValues(from, to);
-        valueAnimator.setDuration(AudioReactor.DUCK_DURATION);
-        valueAnimator.addListener(new AnimatorListenerAdapter() {
-            @Override
-            public void onAnimationStart(final Animator animation) {
-                player.setVolume(from);
-            }
-
-            @Override
-            public void onAnimationCancel(final Animator animation) {
-                player.setVolume(to);
-            }
-
-            @Override
-            public void onAnimationEnd(final Animator animation) {
-                player.setVolume(to);
-            }
-        });
-        valueAnimator.addUpdateListener(animation ->
-                player.setVolume(((float) animation.getAnimatedValue())));
-        valueAnimator.start();
     }
 
     /*//////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)

#### Description of the changes in your PR
Removed the animated volume ducking behavior from audio focus handling. The -based approach was causing issues with volume adjustment in background playback notifications. Replaced the complex animation logic with direct volume control, which is more reliable and predictable.

Changes:
- Removed animation-related imports and the  method
- Removed  constant
- Removed  from the audio focus request builder
- Simplified  to directly set volume to 1.0f

This simplification eliminates the timing issues that were affecting notification volume adjustment during background playback.

#### Fixes the following issue(s)
- Fixes #13283

#### Due diligence
- [x] I read the contribution guidelines.
- [x] The proposed changes follow the AI policy.
- [x] I tested the changes using an emulator or a physical device.