### PR TITLE
Fix audio-video sync issue in DASH MP4 muxer

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/streams/Mp4FromDashWriter.java
+++ b/app/src/main/java/org/schabi/newpipe/streams/Mp4FromDashWriter.java
@@ -357,12 +357,16 @@ public class Mp4FromDashWriter {
                     }
 
                     if (!minPtsComputedArr[0]) {
-                        boolean allSet = true;
-                        for (int k = 0; k < readers.length; k++) {
-                            if (!firstPtsSet[k]) {
-                                allSet = false;
-                                break;
+                        final boolean allSet;
+                        {
+                            boolean temp = true;
+                            for (int k = 0; k < readers.length; k++) {
+                                if (!firstPtsSet[k]) {
+                                    temp = false;
+                                    break;
+                                }
                             }
+                            allSet = temp;
                         }
 
                         if (allSet) {

--- a/app/src/main/java/org/schabi/newpipe/streams/Mp4FromDashWriter.java
+++ b/app/src/main/java/org/schabi/newpipe/streams/Mp4FromDashWriter.java
@@ -162,12 +162,12 @@ public class Mp4FromDashWriter {
         final int[] defaultMediaTime = new int[readers.length];
         final int[] defaultSampleDuration = new int[readers.length];
         final int[] sampleCount = new int[readers.length];
-        long[] firstPts = new long[readers.length];
-        boolean[] firstPtsSet = new boolean[readers.length];
+        final long[] firstPts = new long[readers.length];
+        final boolean[] firstPtsSet = new boolean[readers.length];
+        final long[] basePts = new long[readers.length];
+        final boolean[] basePtsSet = new boolean[readers.length];
         boolean minPtsComputed = false;
         long minPts = 0;
-        long[] basePts = new long[readers.length];
-        boolean[] basePtsSet = new boolean[readers.length];
 
         final TablesInfo[] tablesInfo = new TablesInfo[tracks.length];
         for (int i = 0; i < tablesInfo.length; i++) {
@@ -350,7 +350,7 @@ public class Mp4FromDashWriter {
                     }
 
                     // Normalize composition timestamps to align audio and video timelines
-                    long pts = sample.info.sampleCompositionTimeOffset;
+                    final long pts = sample.info.sampleCompositionTimeOffset;
                     if (!firstPtsSet[i]) {
                         firstPts[i] = pts;
                         firstPtsSet[i] = true;
@@ -385,7 +385,7 @@ public class Mp4FromDashWriter {
                         basePtsSet[i] = true;
                     }
 
-                    int correctedOffset = (int) (pts - basePts[i]);
+                    final int correctedOffset = (int) (pts - basePts[i]);
                     if (tablesInfo[i].ctts > 0) {
                         if (correctedOffset == sampleExtra[i]) {
                             sampleCount[i]++;

--- a/app/src/main/java/org/schabi/newpipe/streams/Mp4FromDashWriter.java
+++ b/app/src/main/java/org/schabi/newpipe/streams/Mp4FromDashWriter.java
@@ -166,8 +166,8 @@ public class Mp4FromDashWriter {
         final boolean[] firstPtsSet = new boolean[readers.length];
         final long[] basePts = new long[readers.length];
         final boolean[] basePtsSet = new boolean[readers.length];
-        boolean minPtsComputed = false;
-        long minPts = 0;
+        final boolean[] minPtsComputedArr = new boolean[]{false};
+        final long[] minPtsArr = new long[]{0};
 
         final TablesInfo[] tablesInfo = new TablesInfo[tracks.length];
         for (int i = 0; i < tablesInfo.length; i++) {
@@ -356,7 +356,7 @@ public class Mp4FromDashWriter {
                         firstPtsSet[i] = true;
                     }
 
-                    if (!minPtsComputed) {
+                    if (!minPtsComputedArr[0]) {
                         boolean allSet = true;
                         for (int k = 0; k < readers.length; k++) {
                             if (!firstPtsSet[k]) {
@@ -366,19 +366,19 @@ public class Mp4FromDashWriter {
                         }
 
                         if (allSet) {
-                            minPts = firstPts[0];
+                            minPtsArr[0] = firstPts[0];
                             for (int k = 1; k < readers.length; k++) {
-                                minPts = Math.min(minPts, firstPts[k]);
+                                minPtsArr[0] = Math.min(minPtsArr[0], firstPts[k]);
                             }
-                            minPtsComputed = true;
+                            minPtsComputedArr[0] = true;
                         }
                     }
 
                     sampleIndex[i]++;
 
                     if (!basePtsSet[i]) {
-                        if (minPtsComputed) {
-                            basePts[i] = minPts;
+                        if (minPtsComputedArr[0]) {
+                            basePts[i] = minPtsArr[0];
                         } else {
                             basePts[i] = firstPts[i];
                         }

--- a/app/src/main/java/org/schabi/newpipe/streams/Mp4FromDashWriter.java
+++ b/app/src/main/java/org/schabi/newpipe/streams/Mp4FromDashWriter.java
@@ -162,6 +162,12 @@ public class Mp4FromDashWriter {
         final int[] defaultMediaTime = new int[readers.length];
         final int[] defaultSampleDuration = new int[readers.length];
         final int[] sampleCount = new int[readers.length];
+        long[] firstPts = new long[readers.length];
+        boolean[] firstPtsSet = new boolean[readers.length];
+        boolean minPtsComputed = false;
+        long minPts = 0;
+        long[] basePts = new long[readers.length];
+        boolean[] basePtsSet = new boolean[readers.length];
 
         final TablesInfo[] tablesInfo = new TablesInfo[tracks.length];
         for (int i = 0; i < tablesInfo.length; i++) {
@@ -317,7 +323,7 @@ public class Mp4FromDashWriter {
 
             for (int i = 0; i < readers.length; i++) {
                 if (sampleIndex[i] < 0) {
-                    continue; // track is done
+                    continue;
                 }
 
                 final long chunkOffset = writeOffset;
@@ -336,26 +342,62 @@ public class Mp4FromDashWriter {
                     if (sample == null) {
                         if (tablesInfo[i].ctts > 0 && sampleExtra[i] >= 0) {
                             writeEntryArray(tablesInfo[i].ctts, 1, sampleCount[i],
-                                    sampleExtra[i]); // flush last entries
+                                    sampleExtra[i]);
                             outRestore();
                         }
                         sampleIndex[i] = -1;
                         break;
                     }
 
+                    // Normalize composition timestamps to align audio and video timelines
+                    long pts = sample.info.sampleCompositionTimeOffset;
+                    if (!firstPtsSet[i]) {
+                        firstPts[i] = pts;
+                        firstPtsSet[i] = true;
+                    }
+
+                    if (!minPtsComputed) {
+                        boolean allSet = true;
+                        for (int k = 0; k < readers.length; k++) {
+                            if (!firstPtsSet[k]) {
+                                allSet = false;
+                                break;
+                            }
+                        }
+
+                        if (allSet) {
+                            minPts = firstPts[0];
+                            for (int k = 1; k < readers.length; k++) {
+                                minPts = Math.min(minPts, firstPts[k]);
+                            }
+                            minPtsComputed = true;
+                        }
+                    }
+
                     sampleIndex[i]++;
 
+                    if (!basePtsSet[i]) {
+                        if (minPtsComputed) {
+                            basePts[i] = minPts;
+                        } else {
+                            basePts[i] = firstPts[i];
+                        }
+                        basePtsSet[i] = true;
+                    }
+
+                    int correctedOffset = (int) (pts - basePts[i]);
                     if (tablesInfo[i].ctts > 0) {
-                        if (sample.info.sampleCompositionTimeOffset == sampleExtra[i]) {
+                        if (correctedOffset == sampleExtra[i]) {
                             sampleCount[i]++;
                         } else {
                             if (sampleExtra[i] >= 0) {
-                                tablesInfo[i].ctts = writeEntryArray(tablesInfo[i].ctts, 2,
-                                        sampleCount[i], sampleExtra[i]);
+                                tablesInfo[i].ctts = writeEntryArray(
+                                        tablesInfo[i].ctts, 2, sampleCount[i], sampleExtra[i]
+                                );
                                 outRestore();
                             }
                             sampleCount[i] = 1;
-                            sampleExtra[i] = sample.info.sampleCompositionTimeOffset;
+                            sampleExtra[i] = correctedOffset;
                         }
                     }
 


### PR DESCRIPTION
### What is it?

- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [x] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

---

### Description of the changes in your PR

Fix audio-video synchronization issue in DASH MP4 muxing.

Audio and video tracks extracted from DASH streams may have different starting
composition timestamps (PTS), which previously caused desynchronization.

This PR normalizes timestamps by:
- Capturing initial PTS for each track
- Computing a global minimum PTS once all tracks are initialized
- Introducing a stable per-track base timestamp (`basePts`)
- Preventing mid-stream timestamp reference switching
- Adjusting CTTS offset calculation accordingly

This ensures both tracks share a consistent timeline during muxing.

---

### APK testing

Tested using locally built APK.

- Verified on multiple YouTube videos (480p, 720p)
- Checked using frame-by-frame playback in VLC
- No audio-video desync observed

---

### Due diligence

- [x] I read the contribution guidelines.
- [x] The proposed changes follow the AI policy.
- [x] I tested the changes using an emulator or a physical device.

---

### Issue

Fixes #12640