### PR TITLE
Add MP4 metadata (title, artist, cover) support

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/streams/Mp4FromDashWriter.java
+++ b/app/src/main/java/org/schabi/newpipe/streams/Mp4FromDashWriter.java
@@ -11,6 +11,7 @@ import org.schabi.newpipe.streams.io.SharpStream;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 
 /**
@@ -47,6 +48,10 @@ public class Mp4FromDashWriter {
     private Mp4DashChunk[] readersChunks;
 
     private int overrideMainBrand = 0x00;
+
+    private String metadataTitle;
+    private String metadataArtist;
+    private byte[] metadataCover;
 
     private final ArrayList<Integer> compatibleBrands = new ArrayList<>(5);
 
@@ -114,6 +119,12 @@ public class Mp4FromDashWriter {
 
     public void setMainBrand(final int brand) {
         overrideMainBrand = brand;
+    }
+
+    public void setMetadata(final String title, final String artist, final byte[] cover) {
+        metadataTitle = title;
+        metadataArtist = artist;
+        metadataCover = cover;
     }
 
     public boolean isDone() {
@@ -720,7 +731,119 @@ public class Mp4FromDashWriter {
             makeTrak(i, durations[i], defaultMediaTime[i], tablesInfo[i], is64);
         }
 
+        if (metadataTitle != null || metadataArtist != null || metadataCover != null) {
+            makeUdta();
+        }
+
         return lengthFor(start);
+    }
+
+    private void makeUdta() throws IOException {
+        final int start = auxOffset();
+
+        auxWrite(new byte[]{
+                0x00, 0x00, 0x00, 0x00, 0x75, 0x64, 0x74, 0x61
+        });
+
+        makeMeta();
+
+        lengthFor(start);
+    }
+
+    private void makeMeta() throws IOException {
+        final int start = auxOffset();
+
+        auxWrite(new byte[]{
+                0x00, 0x00, 0x00, 0x00, 0x6D, 0x65, 0x74, 0x61,
+                0x00, 0x00, 0x00, 0x00
+        });
+
+        makeMetaHdlr();
+        makeIlst();
+
+        lengthFor(start);
+    }
+
+    private void makeMetaHdlr() throws IOException {
+        final int start = auxOffset();
+
+        auxWrite(new byte[]{
+                0x00, 0x00, 0x00, 0x00, 0x68, 0x64, 0x6C, 0x72,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x6D, 0x64, 0x69, 0x72, 0x61, 0x70, 0x70, 0x6C, // "mdir" handler, "appl" manuf.
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00
+        });
+
+        lengthFor(start);
+    }
+
+    private void makeIlst() throws IOException {
+        final int start = auxOffset();
+
+        auxWrite(new byte[]{
+                0x00, 0x00, 0x00, 0x00, 0x69, 0x6C, 0x73, 0x74
+        });
+
+        if (metadataTitle != null && !metadataTitle.isEmpty()) {
+            makeIlstEntry(new byte[]{(byte) 0xA9, 0x6E, 0x61, 0x6D}, metadataTitle); // nam
+        }
+        if (metadataArtist != null && !metadataArtist.isEmpty()) {
+            makeIlstEntry(new byte[]{(byte) 0xA9, 0x41, 0x52, 0x54}, metadataArtist); // ART
+            makeIlstEntry(new byte[]{0x61, 0x41, 0x52, 0x54}, metadataArtist); // aART
+        }
+        if (metadataCover != null && metadataCover.length > 0) {
+            makeIlstCover();
+        }
+
+        lengthFor(start);
+    }
+
+    private void makeIlstEntry(final byte[] fourCc, final String value) throws IOException {
+        final byte[] text = value.getBytes(StandardCharsets.UTF_8);
+        final int start = auxOffset();
+
+        auxWrite(new byte[]{0x00, 0x00, 0x00, 0x00});
+        auxWrite(fourCc);
+
+        final int dataStart = auxOffset();
+
+        auxWrite(new byte[]{
+                0x00, 0x00, 0x00, 0x00, 0x64, 0x61, 0x74, 0x61,
+                0x00, 0x00, 0x00, 0x01, // UTF-8 text
+                0x00, 0x00, 0x00, 0x00
+        });
+        auxWrite(text);
+
+        lengthFor(dataStart);
+        lengthFor(start);
+    }
+
+    private void makeIlstCover() throws IOException {
+        final int start = auxOffset();
+        final int type = detectImageDataType(metadataCover); // 13 JPEG, 14 PNG, 0 unspecified
+
+        auxWrite(new byte[]{0x00, 0x00, 0x00, 0x00, 0x63, 0x6F, 0x76, 0x72});
+
+        final int dataStart = auxOffset();
+
+        auxWrite(new byte[]{0x00, 0x00, 0x00, 0x00, 0x64, 0x61, 0x74, 0x61});
+        auxWrite(ByteBuffer.allocate(8).putInt(type).putInt(0x00).array());
+        auxWrite(metadataCover);
+
+        lengthFor(dataStart);
+        lengthFor(start);
+    }
+
+    private static int detectImageDataType(final byte[] data) {
+        if (data.length > 2 && (data[0] & 0xFF) == 0xFF && (data[1] & 0xFF) == 0xD8) {
+            return 13;
+        }
+        if (data.length > 3 && (data[0] & 0xFF) == 0x89 && data[1] == 0x50
+                && data[2] == 0x4E && data[3] == 0x47) {
+            return 14;
+        }
+        return 0;
     }
 
     private void makeTrak(final int index, final long duration, final int defaultMediaTime,

--- a/app/src/main/java/us/shandian/giga/postprocessing/M4aNoDash.java
+++ b/app/src/main/java/us/shandian/giga/postprocessing/M4aNoDash.java
@@ -32,6 +32,7 @@ class M4aNoDash extends Postprocessing {
     int process(SharpStream out, SharpStream... sources) throws IOException {
         Mp4FromDashWriter muxer = new Mp4FromDashWriter(sources[0]);
         muxer.setMainBrand(0x4D344120);// binary string "M4A "
+        muxer.setMetadata(streamInfo.getName(), streamInfo.getUploaderName(), fetchCoverArt());
         muxer.parseSources();
         muxer.selectTracks(0);
         muxer.build(out);

--- a/app/src/main/java/us/shandian/giga/postprocessing/Mp4FromDashMuxer.java
+++ b/app/src/main/java/us/shandian/giga/postprocessing/Mp4FromDashMuxer.java
@@ -17,6 +17,7 @@ class Mp4FromDashMuxer extends Postprocessing {
     @Override
     int process(SharpStream out, SharpStream... sources) throws IOException {
         Mp4FromDashWriter muxer = new Mp4FromDashWriter(sources);
+        muxer.setMetadata(streamInfo.getName(), streamInfo.getUploaderName(), fetchCoverArt());
         muxer.parseSources();
         muxer.selectTracks(0, 0);
         muxer.build(out);

--- a/app/src/main/java/us/shandian/giga/postprocessing/Postprocessing.java
+++ b/app/src/main/java/us/shandian/giga/postprocessing/Postprocessing.java
@@ -1,15 +1,28 @@
 package us.shandian.giga.postprocessing;
 
+import android.content.Context;
+import android.content.SharedPreferences;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
+import androidx.preference.PreferenceManager;
 
+import org.schabi.newpipe.App;
+import org.schabi.newpipe.DownloaderImpl;
+import org.schabi.newpipe.R;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.streams.io.SharpStream;
+import org.schabi.newpipe.util.ListHelper;
+import org.schabi.newpipe.util.image.ImageStrategy;
+import org.schabi.newpipe.util.image.PreferredImageQuality;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
+
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
 
 import us.shandian.giga.get.DownloadMission;
 import us.shandian.giga.io.ChunkFileInputStream;
@@ -24,6 +37,8 @@ import static us.shandian.giga.get.DownloadMission.ERROR_POSTPROCESSING_HOLD;
 public abstract class Postprocessing implements Serializable {
 
     static transient final byte OK_RESULT = ERROR_NOTHING;
+
+    private static final long MAX_COVER_ART_BYTES = 8L * 1024 * 1024; // 8 MiB
 
     public transient static final String ALGORITHM_TTML_CONVERTER = "ttml";
     public transient static final String ALGORITHM_WEBM_MUXER = "webm";
@@ -239,6 +254,62 @@ public abstract class Postprocessing implements Serializable {
         }
 
         return args[index];
+    }
+
+    /**
+     * Downloads the best available thumbnail for {@link #streamInfo} to embed as cover art.
+     * Skipped if mobile data usage is limited and the network is currently metered.
+     *
+     * @return the cover art bytes, or an empty array if none could be obtained
+     */
+    byte[] fetchCoverArt() {
+        if (streamInfo == null || isMobileDataLimited()) {
+            return new byte[0];
+        }
+
+        try {
+            final String url = ImageStrategy.choosePreferredImage(
+                    streamInfo.getThumbnails(), PreferredImageQuality.HIGH);
+            if (url == null) {
+                return new byte[0];
+            }
+
+            final Request request = new Request.Builder().url(url).build();
+
+            try (final Response response = DownloaderImpl.getInstance().getClient()
+                    .newCall(request).execute()) {
+                final ResponseBody body = response.body();
+                if (!response.isSuccessful() || body == null) {
+                    return new byte[0];
+                }
+
+                if (body.contentLength() > MAX_COVER_ART_BYTES) {
+                    return new byte[0];
+                }
+
+                final byte[] cover = body.bytes();
+                return cover.length > MAX_COVER_ART_BYTES ? new byte[0] : cover;
+            }
+        } catch (final IOException e) {
+            Log.w(getClass().getSimpleName(), "Failed to fetch cover art", e);
+            return new byte[0];
+        }
+    }
+
+    private boolean isMobileDataLimited() {
+        final Context context = App.getInstance();
+
+        if (!ListHelper.isMeteredNetwork(context)) {
+            return false;
+        }
+
+        final SharedPreferences preferences =
+                PreferenceManager.getDefaultSharedPreferences(context);
+        final String defValue = context.getString(R.string.limit_data_usage_none_key);
+        final String value = preferences.getString(
+                context.getString(R.string.limit_mobile_data_usage_key), defValue);
+
+        return !defValue.equals(value);
     }
 
     @NonNull


### PR DESCRIPTION
Embed metadata into MP4/M4A outputs: Mp4FromDashWriter now stores title, artist and cover bytes, exposes setMetadata(), and writes udta/meta/ilst atoms (including image type detection). M4aNoDash and Mp4FromDashMuxer pass stream info to setMetadata. Postprocessing gained fetchCoverArt() which downloads the preferred thumbnail via DownloaderImpl (obeys metered-data preference and an 8 MiB size cap) and isMobileDataLimited() to avoid downloads on limited mobile data. Added required imports and safety checks.