### PR TITLE
Catch IllegalStateException during ViewPager state restoration of missing fragments

### DIFF
--- a/app/src/main/java/androidx/fragment/app/FragmentStatePagerAdapterMenuWorkaround.java
+++ b/app/src/main/java/androidx/fragment/app/FragmentStatePagerAdapterMenuWorkaround.java
@@ -323,7 +323,13 @@ public abstract class FragmentStatePagerAdapterMenuWorkaround extends PagerAdapt
             for (final String key : keys) {
                 if (key.startsWith("f")) {
                     final int index = Integer.parseInt(key.substring(1));
-                    final Fragment f = mFragmentManager.getFragment(bundle, key);
+                    final Fragment f;
+                    try {
+                        f = mFragmentManager.getFragment(bundle, key);
+                    } catch (final IllegalStateException e) {
+                        Log.w(TAG, "Bad fragment at key " + key, e);
+                        continue;
+                    }
                     if (f != null) {
                         while (mFragments.size() <= index) {
                             mFragments.add(null);

--- a/app/src/test/java/androidx/fragment/app/FragmentStatePagerAdapterMenuWorkaroundTest.java
+++ b/app/src/test/java/androidx/fragment/app/FragmentStatePagerAdapterMenuWorkaroundTest.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: 2026 NewPipe e.V. <https://newpipe-ev.de>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package androidx.fragment.app;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import android.os.Bundle;
+import android.util.Log;
+
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+import java.util.Collections;
+import java.util.Set;
+
+public class FragmentStatePagerAdapterMenuWorkaroundTest {
+
+    @Test
+    public void testRestoreStateWithMissingFragmentDoesNotThrow() {
+        final FragmentManager fragmentManager = mock(FragmentManager.class);
+        final Bundle bundle = mock(Bundle.class);
+        final Set<String> keys = Collections.singleton("f2");
+
+        when(bundle.keySet()).thenReturn(keys);
+        when(fragmentManager.getFragment(bundle, "f2"))
+                .thenThrow(new IllegalStateException("Fragment no longer exists for key f2"));
+
+        final FragmentStatePagerAdapterMenuWorkaround adapter =
+                new FragmentStatePagerAdapterMenuWorkaround(fragmentManager,
+                        FragmentStatePagerAdapterMenuWorkaround
+                                .BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
+                    @Override
+                    public Fragment getItem(final int position) {
+                        return mock(Fragment.class);
+                    }
+
+                    @Override
+                    public int getCount() {
+                        return 3;
+                    }
+                };
+
+        try (MockedStatic<Log> mockedLog = mockStatic(Log.class)) {
+            adapter.restoreState(bundle, getClass().getClassLoader());
+
+            mockedLog.verify(() -> Log.w(
+                    eq("FragmentStatePagerAdapt"),
+                    eq("Bad fragment at key f2"),
+                    any(IllegalStateException.class)
+            ));
+        }
+    }
+}


### PR DESCRIPTION
#### What is it?

- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR

##### **Problem & Root Cause**

An intermittent crash (`java.lang.IllegalStateException: Fragment no longer exists for key...`) occurs when performing gesture back-navigation immediately after searching. This surfaces in `MainFragment$SelectedTabsPagerAdapter.restoreState` during state restoration of the home tabs `ViewPager`.

In modern versions of the AndroidX Fragment library, `FragmentManager.getFragment(bundle, key)` throws an `IllegalStateException` rather than returning `null` if the key exists in the bundle but the fragment's unique `"who"` ID is not registered in the current `FragmentManager`'s active list. This state mismatch occurs when the child `FragmentManager` is torn down and recreated (such as during back-stack pops) between when the `ViewPager` saves its state and when it is restored. Because `FragmentStatePagerAdapter` is a deprecated class vendored directly into the NewPipe codebase, we cannot resolve this via upstream dependency updates and must fix it locally.

##### **The Fix**

We wrap the call to `mFragmentManager.getFragment(bundle, key)` in a `try/catch` block for `IllegalStateException`. If caught, the adapter logs a warning (`W/FragmentStatePagerAdapt: Bad fragment at key ...`) and uses `continue` to safely skip restoring that tab index.

##### **Verification**

* **Code Quality:** Verified that the project compiles cleanly (`./gradlew assembleDebug`) and passes all style audits (`./gradlew :app:runCheckstyle`).

* **Unit Tests:** Created a new unit test suite `FragmentStatePagerAdapterMenuWorkaroundTest` that mocks the `FragmentManager` and `Bundle` state. Confirmed the test passes (`./gradlew :app:testDebugUnitTest`), verifying the exception is caught and logged.

* **Repro Scenarios:** We attempted to reproduce the crash on an Android 15 (API 35) emulator under multiple scenarios (standard back-navigation, screen rotation, and simulated background process death). The app successfully restored state without throwing in all cases. This suggests the crash is timing-sensitive (e.g. races with Android's predictive back swipe-previews) or OS-specific (e.g. GrapheneOS's aggressive background memory limits).

##### **AI disclosure**

The Antigravity AI coding assistant generated the initial fix and the unit test, and executed the build, checkstyle, and emulator verification runs under my close direction. I critically reviewed and validated all code, logs, and outputs to ensure technical accuracy.

#### Before/After Screenshots/Screen Record

- Before: N/A (Non-visual bugfix to prevent a crash)
- After: N/A (Non-visual bugfix to prevent a crash)

#### Fixes the following issue(s)

- Fixes #13740

#### Relies on the following changes

- None

#### APK testing

The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR.

#### Due diligence

- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).