### PR TITLE
Update extractor and remove proguard rules for jsoup

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -16,11 +16,6 @@
 -dontwarn javax.script.**
 -keep class jdk.dynalink.** { *; }
 -dontwarn jdk.dynalink.**
-# Rules for jsoup
-# Ignore intended-to-be-optional re2j classes - only needed if using re2j for jsoup regex
-# jsoup safely falls back to JDK regex if re2j not on classpath, but has concrete re2j refs
-# See https://github.com/jhy/jsoup/issues/2459 - may be resolved in future, then this may be removed
--dontwarn com.google.re2j.**
 
 ## Rules for ExoPlayer
 -keep class com.google.android.exoplayer2.** { *; }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -60,7 +60,7 @@ teamnewpipe-nanojson = "e9d656ddb49a412a5a0a5d5ef20ca7ef09549996"
 # the corresponding commit hash, since JitPack sometimes deletes artifacts.
 # If there’s already a git hash, just add more of it to the end (or remove a letter)
 # to cause jitpack to regenerate the artifact.
-teamnewpipe-newpipe-extractor = "v0.26.1"
+teamnewpipe-newpipe-extractor = "1512cf3222b0c5d87a249e6ac231b98090c42623"
 viewpager2 = "1.1.0"
 webkit = "1.15.0"
 work = "2.11.2"


### PR DESCRIPTION
#### What is it?
- [x] Codebase improvement (dev facing)

#### Description of the changes in your PR
- update extractor
- Remove proguard rules for optional jsoup classes. The underlying problem is fixed with jsoup 1.12.2. See https://github.com/TeamNewPipe/NewPipeExtractor/pull/1480. Revert 6c5d58bed3a4e7945580c644a875aa1addf3a89b /  #13038.


#### APK testing

Build release APK with `./gradlew assembleRelease`. No errors during compilation and no runtime problems.

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
- [x] The proposed changes follow the [AI policy](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md#ai-policy).
- [x] I tested the changes using an emulator or a physical device.
