### PR TITLE
Fix repeat mode UI out-of-sync when switching videos

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
@@ -988,16 +988,14 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
     }
 
     private void setRepeatButton(final int repeatMode) {
-        if (repeatMode == REPEAT_MODE_ALL) {
-            binding.repeatButton.setImageResource(
-                    com.google.android.exoplayer2.ui.R.drawable.exo_controls_repeat_all);
-        } else if (repeatMode == REPEAT_MODE_ONE) {
-            binding.repeatButton.setImageResource(
-                    com.google.android.exoplayer2.ui.R.drawable.exo_controls_repeat_one);
-        } else /* repeatMode == REPEAT_MODE_OFF */ {
-            binding.repeatButton.setImageResource(
-                    com.google.android.exoplayer2.ui.R.drawable.exo_controls_repeat_off);
-        }
+        final int resId = switch (repeatMode) {
+            case REPEAT_MODE_ALL
+                    -> com.google.android.exoplayer2.ui.R.drawable.exo_controls_repeat_all;
+            case REPEAT_MODE_ONE
+                    -> com.google.android.exoplayer2.ui.R.drawable.exo_controls_repeat_one;
+            default -> com.google.android.exoplayer2.ui.R.drawable.exo_controls_repeat_off;
+        };
+        binding.repeatButton.setImageResource(resId);
     }
 
     //endregion

--- a/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
@@ -399,6 +399,10 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
 
         // #6825 - Ensure that the shuffle-button is in the correct state on the UI
         setShuffleButton(player.getExoPlayer().getShuffleModeEnabled());
+
+        // Set repeat button to the correct UI state
+        setRepeatButton(player.getExoPlayer().getRepeatMode());
+
     }
 
     public abstract void removeViewFromParent();
@@ -982,6 +986,20 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
     private void setShuffleButton(final boolean shuffled) {
         binding.shuffleButton.setImageAlpha(shuffled ? 255 : 77);
     }
+
+    private void setRepeatButton(final int repeatMode) {
+        if (repeatMode == REPEAT_MODE_ALL) {
+            binding.repeatButton.setImageResource(
+                    com.google.android.exoplayer2.ui.R.drawable.exo_controls_repeat_all);
+        } else if (repeatMode == REPEAT_MODE_ONE) {
+            binding.repeatButton.setImageResource(
+                    com.google.android.exoplayer2.ui.R.drawable.exo_controls_repeat_one);
+        } else /* repeatMode == REPEAT_MODE_OFF */ {
+            binding.repeatButton.setImageResource(
+                    com.google.android.exoplayer2.ui.R.drawable.exo_controls_repeat_off);
+        }
+    }
+
     //endregion
 
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing) ⚠️ **Your PR must target the [`refactor`](https://github.com/TeamNewPipe/NewPipe/tree/refactor) branch**
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This PR fixes the issue described below (and in #13506) by syncing the repeat button's visual state using a helper method called during initPlayback() in VideoPlayerUi, similar to how shuffle mode is already handled there.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
Warning, the sound might be loud!

- Before: https://github.com/user-attachments/assets/74a76b2d-9ea7-446a-90ae-5510ac71dcb5

- After: https://github.com/user-attachments/assets/d7937da7-480a-46f2-8da7-d80b42202af0

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #13506
###### The issue
When switching videos while using the mini player with repeat mode set to ONE or ALL (start a video, set repeat mode to ONE or ALL, minimize the video, then open another video while the first is still playing), **the repeat mode button shows an active state even though repeat is actually not enabled**.

This happens because Player.java recreates the ExoPlayer instance when switching media, which resets repeat mode back to OFF internally. However, the UI is not updated after this, so the repeat button may still show Repeat One or Repeat All as active. As mentioned, in this case the video will not actually repeat, even though the UI suggests it will.

If the user then presses the repeat button, the mismatch causes confusing behavior: the first press may look like it does nothing if the previous state was ONE, or may look incorrect if the previous state was ALL, since the UI and player state are out of sync.

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Note
As mentioned, this happens because the ExoPlayer instance is recreated on media change, which resets playback state. This PR fixes the UI sync, but in the long-term it may be worth considering remembering the repeat and shuffle states when player recreation happens and re-applying them.

This is my first contribution to this project. Happy to adjust if anything is not aligned with the contribution guidelines!

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
- [x] The proposed changes follow the [AI policy](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md#ai-policy).
- [x] I tested the changes using an emulator or a physical device.