### PR TITLE
[Feature] "Play x" Voice Commands via Assistant/Gemini on Android Auto

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -429,6 +429,25 @@
             </intent-filter>
 
         </activity>
+
+        <!-- Declares voice "play from search" support. Android Auto / Assistant only route a
+             spoken MEDIA_PLAY_FROM_SEARCH command to the MediaSession (onPlayFromSearch) when the
+             app declares an activity with this *bare* intent filter (no data constraints) - see
+             android/uamp#479. This activity also directly handles the legacy activity-style
+             MEDIA_PLAY_FROM_SEARCH intent (e.g. from automation tools) by searching and playing. -->
+        <activity
+            android:name=".PlayMediaFromSearchActivity"
+            android:excludeFromRecents="true"
+            android:exported="true"
+            android:noHistory="true"
+            android:taskAffinity=""
+            android:theme="@android:style/Theme.Translucent.NoTitleBar">
+            <intent-filter>
+                <action android:name="android.media.action.MEDIA_PLAY_FROM_SEARCH" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+
         <service
             android:name=".RouterActivity$FetcherService"
             android:foregroundServiceType="dataSync"

--- a/app/src/main/java/org/schabi/newpipe/PlayMediaFromSearchActivity.kt
+++ b/app/src/main/java/org/schabi/newpipe/PlayMediaFromSearchActivity.kt
@@ -1,0 +1,87 @@
+package org.schabi.newpipe
+
+import android.app.Activity
+import android.app.SearchManager
+import android.content.Intent
+import android.os.Bundle
+import android.util.Log
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
+import io.reactivex.rxjava3.disposables.Disposable
+import io.reactivex.rxjava3.schedulers.Schedulers
+import org.schabi.newpipe.extractor.stream.StreamInfoItem
+import org.schabi.newpipe.player.playqueue.SinglePlayQueue
+import org.schabi.newpipe.util.ExtractorHelper
+import org.schabi.newpipe.util.NavigationHelper
+import org.schabi.newpipe.util.ServiceHelper
+
+/**
+ * Handles the "Play <something>" voice intent ([android.media.action.MEDIA_PLAY_FROM_SEARCH]) when
+ * it arrives as a plain text query (i.e. without a media URL), e.g. from Google Assistant or an
+ * automation tool.
+ *
+ * Declaring this activity with a bare MEDIA_PLAY_FROM_SEARCH intent filter is also what makes
+ * Android Auto route spoken play-from-search commands to our MediaSession (see
+ * MediaBrowserPlaybackPreparer.onPrepareFromSearch); Auto uses the session path and does not
+ * actually launch this activity.
+ *
+ * When launched directly, it searches the user's selected service and starts background playback of
+ * the first matching stream, falling back to the search results screen if nothing is found.
+ *
+ * It has no UI of its own (translucent theme): it kicks off playback and finishes.
+ */
+class PlayMediaFromSearchActivity : Activity() {
+    private var searchDisposable: Disposable? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val query = intent?.getStringExtra(SearchManager.QUERY)
+            ?: intent?.getStringExtra(Intent.EXTRA_TEXT)
+
+        if (query.isNullOrBlank()) {
+            // Nothing to search for; just open the app rather than failing silently.
+            NavigationHelper.openMainActivity(this)
+            finish()
+            return
+        }
+
+        val serviceId = ServiceHelper.getSelectedServiceId(this)
+
+        searchDisposable = ExtractorHelper.searchFor(serviceId, query, emptyList(), "")
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe(
+                { searchInfo ->
+                    val firstStream = searchInfo.relatedItems
+                        .filterIsInstance<StreamInfoItem>()
+                        .firstOrNull()
+                    if (firstStream == null) {
+                        // No playable result: show the search results screen as a fallback.
+                        NavigationHelper.openSearch(this, serviceId, query)
+                    } else {
+                        NavigationHelper.playOnBackgroundPlayer(
+                            this,
+                            SinglePlayQueue(firstStream),
+                            true
+                        )
+                    }
+                    finish()
+                },
+                { throwable ->
+                    Log.e(TAG, "Failed to play from search query [$query]", throwable)
+                    // Don't dead-end the user: fall back to the search results screen.
+                    NavigationHelper.openSearch(this, serviceId, query)
+                    finish()
+                }
+            )
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        searchDisposable?.dispose()
+    }
+
+    companion object {
+        private val TAG = PlayMediaFromSearchActivity::class.java.simpleName
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/mediabrowser/MediaBrowserPlaybackPreparer.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/mediabrowser/MediaBrowserPlaybackPreparer.kt
@@ -23,6 +23,7 @@ import org.schabi.newpipe.error.ErrorInfo
 import org.schabi.newpipe.extractor.InfoItem.InfoType
 import org.schabi.newpipe.extractor.exceptions.ContentNotAvailableException
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler
+import org.schabi.newpipe.extractor.stream.StreamInfoItem
 import org.schabi.newpipe.local.playlist.LocalPlaylistManager
 import org.schabi.newpipe.local.playlist.RemotePlaylistManager
 import org.schabi.newpipe.player.playqueue.ChannelTabPlayQueue
@@ -32,6 +33,7 @@ import org.schabi.newpipe.player.playqueue.SinglePlayQueue
 import org.schabi.newpipe.util.ChannelTabHelper
 import org.schabi.newpipe.util.ExtractorHelper
 import org.schabi.newpipe.util.NavigationHelper
+import org.schabi.newpipe.util.ServiceHelper
 
 /**
  * This class is used to cleanly separate the Service implementation (in
@@ -62,7 +64,13 @@ class MediaBrowserPlaybackPreparer(
 
     //region Overrides
     override fun getSupportedPrepareActions(): Long {
-        return PlaybackStateCompat.ACTION_PLAY_FROM_MEDIA_ID
+        // Advertise both PLAY_FROM and PREPARE_FROM variants (UAMP pattern): some controllers send
+        // prepareFromSearch instead of playFromSearch, and the connector drops it unless the
+        // matching action is advertised.
+        return PlaybackStateCompat.ACTION_PREPARE_FROM_MEDIA_ID or
+            PlaybackStateCompat.ACTION_PLAY_FROM_MEDIA_ID or
+            PlaybackStateCompat.ACTION_PREPARE_FROM_SEARCH or
+            PlaybackStateCompat.ACTION_PLAY_FROM_SEARCH
     }
 
     override fun onPrepare(playWhenReady: Boolean) {
@@ -91,7 +99,50 @@ class MediaBrowserPlaybackPreparer(
     }
 
     override fun onPrepareFromSearch(query: String, playWhenReady: Boolean, extras: Bundle?) {
-        onUnsupportedError()
+        if (MainActivity.DEBUG) {
+            Log.d(TAG, "onPrepareFromSearch($query, $playWhenReady, $extras)")
+        }
+
+        // An empty query (e.g. a bare "play music" voice command, which Android Auto / AAOS can
+        // send) should start something rather than error out: returning ERROR_CODE_NOT_SUPPORTED
+        // can make the voice agent treat the app as not search-capable. Resume the most recently
+        // played stream instead.
+        if (query.isBlank()) {
+            playMostRecentlyPlayed(playWhenReady)
+            return
+        }
+
+        // Search the user's currently selected service (YouTube by default) and play the first
+        // stream result, mirroring the "Play <something> on NewPipe" voice intent.
+        val serviceId = ServiceHelper.getSelectedServiceId(context)
+
+        disposable?.dispose()
+        disposable = ExtractorHelper.searchFor(serviceId, query, emptyList(), "")
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe(
+                { searchInfo ->
+                    val firstStream = searchInfo.relatedItems
+                        .filterIsInstance<StreamInfoItem>()
+                        .firstOrNull()
+                    if (firstStream == null) {
+                        onPrepareError(
+                            ContentNotAvailableException("No streams found for query \"$query\"")
+                        )
+                    } else {
+                        clearMediaSessionError.run()
+                        NavigationHelper.playOnBackgroundPlayer(
+                            context,
+                            SinglePlayQueue(firstStream),
+                            playWhenReady
+                        )
+                    }
+                },
+                { throwable ->
+                    Log.e(TAG, "Failed to play from search query [$query]", throwable)
+                    onPrepareError(throwable)
+                }
+            )
     }
 
     override fun onPrepareFromUri(uri: Uri, playWhenReady: Boolean, extras: Bundle?) {
@@ -125,6 +176,33 @@ class MediaBrowserPlaybackPreparer(
     //endregion
 
     //region Building play queues from playlists and history
+    private fun playMostRecentlyPlayed(playWhenReady: Boolean) {
+        disposable?.dispose()
+        disposable = database.streamHistoryDAO().history
+            .firstOrError()
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe(
+                { history ->
+                    val mostRecent = history.firstOrNull()?.toStreamInfoItem()
+                    if (mostRecent == null) {
+                        onUnsupportedError()
+                    } else {
+                        clearMediaSessionError.run()
+                        NavigationHelper.playOnBackgroundPlayer(
+                            context,
+                            SinglePlayQueue(mostRecent),
+                            playWhenReady
+                        )
+                    }
+                },
+                { throwable ->
+                    Log.e(TAG, "Failed to play most recent stream for empty query", throwable)
+                    onPrepareError(throwable)
+                }
+            )
+    }
+
     private fun extractLocalPlayQueue(playlistId: Long, index: Int): Single<PlayQueue> {
         return LocalPlaylistManager(database).getPlaylistStreams(playlistId).firstOrError()
             .map { items -> SinglePlayQueue(items.map { it.toStreamInfoItem() }, index) }


### PR DESCRIPTION
### What this PR Adds
As the title suggests, you can now say "Play x" on Android Auto and it'll play x on NewPipe - with slight caveats (see below)

https://github.com/user-attachments/assets/b3145ef5-7003-47b4-bc2f-d3ff478c79f7

According to PR #12044, this isn't possible:
>voice search from within the app works, but search from the google assistant (e.g., "play on NewPipe") only supports applications from the Google Play Store.

But that didn't stop me because I'm too lazy to read!
<img width="800" height="450" alt="image" src="https://github.com/user-attachments/assets/ce3b3e4e-cfd1-4d4e-87c9-89d826f7ca5d" />

### Testing and Caveats

I tested this on two devices in 3 configurations.
- My Pixel 5 running regular Google Assistant (not Gemini) and no other media apps such as Spotify "Just Works".  You say "Play Chocolate Rain", it plays Chocolate Rain - no questions asked.
- My Wife's Pixel 7 running Gemini, and also with Spotify installed would play some videos, sometimes.  Gemini seems to have a "safety" feature that blocks it from playing a video if you're driving - and what it defines as a "video" seems to be nondeterministic.  For example, it will gladly comply if you say "Play Chocolate Rain by Tay Zonday", but not "Play Chocolate Rain".  And sometimes it doesn't enforce the safety feature at all and lets you play whatever you want?  It's strange.
- Using my Wife's Pixel 7, but with regular Google Assistant, complies 100% of the time but will very eagerly try to route requests to Spotify.  In order to get it to work reliably, I had to open NewPipe manually and play a piece of media.  Then, all future requests would be routed to NewPipe until I played something on Spotify again.  It doesn't look like there's a way to fix this, we can't define "play on NewPipe" without going through the Google Play Store process (OK, maybe I can read a little bit).

### Who actually deserves the credit for this

All code written by Claude Opus 4.8 with some gentle steering on my end.
Unedited Claude PR text below:

---

NewPipe's `onPrepareFromSearch` was a no-op (it returned `ERROR_CODE_NOT_SUPPORTED`), so voice "play &lt;something&gt;" commands in Android Auto did nothing. This implements it.

### Changes
- **Implement `onPrepareFromSearch`** — search the selected service and play the top result. An empty query (e.g. a bare "play music") resumes the most recently played stream instead of erroring.
- **Advertise the search actions** in `getSupportedPrepareActions()` (`PREPARE`/`PLAY_FROM_MEDIA_ID` + `PREPARE`/`PLAY_FROM_SEARCH`), so the connector forwards both `playFromSearch` and `prepareFromSearch`.
- **Add `PlayMediaFromSearchActivity`** with a bare `MEDIA_PLAY_FROM_SEARCH` intent filter. Android Auto only routes a spoken play-from-search to an app that declares such an activity (see android/uamp#479); NewPipe's existing filters are all gated behind YouTube-URL `data` constraints, so AA never treated it as voice-search-capable. The activity also handles the direct intent (search + play) for automation tools.

### Testing
Verified in Android Auto (Desktop Head Unit + a real connection) on Pixel 5 and Pixel 7: saying "play &lt;query&gt;" plays the top result.

### Note / scope
This targets **Android Auto**. The phone Google Assistant/Gemini only routes "play on &lt;app&gt;" to apps in Google's curated media-provider catalog, so it won't trigger this for a non-listed app like NewPipe — that's a Google-side gate, not something the app can change.
