### PR TITLE
Close keyboard first when navigating back from search

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/list/search/SearchFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/search/SearchFragment.java
@@ -720,11 +720,14 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
 
     @Override
     public boolean onBackPressed() {
+        if (KeyboardUtil.isKeyboardVisible(activity, searchEditText)) {
+            hideKeyboardSearch();
+            return true;
+        }
         if (suggestionsPanelVisible
                 && !infoListAdapter.getItemsList().isEmpty()
                 && !isLoading.get()) {
             hideSuggestionsPanel();
-            hideKeyboardSearch();
             searchEditText.setText(lastSearchedString);
             return true;
         }

--- a/app/src/main/java/org/schabi/newpipe/util/KeyboardUtil.java
+++ b/app/src/main/java/org/schabi/newpipe/util/KeyboardUtil.java
@@ -52,4 +52,13 @@ public final class KeyboardUtil {
 
         editText.clearFocus();
     }
+
+    public static boolean isKeyboardVisible(final Activity activity, final EditText editText) {
+        if (activity == null || editText == null) {
+            return false;
+        }
+        final InputMethodManager imm = ContextCompat.getSystemService(activity,
+                InputMethodManager.class);
+        return imm.isActive(editText);
+    }
 }


### PR DESCRIPTION
## About this PR
The back button in search was closing the suggestions panel even when the keyboard was open, which is annoying. Fixed it by checking if the keyboard is visible first and closing that instead. Extracted the keyboard visibility check into a new isKeyboardVisible() method on KeyboardUtil.

## Checklist
- [x] I am able to reproduce the bug with the latest version
- [x] I made sure that there are no existing PRs for the same issue
- [x] I have read the contribution guidelines
- [x] I have tested my changes on device/emulator
- [x] This PR fixes #13431