### PR TITLE
Fix opening links with timestamps

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -1762,7 +1762,6 @@ public final class Player implements PlaybackListener, Listener {
         if (isStopped()) {
             // Some phones suspend a paused player after 10 minutes. This causes the player to
             // enter STATE_IDLE, causing playback to fail. So we try to recover from that here.
-            setRecovery();
             reloadPlayQueueManager();
         }
 


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
- Fixes a regression from #13390 where the timestamp from links was immediately overridden by a new "0" timestamp. This caused the timestamp to be ignored.
- As far as my testing goes this does not affect #13390 in any way. The actual fix is in `reloadPlayQueueManager()`, `setRecovery()` just remembers where the video was when the video was started again. Additional testing is of course welcome.

#### Fixes the following issue(s)
- Fixes #13754

#### APK testing
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
- [x] The proposed changes follow the [AI policy](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md#ai-policy).
- [x] I tested the changes using an emulator or a physical device.
