### PR TITLE
[YouTube]  Add support for "Podcasts" and "Courses" tabs

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/settings/migration/SettingMigrations.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/migration/SettingMigrations.java
@@ -221,6 +221,25 @@ public final class SettingMigrations {
         }
     };
 
+    private static final Migration MIGRATION_8_9 = new Migration(8, 9) {
+        @Override
+        protected void migrate(@NonNull final Context context) {
+            // Support for courses and podcasts tabs were added.
+            // If the user changed the displayed tabs the new ones need to be added to the list
+            // of displayed tabs.
+            final Set<String> enabledTabs = sp.getStringSet(context.getString(
+                    R.string.show_channel_tabs_key), null);
+            if (enabledTabs != null) {
+                enabledTabs.add(context.getString(R.string.show_channel_tabs_courses));
+                enabledTabs.add(context.getString(R.string.show_channel_tabs_podcasts));
+                sp.edit()
+                        .putStringSet(context.getString(R.string.show_channel_tabs_key),
+                                enabledTabs)
+                        .apply();
+            }
+        }
+    };
+
     /**
      * List of all implemented migrations.
      * <p>
@@ -236,12 +255,13 @@ public final class SettingMigrations {
             MIGRATION_5_6,
             MIGRATION_6_7,
             MIGRATION_7_8,
+            MIGRATION_8_9,
     };
 
     /**
      * Version number for preferences. Must be incremented every time a migration is necessary.
      */
-    private static final int VERSION = 8;
+    private static final int VERSION = 9;
 
 
     static void runMigrationsIfNeeded(@NonNull final Context context) {

--- a/app/src/main/java/org/schabi/newpipe/util/ChannelTabHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ChannelTabHelper.java
@@ -27,6 +27,8 @@ public final class ChannelTabHelper {
             case ChannelTabs.LIKES:
             case ChannelTabs.SHORTS:
             case ChannelTabs.LIVESTREAMS:
+            case ChannelTabs.PODCASTS:
+            case ChannelTabs.COURSES:
                 return true;
             default:
                 return false;
@@ -65,6 +67,10 @@ public final class ChannelTabHelper {
                 return R.string.show_channel_tabs_albums;
             case ChannelTabs.LIKES:
                 return R.string.show_channel_tabs_likes;
+            case ChannelTabs.PODCASTS:
+                return R.string.show_channel_tabs_podcasts;
+            case ChannelTabs.COURSES:
+                return R.string.show_channel_tabs_courses;
             default:
                 return -1;
         }
@@ -83,6 +89,10 @@ public final class ChannelTabHelper {
                 return R.string.fetch_channel_tabs_livestreams;
             case ChannelTabs.LIKES:
                 return R.string.fetch_channel_tabs_likes;
+            case ChannelTabs.PODCASTS:
+                return R.string.fetch_channel_tabs_podcasts;
+            case ChannelTabs.COURSES:
+                return R.string.fetch_channel_tabs_courses;
             default:
                 return -1;
         }
@@ -107,6 +117,10 @@ public final class ChannelTabHelper {
                 return R.string.channel_tab_albums;
             case ChannelTabs.LIKES:
                 return R.string.channel_tab_likes;
+            case ChannelTabs.PODCASTS:
+                return R.string.channel_tab_podcasts;
+            case ChannelTabs.COURSES:
+                return R.string.channel_tab_courses;
             default:
                 return R.string.unknown_content;
         }

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -297,6 +297,8 @@
     <string name="show_channel_tabs_playlists">show_channel_tabs_playlists</string>
     <string name="show_channel_tabs_albums">show_channel_tabs_albums</string>
     <string name="show_channel_tabs_likes">show_channel_tabs_likes</string>
+    <string name="show_channel_tabs_podcasts">show_channel_tabs_podcasts</string>
+    <string name="show_channel_tabs_courses">show_channel_tabs_courses</string>
     <string name="show_channel_tabs_about">show_channel_tabs_about</string>
     <string-array name="show_channel_tabs_value_list">
         <item>@string/show_channel_tabs_videos</item>
@@ -307,6 +309,8 @@
         <item>@string/show_channel_tabs_playlists</item>
         <item>@string/show_channel_tabs_albums</item>
         <item>@string/show_channel_tabs_likes</item>
+        <item>@string/show_channel_tabs_podcasts</item>
+        <item>@string/show_channel_tabs_courses</item>
         <item>@string/show_channel_tabs_about</item>
     </string-array>
     <string-array name="show_channel_tabs_description_list">
@@ -318,6 +322,8 @@
         <item>@string/channel_tab_playlists</item>
         <item>@string/channel_tab_albums</item>
         <item>@string/channel_tab_likes</item>
+        <item>@string/channel_tab_podcasts</item>
+        <item>@string/channel_tab_courses</item>
         <item>@string/channel_tab_about</item>
     </string-array>
     <string name="show_search_suggestions_key">show_search_suggestions</string>
@@ -396,12 +402,16 @@
     <string name="fetch_channel_tabs_shorts">fetch_channel_tabs_shorts</string>
     <string name="fetch_channel_tabs_livestreams">fetch_channel_tabs_livestreams</string>
     <string name="fetch_channel_tabs_likes">fetch_channel_tabs_likes</string>
+    <string name="fetch_channel_tabs_podcasts">fetch_channel_tabs_podcasts</string>
+    <string name="fetch_channel_tabs_courses">fetch_channel_tabs_courses</string>
     <string-array name="feed_fetch_channel_tabs_value_list">
         <item>@string/fetch_channel_tabs_videos</item>
         <item>@string/fetch_channel_tabs_tracks</item>
         <item>@string/fetch_channel_tabs_shorts</item>
         <item>@string/fetch_channel_tabs_livestreams</item>
         <item>@string/fetch_channel_tabs_likes</item>
+        <item>@string/fetch_channel_tabs_podcasts</item>
+        <item>@string/fetch_channel_tabs_courses</item>
     </string-array>
     <string-array name="feed_fetch_channel_tabs_description_list">
         <item>@string/channel_tab_videos</item>
@@ -409,6 +419,8 @@
         <item>@string/channel_tab_shorts</item>
         <item>@string/channel_tab_livestreams</item>
         <item>@string/channel_tab_likes</item>
+        <item>@string/channel_tab_podcasts</item>
+        <item>@string/channel_tab_courses</item>
     </string-array>
 
     <string name="import_export_data_path">import_export_data_path</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -849,6 +849,8 @@
     <string name="channel_tab_playlists">Playlists</string>
     <string name="channel_tab_albums">Albums</string>
     <string name="channel_tab_likes">Likes</string>
+    <string name="channel_tab_podcasts">Podcasts</string>
+    <string name="channel_tab_courses">Courses</string>
     <string name="channel_tab_about">About</string>
     <string name="show_channel_tabs">Channel tabs</string>
     <string name="show_channel_tabs_summary">What tabs are shown on the channel pages</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -73,7 +73,7 @@ teamnewpipe-nanojson = "e9d656ddb49a412a5a0a5d5ef20ca7ef09549996"
 # the corresponding commit hash, since JitPack sometimes deletes artifacts.
 # If there’s already a git hash, just add more of it to the end (or remove a letter)
 # to cause jitpack to regenerate the artifact.
-teamnewpipe-newpipe-extractor = "4de221bf67ec0bf8dbdf573fbc9d4412a8561cb0"
+teamnewpipe-newpipe-extractor = "4b70576661aadf663a935df5b904a43147d9fc50"
 viewpager2 = "1.1.0"
 webkit = "1.15.0" # New versions require minSdk 24
 work = "2.11.2"


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
This adds support for YouTube's podcasts and courses channel tabs.

#### Before/After Screenshots/Screen Record
<img width="300"  alt="Screenshot_20260723_114641" src="https://github.com/user-attachments/assets/c7fc38d6-8961-4beb-9734-177219b1744f" />

#### Fixes the following issue(s)
Fixes #13727
Fixes #11968 

#### Relies on the following changes
https://github.com/TeamNewPipe/NewPipeExtractor/pull/1524

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
- [x] The proposed changes follow the [AI policy](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md#ai-policy).
- [x] I tested the changes using an emulator or a physical device.
