### PR TITLE
Fix inconsistent History page title when opening the History page from the sidebar.

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
@@ -102,7 +102,7 @@ public class StatisticsPlaylistFragment
     public void onResume() {
         super.onResume();
         if (activity != null) {
-            setTitle(activity.getString(R.string.title_activity_history));
+            displaySortMode(sortMode);
         }
     }
 
@@ -384,9 +384,24 @@ public class StatisticsPlaylistFragment
         return new SinglePlayQueue(streamInfoItems, index);
     }
 
+    private void displaySortMode(final StatisticSortMode mode) {
+        final int resourceIdOfSortMode = mode.getResourceId();
+        setTitle(getString(resourceIdOfSortMode));
+    }
+
     private enum StatisticSortMode {
-        LAST_PLAYED,
-        MOST_PLAYED,
+        LAST_PLAYED(R.string.title_last_played),
+        MOST_PLAYED(R.string.title_most_played);
+
+        private final int resourceId;
+
+        StatisticSortMode(final int theResourceId) {
+            this.resourceId = theResourceId;
+        }
+
+        int getResourceId() {
+            return resourceId;
+        }
     }
 }
 


### PR DESCRIPTION

<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing) ⚠️ **Your PR must target the [`refactor`](https://github.com/TeamNewPipe/NewPipe/tree/refactor) branch**
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR

- Add a helper method `displaySortMode()` to show the current sort mode in `onResume()`, instead of always resetting the top bar title to `History`
- Move sort mode ↔ string resource mapping into `StatisticSortMode`: This avoids adding extra conditional branches, such as if-else or switch-case, in `displaySortMode()` when more sort modes are introduced in the future.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before: The top title changes between page name "History" and current sort mode, remaining inconsistent every time the page is entered.
- After: The History page title now always correctly reflects the current sort mode. Please see the screen recording after the fix:

https://github.com/user-attachments/assets/ce22c695-f1c1-4b5a-8e42-4b07b180d0b6



#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #13439



#### APK testing

Tested on device:

- Enter History page from sidebar
- Verify title reflects current sort mode
- Toggle sort mode
- Leave page and re-enter History
- Confirm title remains consistent


#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
- [x] The proposed changes follow the [AI policy](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md#ai-policy).
- [x] I tested the changes using an emulator or a physical device.
