### PR TITLE
Force keyboard dismissal on non-touch devices

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/util/KeyboardUtil.java
+++ b/app/src/main/java/org/schabi/newpipe/util/KeyboardUtil.java
@@ -13,6 +13,14 @@ import androidx.core.content.ContextCompat;
  * </p>
  */
 public final class KeyboardUtil {
+
+    /**
+     * Flag for {@link #hideKeyboard(Activity, EditText)} to force the keyboard to hide.
+     * This is required for non-touch devices like Fire TV where the system
+     * flags the focus as an explicit user action.
+     */
+    private static final int CLEAR_SOFT_INPUT_FORCED = 0;
+
     private KeyboardUtil() {
     }
 
@@ -24,6 +32,7 @@ public final class KeyboardUtil {
         if (editText.requestFocus()) {
             final InputMethodManager imm = ContextCompat.getSystemService(activity,
                     InputMethodManager.class);
+
             if (!imm.showSoftInput(editText, InputMethodManager.SHOW_FORCED)) {
                 /*
                  * Sometimes the keyboard can't be shown because Android's ImeFocusController is in
@@ -47,8 +56,9 @@ public final class KeyboardUtil {
 
         final InputMethodManager imm = ContextCompat.getSystemService(activity,
                 InputMethodManager.class);
-        imm.hideSoftInputFromWindow(editText.getWindowToken(),
-                InputMethodManager.HIDE_NOT_ALWAYS);
+        if (imm != null) {
+            imm.hideSoftInputFromWindow(editText.getWindowToken(), CLEAR_SOFT_INPUT_FORCED);
+        }
 
         editText.clearFocus();
     }


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user-facing)
- [ ] Feature (user facing) ⚠️ **Your PR must target the [refactor](https://github.com/TeamNewPipe/NewPipe/tree/refactor) branch**
- [ ] Codebase improvement (dev-facing)
- [ ] Meta improvement to the project (dev-facing)

#### Description of the changes in your PR
- Restored functional keyboard dismissal for non-touch devices (Fire TV Stick, D-Pad, Android TV).
- Introduced a documented constant `CLEAR_SOFT_INPUT_FORCED` (value `0`) in `KeyboardUtil.java` to replace `HIDE_NOT_ALWAYS`.
- On non-touch systems, the IME flags the initial focus as an explicit user action, making `HIDE_NOT_ALWAYS` ineffective; using flag `0` ensures a forced dismissal while remaining lint-compliant.

#### Fixes the following issue(s)
- Fixes #13337

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts", and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
- [x] The proposed changes follow the [AI policy](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md#ai-policy).
- [x] I tested the changes using an emulator or a physical device.