### PR TITLE
Feature: Add "(edited)" indicator to modified comments

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/ui/components/video/comment/Comment.kt
+++ b/app/src/main/java/org/schabi/newpipe/ui/components/video/comment/Comment.kt
@@ -112,8 +112,7 @@ fun Comment(comment: CommentsInfoItem, onCommentAuthorOpened: () -> Unit) {
                     text = nameAndDate,
                     style = MaterialTheme.typography.titleSmall,
                     maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.weight(1f, fill = false)
+                    overflow = TextOverflow.Ellipsis
                 )
 
                 if (comment.isEdited) {
@@ -121,7 +120,8 @@ fun Comment(comment: CommentsInfoItem, onCommentAuthorOpened: () -> Unit) {
                         text = stringResource(R.string.edited_comment_indicator),
                         style = MaterialTheme.typography.titleSmall,
                         modifier = Modifier.padding(start = 4.dp),
-                        maxLines = 1
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
                     )
                 }
             }
@@ -238,7 +238,7 @@ private class CommentPreviewProvider : CollectionPreviewParameterProvider<Commen
             isHeartedByUploader = true,
             replies = null,
             replyCount = 0,
-            isEdited = true
+            isEdited = false
         ),
         CommentsInfoItem(
             commentText = Description("Hello world, long long long text lorem ipsum dolor sit amet!<br><br>This line should be hidden by default.", Description.HTML),

--- a/app/src/main/java/org/schabi/newpipe/ui/components/video/comment/Comment.kt
+++ b/app/src/main/java/org/schabi/newpipe/ui/components/video/comment/Comment.kt
@@ -112,8 +112,18 @@ fun Comment(comment: CommentsInfoItem, onCommentAuthorOpened: () -> Unit) {
                     text = nameAndDate,
                     style = MaterialTheme.typography.titleSmall,
                     maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f, fill = false)
                 )
+
+                if (comment.isEdited) {
+                    Text(
+                        text = stringResource(R.string.edited_comment_indicator),
+                        style = MaterialTheme.typography.titleSmall,
+                        modifier = Modifier.padding(start = 4.dp),
+                        maxLines = 1
+                    )
+                }
             }
 
             Text(
@@ -204,7 +214,8 @@ fun CommentsInfoItem(
     isHeartedByUploader: Boolean = false,
     isPinned: Boolean = false,
     replies: Page? = null,
-    replyCount: Int = 0
+    replyCount: Int = 0,
+    isEdited: Boolean = false
 ) = CommentsInfoItem(serviceId, url, name).apply {
     this.commentText = commentText
     this.uploaderName = uploaderName
@@ -214,6 +225,7 @@ fun CommentsInfoItem(
     this.isPinned = isPinned
     this.replies = replies
     this.replyCount = replyCount
+    this.isEdited = isEdited
 }
 
 private class CommentPreviewProvider : CollectionPreviewParameterProvider<CommentsInfoItem>(
@@ -225,7 +237,8 @@ private class CommentPreviewProvider : CollectionPreviewParameterProvider<Commen
             isPinned = false,
             isHeartedByUploader = true,
             replies = null,
-            replyCount = 0
+            replyCount = 0,
+            isEdited = true
         ),
         CommentsInfoItem(
             commentText = Description("Hello world, long long long text lorem ipsum dolor sit amet!<br><br>This line should be hidden by default.", Description.HTML),
@@ -234,7 +247,8 @@ private class CommentPreviewProvider : CollectionPreviewParameterProvider<Commen
             isPinned = true,
             isHeartedByUploader = false,
             replies = Page(""),
-            replyCount = 10
+            replyCount = 10,
+            isEdited = true
         ),
         CommentsInfoItem(
             commentText = Description("Hello world, long long long text lorem ipsum dolor sit amet!<br><br>This line should be hidden by default.", Description.HTML),
@@ -243,7 +257,8 @@ private class CommentPreviewProvider : CollectionPreviewParameterProvider<Commen
             isPinned = true,
             isHeartedByUploader = true,
             replies = null,
-            replyCount = 0
+            replyCount = 0,
+            isEdited = true
         ),
         CommentsInfoItem(
             commentText = Description("Short comment", Description.HTML),

--- a/app/src/main/java/org/schabi/newpipe/ui/components/video/comment/CommentRepliesHeader.kt
+++ b/app/src/main/java/org/schabi/newpipe/ui/components/video/comment/CommentRepliesHeader.kt
@@ -81,12 +81,22 @@ fun CommentRepliesHeader(comment: CommentsInfoItem, onCommentAuthorOpened: () ->
                         style = MaterialTheme.typography.titleSmall
                     )
 
-                    Localization.relativeTimeOrTextual(
-                        context,
-                        comment.uploadDate,
-                        comment.textualUploadDate
-                    )?.let {
-                        Text(text = it, style = MaterialTheme.typography.bodySmall)
+                    Row {
+                        Localization.relativeTimeOrTextual(
+                            context,
+                            comment.uploadDate,
+                            comment.textualUploadDate
+                        )?.let {
+                            Text(text = it, style = MaterialTheme.typography.bodySmall)
+                        }
+                        if (comment.isEdited) {
+                            Text(
+                                text = stringResource(R.string.edited_comment_indicator),
+                                style = MaterialTheme.typography.bodySmall,
+                                modifier = Modifier.padding(start = 4.dp),
+                                maxLines = 1
+                            )
+                        }
                     }
                 }
             }
@@ -140,7 +150,8 @@ fun CommentRepliesHeaderPreview() {
         uploaderName = "Test really long lorem ipsum dolor sit",
         likeCount = 1000,
         isPinned = true,
-        isHeartedByUploader = true
+        isHeartedByUploader = true,
+        isEdited = true
     )
 
     AppTheme {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -915,4 +915,5 @@
     <string name="api23_requirement_dialog_title">NewPipe is dropping support for Android 5</string>
     <string name="api23_requirement_dialog_message">Unfortunately NewPipe depends on a few libraries that dropped support for Android 5.0 and 5.1. The next NewPipe release will therefore only work on devices with Android 6 or higher, sadly. Read more in the blogpost.</string>
     <string name="api23_requirement_dialog_blogpost">Blogpost</string>
+    <string name="edited_comment_indicator">(edited)</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -77,7 +77,7 @@ teamnewpipe-nanojson = "e9d656ddb49a412a5a0a5d5ef20ca7ef09549996"
 # the corresponding commit hash, since JitPack sometimes deletes artifacts.
 # If there’s already a git hash, just add more of it to the end (or remove a letter)
 # to cause jitpack to regenerate the artifact.
-teamnewpipe-newpipe-extractor = "v0.26.3"
+teamnewpipe-newpipe-extractor = "a79e6062856d29bc1a9ff31c51765bfb4ac89358"
 webkit = "1.15.0" # New versions require minSdk 24
 work = "2.11.2"
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing) ⚠️ **Your PR must target the [`refactor`](https://github.com/TeamNewPipe/NewPipe/tree/refactor) branch**
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Implemented a weighted Row layout for the comment header. By applying Modifier.weight(1f, fill = false) to the author's name and date, the layout guarantees that extremely long usernames will correctly truncate (TextOverflow.Ellipsis) rather than pushing  the new `(edited)` string off the edge of the screen.
- The indicator logic has been applied to both the main comment list and the expanded "(x replies)" sub-header view.
- Updated teamnewpipe-newpipe-extractor in `gradle/libs.versions.toml` to point to the specific commit hash of the corresponding backend PR that exposes the isEdited flag.


#### Before/After Screenshots/Screen Record
- Before:
<img width="300"  alt="Screenshot_20260614_172153" src="https://github.com/user-attachments/assets/21d15ea4-dda7-4996-a3a9-1bfb397dbec6" />
<img width="300" alt="Screenshot_20260614_172121" src="https://github.com/user-attachments/assets/d70dd6cb-ab2b-4d0d-aa05-927f79d5a043" />

- After:
<img width="300" alt="after2" src="https://github.com/user-attachments/assets/027e11b5-70e7-4ddb-b93e-8602e2e365f8" />
<img width="300" alt="after1" src="https://github.com/user-attachments/assets/71a89459-5c6a-4764-8ee3-bdb01d8a9804" />


#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #13209
- Closes #13595 

#### Relies on the following changes
- This frontend feature requires the upstream extraction logic to be merged first. Relies on TeamNewPipe/NewPipeExtractor#1513

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
- [x] The proposed changes follow the [AI policy](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md#ai-policy).
- [x] I tested the changes using an emulator or a physical device.
