### PR TITLE
Fix crash when loading offline comments in CommentRepliesSource

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/paging/CommentRepliesSource.kt
+++ b/app/src/main/java/org/schabi/newpipe/paging/CommentRepliesSource.kt
@@ -15,12 +15,20 @@ class CommentRepliesSource(
     private val service = NewPipe.getService(commentInfo.serviceId)
 
     override suspend fun load(params: LoadParams<Page>): LoadResult<Page, CommentsInfoItem> {
-        // params.key is null the first time load() is called, and we need to return the first page
-        val repliesPage = params.key ?: commentInfo.replies
-        val info = withContext(Dispatchers.IO) {
-            CommentsInfo.getMoreItems(service, commentInfo.url, repliesPage)
+        return try {
+            // params.key is null the first time load() is called, and we need to return the first page
+            val repliesPage = params.key ?: commentInfo.replies
+
+            val info = withContext(Dispatchers.IO) {
+                CommentsInfo.getMoreItems(service, commentInfo.url, repliesPage)
+            }
+
+            LoadResult.Page(info.items, null, info.nextPage)
+        } catch (e: Exception) {
+            // Catches UnknownHostException (offline) or any extraction errors
+            // and tells Paging3 to show the error state in the UI.
+            LoadResult.Error(e)
         }
-        return LoadResult.Page(info.items, null, info.nextPage)
     }
 
     override fun getRefreshKey(state: PagingState<Page, CommentsInfoItem>) = null


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing) ⚠️ **Your PR must target the [`refactor`](https://github.com/TeamNewPipe/NewPipe/tree/refactor) branch**
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Wrapped the network call `CommentsInfo.getMoreItems` inside a `try-catch` block in `CommentRepliesSource.kt`.
- When an extraction or network exception (like `UnknownHostException` when offline) occurs during pagination, it now correctly returns a `LoadResult.Error(e)` instead of crashing the app.
- This allows Jetpack Compose's Paging 3 to catch the state and display the UI error panel (implemented in #11716) instead of triggering a fatal ACRA crash.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before: The app immediately crashed when trying to load more comment replies without an internet connection.
- After: The app catches the exception and displays the standard comment error UI panel with a retry button.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #11717

#### APK testing
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
- [x] The proposed changes follow the [AI policy](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md#ai-policy).
- [x] I tested the changes using an emulator or a physical device.