### PR TITLE
Added new Hide Watched button in history flow

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/database/stream/StreamStatisticsEntry.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/stream/StreamStatisticsEntry.kt
@@ -13,6 +13,7 @@ import java.time.OffsetDateTime
 import org.schabi.newpipe.database.LocalItem
 import org.schabi.newpipe.database.history.model.StreamHistoryEntity
 import org.schabi.newpipe.database.stream.model.StreamEntity
+import org.schabi.newpipe.database.stream.model.StreamStateEntity.Companion.PLAYBACK_FINISHED_END_MILLISECONDS
 import org.schabi.newpipe.database.stream.model.StreamStateEntity.Companion.STREAM_PROGRESS_MILLIS
 import org.schabi.newpipe.extractor.stream.StreamInfoItem
 import org.schabi.newpipe.util.image.ImageStrategy
@@ -50,6 +51,23 @@ data class StreamStatisticsEntry(
             uploaderUrl = streamEntity.uploaderUrl
             thumbnails = ImageStrategy.dbUrlToImageList(streamEntity.thumbnailUrl)
         }
+    }
+
+    /**
+     * The video will be considered as finished, if the time left is less than
+     * [PLAYBACK_FINISHED_END_MILLISECONDS] and the progress is at least 3/4 of the video length.
+     * The state will be saved anyway, so that it can be shown under stream info items, but the
+     * player will not resume if a state is considered as finished. Finished streams are also the
+     * ones that can be filtered out in the feed fragment.
+     * @return whether the stream is finished or not
+     *
+     * TODO: We already have isFinished method under StreamStateEntity in future we can club into
+     * helper class
+     */
+    fun isFinished(): Boolean {
+        val durationInSeconds = streamEntity.duration
+        return progressMillis >= durationInSeconds * 1000 - PLAYBACK_FINISHED_END_MILLISECONDS &&
+            progressMillis >= durationInSeconds * 1000 * 3 / 4
     }
 
     companion object {

--- a/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
@@ -64,6 +64,7 @@ public class StatisticsPlaylistFragment
     /* Used for independent events */
     private Subscription databaseSubscription;
     private HistoryRecordManager recordManager;
+    private boolean isFullyWatchedFilterApply = true;
 
     private List<StreamStatisticsEntry> processResult(final List<StreamStatisticsEntry> results) {
         final Comparator<StreamStatisticsEntry> comparator;
@@ -78,6 +79,12 @@ public class StatisticsPlaylistFragment
                 return null;
         }
         Collections.sort(results, comparator.reversed());
+
+        // Filter fully watched videos
+        if (!isFullyWatchedFilterApply) {
+            return results.stream().filter(it -> !it.isFinished()).toList();
+        }
+
         return results;
     }
 
@@ -277,6 +284,10 @@ public class StatisticsPlaylistFragment
         PlayButtonHelper.initPlaylistControlClickListener(activity, playlistControlBinding, this);
 
         headerBinding.sortButton.setOnClickListener(view -> toggleSortMode());
+        headerBinding.fullyWatchedFilterButtonCheckBox.setOnClickListener(view -> {
+            isFullyWatchedFilterApply = !isFullyWatchedFilterApply;
+            startLoading(true);
+        });
 
         hideLoading();
     }

--- a/app/src/main/res/layout/statistic_playlist_control.xml
+++ b/app/src/main/res/layout/statistic_playlist_control.xml
@@ -1,41 +1,87 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical">
 
-    <RelativeLayout
-        android:id="@+id/sortButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:background="?attr/selectableItemBackground"
-        android:clickable="true"
-        android:focusable="true">
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
 
-        <ImageView
-            android:id="@+id/sortButtonIcon"
-            android:layout_width="48dp"
-            android:layout_height="28dp"
-            android:layout_alignParentLeft="true"
-            android:layout_centerVertical="true"
-            android:layout_marginLeft="12dp"
-            android:layout_marginRight="12dp"
-            android:src="@drawable/ic_filter_list"
-            tools:ignore="ContentDescription,RtlHardcoded" />
+        <RelativeLayout
+            android:id="@+id/sortButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:background="?attr/selectableItemBackground"
+            android:clickable="true"
+            android:focusable="true"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/fullyWatchedFilterButton"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintHorizontal_weight="1">
 
-        <org.schabi.newpipe.views.NewPipeTextView
-            android:id="@+id/sortButtonText"
-            android:layout_width="match_parent"
-            android:layout_height="50dp"
-            android:layout_toRightOf="@id/sortButtonIcon"
-            android:gravity="left|center"
-            android:text="@string/title_most_played"
-            android:textAppearance="?android:attr/textAppearanceLarge"
-            android:textSize="15sp"
-            android:textStyle="bold"
-            tools:ignore="RtlHardcoded" />
-    </RelativeLayout>
+            <ImageView
+                android:id="@+id/sortButtonIcon"
+                android:layout_width="48dp"
+                android:layout_height="28dp"
+                android:layout_alignParentStart="true"
+                android:layout_centerVertical="true"
+                android:layout_marginStart="12dp"
+                android:layout_marginEnd="12dp"
+                android:src="@drawable/ic_filter_list"
+                tools:ignore="ContentDescription" />
+
+            <org.schabi.newpipe.views.NewPipeTextView
+                android:id="@+id/sortButtonText"
+                android:layout_width="wrap_content"
+                android:layout_height="50dp"
+                android:layout_toEndOf="@id/sortButtonIcon"
+                android:gravity="start|center_vertical"
+                android:text="@string/title_most_played"
+                android:textSize="15sp"
+                android:textStyle="bold" />
+
+        </RelativeLayout>
+
+        <RelativeLayout
+            android:id="@+id/fullyWatchedFilterButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:background="?attr/selectableItemBackground"
+            android:clickable="true"
+            android:focusable="true"
+            app:layout_constraintStart_toEndOf="@id/sortButton"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintHorizontal_weight="1">
+
+            <CheckBox
+                android:id="@+id/fullyWatchedFilterButtonCheckBox"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentStart="true"
+                android:layout_centerVertical="true"
+                android:layout_marginStart="12dp"
+                android:layout_marginEnd="12dp"
+                android:checked="false" />
+
+            <org.schabi.newpipe.views.NewPipeTextView
+                android:id="@+id/fullyWatchedFilterButtonText"
+                android:layout_width="wrap_content"
+                android:layout_height="50dp"
+                android:layout_toEndOf="@id/fullyWatchedFilterButtonCheckBox"
+                android:gravity="start|center_vertical"
+                android:text="@string/title_hide_watched"
+                android:textSize="15sp"
+                android:textStyle="bold" />
+
+        </RelativeLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <include
         android:id="@+id/playlist_control"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -905,4 +905,5 @@
     <string name="api23_requirement_dialog_title">NewPipe is dropping support for Android 5</string>
     <string name="api23_requirement_dialog_message">Unfortunately NewPipe depends on a few libraries that dropped support for Android 5.0 and 5.1. The next NewPipe release will therefore only work on devices with Android 6 or higher, sadly. Read more in the blogpost.</string>
     <string name="api23_requirement_dialog_blogpost">Blogpost</string>
+    <string name="title_hide_watched">Hide Watched</string>
 </resources>


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
- Added new view for `Hide Watched` button.
- Modified existing `statistic_playlist_control `layout.
- Introduced new method in `StreamStatisticsEntry `which help to filter out watched videos.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before:
<img width="365" height="732" alt="Screenshot 2026-09-02 163338" src="https://github.com/user-attachments/assets/de78f9f9-c1aa-4e49-bf8b-e2ae8f8da9c4" />

- After:
<img width="365" height="732" alt="Screenshot 2026-09-02 162851" src="https://github.com/user-attachments/assets/74ddb890-6b26-468e-83e1-d140488731d6" />
<img width="365" height="732" alt="Screenshot 2026-09-02 162828" src="https://github.com/user-attachments/assets/5739f59d-18a8-45b1-bce5-cbff2dbddb3c" />

**Demo Video:**

https://github.com/user-attachments/assets/451ab69a-4ea7-4a52-b650-dc3a6a715307

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #13260 

#### Testing/QA

##### Devices
- tested on device/emulator(Pixel4A) running Android 13.0

##### Steps for testing
-  Watch few videos, and complete few from them
-  Open Histoy screen
- Click on Hide Watched button check box
- We'll see watched video is filter out and vice versa

##### APK for testing
<!-- Use a new, meaningfully named branch. The name is used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe, e.g. "commentfix", if your PR implements a bugfix for comments. (No names like "patch-0" and "feature-1".)  -->
<!-- Remove the following line if you directly link the APK created by the CI pipeline. Directly linking is preferred if you need to let users test.-->
The APK can be found by going to the "Checks" tab below the title. On the left pane, click on "CI", scroll down to "artifacts" and click "app" to download the zip file which contains the debug APK of this PR. You can find more info and a video demonstration [on this wiki page](https://github.com/TeamNewPipe/NewPipe/wiki/Download-APK-for-PR).

#### Due diligence
- [x] I read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md).
- [x] The proposed changes follow the [AI policy](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md#ai-policy).
- [x] I tested the changes using an emulator or a physical device.
