### PR TITLE
Add 'Stop after current song' playback option

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/PlayQueueActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayQueueActivity.java
@@ -568,19 +568,27 @@ public final class PlayQueueActivity extends AppCompatActivity
     }
 
     private void onPlayModeChanged(final int repeatMode, final boolean shuffled) {
-        switch (repeatMode) {
-            case com.google.android.exoplayer2.Player.REPEAT_MODE_OFF:
-                queueControlBinding.controlRepeat.setImageResource(
-                        com.google.android.exoplayer2.ui.R.drawable.exo_controls_repeat_off);
-                break;
-            case com.google.android.exoplayer2.Player.REPEAT_MODE_ONE:
-                queueControlBinding.controlRepeat.setImageResource(
-                        com.google.android.exoplayer2.ui.R.drawable.exo_controls_repeat_one);
-                break;
-            case com.google.android.exoplayer2.Player.REPEAT_MODE_ALL:
-                queueControlBinding.controlRepeat.setImageResource(
-                        com.google.android.exoplayer2.ui.R.drawable.exo_controls_repeat_all);
-                break;
+        if (player != null && player.isStopAfterCurrentSong()) {
+            // Show a half-transparent repeat_one icon for "stop after current song"
+            queueControlBinding.controlRepeat.setImageResource(
+                    com.google.android.exoplayer2.ui.R.drawable.exo_controls_repeat_one);
+            queueControlBinding.controlRepeat.setAlpha(0.5f);
+        } else {
+            queueControlBinding.controlRepeat.setAlpha(1.0f);
+            switch (repeatMode) {
+                case com.google.android.exoplayer2.Player.REPEAT_MODE_OFF:
+                    queueControlBinding.controlRepeat.setImageResource(
+                            com.google.android.exoplayer2.ui.R.drawable.exo_controls_repeat_off);
+                    break;
+                case com.google.android.exoplayer2.Player.REPEAT_MODE_ONE:
+                    queueControlBinding.controlRepeat.setImageResource(
+                            com.google.android.exoplayer2.ui.R.drawable.exo_controls_repeat_one);
+                    break;
+                case com.google.android.exoplayer2.Player.REPEAT_MODE_ALL:
+                    queueControlBinding.controlRepeat.setImageResource(
+                            com.google.android.exoplayer2.ui.R.drawable.exo_controls_repeat_all);
+                    break;
+            }
         }
 
         final int shuffleAlpha = shuffled ? 255 : 77;

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -234,6 +234,7 @@ public final class Player implements PlaybackListener, Listener {
     // minimized to background but will resume automatically to the original player type
     private boolean isAudioOnly = false;
     private boolean isPrepared = false;
+    private boolean stopAfterCurrentSong = false;
 
     /*//////////////////////////////////////////////////////////////////////////
     // UIs, listeners and disposables
@@ -671,6 +672,7 @@ public final class Player implements PlaybackListener, Listener {
         }
         UIs.call(PlayerUi::destroyPlayer);
 
+        stopAfterCurrentSong = false;
         if (!exoPlayerIsNull()) {
             simpleExoPlayer.removeListener(this);
             simpleExoPlayer.stop();
@@ -1263,8 +1265,20 @@ public final class Player implements PlaybackListener, Listener {
         return exoPlayerIsNull() ? REPEAT_MODE_OFF : simpleExoPlayer.getRepeatMode();
     }
 
+    public boolean isStopAfterCurrentSong() {
+        return stopAfterCurrentSong;
+    }
+
     public void cycleNextRepeatMode() {
         if (!exoPlayerIsNull()) {
+            if (stopAfterCurrentSong) {
+                // If stop-after-current is active, first disable it and go to REPEAT_MODE_OFF
+                stopAfterCurrentSong = false;
+                simpleExoPlayer.setRepeatMode(REPEAT_MODE_OFF);
+                UIs.call(playerUi -> playerUi.onStopAfterCurrentSongChanged(false));
+                notifyPlaybackUpdateToListeners();
+                return;
+            }
             @RepeatMode final int repeatMode;
             switch (simpleExoPlayer.getRepeatMode()) {
                 case REPEAT_MODE_OFF:
@@ -1275,8 +1289,12 @@ public final class Player implements PlaybackListener, Listener {
                     break;
                 case REPEAT_MODE_ALL:
                 default:
-                    repeatMode = REPEAT_MODE_OFF;
-                    break;
+                    // Go to "stop after current song" mode
+                    stopAfterCurrentSong = true;
+                    simpleExoPlayer.setRepeatMode(REPEAT_MODE_OFF);
+                    UIs.call(playerUi -> playerUi.onStopAfterCurrentSongChanged(true));
+                    notifyPlaybackUpdateToListeners();
+                    return;
             }
             simpleExoPlayer.setRepeatMode(repeatMode);
         }
@@ -1445,6 +1463,18 @@ public final class Player implements PlaybackListener, Listener {
                     + "discontinuityReason = [" + discontinuityReason + "]");
         }
         if (playQueue == null) {
+            return;
+        }
+
+        // Stop after current song: when the current track ends and the next one is about
+        // to start, stop playback instead of advancing. The queue remains intact.
+        if (stopAfterCurrentSong && (discontinuityReason == DISCONTINUITY_REASON_AUTO_TRANSITION
+                || discontinuityReason == DISCONTINUITY_REASON_REMOVE)
+                && newIndex != playQueue.getIndex()) {
+            stopAfterCurrentSong = false;
+            simpleExoPlayer.setPlayWhenReady(false);
+            UIs.call(playerUi -> playerUi.onStopAfterCurrentSongChanged(false));
+            notifyPlaybackUpdateToListeners();
             return;
         }
 

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -1470,7 +1470,7 @@ public final class Player implements PlaybackListener, Listener {
         // to start, stop playback instead of advancing. The queue remains intact.
         if (stopAfterCurrentSong && (discontinuityReason == DISCONTINUITY_REASON_AUTO_TRANSITION
                 || discontinuityReason == DISCONTINUITY_REASON_REMOVE)
-                && newIndex != playQueue.getIndex()) {
+                && newPosition.mediaItemIndex != playQueue.getIndex()) {
             stopAfterCurrentSong = false;
             simpleExoPlayer.setPlayWhenReady(false);
             UIs.call(playerUi -> playerUi.onStopAfterCurrentSongChanged(false));

--- a/app/src/main/java/org/schabi/newpipe/player/mediasession/MediaSessionPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/mediasession/MediaSessionPlayerUi.java
@@ -262,6 +262,12 @@ public class MediaSessionPlayerUi extends PlayerUi
     }
 
     @Override
+    public void onStopAfterCurrentSongChanged(final boolean stopAfterCurrentSong) {
+        super.onStopAfterCurrentSongChanged(stopAfterCurrentSong);
+        updateMediaSessionActions();
+    }
+
+    @Override
     public void onShuffleModeEnabledChanged(final boolean shuffleModeEnabled) {
         super.onShuffleModeEnabledChanged(shuffleModeEnabled);
         updateMediaSessionActions();

--- a/app/src/main/java/org/schabi/newpipe/player/notification/NotificationActionData.java
+++ b/app/src/main/java/org/schabi/newpipe/player/notification/NotificationActionData.java
@@ -145,7 +145,12 @@ public final class NotificationActionData {
                 }
 
             case NotificationConstants.REPEAT:
-                if (player.getRepeatMode() == REPEAT_MODE_ALL) {
+                if (player.isStopAfterCurrentSong()) {
+                    return new NotificationActionData(ACTION_REPEAT,
+                            ctx.getString(R.string.notification_action_stop_after_current),
+                            com.google.android.exoplayer2.ext.mediasession.R.drawable
+                                    .exo_media_action_repeat_one);
+                } else if (player.getRepeatMode() == REPEAT_MODE_ALL) {
                     return new NotificationActionData(ACTION_REPEAT,
                             ctx.getString(com.google.android.exoplayer2.ui.R.string
                                     .exo_controls_repeat_all_description),

--- a/app/src/main/java/org/schabi/newpipe/player/notification/NotificationPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/notification/NotificationPlayerUi.java
@@ -88,6 +88,12 @@ public final class NotificationPlayerUi extends PlayerUi {
     }
 
     @Override
+    public void onStopAfterCurrentSongChanged(final boolean stopAfterCurrentSong) {
+        super.onStopAfterCurrentSongChanged(stopAfterCurrentSong);
+        notificationUtil.createNotificationIfNeededAndUpdate(false);
+    }
+
+    @Override
     public void onShuffleModeEnabledChanged(final boolean shuffleModeEnabled) {
         super.onShuffleModeEnabledChanged(shuffleModeEnabled);
         notificationUtil.createNotificationIfNeededAndUpdate(false);

--- a/app/src/main/java/org/schabi/newpipe/player/ui/PlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/PlayerUi.java
@@ -148,6 +148,9 @@ public abstract class PlayerUi {
     public void onRepeatModeChanged(@RepeatMode final int repeatMode) {
     }
 
+    public void onStopAfterCurrentSongChanged(final boolean stopAfterCurrentSong) {
+    }
+
     public void onShuffleModeEnabledChanged(final boolean shuffleModeEnabled) {
     }
 

--- a/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
@@ -954,15 +954,33 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
     public void onRepeatModeChanged(@RepeatMode final int repeatMode) {
         super.onRepeatModeChanged(repeatMode);
 
-        if (repeatMode == REPEAT_MODE_ALL) {
-            binding.repeatButton.setImageResource(
-                    com.google.android.exoplayer2.ui.R.drawable.exo_controls_repeat_all);
-        } else if (repeatMode == REPEAT_MODE_ONE) {
+        // Only update icon if stop-after-current is not active
+        if (!player.isStopAfterCurrentSong()) {
+            if (repeatMode == REPEAT_MODE_ALL) {
+                binding.repeatButton.setImageResource(
+                        com.google.android.exoplayer2.ui.R.drawable.exo_controls_repeat_all);
+            } else if (repeatMode == REPEAT_MODE_ONE) {
+                binding.repeatButton.setImageResource(
+                        com.google.android.exoplayer2.ui.R.drawable.exo_controls_repeat_one);
+            } else /* repeatMode == REPEAT_MODE_OFF */ {
+                binding.repeatButton.setImageResource(
+                        com.google.android.exoplayer2.ui.R.drawable.exo_controls_repeat_off);
+            }
+        }
+    }
+
+    @Override
+    public void onStopAfterCurrentSongChanged(final boolean stopAfterCurrentSong) {
+        super.onStopAfterCurrentSongChanged(stopAfterCurrentSong);
+        if (stopAfterCurrentSong) {
+            // Use repeat_one icon with a different tint to indicate "stop after current"
             binding.repeatButton.setImageResource(
                     com.google.android.exoplayer2.ui.R.drawable.exo_controls_repeat_one);
-        } else /* repeatMode == REPEAT_MODE_OFF */ {
-            binding.repeatButton.setImageResource(
-                    com.google.android.exoplayer2.ui.R.drawable.exo_controls_repeat_off);
+            binding.repeatButton.setAlpha(0.5f);
+        } else {
+            binding.repeatButton.setAlpha(1.0f);
+            // Restore the normal repeat mode icon
+            setRepeatButton(player.getExoPlayer().getRepeatMode());
         }
     }
 
@@ -988,14 +1006,21 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
     }
 
     private void setRepeatButton(final int repeatMode) {
-        final int resId = switch (repeatMode) {
-            case REPEAT_MODE_ALL
-                    -> com.google.android.exoplayer2.ui.R.drawable.exo_controls_repeat_all;
-            case REPEAT_MODE_ONE
-                    -> com.google.android.exoplayer2.ui.R.drawable.exo_controls_repeat_one;
-            default -> com.google.android.exoplayer2.ui.R.drawable.exo_controls_repeat_off;
-        };
-        binding.repeatButton.setImageResource(resId);
+        if (player.isStopAfterCurrentSong()) {
+            binding.repeatButton.setImageResource(
+                    com.google.android.exoplayer2.ui.R.drawable.exo_controls_repeat_one);
+            binding.repeatButton.setAlpha(0.5f);
+        } else {
+            binding.repeatButton.setAlpha(1.0f);
+            final int resId = switch (repeatMode) {
+                case REPEAT_MODE_ALL
+                        -> com.google.android.exoplayer2.ui.R.drawable.exo_controls_repeat_all;
+                case REPEAT_MODE_ONE
+                        -> com.google.android.exoplayer2.ui.R.drawable.exo_controls_repeat_one;
+                default -> com.google.android.exoplayer2.ui.R.drawable.exo_controls_repeat_off;
+            };
+            binding.repeatButton.setImageResource(resId);
+        }
     }
 
     //endregion

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,6 +66,7 @@
     <string name="notification_actions_summary_android13">Edit each notification action below by tapping on it. The first three actions (play/pause, previous and next) are set by the system and cannot be customized.</string>
     <string name="notification_actions_at_most_three">You can select at most three actions to show in the compact notification!</string>
     <string name="notification_action_repeat">Repeat</string>
+    <string name="notification_action_stop_after_current">Stop after current song</string>
     <string name="notification_action_shuffle">Shuffle</string>
     <string name="notification_action_buffering">Buffering</string>
     <string name="notification_action_nothing">Nothing</string>


### PR DESCRIPTION
## What is it?

-   Feature (user facing)

## Description of the changes in your PR

Adds a fourth repeat mode cycle state that stops playback after the current song ends while keeping the queue intact.

The repeat button now cycles through:
1. No repeat (REPEAT_MODE_OFF)
2. Repeat one (REPEAT_MODE_ONE)
3. Repeat all (REPEAT_MODE_ALL)
4. **Stop after current song** (new custom state)

When 'stop after current song' is active:
- The repeat button shows a half-transparent repeat_one icon to distinguish from normal repeat-one
- Playback stops when the current track transitions to the next
- The queue remains intact for later continuation
- The mode automatically resets when the track ends

### Implementation details

- Added `stopAfterCurrentSong` boolean field in Player.java
- Added `isStopAfterCurrentSong()` getter and `onStopAfterCurrentSongChanged()` callback
- Modified `cycleNextRepeatMode()` to include the 4th state (cycles: OFF -> ONE -> ALL -> STOP_CURRENT -> OFF)
- Updated VideoPlayerUi, PlayQueueActivity, NotificationPlayerUi, MediaSessionPlayerUi, and NotificationActionData to handle the new mode
- Added string resource `notification_action_stop_after_current`

## Fixes the following issue(s)

- Fixes #12726

## Due diligence

- I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
- The proposed changes follow the [AI policy](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md#ai-policy).
