### PR TITLE
Feature/channel filter final

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelTabFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelTabFragment.java
@@ -31,6 +31,17 @@ import org.schabi.newpipe.util.ChannelTabHelper;
 import org.schabi.newpipe.util.ExtractorHelper;
 import org.schabi.newpipe.util.PlayButtonHelper;
 
+import android.content.SharedPreferences;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+
+import androidx.appcompat.app.AlertDialog;
+import androidx.preference.PreferenceManager;
+
+import org.schabi.newpipe.database.stream.model.StreamStateEntity;
+import org.schabi.newpipe.local.history.HistoryRecordManager;
+
 import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -70,7 +81,7 @@ public class ChannelTabFragment extends BaseListInfoFragment<InfoItem, ChannelTa
     @Override
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setHasOptionsMenu(false);
+        setHasOptionsMenu(true);
     }
 
     @Override
@@ -93,6 +104,69 @@ public class ChannelTabFragment extends BaseListInfoFragment<InfoItem, ChannelTa
     }
 
     @Override
+    public void onCreateOptionsMenu(@NonNull final Menu menu,
+                                    @NonNull final MenuInflater inflater) {
+        super.onCreateOptionsMenu(menu, inflater);
+        if (ChannelTabHelper.isStreamsTab(tabHandler)) {
+            final MenuItem item = menu.add(Menu.NONE, R.id.menu_item_feed_toggle_played_items,
+                    Menu.NONE, R.string.feed_show_hide_streams);
+            item.setIcon(R.drawable.ic_visibility_on);
+            item.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);
+        }
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(@NonNull final MenuItem item) {
+        if (item.getItemId() == R.id.menu_item_feed_toggle_played_items) {
+            showStreamVisibilityDialog();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    private void showStreamVisibilityDialog() {
+        final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(activity);
+        final String showWatchedKey = getString(R.string.feed_show_watched_items_key);
+        final String showPartiallyWatchedKey =
+                getString(R.string.feed_show_partially_watched_items_key);
+
+        final String[] dialogItems = {
+                getString(R.string.feed_show_watched),
+                getString(R.string.feed_show_partially_watched)
+        };
+
+        final boolean[] checkedDialogItems = {
+                prefs.getBoolean(showWatchedKey, true),
+                prefs.getBoolean(showPartiallyWatchedKey, true)
+        };
+
+        new AlertDialog.Builder(requireContext())
+                .setTitle(R.string.feed_hide_streams_title)
+                .setMultiChoiceItems(dialogItems, checkedDialogItems,
+                        (dialog, which, isChecked) -> checkedDialogItems[which] = isChecked)
+                .setPositiveButton(R.string.ok, (dialog, which) -> {
+                    boolean changed = false;
+                    final SharedPreferences.Editor editor = prefs.edit();
+
+                    if (prefs.getBoolean(showWatchedKey, true) != checkedDialogItems[0]) {
+                        editor.putBoolean(showWatchedKey, checkedDialogItems[0]);
+                        changed = true;
+                    }
+                    if (prefs.getBoolean(showPartiallyWatchedKey, true) != checkedDialogItems[1]) {
+                        editor.putBoolean(showPartiallyWatchedKey, checkedDialogItems[1]);
+                        changed = true;
+                    }
+
+                    if (changed) {
+                        editor.apply();
+                        startLoading(true);
+                    }
+                })
+                .setNegativeButton(R.string.cancel, null)
+                .show();
+    }
+
+    @Override
     protected Supplier<View> getListHeaderSupplier() {
         if (ChannelTabHelper.isStreamsTab(tabHandler)) {
             playlistControlBinding = PlaylistControlBinding
@@ -104,12 +178,104 @@ public class ChannelTabFragment extends BaseListInfoFragment<InfoItem, ChannelTa
 
     @Override
     protected Single<ChannelTabInfo> loadResult(final boolean forceLoad) {
-        return ExtractorHelper.getChannelTab(serviceId, tabHandler, forceLoad);
+        final SharedPreferences prefs =
+                PreferenceManager.getDefaultSharedPreferences(requireContext());
+        final boolean showPlayed = prefs.getBoolean(
+                getString(R.string.feed_show_watched_items_key), true);
+        final boolean showPartiallyPlayed = prefs.getBoolean(
+                getString(R.string.feed_show_partially_watched_items_key), true);
+
+        final HistoryRecordManager historyRecordManager = new HistoryRecordManager(
+                requireContext().getApplicationContext());
+
+        return ExtractorHelper.getChannelTab(serviceId, tabHandler, forceLoad)
+                .map(info -> filterStreams(info, showPlayed, showPartiallyPlayed,
+                        historyRecordManager));
     }
 
     @Override
     protected Single<ListExtractor.InfoItemsPage<InfoItem>> loadMoreItemsLogic() {
-        return ExtractorHelper.getMoreChannelTabItems(serviceId, tabHandler, currentNextPage);
+        final SharedPreferences prefs =
+                PreferenceManager.getDefaultSharedPreferences(requireContext());
+        final boolean showPlayed = prefs.getBoolean(
+                getString(R.string.feed_show_watched_items_key), true);
+        final boolean showPartiallyPlayed = prefs.getBoolean(
+                getString(R.string.feed_show_partially_watched_items_key), true);
+
+        final HistoryRecordManager historyRecordManager = new HistoryRecordManager(
+                requireContext().getApplicationContext());
+
+        return ExtractorHelper.getMoreChannelTabItems(serviceId, tabHandler, currentNextPage)
+                .map(page -> filterStreamsPage(page, showPlayed, showPartiallyPlayed,
+                        historyRecordManager));
+    }
+
+    private boolean shouldIncludeItem(final InfoItem item,
+                                      final boolean showPlayed,
+                                      final boolean showPartiallyPlayed,
+                                      final HistoryRecordManager historyRecordManager) {
+        if (!(item instanceof StreamInfoItem)) {
+            return true;
+        }
+        final StreamInfoItem streamItem = (StreamInfoItem) item;
+        try {
+            final StreamStateEntity[] result =
+                    historyRecordManager.loadStreamState(streamItem).blockingGet();
+            final StreamStateEntity state =
+                    (result != null && result.length > 0) ? result[0] : null;
+            if (state != null) {
+                final long duration = streamItem.getDuration();
+                final boolean isFinished = state.isFinished(duration);
+                final boolean isPartiallyPlayed = state.isValid(duration) && !isFinished;
+
+                if (!showPlayed && isFinished) {
+                    return false;
+                }
+                if (!showPartiallyPlayed && isPartiallyPlayed) {
+                    return false;
+                }
+            }
+        } catch (final Exception e) {
+            Log.w(TAG, "Could not load stream state", e);
+        }
+        return true;
+    }
+
+    private ChannelTabInfo filterStreams(final ChannelTabInfo info,
+                                         final boolean showPlayed,
+                                         final boolean showPartiallyPlayed,
+                                         final HistoryRecordManager historyRecordManager) {
+        if (!ChannelTabHelper.isStreamsTab(tabHandler)
+                || (showPlayed && showPartiallyPlayed)) {
+            return info;
+        }
+
+        final List<InfoItem> filteredItems = info.getRelatedItems().stream()
+                .filter(item -> shouldIncludeItem(item, showPlayed,
+                        showPartiallyPlayed, historyRecordManager))
+                .collect(Collectors.toList());
+
+        info.setRelatedItems(filteredItems);
+
+        return info;
+    }
+
+    private ListExtractor.InfoItemsPage<InfoItem> filterStreamsPage(
+            final ListExtractor.InfoItemsPage<InfoItem> page,
+            final boolean showPlayed,
+            final boolean showPartiallyPlayed,
+            final HistoryRecordManager historyRecordManager) {
+        if (!ChannelTabHelper.isStreamsTab(tabHandler)
+                || (showPlayed && showPartiallyPlayed)) {
+            return page;
+        }
+
+        final List<InfoItem> filtered = page.getItems().stream()
+                .filter(item -> shouldIncludeItem(item, showPlayed,
+                        showPartiallyPlayed, historyRecordManager))
+                .collect(Collectors.toList());
+
+        return new ListExtractor.InfoItemsPage<>(filtered, page.getNextPage(), page.getErrors());
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelTabFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelTabFragment.java
@@ -219,10 +219,8 @@ public class ChannelTabFragment extends BaseListInfoFragment<InfoItem, ChannelTa
         }
         final StreamInfoItem streamItem = (StreamInfoItem) item;
         try {
-            final StreamStateEntity[] result =
-                    historyRecordManager.loadStreamState(streamItem).blockingGet();
             final StreamStateEntity state =
-                    (result != null && result.length > 0) ? result[0] : null;
+                    historyRecordManager.loadStreamState(streamItem).blockingGet();
             if (state != null) {
                 final long duration = streamItem.getDuration();
                 final boolean isFinished = state.isFinished(duration);


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing) ⚠️ **Your PR must target the [`refactor`](https://github.com/TeamNewPipe/NewPipe/tree/refactor) branch**
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
- Added `setHasOptionsMenu(true)` in `ChannelTabFragment` to dynamically inject the standard "Eyeball" visibility toggle icon specifically within the Streams tab.
- Reused `showStreamVisibilityDialog()` and the existing `feed_show_watched_items_key` SharedPreferences to maintain a cohesive user experience with the main feed.
- Intercepted the RxJava streams in `loadResult()` and `loadMoreItemsLogic()` using `.map()` to apply the filter asynchronously off-thread, preventing UI frame drops.
- Implemented `shouldIncludeItem()` to query the `HistoryRecordManager` for local watch states, evaluating `isFinished()` and `isValid()` based on the user's preferences.
- Handled the `Collections.unmodifiableList` constraint from `NewPipeExtractor` by creating a filtered list and updating it via `info.setRelatedItems(filteredItems)`, safely dropping unwatched/watched streams.

#### Before/After Screenshots/Screen Record
- Before:<br>
<img src="https://github.com/user-attachments/assets/408bea38-036c-4a9f-b552-2f2118f956ca" width="300" />
<br>
- After:<br>
https://github.com/user-attachments/assets/b1a317c4-740a-4012-b668-d5a695f841c3

#### Fixes the following issue(s)
- Fixes #13065

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
- [x] The proposed changes follow the [AI policy](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md#ai-policy).
- [x] I tested the changes using an emulator or a physical device.