### PR TITLE
Fix: black video delay when entering fullscreen

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -1295,9 +1295,15 @@ public final class VideoDetailFragment
             player.UIs().get(MainPlayerUi.class).ifPresent(playerUi -> {
                 // sometimes binding would be null here, even though getView() != null above u.u
                 if (binding != null) {
-                    // prevent from re-adding a view multiple times
-                    playerUi.removeViewFromParent();
-                    binding.playerPlaceholder.addView(playerUi.getBinding().getRoot());
+                    // Only reparent the view if it's not already in the playerPlaceholder.
+                    // Removing and re-adding a SurfaceView destroys its native surface,
+                    // causing a black screen until the video decoder hits the next
+                    // keyframe (2-5 seconds on typical DASH/HLS streams).
+                    if (playerUi.getBinding().getRoot().getParent()
+                            != binding.playerPlaceholder) {
+                        playerUi.removeViewFromParent();
+                        binding.playerPlaceholder.addView(playerUi.getBinding().getRoot());
+                    }
                     playerUi.setupVideoSurfaceIfNeeded();
                 }
             });


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
- Skip unnecessary detachment and re-attachment of the player view in `VideoDetailFragment.tryAddVideoPlayerView()` when the view is already attached to `binding.playerPlaceholder`.
- Previously, toggling fullscreen triggered `tryAddVideoPlayerView()`, which unconditionally executed `playerUi.removeViewFromParent()` followed by `binding.playerPlaceholder.addView(...)`. 
- Removing and re-adding the `SurfaceView` destroyed its native surface (`surfaceDestroyed`), forcing ExoPlayer to set a new surface on `MediaCodec` mid-playback. Hardware decoders cannot render non-keyframes (P/B frames) onto a newly attached surface, causing video output to stall for 2–5 seconds until the next keyframe arrived in the stream (while audio played normally).
- Adding a parent-identity check preserves the native `Surface` during fullscreen transitions, eliminating the black screen delay.

#### Before/After Screen Record

**Before:**
<video src="https://github.com/user-attachments/assets/a5a03262-deed-46d3-86e8-af6a12853e36" controls style="max-height: 360px;"></video>

**After:**
<video src="https://github.com/user-attachments/assets/d6507b7f-29a3-486c-a5c9-642dee072371" controls style="max-height: 360px;"></video>

#### Relies on the following changes
- None

#### Fixes the following issues
- This might fix #12989

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
- [x] The proposed changes follow the [AI policy](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md#ai-policy).
- [x] I tested the changes using an emulator or a physical device.