### PR TITLE
[Backport] Feature: Divide player seekbar by chapters

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
@@ -66,7 +66,9 @@ import org.schabi.newpipe.databinding.PlayerBinding;
 import org.schabi.newpipe.extractor.MediaFormat;
 import org.schabi.newpipe.extractor.stream.AudioStream;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
+import org.schabi.newpipe.extractor.stream.StreamSegment;
 import org.schabi.newpipe.extractor.stream.VideoStream;
+import org.schabi.newpipe.views.ChaptersSeekBar;
 import org.schabi.newpipe.fragments.detail.VideoDetailFragment;
 import org.schabi.newpipe.ktx.AnimationType;
 import org.schabi.newpipe.player.Player;
@@ -86,6 +88,7 @@ import org.schabi.newpipe.util.external_communication.KoreUtils;
 import org.schabi.newpipe.util.external_communication.ShareUtils;
 import org.schabi.newpipe.views.player.PlayerFastSeekOverlay;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -147,6 +150,9 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
     @NonNull
     private final SeekbarPreviewThumbnailHolder seekbarPreviewThumbnailHolder =
             new SeekbarPreviewThumbnailHolder();
+
+    @NonNull
+    private List<StreamSegment> currentChapters = Collections.emptyList();
 
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -586,6 +592,14 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
                         binding.currentSeekbarPreviewThumbnail,
                         binding.subtitleView::getWidth);
 
+        // Chapter title tooltip
+        if (!currentChapters.isEmpty()) {
+            final StreamSegment chapter = getChapterAtMs(progress);
+            if (chapter != null && chapter.getTitle() != null) {
+                binding.currentChapterTitle.setText(chapter.getTitle());
+            }
+        }
+
         adjustSeekbarPreviewContainer();
     }
 
@@ -639,6 +653,10 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
                 AnimationType.SCALE_AND_ALPHA);
         animate(binding.currentSeekbarPreviewThumbnail, true, DEFAULT_CONTROLS_DURATION,
                 AnimationType.SCALE_AND_ALPHA);
+        if (!currentChapters.isEmpty()) {
+            animate(binding.currentChapterTitle, true, DEFAULT_CONTROLS_DURATION,
+                    AnimationType.SCALE_AND_ALPHA);
+        }
     }
 
     @Override // seekbar listener
@@ -655,6 +673,7 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
         binding.playbackCurrentTime.setText(getTimeString(seekBar.getProgress()));
         animate(binding.currentDisplaySeek, false, 200, AnimationType.SCALE_AND_ALPHA);
         animate(binding.currentSeekbarPreviewThumbnail, false, 200, AnimationType.SCALE_AND_ALPHA);
+        animate(binding.currentChapterTitle, false, 200, AnimationType.SCALE_AND_ALPHA);
 
         if (player.getCurrentState() == STATE_PAUSED_SEEK) {
             player.changeState(STATE_BUFFERING);
@@ -664,6 +683,25 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
         }
 
         showControlsThenHide();
+    }
+
+    /**
+     * Returns the chapter active at the given playback position, or {@code null} if
+     * {@code currentChapters} is empty.
+     *
+     * @param positionMs playback position in milliseconds
+     * @return the {@link StreamSegment} whose window contains {@code positionMs}
+     */
+    @Nullable
+    private StreamSegment getChapterAtMs(final long positionMs) {
+        StreamSegment result = null;
+        for (final StreamSegment seg : currentChapters) {
+            if (seg.getStartTimeSeconds() * 1000L > positionMs) {
+                break;
+            }
+            result = seg;
+        }
+        return result;
     }
     //endregion
 
@@ -1021,6 +1059,22 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
         binding.channelTextView.setText(info.getUploaderName());
 
         this.seekbarPreviewThumbnailHolder.resetFrom(player.getContext(), info.getPreviewFrames());
+
+        // Chapter markers on seekbar
+        currentChapters = info.getStreamSegments() != null
+                ? info.getStreamSegments() : Collections.emptyList();
+        Log.d(TAG, "onMetadataChanged: seekBarClass="
+                + binding.playbackSeekBar.getClass().getSimpleName()
+                + " segments=" + currentChapters.size()
+                + " duration=" + info.getDuration());
+        if (binding.playbackSeekBar instanceof ChaptersSeekBar) {
+            ((ChaptersSeekBar) binding.playbackSeekBar)
+                    .setChapters(currentChapters, info.getDuration());
+        } else {
+            Log.e(TAG, "onMetadataChanged: playbackSeekBar is NOT a ChaptersSeekBar! "
+                    + "Check that player.xml was rebuilt.");
+        }
+        binding.currentChapterTitle.setVisibility(View.GONE);
     }
 
     private void updateStreamRelatedViews() {

--- a/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
@@ -28,6 +28,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
 import android.view.GestureDetector;
+import android.view.HapticFeedbackConstants;
 import android.view.Gravity;
 import android.view.KeyEvent;
 import android.view.Menu;
@@ -153,6 +154,8 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
 
     @NonNull
     private List<StreamSegment> currentChapters = Collections.emptyList();
+    @Nullable
+    private StreamSegment lastChapterForHaptic = null;
 
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -592,11 +595,15 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
                         binding.currentSeekbarPreviewThumbnail,
                         binding.subtitleView::getWidth);
 
-        // Chapter title tooltip
+        // Chapter title tooltip + haptic feedback at chapter boundaries
         if (!currentChapters.isEmpty()) {
             final StreamSegment chapter = getChapterAtMs(progress);
             if (chapter != null && chapter.getTitle() != null) {
                 binding.currentChapterTitle.setText(chapter.getTitle());
+            }
+            if (chapter != lastChapterForHaptic) {
+                lastChapterForHaptic = chapter;
+                seekBar.performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK);
             }
         }
 
@@ -1063,17 +1070,9 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
         // Chapter markers on seekbar
         currentChapters = info.getStreamSegments() != null
                 ? info.getStreamSegments() : Collections.emptyList();
-        Log.d(TAG, "onMetadataChanged: seekBarClass="
-                + binding.playbackSeekBar.getClass().getSimpleName()
-                + " segments=" + currentChapters.size()
-                + " duration=" + info.getDuration());
-        if (binding.playbackSeekBar instanceof ChaptersSeekBar) {
-            ((ChaptersSeekBar) binding.playbackSeekBar)
-                    .setChapters(currentChapters, info.getDuration());
-        } else {
-            Log.e(TAG, "onMetadataChanged: playbackSeekBar is NOT a ChaptersSeekBar! "
-                    + "Check that player.xml was rebuilt.");
-        }
+        lastChapterForHaptic = null;
+        ((ChaptersSeekBar) binding.playbackSeekBar)
+                .setChapters(currentChapters, info.getDuration());
         binding.currentChapterTitle.setVisibility(View.GONE);
     }
 

--- a/app/src/main/java/org/schabi/newpipe/views/ChaptersSeekBar.java
+++ b/app/src/main/java/org/schabi/newpipe/views/ChaptersSeekBar.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) NewPipe Contributors
+ * ChaptersSeekBar.java is part of NewPipe.
+ *
+ * NewPipe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NewPipe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NewPipe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.schabi.newpipe.views;
+
+import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.util.AttributeSet;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.schabi.newpipe.extractor.stream.StreamSegment;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A {@link FocusAwareSeekBar} that draws thin white vertical tick marks at chapter boundaries.
+ * Call {@link #setChapters(List, long)} whenever a new stream loads.
+ */
+public final class ChaptersSeekBar extends FocusAwareSeekBar {
+
+    private static final String TAG = "ChaptersSeekBar";
+
+    private static final int   TICK_ALPHA           = 180;  // ~70% opacity
+    private static final float TICK_WIDTH_DP        = 2f;
+    private static final float TICK_HEIGHT_FRACTION = 0.6f; // fraction of view height
+
+    private final Paint tickPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+
+    @NonNull private List<StreamSegment> chapters = Collections.emptyList();
+    private long durationSeconds = 0;
+
+    public ChaptersSeekBar(@NonNull final Context context) {
+        super(context);
+        init();
+    }
+
+    public ChaptersSeekBar(@NonNull final Context context,
+                           @Nullable final AttributeSet attrs) {
+        super(context, attrs);
+        init();
+    }
+
+    public ChaptersSeekBar(@NonNull final Context context,
+                           @Nullable final AttributeSet attrs,
+                           final int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init();
+    }
+
+    private void init() {
+        tickPaint.setColor(Color.WHITE);
+        tickPaint.setAlpha(TICK_ALPHA);
+        tickPaint.setStyle(Paint.Style.FILL);
+        Log.d(TAG, "init: ChaptersSeekBar created");
+    }
+
+    /**
+     * Stores chapter data for rendering tick marks.
+     *
+     * @param newChapters     list of {@link StreamSegment}s; may be empty but never null
+     * @param newDurationSecs total duration in seconds; used to compute fractional positions
+     */
+    public void setChapters(@NonNull final List<StreamSegment> newChapters,
+                            final long newDurationSecs) {
+        chapters = newChapters;
+        durationSeconds = newDurationSecs;
+        Log.d(TAG, "setChapters: count=" + newChapters.size()
+                + " durationSeconds=" + newDurationSecs);
+        for (final StreamSegment seg : newChapters) {
+            Log.d(TAG, "  chapter: startSec=" + seg.getStartTimeSeconds()
+                    + " title=" + seg.getTitle());
+        }
+        invalidate();
+    }
+
+    @Override
+    protected void onDraw(@NonNull final Canvas canvas) {
+        super.onDraw(canvas);
+
+        if (chapters.isEmpty() || durationSeconds <= 0) {
+            Log.d(TAG, "onDraw: skipped — chapters=" + chapters.size()
+                    + " durationSeconds=" + durationSeconds);
+            return;
+        }
+
+        final float density = getResources().getDisplayMetrics().density;
+        final float tickWidthPx = TICK_WIDTH_DP * density;
+
+        // Track bounds: AbsSeekBar pads the track by getPaddingLeft/getPaddingRight
+        final int paddingLeft  = getPaddingLeft();
+        final int paddingRight = getPaddingRight();
+        final float trackWidth = getWidth() - paddingLeft - paddingRight;
+
+        Log.d(TAG, "onDraw: w=" + getWidth() + " h=" + getHeight()
+                + " paddingL=" + paddingLeft + " paddingR=" + paddingRight
+                + " trackWidth=" + trackWidth + " chapters=" + chapters.size()
+                + " durationSeconds=" + durationSeconds);
+
+        if (trackWidth <= 0) {
+            Log.d(TAG, "onDraw: trackWidth<=0, skipping");
+            return;
+        }
+
+        // Center ticks vertically, scaling height as a fraction of the view
+        final float tickHeight = getHeight() * TICK_HEIGHT_FRACTION;
+        final float tickTop    = (getHeight() - tickHeight) / 2f;
+        final float tickBottom = tickTop + tickHeight;
+
+        for (final StreamSegment seg : chapters) {
+            final int startSec = seg.getStartTimeSeconds();
+            // Skip the very beginning and anything at or past the end
+            if (startSec <= 0 || startSec >= durationSeconds) {
+                Log.d(TAG, "  skipping seg startSec=" + startSec);
+                continue;
+            }
+            final float x = paddingLeft + (startSec / (float) durationSeconds) * trackWidth;
+            Log.d(TAG, "  drawing tick at x=" + x + " for startSec=" + startSec
+                    + " title=" + seg.getTitle());
+            canvas.drawRect(
+                    x - tickWidthPx / 2f,
+                    tickTop,
+                    x + tickWidthPx / 2f,
+                    tickBottom,
+                    tickPaint);
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/views/ChaptersSeekBar.java
+++ b/app/src/main/java/org/schabi/newpipe/views/ChaptersSeekBar.java
@@ -19,10 +19,11 @@ package org.schabi.newpipe.views;
 
 import android.content.Context;
 import android.graphics.Canvas;
-import android.graphics.Color;
 import android.graphics.Paint;
+import android.graphics.PorterDuff;
+import android.graphics.PorterDuffXfermode;
+import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -33,18 +34,15 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * A {@link FocusAwareSeekBar} that draws thin white vertical tick marks at chapter boundaries.
+ * A {@link FocusAwareSeekBar} that renders narrow transparent gaps at chapter boundaries,
+ * giving the seekbar a segmented "chopped" appearance.
  * Call {@link #setChapters(List, long)} whenever a new stream loads.
  */
 public final class ChaptersSeekBar extends FocusAwareSeekBar {
 
-    private static final String TAG = "ChaptersSeekBar";
+    private static final float GAP_WIDTH_DP = 2f;
 
-    private static final int   TICK_ALPHA           = 180;  // ~70% opacity
-    private static final float TICK_WIDTH_DP        = 2f;
-    private static final float TICK_HEIGHT_FRACTION = 0.6f; // fraction of view height
-
-    private final Paint tickPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private final Paint gapPaint = new Paint();
 
     @NonNull private List<StreamSegment> chapters = Collections.emptyList();
     private long durationSeconds = 0;
@@ -68,14 +66,12 @@ public final class ChaptersSeekBar extends FocusAwareSeekBar {
     }
 
     private void init() {
-        tickPaint.setColor(Color.WHITE);
-        tickPaint.setAlpha(TICK_ALPHA);
-        tickPaint.setStyle(Paint.Style.FILL);
-        Log.d(TAG, "init: ChaptersSeekBar created");
+        gapPaint.setStyle(Paint.Style.FILL);
+        gapPaint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.CLEAR));
     }
 
     /**
-     * Stores chapter data for rendering tick marks.
+     * Stores chapter data for rendering segment gaps.
      *
      * @param newChapters     list of {@link StreamSegment}s; may be empty but never null
      * @param newDurationSecs total duration in seconds; used to compute fractional positions
@@ -84,64 +80,46 @@ public final class ChaptersSeekBar extends FocusAwareSeekBar {
                             final long newDurationSecs) {
         chapters = newChapters;
         durationSeconds = newDurationSecs;
-        Log.d(TAG, "setChapters: count=" + newChapters.size()
-                + " durationSeconds=" + newDurationSecs);
-        for (final StreamSegment seg : newChapters) {
-            Log.d(TAG, "  chapter: startSec=" + seg.getStartTimeSeconds()
-                    + " title=" + seg.getTitle());
-        }
         invalidate();
     }
 
     @Override
     protected void onDraw(@NonNull final Canvas canvas) {
+        if (chapters.isEmpty() || durationSeconds <= 0) {
+            super.onDraw(canvas);
+            return;
+        }
+
+        // Draw the seekbar into an offscreen layer so CLEAR mode can punch transparent gaps
+        final int sc = canvas.saveLayer(null, null);
         super.onDraw(canvas);
 
-        if (chapters.isEmpty() || durationSeconds <= 0) {
-            Log.d(TAG, "onDraw: skipped — chapters=" + chapters.size()
-                    + " durationSeconds=" + durationSeconds);
-            return;
-        }
-
         final float density = getResources().getDisplayMetrics().density;
-        final float tickWidthPx = TICK_WIDTH_DP * density;
+        final float gapHalfWidth = (GAP_WIDTH_DP * density) / 2f;
+        final int paddingLeft = getPaddingLeft();
+        final float trackWidth = getWidth() - paddingLeft - getPaddingRight();
 
-        // Track bounds: AbsSeekBar pads the track by getPaddingLeft/getPaddingRight
-        final int paddingLeft  = getPaddingLeft();
-        final int paddingRight = getPaddingRight();
-        final float trackWidth = getWidth() - paddingLeft - paddingRight;
-
-        Log.d(TAG, "onDraw: w=" + getWidth() + " h=" + getHeight()
-                + " paddingL=" + paddingLeft + " paddingR=" + paddingRight
-                + " trackWidth=" + trackWidth + " chapters=" + chapters.size()
-                + " durationSeconds=" + durationSeconds);
-
-        if (trackWidth <= 0) {
-            Log.d(TAG, "onDraw: trackWidth<=0, skipping");
-            return;
+        if (trackWidth > 0) {
+            for (final StreamSegment seg : chapters) {
+                final int startSec = seg.getStartTimeSeconds();
+                // Skip the very first position and anything at or past the end
+                if (startSec <= 0 || startSec >= durationSeconds) {
+                    continue;
+                }
+                final float x = paddingLeft + (startSec / (float) durationSeconds) * trackWidth;
+                canvas.drawRect(x - gapHalfWidth, 0, x + gapHalfWidth, getHeight(), gapPaint);
+            }
         }
 
-        // Center ticks vertically, scaling height as a fraction of the view
-        final float tickHeight = getHeight() * TICK_HEIGHT_FRACTION;
-        final float tickTop    = (getHeight() - tickHeight) / 2f;
-        final float tickBottom = tickTop + tickHeight;
+        canvas.restoreToCount(sc);
 
-        for (final StreamSegment seg : chapters) {
-            final int startSec = seg.getStartTimeSeconds();
-            // Skip the very beginning and anything at or past the end
-            if (startSec <= 0 || startSec >= durationSeconds) {
-                Log.d(TAG, "  skipping seg startSec=" + startSec);
-                continue;
-            }
-            final float x = paddingLeft + (startSec / (float) durationSeconds) * trackWidth;
-            Log.d(TAG, "  drawing tick at x=" + x + " for startSec=" + startSec
-                    + " title=" + seg.getTitle());
-            canvas.drawRect(
-                    x - tickWidthPx / 2f,
-                    tickTop,
-                    x + tickWidthPx / 2f,
-                    tickBottom,
-                    tickPaint);
+        // Redraw the thumb on top so it visually overlaps the gaps
+        final Drawable thumb = getThumb();
+        if (thumb != null) {
+            final int thumbSave = canvas.save();
+            canvas.translate(getPaddingLeft() - getThumbOffset(), getPaddingTop());
+            thumb.draw(canvas);
+            canvas.restoreToCount(thumbSave);
         }
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/views/FocusAwareSeekBar.java
+++ b/app/src/main/java/org/schabi/newpipe/views/FocusAwareSeekBar.java
@@ -33,7 +33,7 @@ import org.schabi.newpipe.util.DeviceUtils;
  * (onStartTrackingTouch/onStopTrackingTouch), so existing code does not need to be changed to
  * work with it.
   */
-public final class FocusAwareSeekBar extends AppCompatSeekBar {
+public class FocusAwareSeekBar extends AppCompatSeekBar {
     private NestedListener listener;
 
     private ViewTreeObserver treeObserver;

--- a/app/src/main/res/layout/player.xml
+++ b/app/src/main/res/layout/player.xml
@@ -416,6 +416,23 @@
                     android:paddingBottom="12dp">
 
                     <org.schabi.newpipe.views.NewPipeTextView
+                        android:id="@+id/currentChapterTitle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:background="#60000000"
+                        android:ellipsize="end"
+                        android:maxLines="1"
+                        android:paddingLeft="5dp"
+                        android:paddingRight="5dp"
+                        android:paddingBottom="2dp"
+                        android:textColor="@android:color/white"
+                        android:textSize="12sp"
+                        android:visibility="gone"
+                        tools:ignore="RtlHardcoded"
+                        tools:text="Introduction"
+                        tools:visibility="visible" />
+
+                    <org.schabi.newpipe.views.NewPipeTextView
                         android:id="@+id/currentDisplaySeek"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
@@ -467,7 +484,7 @@
                     tools:text="1:06:29" />
 
 
-                <org.schabi.newpipe.views.FocusAwareSeekBar
+                <org.schabi.newpipe.views.ChaptersSeekBar
                     android:id="@+id/playbackSeekBar"
                     style="@style/Widget.AppCompat.SeekBar"
                     android:layout_width="0dp"


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Feature (user facing) 
- [ ] Bugfix (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This is the requested **backport of PR #13413 to the `dev` branch** to maintain feature parity.

It includes the original Java implementation of the `ChaptersSeekBar` with visual markers, gap rendering based on video metadata (`StreamInfo`), and haptic feedback, exactly as they were implemented before the Kotlin migration requested for the `refactor` branch.

#### Before/After Screenshots/Screen Record
*(Same UI changes as demonstrated in #13413)*
**After:**
[https://github.com/user-attachments/assets/80f2cf57-d500-4670-bcd5-4e45c6d4fdcf](https://github.com/user-attachments/assets/80f2cf57-d500-4670-bcd5-4e45c6d4fdcf)

#### Fixes the following issue(s)
- Fixes #6270
- Backports #13413

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
- [x] The proposed changes follow the [AI policy](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md#ai-policy).
- [x] I tested the changes using an emulator or a physical device.