### PR TITLE
Fix crash when seeking to the end of special videos (again)

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/seekbarpreview/SeekbarPreviewThumbnailHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/player/seekbarpreview/SeekbarPreviewThumbnailHolder.java
@@ -134,7 +134,7 @@ public class SeekbarPreviewThumbnailHolder {
                 // Get the bounds where the frame is found
                 final int[] bounds = frameset.getFrameBoundsAt(currentPosMs);
                 generatedDataForUrl.put(currentPosMs,
-                                        createBitmapSupplier(srcBitMap, bounds, frameset));
+                        createBitmapSupplier(srcBitMap, bounds, frameset));
 
                 currentPosMs += frameset.getDurationPerFrame();
                 pos++;
@@ -192,7 +192,7 @@ public class SeekbarPreviewThumbnailHolder {
             // Reference: https://stackoverflow.com/a/23683075 + first comment
             // Fixes: https://github.com/TeamNewPipe/NewPipe/issues/11461
             return cutOutBitmap == srcBitMap
-                    ? cutOutBitmap.copy(cutOutBitmap.getConfig(), true) : cutOutBitmap;
+                    ? cutOutBitmap.copy(Bitmap.Config.ARGB_8888, true) : cutOutBitmap;
         };
     }
 


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing) ⚠️ **Your PR must target the [`refactor`](https://github.com/TeamNewPipe/NewPipe/tree/refactor) branch**
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This is strongly related to #11584.
Apparently Coils behavior has changed in recent years (?) so the returned bitmap is of type `HARDWARE` and not of some software type. These hardware bitmaps are immutable so we cannot create an identical copy and need to create a software (ARGB_8888) bitmap instead.

#### Fixes the following issue(s)
- Fixes #13450 

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
- [x] The proposed changes follow the [AI policy](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md#ai-policy).
- [x] I tested the changes using an emulator or a physical device.
