### PR TITLE
Fix follow-system app language to use primary locale

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java
@@ -63,7 +63,13 @@ public class ContentSettingsFragment extends BasePreferenceFragment {
         appLanguagePref.setOnPreferenceChangeListener((preference, newValue) -> {
             final String language = (String) newValue;
             final String systemLang = getString(R.string.default_localization_key);
-            final String tag = systemLang.equals(language) ? null : language;
+            final String tag;
+            if (systemLang.equals(language)) {
+                final Locale systemLocale = LocaleListCompat.getAdjustedDefault().get(0);
+                tag = (systemLocale == null ? Locale.getDefault() : systemLocale).toLanguageTag();
+            } else {
+                tag = language;
+            }
             AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags(tag));
             return true;
         });


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing) ⚠️ **Your PR must target the [`refactor`](https://github.com/TeamNewPipe/NewPipe/tree/refactor) branch**
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR

Fixes inconsistent/mixed UI language behavior when Android has multiple system languages configured and NewPipe is set to use the default/system app language.

The issue was reported in #13107. For example, when Android system languages are configured as:

1. English (US)
2. Japanese

some NewPipe UI strings could appear in Japanese even though the primary system language is English.

This PR fixes the locale handling so that NewPipe uses the intended primary/default app locale consistently instead of mixing strings from a secondary system language.

Changed area:
 - `app/src/main/java/org/schabi/newpipe/settings/ContentSettingsFragment.java`

#### What is actually fixed?

Before this change, NewPipe could show UI strings from multiple languages when the app language was set to default/follow system and Android had more than one system language configured.

After this change, NewPipe consistently uses the expected app/system UI language. If English (US) is the primary Android language and Japanese is secondary, NewPipe UI remains in English instead of randomly mixing English and Japanese strings.

#### Fixes the following issue(s)

Fixes #13107

#### APK testing

Tested manually with the following language configurations:

- English (US) primary, Japanese secondary
- English (US) primary, English (UK) secondary, Japanese third
- Japanese primary, English (US) secondary

Checked:
- NewPipe starts without mixed UI strings.
- App language set to default/follow system works correctly.
- Explicit app language selection still works.
- Restarting the app keeps the expected language behavior.

#### Before/After Screenshots/Screen Record

Before:
- UI could show mixed English/Japanese strings when Android had multiple system languages.

After:
- UI consistently follows the selected/default app language.

#### Due diligence

- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
- [x] The proposed changes follow the [AI policy](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md#ai-policy).
- [x] I tested the changes using an emulator or a physical device.