### PR TITLE
Fix playback not working after player enters idle state

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -1752,6 +1752,13 @@ public final class Player implements PlaybackListener, Listener {
             }
         }
 
+        if (isStopped()) {
+            // Some phones suspend a paused player after 10 minutes. This causes the player to
+            // enter STATE_IDLE, causing playback to fail. So we try to recover from that here.
+            setRecovery();
+            reloadPlayQueueManager();
+        }
+
         simpleExoPlayer.play();
         saveStreamProgressState();
     }


### PR DESCRIPTION
#### What is it?
- [X] Bugfix (user facing)

#### Description of the changes in your PR
- On some phones the video player enters the STATE_IDLE 10 minutes after being paused. After that the play button on video popups stop working.
- This bug only happens on certain phones (e.g. Oppo and Oneplus). Doesn't happen on Pixel phones.
- This happens because once a player has become idle, we need to call prepare() before playback can happen again.

How I implemented the changes:
- I first tried doing this when the player was idle:
```java
if (isStopped()) {
    simpleExoPlayer.prepare();
    simpleExoPlayer.setPlayWhenReady(true);
}
```
- But this caused the video to become black and not actually play.
- Then I decided to execute the same code that happens when ERROR_CODE_UNSPECIFIED occurs. This causes playback to resume normally.

#### How to reproduce
If you have a Oneplus or Oppo phone then:
- Open a video using a popup
- Pause the video
- Turn off the screen and wait 10 minutes
- After ten minutes, try resuming the video
- Resuming fails

If your phone is different, you can simulate this by adding the following code to Player.java:
```java
    public void setPlaybackSpeed(final float speed) {
        setPlaybackParameters(speed, getPlaybackPitch(), getPlaybackSkipSilence());
        
        // TEMPORARY: Put the player into STATE_IDLE if speed is set to 1.5x
        if (speed == 1.5f) {
            simpleExoPlayer.stop();
        }
    }
```
- After that, you can launch a popup video
- Pause the video
- Set the speed to 1.5x to make the player enter STATE_IDLE
- Try resuming the video. Resuming will fail. 

#### Before/After Screenshots/Screen Record
- Before:
In the video below, I paused the video, then turned my screen off for 10 minutes. After that, pressing the play button does nothing.

https://github.com/user-attachments/assets/9b8bb692-26ff-40d8-8ee5-1483be816796


- After:
After my code changes, I did the same steps as before, but now the play button worked as expected.

#### Fixes the following issue(s)
- I wasn't able to find an existing issue for this. But this problem has existed since I switched from Pixel phones to Oppo and Oneplus a few months ago.
- Fixes #13411


#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [X] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
- [X] The proposed changes follow the [AI policy](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md#ai-policy).
    - I first tried making the fix myself. Then I got assistance using Claude Code. I reviewed the change myself and it seemed to make sense.
- [X] I tested the changes using an emulator or a physical device.
    - I tested my change on my physical device
