### PR TITLE
Fix: allow saving default player preference for downloaded files

### DIFF
--- a/app/src/main/java/us/shandian/giga/ui/adapter/MissionAdapter.java
+++ b/app/src/main/java/us/shandian/giga/ui/adapter/MissionAdapter.java
@@ -1,7 +1,6 @@
 package us.shandian.giga.ui.adapter;
 
 import static android.content.Intent.FLAG_ACTIVITY_NEW_TASK;
-import static android.content.Intent.FLAG_GRANT_PREFIX_URI_PERMISSION;
 import static android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION;
 import static android.content.Intent.createChooser;
 import static us.shandian.giga.get.DownloadMission.ERROR_CONNECT_HOST;
@@ -70,12 +69,12 @@ import org.schabi.newpipe.util.external_communication.ShareUtils;
 
 import java.io.File;
 import java.net.URI;
+import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.Date;
+import java.util.Iterator;
 import java.util.Locale;
-import java.text.DateFormat;
 
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 import io.reactivex.rxjava3.core.Observable;
@@ -348,20 +347,28 @@ public class MissionAdapter extends Adapter<ViewHolder> implements Handler.Callb
 
         String mimeType = resolveMimeType(mission);
 
-        if (BuildConfig.DEBUG)
+        if (BuildConfig.DEBUG) {
             Log.v(TAG, "Mime: " + mimeType + " package: " + BuildConfig.APPLICATION_ID + ".provider");
+        }
 
+        // Create the intent to view/play the downloaded file
         Intent viewIntent = new Intent(Intent.ACTION_VIEW);
+
+        // Attach the file URI and its corresponding MIME type
         viewIntent.setDataAndType(resolveShareableUri(mission), mimeType);
-        viewIntent.addFlags(FLAG_GRANT_READ_URI_PERMISSION);
-        viewIntent.addFlags(FLAG_GRANT_PREFIX_URI_PERMISSION);
 
-        Intent chooserIntent = createChooser(viewIntent, null);
-        chooserIntent.addFlags(FLAG_ACTIVITY_NEW_TASK);
-        chooserIntent.addFlags(FLAG_GRANT_READ_URI_PERMISSION);
-        chooserIntent.addFlags(FLAG_GRANT_PREFIX_URI_PERMISSION);
+        /*
+         * Note: We pass viewIntent directly to openIntentInApp instead of using Intent.createChooser().
+         * On modern Android versions, wrapping an intent with createChooser() prevents the
+         * system from showing the "Always" option, forcing the user to pick an app every time.
+         * By removing the chooser, we allow the OS to respect and save the user's default app preference.
+         */
+        viewIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        viewIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        viewIntent.addFlags(Intent.FLAG_GRANT_PREFIX_URI_PERMISSION);
 
-        ShareUtils.openIntentInApp(mContext, chooserIntent);
+        // Open the intent directly to trigger the standard system resolver
+        ShareUtils.openIntentInApp(mContext, viewIntent);
     }
 
     private void shareFile(Mission mission) {


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [x] This PR is for the `dev` branch.

#### Description of the changes in the PR
This PR fixes the issue where the default media player preference for downloaded files could not be saved on modern Android versions.

#### Fixes the following issue(s)
Fixes #13043

#### Relies on the following changes
The root cause was the usage of `Intent.createChooser()`, which intentionally prevents the system from showing the "Always/Just Once" options and ignores existing defaults. By passing the `viewIntent` directly to `ShareUtils.openIntentInApp()`, the standard system resolver is restored, allowing users to set and persist their preferred media player.

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->

The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
- [x] The proposed changes follow the [AI policy](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md#ai-policy).
- [x] I have tested my changes and they work as expected.