### PR TITLE
app: Access themes by resource IDs instead of names

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/util/ThemeHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ThemeHelper.java
@@ -171,8 +171,7 @@ public final class ThemeHelper {
         }
 
         themeName += "." + service.getServiceInfo().getName();
-        final int resourceId = context.getResources()
-                .getIdentifier(themeName, "style", context.getPackageName());
+        final int resourceId = getThemeOrDefault(themeName, baseTheme);
 
         if (resourceId > 0) {
             return resourceId;
@@ -411,5 +410,27 @@ public final class ThemeHelper {
      */
     public static int getGridSpanCount(final Context context, final int minWidth) {
         return Math.max(1, context.getResources().getDisplayMetrics().widthPixels / minWidth);
+    }
+
+    @StyleRes
+    private static int getThemeOrDefault(final String name, @StyleRes final int baseTheme) {
+        return switch (name) {
+            case "LightTheme.YouTube" -> R.style.LightTheme_YouTube;
+            case "DarkTheme.YouTube" -> R.style.DarkTheme_YouTube;
+            case "BlackTheme.YouTube" -> R.style.BlackTheme_YouTube;
+            case "LightTheme.SoundCloud" -> R.style.LightTheme_SoundCloud;
+            case "DarkTheme.SoundCloud" -> R.style.DarkTheme_SoundCloud;
+            case "BlackTheme.SoundCloud" -> R.style.BlackTheme_SoundCloud;
+            case "LightTheme.PeerTube" -> R.style.LightTheme_PeerTube;
+            case "DarkTheme.PeerTube" -> R.style.DarkTheme_PeerTube;
+            case "BlackTheme.PeerTube" -> R.style.BlackTheme_PeerTube;
+            case "LightTheme.media.ccc.de" -> R.style.LightTheme_media_ccc_de;
+            case "DarkTheme.media.ccc.de" -> R.style.DarkTheme_media_ccc_de;
+            case "BlackTheme.media.ccc.de" -> R.style.BlackTheme_media_ccc_de;
+            case "LightTheme.Bandcamp" -> R.style.LightTheme_Bandcamp;
+            case "DarkTheme.Bandcamp" -> R.style.DarkTheme_Bandcamp;
+            case "BlackTheme.Bandcamp" -> R.style.BlackTheme_Bandcamp;
+            default -> baseTheme;
+        };
     }
 }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing) ⚠️ **Your PR must target the [`refactor`](https://github.com/TeamNewPipe/NewPipe/tree/refactor) branch**
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR

- Fixes a bug where changing services didn't update the theme
- 
#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
- [x] The proposed changes follow the [AI policy](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md#ai-policy).
- [x] I tested the changes using an emulator or a physical device.
