### PR TITLE
fix: return to portrait after video finish in fullscreen

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -1473,7 +1473,19 @@ public final class VideoDetailFragment
         // Note for tablet: trying to avoid orientation changes since it's not easy
         // to physically rotate the tablet every time
         if (activity != null && !DeviceUtils.isTablet(activity)) {
-            activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
+            if (globalScreenOrientationLocked(activity)) {
+                // If global screen orientation is locked, check the current system rotation setting
+                // to restore the correct locked orientation (portrait vs landscape).
+                final int userRotation = Settings.System.getInt(
+                        activity.getContentResolver(), Settings.System.USER_ROTATION, 0);
+                if (userRotation == 1 || userRotation == 3) {
+                    activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+                } else {
+                    activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+                }
+            } else {
+                activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
+            }
         }
     }
 
@@ -2368,6 +2380,7 @@ public final class VideoDetailFragment
                         manageSpaceAtTheBottom(true);
 
                         bottomSheetBehavior.setPeekHeight(0);
+                        restoreDefaultOrientation();
                         cleanUp();
                         break;
                     case BottomSheetBehavior.STATE_EXPANDED:

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -1473,19 +1473,7 @@ public final class VideoDetailFragment
         // Note for tablet: trying to avoid orientation changes since it's not easy
         // to physically rotate the tablet every time
         if (activity != null && !DeviceUtils.isTablet(activity)) {
-            if (globalScreenOrientationLocked(activity)) {
-                // If global screen orientation is locked, check the current system rotation setting
-                // to restore the correct locked orientation (portrait vs landscape).
-                final int userRotation = Settings.System.getInt(
-                        activity.getContentResolver(), Settings.System.USER_ROTATION, 0);
-                if (userRotation == 1 || userRotation == 3) {
-                    activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
-                } else {
-                    activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
-                }
-            } else {
-                activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
-            }
+            PlayerHelper.restoreLockedOrientation(activity);
         }
     }
 

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
@@ -9,10 +9,13 @@ import static org.schabi.newpipe.player.helper.PlayerHelper.MinimizeMode.MINIMIZ
 import static java.lang.annotation.RetentionPolicy.SOURCE;
 
 import android.annotation.SuppressLint;
+import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.provider.Settings;
+import android.view.Surface;
 import android.view.accessibility.CaptioningManager;
 
 import androidx.annotation.IntDef;
@@ -366,6 +369,29 @@ public final class PlayerHelper {
                 context.getContentResolver(), Settings.System.ACCELEROMETER_ROTATION, 0) == 0
                     || !context.getPackageManager()
                         .hasSystemFeature(PackageManager.FEATURE_SENSOR_ACCELEROMETER);
+    }
+
+    /**
+     * Restore the correct locked orientation (portrait vs landscape)
+     * according to system rotation lock settings.
+     * If the orientation is not locked globally, resets orientation to UNSPECIFIED.
+     *
+     * @param activity the activity to set the orientation for
+     */
+    public static void restoreLockedOrientation(@NonNull final Activity activity) {
+        if (globalScreenOrientationLocked(activity)) {
+            final int userRotation = Settings.System.getInt(
+                    activity.getContentResolver(),
+                    Settings.System.USER_ROTATION,
+                    Surface.ROTATION_0);
+            if (userRotation == Surface.ROTATION_90 || userRotation == Surface.ROTATION_270) {
+                activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+            } else {
+                activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+            }
+        } else {
+            activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
+        }
     }
 
     public static int getProgressiveLoadIntervalBytes(@NonNull final Context context) {

--- a/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
@@ -16,7 +16,6 @@ import static org.schabi.newpipe.player.helper.PlayerHelper.globalScreenOrientat
 import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_PLAY_PAUSE;
 
 import android.app.Activity;
-import android.content.pm.ActivityInfo;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Resources;
@@ -940,23 +939,7 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
         if (!isFullscreen) {
             getParentActivity().ifPresent(activity -> {
                 if (!DeviceUtils.isTablet(activity)) {
-                    if (globalScreenOrientationLocked(activity)) {
-                        // Restore correct orientation according to system rotation lock settings
-                        // when exiting fullscreen mode.
-                        final int userRotation = Settings.System.getInt(
-                                activity.getContentResolver(),
-                                Settings.System.USER_ROTATION, 0);
-                        if (userRotation == 1 || userRotation == 3) {
-                            activity.setRequestedOrientation(
-                                    ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
-                        } else {
-                            activity.setRequestedOrientation(
-                                    ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
-                        }
-                    } else {
-                        activity.setRequestedOrientation(
-                                ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
-                    }
+                    PlayerHelper.restoreLockedOrientation(activity);
                 }
             });
         }

--- a/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
@@ -16,6 +16,7 @@ import static org.schabi.newpipe.player.helper.PlayerHelper.globalScreenOrientat
 import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_PLAY_PAUSE;
 
 import android.app.Activity;
+import android.content.pm.ActivityInfo;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Resources;
@@ -935,6 +936,30 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
         binding.metadataView.setVisibility(isFullscreen ? View.VISIBLE : View.GONE);
         binding.playerCloseButton.setVisibility(isFullscreen ? View.GONE : View.VISIBLE);
         setupScreenRotationButton();
+
+        if (!isFullscreen) {
+            getParentActivity().ifPresent(activity -> {
+                if (!DeviceUtils.isTablet(activity)) {
+                    if (globalScreenOrientationLocked(activity)) {
+                        // Restore correct orientation according to system rotation lock settings
+                        // when exiting fullscreen mode.
+                        final int userRotation = Settings.System.getInt(
+                                activity.getContentResolver(),
+                                Settings.System.USER_ROTATION, 0);
+                        if (userRotation == 1 || userRotation == 3) {
+                            activity.setRequestedOrientation(
+                                    ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+                        } else {
+                            activity.setRequestedOrientation(
+                                    ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+                        }
+                    } else {
+                        activity.setRequestedOrientation(
+                                ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
+                    }
+                }
+            });
+        }
     }
 
     public void checkLandscape() {


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing) ⚠️ **Your PR must target the [`refactor`](https://github.com/TeamNewPipe/NewPipe/tree/refactor) branch**
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->

With the changes in PR , video now switches back to portrait mode when playback is completed , closed using the "X" button.
This also fixes the case mentioned in https://github.com/TeamNewPipe/NewPipe/issues/13482 , where the video is minimised by swiping down and then closed using the "X" button. Additionally, double swiping down the video to close it also returns the app to portrait mode.

<b> Note on config: Tablet mode Off / Auto (with less than 480 dp) </b>

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before:
---
- After:


https://github.com/user-attachments/assets/af4a284b-9d0b-4dce-98d7-8e0cc046db1a


#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #

- #5967
-  #13057  
(Already open PR  - #13178 ) 
When I tested the ci build, it did not work for me (possibly due to the AVD configuration, though I’m not sure). 

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
- [x] The proposed changes follow the [AI policy](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md#ai-policy).
- [x] I tested the changes using an emulator or a physical device.
