### PR TITLE
fix: blacklist JMGO N1S 4K and TCL 65Q651G for media tunneling

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
@@ -44,7 +44,7 @@ public final class DeviceUtils {
      * support media tunneling to match the <strong>upcoming</strong> version code.</p>
      * @see #shouldSupportMediaTunneling()
      */
-    public static final int MEDIA_TUNNELING_DEVICE_BLACKLIST_VERSION = 995;
+    public static final int MEDIA_TUNNELING_DEVICE_BLACKLIST_VERSION = 1015;
 
     // region: devices not supporting media tunneling / media tunneling blacklist
     /**

--- a/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
@@ -44,7 +44,7 @@ public final class DeviceUtils {
      * support media tunneling to match the <strong>upcoming</strong> version code.</p>
      * @see #shouldSupportMediaTunneling()
      */
-    public static final int MEDIA_TUNNELING_DEVICE_BLACKLIST_VERSION = 994;
+    public static final int MEDIA_TUNNELING_DEVICE_BLACKLIST_VERSION = 995;
 
     // region: devices not supporting media tunneling / media tunneling blacklist
     /**
@@ -120,6 +120,16 @@ public final class DeviceUtils {
      *     #10122</a></p>
      */
     private static final boolean HMB9213NW = Build.DEVICE.equals("HMB9213NW");
+    /**
+     * <p>JMGO N1S 4K.</p>
+     * <p>Blacklist reason: fullscreen crash</p>
+     */
+    private static final boolean LONAVLA = Build.DEVICE.equals("lonavla");
+    /**
+     * <p>TCL 65Q651G.</p>
+     * <p>Blacklist reason: fullscreen crash</p>
+     */
+    private static final boolean G10 = Build.DEVICE.equals("G10");
     // endregion
 
     private DeviceUtils() {
@@ -334,7 +344,9 @@ public final class DeviceUtils {
                 && !BRAVIA_ATV3_4K
                 && !PH7M_EU_5596
                 && !TX_50JXW834
-                && !HMB9213NW;
+                && !HMB9213NW
+                && !LONAVLA
+                && !G10;
     }
 
     /**


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
Disabled media tunneling on affected devices:
- JMGO N1S 4K (lonavla)
- TCL 65Q651G (G10)

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #13757

#### APK testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
- [x] The proposed changes follow the [AI policy](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md#ai-policy).
- [x] I tested the changes using an emulator or a physical device.
