### PR TITLE
Fix NullPointerException in enqueue actions by using Application Context

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/info_list/dialog/StreamDialogDefaultEntry.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/dialog/StreamDialogDefaultEntry.java
@@ -5,6 +5,7 @@ import static org.schabi.newpipe.util.SparseItemUtil.fetchItemInfoIfSparse;
 import static org.schabi.newpipe.util.SparseItemUtil.fetchStreamInfoAndSaveToDatabase;
 import static org.schabi.newpipe.util.SparseItemUtil.fetchUploaderUrlIfSparse;
 
+import android.content.Context;
 import android.net.Uri;
 
 import androidx.annotation.NonNull;
@@ -52,28 +53,33 @@ public enum StreamDialogDefaultEntry {
     /**
      * Enqueues the stream automatically to the current PlayerType.
      */
-    ENQUEUE(R.string.enqueue_stream, (fragment, item) ->
-            fetchItemInfoIfSparse(fragment.requireContext(), item, singlePlayQueue ->
-                NavigationHelper.enqueueOnPlayer(fragment.getContext(), singlePlayQueue))
-    ),
+    ENQUEUE(R.string.enqueue_stream, (fragment, item) -> {
+            final Context ctx = fragment.requireContext().getApplicationContext();
+            fetchItemInfoIfSparse(ctx, item, singlePlayQueue ->
+                NavigationHelper.enqueueOnPlayer(ctx, singlePlayQueue));
+    }),
 
     /**
      * Enqueues the stream automatically to the current PlayerType
      * after the currently playing stream.
      */
-    ENQUEUE_NEXT(R.string.enqueue_next_stream, (fragment, item) ->
-            fetchItemInfoIfSparse(fragment.requireContext(), item, singlePlayQueue ->
-                NavigationHelper.enqueueNextOnPlayer(fragment.getContext(), singlePlayQueue))
-    ),
+    ENQUEUE_NEXT(R.string.enqueue_next_stream, (fragment, item) -> {
+            final Context ctx = fragment.requireContext().getApplicationContext();
+            fetchItemInfoIfSparse(ctx, item, singlePlayQueue ->
+                NavigationHelper.enqueueNextOnPlayer(ctx, singlePlayQueue));
+    }),
 
-    START_HERE_ON_BACKGROUND(R.string.start_here_on_background, (fragment, item) ->
-            fetchItemInfoIfSparse(fragment.requireContext(), item, singlePlayQueue ->
-                NavigationHelper.playOnBackgroundPlayer(
-                        fragment.getContext(), singlePlayQueue, true))),
+    START_HERE_ON_BACKGROUND(R.string.start_here_on_background, (fragment, item) -> {
+            final Context ctx = fragment.requireContext().getApplicationContext();
+            fetchItemInfoIfSparse(ctx, item, singlePlayQueue ->
+                NavigationHelper.playOnBackgroundPlayer(ctx, singlePlayQueue, true));
+    }),
 
-    START_HERE_ON_POPUP(R.string.start_here_on_popup, (fragment, item) ->
-            fetchItemInfoIfSparse(fragment.requireContext(), item, singlePlayQueue ->
-                NavigationHelper.playOnPopupPlayer(fragment.getContext(), singlePlayQueue, true))),
+    START_HERE_ON_POPUP(R.string.start_here_on_popup, (fragment, item) -> {
+            final Context ctx = fragment.requireContext().getApplicationContext();
+            fetchItemInfoIfSparse(ctx, item, singlePlayQueue ->
+                NavigationHelper.playOnPopupPlayer(ctx, singlePlayQueue, true));
+    }),
 
     SET_AS_PLAYLIST_THUMBNAIL(R.string.set_as_playlist_thumbnail, (fragment, item) -> {
         throw new UnsupportedOperationException("This needs to be implemented manually "


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing) ⚠️ **Your PR must target the [`refactor`](https://github.com/TeamNewPipe/NewPipe/tree/refactor) branch**
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- In `StreamDialogDefaultEntry`, the `ENQUEUE`, `ENQUEUE_NEXT`, `START_HERE_ON_BACKGROUND`, and `START_HERE_ON_POPUP` entries used `fragment.getContext()` inside the async callback of `fetchItemInfoIfSparse()`. Since the callback runs asynchronously, the fragment may have already been detached (e.g., due to entering fullscreen or rotating the device), causing `getContext()` to return `null`.
- Replaced with `fragment.requireContext().getApplicationContext()` captured **before** the async call, while the fragment is still attached. The `Application` context is lifecycle-safe and remains valid regardless of configuration changes.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
N/A — no UI changes, this is a crash fix only.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #13350

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
- [x] The proposed changes follow the [AI policy](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md#ai-policy).
- [x] I tested the changes using an emulator or a physical device.
