### PR TITLE
Add a history search UI for history page

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
@@ -9,6 +9,9 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.inputmethod.InputMethodManager;
+import android.view.inputmethod.EditorInfo;
+import android.view.KeyEvent;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -155,6 +158,55 @@ public class StatisticsPlaylistFragment
                     showInfoItemDialog((StreamStatisticsEntry) selectedItem);
                 }
             }
+        });
+
+        initHistorySearchOverlayActions();
+
+        initHistorySearchInputActions();
+
+        initHistorySearchClearActions();
+    }
+
+    private void initHistorySearchOverlayActions() {
+        // Show search overlay
+        headerBinding.searchButton.setOnClickListener(view -> {
+            if (headerBinding.historySearchBar.getVisibility() == View.GONE) {
+                headerBinding.historySearchBar.setVisibility(View.VISIBLE);
+                headerBinding.historySearchInput.requestFocus();
+
+                // Show soft keyboard
+                final InputMethodManager imm =
+                        (InputMethodManager) requireContext()
+                        .getSystemService(Context.INPUT_METHOD_SERVICE);
+                imm.showSoftInput(
+                        headerBinding.historySearchInput,
+                        InputMethodManager.SHOW_IMPLICIT
+                    );
+            }
+        });
+    }
+
+    private void initHistorySearchInputActions() {
+        headerBinding.historySearchInput.setOnEditorActionListener((v, actionId, event) -> {
+            if ((EditorInfo.IME_ACTION_SEARCH == actionId)
+                    || ((null != event) && (KeyEvent.KEYCODE_ENTER == event.getKeyCode()))) {
+
+                // hide keyboard
+                final InputMethodManager imm = (InputMethodManager)
+                        requireContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+                imm.hideSoftInputFromWindow(v.getWindowToken(), 0);
+
+                return true;
+            }
+            return false;
+        });
+    }
+
+    private void initHistorySearchClearActions() {
+        // Clear input & hide search overlay
+        headerBinding.historySearchClearIcon.setOnClickListener(view -> {
+            headerBinding.historySearchInput.setText("");
+            headerBinding.historySearchBar.setVisibility(View.GONE);
         });
     }
 

--- a/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
@@ -13,6 +13,8 @@ import android.view.inputmethod.InputMethodManager;
 import android.view.inputmethod.EditorInfo;
 import android.view.KeyEvent;
 import android.widget.Toast;
+import android.text.TextWatcher;
+import android.text.Editable;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -48,6 +50,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Supplier;
+import java.util.Locale;
 
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 import io.reactivex.rxjava3.disposables.CompositeDisposable;
@@ -67,6 +70,8 @@ public class StatisticsPlaylistFragment
     /* Used for independent events */
     private Subscription databaseSubscription;
     private HistoryRecordManager recordManager;
+
+    private List<StreamStatisticsEntry> allHistoryEntries = new ArrayList<>();
 
     private List<StreamStatisticsEntry> processResult(final List<StreamStatisticsEntry> results) {
         final Comparator<StreamStatisticsEntry> comparator;
@@ -200,6 +205,28 @@ public class StatisticsPlaylistFragment
             }
             return false;
         });
+
+        headerBinding.historySearchInput.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(final CharSequence s,
+                                          final int start,
+                                          final int count,
+                                          final int after) {
+            }
+
+            @Override
+            public void onTextChanged(final CharSequence s,
+                                      final int start,
+                                      final int before,
+                                      final int count) {
+                final String userInputText = s.toString();
+                filterHistory(userInputText);
+            }
+
+            @Override
+            public void afterTextChanged(final Editable s) {
+            }
+        });
     }
 
     private void initHistorySearchClearActions() {
@@ -208,6 +235,52 @@ public class StatisticsPlaylistFragment
             headerBinding.historySearchInput.setText("");
             headerBinding.historySearchBar.setVisibility(View.GONE);
         });
+    }
+
+    private void filterHistory(final String query) {
+        if (itemListAdapter == null) {
+            return;
+        }
+
+        itemListAdapter.clearStreamItemList();
+
+        if (query.isEmpty()) {
+            itemListAdapter.addItems(processResult(allHistoryEntries));
+            return;
+        }
+
+        final List<StreamStatisticsEntry> filtered = new ArrayList<>();
+
+        final String lowerQuery = query.toLowerCase(Locale.ROOT);
+
+        for (final StreamStatisticsEntry historyEntry : allHistoryEntries) {
+            if (matchesHistoryEntry(historyEntry, lowerQuery)) {
+                filtered.add(historyEntry);
+            }
+        }
+
+        itemListAdapter.addItems(processResult(filtered));
+    }
+
+    private boolean matchesHistoryEntry(final StreamStatisticsEntry historyEntry,
+                                        final String lowerQuery) {
+        final String title = historyEntry.getStreamEntity().getTitle();
+        if (null != title) {
+            final String lowerTitle = title.toLowerCase(Locale.ROOT);
+            if (lowerTitle.contains(lowerQuery)) {
+                return true;
+            }
+        }
+
+        final String uploader = historyEntry.getStreamEntity().getUploader();
+        if (null != uploader) {
+            final String lowerUploader = uploader.toLowerCase(Locale.ROOT);
+            if (lowerUploader.contains(lowerQuery)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     @Override
@@ -319,6 +392,8 @@ public class StatisticsPlaylistFragment
             showEmptyState();
             return;
         }
+
+        allHistoryEntries = new ArrayList<>(result);
 
         itemListAdapter.addItems(processResult(result));
         if (itemsListState != null && itemsList.getLayoutManager() != null) {

--- a/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
@@ -395,7 +395,10 @@ public class StatisticsPlaylistFragment
 
         allHistoryEntries = new ArrayList<>(result);
 
-        itemListAdapter.addItems(processResult(result));
+        final String currentQuery =
+                headerBinding.historySearchInput.getText().toString();
+        filterHistory(currentQuery);
+
         if (itemsListState != null && itemsList.getLayoutManager() != null) {
             itemsList.getLayoutManager().onRestoreInstanceState(itemsListState);
             itemsListState = null;

--- a/app/src/main/res/layout/statistic_playlist_control.xml
+++ b/app/src/main/res/layout/statistic_playlist_control.xml
@@ -1,11 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="vertical">
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
 
     <RelativeLayout
+        android:id="@+id/top_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
@@ -56,4 +61,47 @@
         android:id="@+id/playlist_control"
         layout="@layout/playlist_control" />
 
-</LinearLayout>
+    </LinearLayout>
+
+    <!-- Search overlay, positioned on top of sort+search row -->
+    <RelativeLayout
+        android:id="@+id/history_search_bar"
+        android:layout_width="match_parent"
+        android:layout_height="48dp"
+        android:visibility="gone"
+        android:background="?attr/windowBackground"
+        android:layout_gravity="top">
+
+        <!-- Use default cursor so its color follows textColor
+             (theme-driven, no hardcoded color) -->
+        <org.schabi.newpipe.views.NewPipeEditText
+            android:id="@+id/history_search_input"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:textCursorDrawable="@null"
+            android:hint="@string/search_history"
+            android:imeOptions="actionSearch|flagNoFullscreen"
+            android:inputType="textFilter|textNoSuggestions"
+            android:background="@null"
+            android:textColor="?attr/toolbarSearchColor"
+            android:gravity="center_vertical"
+            android:paddingTop="4dp"
+            android:paddingBottom="4dp"
+            android:maxLines="1"/>
+
+        <ImageView
+            android:id="@+id/history_search_clear_icon"
+            android:layout_width="48dp"
+            android:layout_height="match_parent"
+            android:layout_alignParentEnd="true"
+            android:src="@drawable/ic_close"
+            android:tint="?attr/toolbarSearchColor"/>
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_alignParentBottom="true"
+            android:background="?attr/toolbarSearchColor"/>
+    </RelativeLayout>
+
+</FrameLayout>

--- a/app/src/main/res/layout/statistic_playlist_control.xml
+++ b/app/src/main/res/layout/statistic_playlist_control.xml
@@ -26,7 +26,7 @@
 
         <org.schabi.newpipe.views.NewPipeTextView
             android:id="@+id/sortButtonText"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="50dp"
             android:layout_toRightOf="@id/sortButtonIcon"
             android:gravity="left|center"

--- a/app/src/main/res/layout/statistic_playlist_control.xml
+++ b/app/src/main/res/layout/statistic_playlist_control.xml
@@ -87,6 +87,7 @@
             android:gravity="center_vertical"
             android:paddingTop="4dp"
             android:paddingBottom="4dp"
+            android:paddingStart="12dp"
             android:maxLines="1"/>
 
         <ImageView

--- a/app/src/main/res/layout/statistic_playlist_control.xml
+++ b/app/src/main/res/layout/statistic_playlist_control.xml
@@ -6,6 +6,10 @@
     android:orientation="vertical">
 
     <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+    <RelativeLayout
         android:id="@+id/sortButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -35,6 +39,17 @@
             android:textSize="15sp"
             android:textStyle="bold"
             tools:ignore="RtlHardcoded" />
+    </RelativeLayout>
+
+    <ImageButton
+        android:id="@+id/searchButton"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_alignParentEnd="true"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:src="@drawable/ic_search"
+        android:contentDescription="@string/search_history"/>
+
     </RelativeLayout>
 
     <include

--- a/app/src/main/res/layout/statistic_playlist_control.xml
+++ b/app/src/main/res/layout/statistic_playlist_control.xml
@@ -77,6 +77,7 @@
         <org.schabi.newpipe.views.NewPipeEditText
             android:id="@+id/history_search_input"
             android:layout_width="match_parent"
+            android:layout_toStartOf="@id/history_search_clear_icon"
             android:layout_height="match_parent"
             android:textCursorDrawable="@null"
             android:hint="@string/search_history"
@@ -101,6 +102,8 @@
         <View
             android:layout_width="match_parent"
             android:layout_height="1dp"
+            android:layout_marginStart="6dp"
+            android:layout_toStartOf="@id/history_search_clear_icon"
             android:layout_alignParentBottom="true"
             android:background="?attr/toolbarSearchColor"/>
     </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
     <string name="download">Download</string>
     <string name="controls_download_desc">Download stream file</string>
     <string name="search">Search</string>
+    <string name="search_history">Search history</string>
     <string name="search_with_service_name">Search %1$s</string>
     <string name="search_with_service_name_and_filter">Search %1$s (%2$s)</string>
     <string name="settings">Settings</string>


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [✔] Feature (user facing) ⚠️ **Your PR must target the [`refactor`](https://github.com/TeamNewPipe/NewPipe/tree/refactor) branch**
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Adds a history search UI for history page, and users can search some history entries by clicking the search button and entering keywords in stream titles or uploader names.
Detailed description is provided in the comments below.

#### Before/After Screenshots/Screen Record
- Before: There is no search UI for history page.
- After: The history search UI is added. Here is a screen recording that showing the actions of this history search UI:

https://github.com/user-attachments/assets/891efa5e-b8b1-4eb4-b5f1-7b8ae5530a14



#### Fixes the following issue(s)
- Fixes #2977

#### Due diligence
- [✔] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
- [✔] The proposed changes follow the [AI policy](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md#ai-policy).
- [✔] I tested the changes using an emulator or a physical device.
